### PR TITLE
fix(sandboxed-gym): apply independent upstream fixes from the RL fork

### DIFF
--- a/packages/sandboxed_gym/src/sandboxed_gym/host/opensandbox.py
+++ b/packages/sandboxed_gym/src/sandboxed_gym/host/opensandbox.py
@@ -178,6 +178,14 @@ class OpenSandboxGymHostProvider:
             await provider.close(resource_handle)
             raise
         self._resource_handles[resource_handle.sandbox_id] = resource_handle
+        # The resolved URLs cannot be reconstructed from outside, and every downstream
+        # connectivity failure presents only as a timeout against them.
+        LOGGER.info(
+            "gym host %s ready to probe: health=%s rollouts=%s",
+            resource_handle.sandbox_id,
+            routes.health_url,
+            routes.rollout_url,
+        )
         return GymHostHandle(
             host_id=resource_handle.sandbox_id,
             health_url=routes.health_url,
@@ -199,6 +207,8 @@ class OpenSandboxGymHostProvider:
             except Exception as exc:
                 last_error = exc
             await asyncio.sleep(_HEALTH_POLL_S)
+        # Names the URL: a scheme or port mismatch is otherwise indistinguishable from a slow
+        # sandbox, and both present here as a plain timeout.
         raise TimeoutError(
             f"job host {handle.host_id} at {handle.health_url} did not become ready within {timeout_s:g}s"
             + (f": {last_error}" if last_error is not None else "")

--- a/packages/sandboxed_gym/src/sandboxed_gym/orchestrator.py
+++ b/packages/sandboxed_gym/src/sandboxed_gym/orchestrator.py
@@ -143,6 +143,11 @@ def apply_sandbox_runtime_defaults(global_config: dict[str, Any]) -> dict[str, A
     cfg.setdefault("global_aiohttp_connector_limit", 65_536)
     cfg.setdefault("uv_cache_dir", gym_uv_cache_dir())
     cfg.setdefault("uv_venv_dir", gym_uv_venv_dir())
+    # Makes Gym pass `--python <venv>/bin/python` rather than inferring a target: the training
+    # image sets an absolute UV_PYTHON, which outranks the venv Gym just activated and sends the
+    # install into a read-only interpreter tree. The only symptom is every Gym server dying with
+    # "Process `policy_model` finished unexpectedly!".
+    cfg.setdefault("uv_pip_set_python", True)
     return cfg
 
 

--- a/packages/sandboxed_gym/src/sandboxed_gym/orchestrator.py
+++ b/packages/sandboxed_gym/src/sandboxed_gym/orchestrator.py
@@ -6,13 +6,17 @@
 from __future__ import annotations
 
 import asyncio
+import atexit
 import concurrent.futures
 import json
 import logging
+import os
+import signal
 import threading
 import urllib.error
 import urllib.request
-from collections.abc import Coroutine, Mapping
+from collections.abc import Callable, Coroutine, Mapping
+from types import FrameType
 from typing import Any, TypeVar
 from urllib.parse import urlparse
 
@@ -80,6 +84,46 @@ class _SessionAsyncRunner:
         """Stop the shared loop."""
         self._loop.call_soon_threadsafe(self._loop.stop)
         self._thread.join()
+
+
+#: Signals a container runtime sends before SIGKILL. SIGKILL and node loss cannot be caught and
+#: stay the sandbox ttl_s's problem.
+TERMINATION_SIGNALS = (signal.SIGTERM, signal.SIGINT)
+
+
+def install_termination_cleanup(shutdown: Callable[[], None]) -> None:
+    """Run ``shutdown`` when this process exits without it having been called.
+
+    A process that owns a sandbox is the only thing that can name it. Ray tears an actor's worker
+    down without running user teardown, so a job that is cancelled, evicted or preempted otherwise
+    leaves its sandbox running until ttl_s. ``shutdown`` must tolerate being called twice: an
+    ordinary exit runs it directly and then again from ``atexit``.
+
+    For a process the caller owns -- an actor, a CLI. Not for a library embedded in someone else's
+    host, whose signal handling is not ours to replace.
+    """
+    atexit.register(shutdown)
+
+    def _terminate(signum: int, _frame: FrameType | None) -> None:
+        # Restored before the cleanup runs, not after: a second signal arriving mid-shutdown then
+        # takes the default action and terminates, rather than re-entering this handler on top of
+        # an in-flight destroy. Two SIGTERMs mean the sender wants the process gone.
+        signal.signal(signum, signal.SIG_DFL)
+        LOGGER.warning("received signal %s; destroying sandboxed Gym host before exit", signum)
+        try:
+            shutdown()
+        finally:
+            # Re-raised even if cleanup failed, so the exit status still reports the signal --
+            # swallowing it would make a cancelled job look like a clean stop.
+            os.kill(os.getpid(), signum)
+
+    for signum in TERMINATION_SIGNALS:
+        try:
+            signal.signal(signum, _terminate)
+        except ValueError:
+            # Only the main thread may install handlers, and Ray does not promise to call an
+            # actor method there. atexit still covers the ordinary exit.
+            LOGGER.debug("cannot install a %s handler off the main thread", signum)
 
 
 def apply_sandbox_runtime_defaults(global_config: dict[str, Any]) -> dict[str, Any]:

--- a/packages/sandboxed_gym/src/sandboxed_gym/ray/gym_actor.py
+++ b/packages/sandboxed_gym/src/sandboxed_gym/ray/gym_actor.py
@@ -9,13 +9,20 @@ from typing import Any
 
 import ray
 
-from sandboxed_gym.orchestrator import SandboxedGymOrchestrator, SandboxedGymSession
+from sandboxed_gym.orchestrator import (
+    SandboxedGymOrchestrator,
+    SandboxedGymSession,
+    install_termination_cleanup,
+)
 from sandboxed_gym.serve_config import SandboxedGymServeConfig
 
 GYM_ACTOR_FQN = "sandboxed_gym.ray.gym_actor.SandboxedGymActor"
 
 
-@ray.remote(max_restarts=-1, max_task_retries=-1)
+# Deliberately no max_restarts, as on SandboxEpisodeBrokerActor: the host handle lives only in this
+# process, so a restarted actor provisions a second sandbox and leaks the first until its ttl_s. A
+# crash should fail the job. Restarts need label-based reconciliation of the job id on the spec.
+@ray.remote
 class SandboxedGymActor:
     """Trusted Ray proxy: broker + Gym host; returns raw ``/rollouts/run`` results."""
 
@@ -25,6 +32,8 @@ class SandboxedGymActor:
 
     def spinup(self) -> dict[str, Any]:
         self._session = SandboxedGymOrchestrator().start(self._cfg)
+        # After start(), so a spinup that failed leaves nothing registered to destroy.
+        install_termination_cleanup(self.shutdown)
         return self._session.descriptor().model_dump(mode="json")
 
     def run_rollouts(self, examples: list[dict[str, Any]]) -> list[Any]:

--- a/packages/sandboxed_gym/tests/test_opensandbox_host_provider.py
+++ b/packages/sandboxed_gym/tests/test_opensandbox_host_provider.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Readiness diagnostics of the OpenSandbox job-host provider.
+
+These need no OpenSandbox SDK: the module keeps its SDK types under ``TYPE_CHECKING`` and builds
+the driver lazily, so the provider imports and constructs from a plain checkout.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+import pytest
+from sandboxed_gym.host.models import GymHostHandle, GymHostSpec, GymHostVolumeMount
+from sandboxed_gym.host.opensandbox import OpenSandboxGymHostProvider
+
+HEALTH_URL = "https://sandbox.example/gym-1/health"
+ROLLOUT_URL = "https://sandbox.example/gym-1/rollouts/run"
+
+
+@pytest.fixture
+def provider() -> OpenSandboxGymHostProvider:
+    return OpenSandboxGymHostProvider(connection={"domain": "x", "api_key": "k"})
+
+
+def test_readiness_timeout_names_the_url_it_polled(
+    provider: OpenSandboxGymHostProvider, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A scheme or port mismatch is otherwise indistinguishable from a slow sandbox.
+
+    The host id alone cannot be turned back into the URL the poll used, so a misconfigured
+    protocol reads as "the sandbox is taking too long" and sends the reader to the wrong place.
+    """
+    handle = GymHostHandle(host_id="gym-1", health_url=HEALTH_URL, rollout_url=ROLLOUT_URL)
+
+    def _refuse(url: str, headers: Any) -> dict[str, Any]:
+        raise ConnectionRefusedError("connection refused")
+
+    monkeypatch.setattr(provider, "_get_json", _refuse)
+
+    with pytest.raises(TimeoutError) as excinfo:
+        asyncio.run(provider.wait_ready(handle, timeout_s=0.01))
+
+    message = str(excinfo.value)
+    assert HEALTH_URL in message
+    # The underlying error too: knowing which URL was polled is only half of it.
+    assert "connection refused" in message
+
+
+def test_a_created_host_logs_the_urls_it_resolved(
+    provider: OpenSandboxGymHostProvider,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``create_host`` is the only place the resolved URLs are knowable.
+
+    They come back from the SDK's route resolution onto a handle the caller may never print, so
+    without this every downstream connectivity failure is a timeout against an address that
+    appears nowhere in the logs.
+    """
+    routes = _Routes(health_url=HEALTH_URL, rollout_url=ROLLOUT_URL, headers={})
+    monkeypatch.setattr(provider, "_provider_for_spec", lambda spec: _StubDriver())
+    monkeypatch.setattr(provider, "_to_sandbox_spec", lambda spec: spec)
+    monkeypatch.setattr(provider, "_resolve_routes", _returning(routes))
+
+    with caplog.at_level(logging.INFO, logger="sandboxed_gym.host.opensandbox"):
+        asyncio.run(provider.create_host(_spec()))
+
+    assert HEALTH_URL in caplog.text
+    assert ROLLOUT_URL in caplog.text
+    assert "gym-1" in caplog.text
+
+
+class _Routes:
+    def __init__(self, *, health_url: str, rollout_url: str, headers: dict[str, str]) -> None:
+        self.health_url = health_url
+        self.rollout_url = rollout_url
+        self.headers = headers
+
+
+class _ResourceHandle:
+    sandbox_id = "gym-1"
+    raw = object()
+
+
+class _StubDriver:
+    """Stands in for the OpenSandbox SDK driver, which is the only part needing a real cluster."""
+
+    async def create(self, spec: GymHostSpec) -> _ResourceHandle:
+        return _ResourceHandle()
+
+
+def _returning(routes: _Routes):
+    async def _resolve(raw: Any, port: int) -> _Routes:
+        return routes
+
+    return _resolve
+
+
+def _spec() -> GymHostSpec:
+    return GymHostSpec(
+        job_id="job-1",
+        runtime_image="example/gym:latest",
+        environment_mount=GymHostVolumeMount(pvc_claim="env", mount_path="/job/environment", read_only=True),
+        workspace_mount=GymHostVolumeMount(pvc_claim="work", mount_path="/job/work"),
+    )

--- a/packages/sandboxed_gym/tests/test_ray_actors.py
+++ b/packages/sandboxed_gym/tests/test_ray_actors.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Restart policy of the Ray actors, asserted against the source.
+
+Read with ``ast`` rather than by importing: ``ray`` is an optional extra, so these modules are not
+importable in the default test environment, and the property under test is a decorator argument
+that is fixed at import time anyway.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+import sandboxed_gym
+
+RAY_DIR = Path(sandboxed_gym.__file__).parent / "ray"
+RESTART_OPTIONS = ("max_restarts", "max_task_retries")
+
+
+def _ray_remote_keywords(module_path: Path, class_name: str) -> dict[str, str]:
+    """Keyword arguments on the ``@ray.remote`` decorator of ``class_name``."""
+    tree = ast.parse(module_path.read_text())
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef) or node.name != class_name:
+            continue
+        for decorator in node.decorator_list:
+            if isinstance(decorator, ast.Call) and ast.unparse(decorator.func) == "ray.remote":
+                return {kw.arg: ast.unparse(kw.value) for kw in decorator.keywords if kw.arg}
+            if ast.unparse(decorator) == "ray.remote":
+                return {}
+        pytest.fail(f"{class_name} is not decorated with ray.remote")
+    pytest.fail(f"{class_name} not found in {module_path}")
+
+
+@pytest.mark.parametrize(
+    ("module_name", "class_name"),
+    [("gym_actor.py", "SandboxedGymActor"), ("broker_actor.py", "SandboxEpisodeBrokerActor")],
+)
+def test_actors_are_not_restartable(module_name: str, class_name: str) -> None:
+    """Neither actor may be restarted: both hold state a replacement cannot recover.
+
+    The Gym actor holds the only reference to its sandbox, and the broker actor the only handle
+    map. A restart cannot name what its predecessor created, so it provisions a second sandbox and
+    leaks the first until ttl_s -- silently doubling the pods a job holds.
+    """
+    keywords = _ray_remote_keywords(RAY_DIR / module_name, class_name)
+    assert not [option for option in RESTART_OPTIONS if option in keywords]
+
+
+def _method_body(module_path: Path, class_name: str, method_name: str) -> str:
+    tree = ast.parse(module_path.read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            for item in node.body:
+                if isinstance(item, ast.FunctionDef) and item.name == method_name:
+                    return ast.unparse(item)
+    pytest.fail(f"{class_name}.{method_name} not found in {module_path}")
+
+
+def test_spinup_arms_the_termination_cleanup() -> None:
+    """The actor is the only thing that installs the cleanup, so nothing else can catch its loss.
+
+    Without this call a cancelled or evicted job leaves its sandbox running until ttl_s. The
+    behaviour of the cleanup itself is covered in ``test_termination_cleanup``; what is asserted
+    here is that the actor still arms it, which no test of the helper alone can see.
+    """
+    body = _method_body(RAY_DIR / "gym_actor.py", "SandboxedGymActor", "spinup")
+
+    assert "install_termination_cleanup(self.shutdown)" in body

--- a/packages/sandboxed_gym/tests/test_sandboxed_gym_host.py
+++ b/packages/sandboxed_gym/tests/test_sandboxed_gym_host.py
@@ -289,6 +289,25 @@ def test_sandbox_runtime_defaults_preserve_caller_gym_config():
     assert global_config["uv_venv_dir"]
 
 
+def test_sandbox_runtime_defaults_target_gym_installs_at_the_activated_venv():
+    """Gym must install into the venv it activated, not whatever UV_PYTHON names.
+
+    The training image sets UV_PYTHON to an absolute interpreter path, which outranks the active
+    venv when Gym's ``uv pip install`` resolves a target. Without this the install lands in a
+    read-only tree and every Gym server dies during startup.
+    """
+    from sandboxed_gym.orchestrator import apply_sandbox_runtime_defaults
+
+    assert apply_sandbox_runtime_defaults({})["uv_pip_set_python"] is True
+
+
+def test_sandbox_runtime_defaults_respect_an_explicit_uv_pip_set_python():
+    """A caller that has its own answer keeps it -- every uv key here is a default, not an override."""
+    from sandboxed_gym.orchestrator import apply_sandbox_runtime_defaults
+
+    assert apply_sandbox_runtime_defaults({"uv_pip_set_python": False})["uv_pip_set_python"] is False
+
+
 def test_gym_host_spec_defers_to_the_image_entrypoint_when_omitted():
     # The orchestrator cannot name a path inside the host image: resolving one from its own
     # installation would describe its own container. With no entrypoint configured the image

--- a/packages/sandboxed_gym/tests/test_termination_cleanup.py
+++ b/packages/sandboxed_gym/tests/test_termination_cleanup.py
@@ -1,0 +1,137 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Destroying the Gym host when the owning process is terminated rather than shut down.
+
+The handlers are invoked directly rather than by delivering a real signal: the handler's final act
+is to re-raise with the default action installed, which would take the test session down with it.
+"""
+
+from __future__ import annotations
+
+import atexit
+import signal
+from collections.abc import Callable
+
+import pytest
+from sandboxed_gym.orchestrator import TERMINATION_SIGNALS, install_termination_cleanup
+
+
+@pytest.fixture(autouse=True)
+def restore_process_state():
+    """Undo the process-global handlers and atexit hooks each test installs."""
+    original = {signum: signal.getsignal(signum) for signum in TERMINATION_SIGNALS}
+    registered: list[Callable[[], object]] = []
+    real_register = atexit.register
+
+    def _tracking_register(func, *args, **kwargs):
+        registered.append(func)
+        return real_register(func, *args, **kwargs)
+
+    atexit.register = _tracking_register  # ty: ignore[invalid-assignment]
+    try:
+        yield registered
+    finally:
+        atexit.register = real_register
+        for func in registered:
+            atexit.unregister(func)
+        for signum, handler in original.items():
+            signal.signal(signum, handler)
+
+
+@pytest.mark.parametrize("signum", TERMINATION_SIGNALS)
+def test_a_termination_signal_destroys_the_host(signum, monkeypatch: pytest.MonkeyPatch) -> None:
+    """SIGTERM is what Kubernetes sends before SIGKILL, and the last chance to free the sandbox."""
+    calls: list[str] = []
+    monkeypatch.setattr("os.kill", lambda pid, sig: calls.append(f"kill:{sig}"))
+
+    install_termination_cleanup(lambda: calls.append("shutdown"))
+    handler = signal.getsignal(signum)
+    assert not isinstance(handler, int) and handler is not None
+    handler(signum, None)
+
+    assert calls == ["shutdown", f"kill:{signum}"]
+
+
+@pytest.mark.parametrize("signum", TERMINATION_SIGNALS)
+def test_the_signal_is_re_raised_with_the_default_action(signum, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The exit status must still report the signal, or a cancelled job reads as a clean stop."""
+    monkeypatch.setattr("os.kill", lambda pid, sig: None)
+
+    install_termination_cleanup(lambda: None)
+    handler = signal.getsignal(signum)
+    assert not isinstance(handler, int) and handler is not None
+    handler(signum, None)
+
+    assert signal.getsignal(signum) is signal.SIG_DFL
+
+
+@pytest.mark.parametrize("signum", TERMINATION_SIGNALS)
+def test_the_default_action_is_restored_before_cleanup_runs(signum, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A second signal during a slow destroy must terminate, not re-enter this handler.
+
+    Restoring afterwards would leave the handler installed for the whole of ``shutdown()`` -- the
+    slowest part, since it waits on the sandbox being destroyed -- so an impatient second SIGTERM
+    would stack another destroy on top of the in-flight one.
+    """
+    monkeypatch.setattr("os.kill", lambda pid, sig: None)
+    observed: list[object] = []
+
+    install_termination_cleanup(lambda: observed.append(signal.getsignal(signum)))
+    handler = signal.getsignal(signum)
+    assert not isinstance(handler, int) and handler is not None
+    handler(signum, None)
+
+    assert observed == [signal.SIG_DFL]
+
+
+@pytest.mark.parametrize("signum", TERMINATION_SIGNALS)
+def test_the_signal_is_re_raised_even_when_cleanup_fails(signum, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A destroy that raises must not turn a terminated job into a hung one.
+
+    Without the re-raise the exception escapes into whatever the handler interrupted, and the
+    process keeps running with its exit status never reporting the signal.
+    """
+    killed: list[int] = []
+    monkeypatch.setattr("os.kill", lambda pid, sig: killed.append(sig))
+
+    def _explode() -> None:
+        raise RuntimeError("destroy_host failed")
+
+    install_termination_cleanup(_explode)
+    handler = signal.getsignal(signum)
+    assert not isinstance(handler, int) and handler is not None
+
+    with pytest.raises(RuntimeError, match="destroy_host failed"):
+        handler(signum, None)
+
+    assert killed == [signum]
+
+
+def test_shutdown_runs_at_exit(restore_process_state) -> None:
+    """Covers the path a signal cannot: an ordinary interpreter exit with no teardown call.
+
+    Also the only cover when handler installation is refused off the main thread.
+    """
+    calls: list[str] = []
+    install_termination_cleanup(lambda: calls.append("shutdown"))
+
+    assert restore_process_state, "nothing was registered with atexit"
+    for hook in restore_process_state:
+        hook()
+    assert calls == ["shutdown"]
+
+
+def test_handlers_are_optional_off_the_main_thread(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ray does not promise to run an actor method on the main thread.
+
+    ``signal.signal`` raises ValueError there. Registration must degrade to atexit rather than
+    failing spinup, since a sandbox that leaks on SIGTERM still beats one that never starts.
+    """
+
+    def _refuse(signum: int, handler: object) -> None:
+        raise ValueError("signal only works in main thread")
+
+    monkeypatch.setattr(signal, "signal", _refuse)
+
+    install_termination_cleanup(lambda: None)


### PR DESCRIPTION
## Summary

`packages/sandboxed_gym` was vendored from `soluwalana/RL@67821a9` (2026-08-03) and has taken no upstream changes since; fourteen commits have landed there in the meantime. This applies the four that are independent of each other and of the rollout transport path — an actor that leaks sandboxes on restart and on termination, a readiness timeout that cannot be diagnosed, and a Gym config default without which every Gym server dies during startup on the training image.

The remaining upstream work (heartbeat, chunking, proxy-error classification) rewrites the rollout path and is deliberately left for a second PR; see AALGO-584.

## Related Issue

Part of AALGO-584 (drift analysis and full item list attached there). Parent: AALGO-583.

## Changes

Three commits, each naming the upstream commit it ports:

- **`stop the Gym actor leaking sandboxes`** — ports `soluwalana/RL@6e268a2`. Drops `max_restarts=-1, max_task_retries=-1` from `SandboxedGymActor`: the host handle lives only in the actor process, so a restarted actor provisions a second sandbox and leaks the first until its `ttl_s`. The sibling `SandboxEpisodeBrokerActor` already documented this reasoning, so the two files contradicted each other. Adds `install_termination_cleanup` (atexit + SIGTERM/SIGINT) so a cancelled, evicted or preempted job destroys its host instead of leaking it.
- **`name the health URL a job host failed to reach`** — ports the diagnostics half of `soluwalana/RL@d90a51e`. Logs the resolved health/rollout URLs and names the polled URL in the readiness `TimeoutError`.
- **`make Gym install into the venv it activated`** — ports `soluwalana/RL@4968fab` + `@874f947`. Sets `uv_pip_set_python`, absent from this repo entirely.

### Design calls worth a reviewer's attention

- **`install_termination_cleanup` lives in the Ray-free `orchestrator` module**, called from the actor, rather than on the actor as upstream has it. This package keeps the actor a thin wrapper, and `ray` is an optional extra, so logic placed there cannot be tested from a plain checkout.
- **It restores the default signal action *before* running cleanup, deviating from upstream**, which restores after. Upstream leaves its handler installed for the whole of `shutdown()` — the slowest part, since it waits on the sandbox being destroyed — so a second SIGTERM re-enters and stacks another destroy on the in-flight one. Restoring first means a second signal terminates instead. The cleanup is wrapped in `try/finally` so a failed destroy still re-raises. An independent review flagged the upstream ordering as a `major` defect, separately from this change.
- **Not applied to the Evaluator's in-process path.** `plugins/nemo_evaluator/jobs/gym_sandbox.py` embeds `SandboxedGymOrchestrator` directly rather than going through the Ray actor, and a library has no business replacing an embedding host's signal handlers. Its `try/finally` covers the ordinary path; if signal coverage is wanted there it belongs in Evaluator's task runner. The `sandboxed-gym serve` CLI is likewise untouched — a reasonable follow-up, but out of scope here.
- **`uv_pip_set_python` is conditional today and load-bearing shortly.** `docker/rl/Dockerfile.nmp-rl-base:102` is the only image here setting an absolute `UV_PYTHON`; the gym-host and gym-tasks images do not. That is why the live Docker validation on #1400 could not have caught this, and why it goes live the moment the library is shared with the RL actor.

### Deliberately not changed

- The result-ordering fix. Both sides fixed the same `asyncio.as_completed` mispairing independently and incompatibly (upstream tags `[_rowidx, result]`; we copy `_ng_task_index` onto the result). Reconciling them is a wire-format decision for the shared wheel, not a drift item.
- The environment-wheel feature (`gym_env_package.py`), which reintroduces the NeMo-RL dependency this package exists to avoid and overlaps #1522.
- The `requires_opensandbox` skipif on two existing provider tests is stricter than the module needs — the provider imports and constructs without the SDK. Left alone as unrelated.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: no user-visible surface changes. All four are internal defaults and diagnostics; the package README describes architecture, which is unchanged.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `uv run --frozen pytest packages/sandboxed_gym/tests/ -q` → **209 passed, 2 skipped** (2 skips are the pre-existing `requires_opensandbox` guards). Baseline on `main` is 196.
- Each commit is independently green — 205 → 207 → 209 in a scratch worktree, so the history bisects.
- `uv run ruff check packages/sandboxed_gym/` → All checks passed. `ruff format --check` → 51 files already formatted.
- `uv run --frozen ty check` → exit 0. The one diagnostic on changed files is the pre-existing unresolved `import ray` (optional extra, excluded from the repo-wide run).
- `uv run pre-commit run -a` → **exit 0, no failures**, run inside `flox activate` so `uv` is the pinned 0.9.14. Outside Flox the `uv-lock` hook fails on the local uv being 0.9.30; that is a toolchain-version check only — this branch touches no `pyproject.toml` or `uv.lock`, and `Check for uv.lock drift` passes either way.
- Every new test was mutation-checked: the production change was reverted and the corresponding test confirmed to go red, then restored.
- **`uv_pip_set_python` verified honoured, not assumed:** an upstream NeMo-Gym global-config key since `NVIDIA-NeMo/Gym@146b1a5b5` (2025-12-19), read in `nemo_gym/cli/setup_command.py` with a default of `False`; both images pin `nemo-gym==0.5.0`.

### Not verified

Nothing here has been exercised against a real OpenSandbox deployment — the same gap #1400 shipped with. The termination and readiness paths in particular are the ones a live cluster would exercise differently, and the readiness-diagnostics change exists precisely because that path has never run end to end.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Reliability**
  * Sandbox hosts now clean up reliably when processes exit or receive termination signals.
  * Failed sandbox jobs no longer automatically restart after actor crashes.
  * Runtime setup now consistently configures the Python executable for package installation.

* **Diagnostics**
  * Host startup logs resolved health and rollout URLs.
  * Readiness timeout errors now identify the health URL and underlying connection issue.

* **Tests**
  * Added coverage for cleanup behavior, actor failure handling, runtime defaults, and readiness diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->