### PR TITLE
feat(agents): package from a source checkout without the ceremony [ASTD-535]

### DIFF
--- a/plugins/nemo-agents/README.md
+++ b/plugins/nemo-agents/README.md
@@ -192,14 +192,28 @@ has to be one an index can serve:
 
 ```bash
 uv build --package nemo-platform --wheel --out-dir dist && \
-NEMO_AGENTS_WHEEL="$(ls -t dist/nemo_platform-*.whl | head -1)" nemo agents package \
+NEMO_AGENTS_WHEEL=LATEST nemo agents package \
   --agent plugins/nemo-agents/examples/nemo-agent-config/calculator-agent/agent.yaml \
   --tag calculator-agent:local
 ```
 
+`LATEST` resolves to the newest wheel in the checkout's `dist`, so the variable
+survives the rebuild each commit forces — the version carries the commit, so a
+wheel built before your last commit no longer describes your tree. An absolute
+path still works and takes precedence, so a file actually named `LATEST` is
+never mistaken for the sentinel. If the wheel's version differs from the one
+this host runs, the build says so and continues: the wheel is installed instead
+of the pin, so the pin never has to resolve.
+
 It is an environment variable rather than a flag because packaging also runs as
-a platform job, and a flag would only ever reach the CLI. Setting it in the jobs
-execution profile's `env` makes packaging from Studio work the same way.
+a platform job, and a flag would only ever reach the CLI. The subprocess job
+inherits it, so exporting it before `nemo services run` covers Studio-triggered
+builds too:
+
+```bash
+export NEMO_AGENTS_WHEEL=LATEST
+uv run nemo services run --service-group all --controllers jobs --port 8080
+```
 
 Packaging copies the wheel into the build context for the duration of the build
 and removes it afterward. It does not overwrite an existing file with that name.

--- a/plugins/nemo-agents/src/nemo_agents_plugin/container/builder.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/container/builder.py
@@ -339,10 +339,10 @@ def resolve_latest_wheel() -> Path:
             f"{WHEEL_ENV}={WHEEL_LATEST} needs a source checkout with a 'dist' directory, "
             "which this install is not. Point it at a wheel path instead."
         )
-    wheels = sorted(dist.glob("*.whl"), key=lambda path: path.stat().st_mtime, reverse=True)
+    wheels = sorted(dist.glob("nemo_platform-*.whl"), key=lambda path: path.stat().st_mtime, reverse=True)
     if not wheels:
         raise ValueError(
-            f"{WHEEL_ENV}={WHEEL_LATEST} found no wheels in {dist}. Build one with "
+            f"{WHEEL_ENV}={WHEEL_LATEST} found no nemo-platform wheels in {dist}. Build one with "
             "`uv build --package nemo-platform --wheel --out-dir dist`."
         )
     return wheels[0]

--- a/plugins/nemo-agents/src/nemo_agents_plugin/container/builder.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/container/builder.py
@@ -314,6 +314,40 @@ def build_nat_agent_image(
             ignore_file.unlink(missing_ok=True)
 
 
+def _source_checkout_dist_dir() -> Path | None:
+    """Locate ``dist`` in the checkout this package is running from, if it is one."""
+    import importlib.util
+
+    spec = importlib.util.find_spec("nemo_agents_plugin")
+    locations = spec.submodule_search_locations if spec else None
+    if not locations:
+        return None
+    for parent in Path(next(iter(locations))).resolve().parents:
+        if (parent / "pyproject.toml").is_file() and (parent / "plugins").is_dir():
+            dist = parent / "dist"
+            return dist if dist.is_dir() else None
+    return None
+
+
+def resolve_latest_wheel() -> Path:
+    """Return the most recently built wheel in the source checkout's ``dist``."""
+    from nemo_agents_plugin.container.template import WHEEL_ENV, WHEEL_LATEST
+
+    dist = _source_checkout_dist_dir()
+    if dist is None:
+        raise ValueError(
+            f"{WHEEL_ENV}={WHEEL_LATEST} needs a source checkout with a 'dist' directory, "
+            "which this install is not. Point it at a wheel path instead."
+        )
+    wheels = sorted(dist.glob("*.whl"), key=lambda path: path.stat().st_mtime, reverse=True)
+    if not wheels:
+        raise ValueError(
+            f"{WHEEL_ENV}={WHEEL_LATEST} found no wheels in {dist}. Build one with "
+            "`uv build --package nemo-platform --wheel --out-dir dist`."
+        )
+    return wheels[0]
+
+
 def build_fabric_agent_image(
     agent_config: Path,
     pyproject: Path | None = None,
@@ -375,13 +409,18 @@ def build_fabric_agent_image(
     resolved_uv = resolve_value("uv_version", uv_version)
 
     from nemo_agents_plugin.container.metadata import NEMO_PLATFORM_AGENT_FRAMEWORK, extract_agent_metadata
-    from nemo_agents_plugin.container.template import WHEEL_ENV
+    from nemo_agents_plugin.container.template import WHEEL_ENV, WHEEL_LATEST
 
     # The env var is the only caller-facing way in, so it reaches the platform
     # job as well as the CLI.
     if wheel is None:
         from_env = os.environ.get(WHEEL_ENV, "").strip()
-        wheel = Path(from_env) if from_env else None
+        # A real path wins over the sentinel, so a file named LATEST is still usable.
+        if from_env and not Path(from_env).exists() and from_env.upper() == WHEEL_LATEST:
+            wheel = resolve_latest_wheel()
+            emit_progress(on_progress, f"{WHEEL_ENV}={WHEEL_LATEST} resolved to {wheel.name}")
+        else:
+            wheel = Path(from_env) if from_env else None
     if wheel is not None and dockerfile is not None:
         # A supplied Dockerfile installs whatever it wants and never sees the
         # staged wheel, so the wheel must not speak for the version either.
@@ -396,6 +435,12 @@ def build_fabric_agent_image(
     # A wheel is what the image actually installs, so it — not the build host —
     # decides the version the image advertises and hashes into its id.
     contract_version = wheel_contract_version(wheel) if wheel is not None else get_contract_version()
+    if wheel is not None and contract_version != get_contract_version():
+        # Not fatal: the wheel is installed instead of the pin, so the pin never resolves.
+        emit_progress(
+            on_progress,
+            f"warning: {wheel.name} builds {contract_version}, but this host runs {get_contract_version()}",
+        )
 
     build_env_for_id = {
         "agent_framework": NEMO_PLATFORM_AGENT_FRAMEWORK,

--- a/plugins/nemo-agents/src/nemo_agents_plugin/container/builder.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/container/builder.py
@@ -415,12 +415,18 @@ def build_fabric_agent_image(
     # job as well as the CLI.
     if wheel is None:
         from_env = os.environ.get(WHEEL_ENV, "").strip()
+        if from_env and dockerfile is not None:
+            # Decided before resolving, so LATEST does not have to find a wheel
+            # this build was never going to install.
+            emit_progress(
+                on_progress, f"warning: ignoring {WHEEL_ENV}={from_env}; --dockerfile decides what is installed"
+            )
         # A real path wins over the sentinel, so a file named LATEST is still usable.
-        if from_env and not Path(from_env).exists() and from_env.upper() == WHEEL_LATEST:
+        elif from_env and not Path(from_env).exists() and from_env.upper() == WHEEL_LATEST:
             wheel = resolve_latest_wheel()
             emit_progress(on_progress, f"{WHEEL_ENV}={WHEEL_LATEST} resolved to {wheel.name}")
-        else:
-            wheel = Path(from_env) if from_env else None
+        elif from_env:
+            wheel = Path(from_env)
     if wheel is not None and dockerfile is not None:
         # A supplied Dockerfile installs whatever it wants and never sees the
         # staged wheel, so the wheel must not speak for the version either.

--- a/plugins/nemo-agents/src/nemo_agents_plugin/container/template.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/container/template.py
@@ -102,6 +102,9 @@ _ENV_MAP: dict[str, str] = {
 #: host, and packaging runs there for the CLI and the platform job alike.
 WHEEL_ENV = "NEMO_AGENTS_WHEEL"
 
+#: Newest wheel in the checkout's ``dist``, so the value survives every rebuild.
+WHEEL_LATEST = "LATEST"
+
 PINNED_NEMO_RELAY_CLI_VERSION = "0.7.3"
 PINNED_NEMO_RELAY_INSTALLER_COMMIT = "40c5990361afc26ae8b901ff1f49c2b03ddd9ede"
 PINNED_NEMO_RELAY_INSTALLER_SHA256 = "ba2585a32e568643819992fa66b750004328351fce422b979d8c11cfc8bbfadb"

--- a/plugins/nemo-agents/tests/unit/test_container.py
+++ b/plugins/nemo-agents/tests/unit/test_container.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -2806,6 +2807,71 @@ class TestFabricWheelInstall:
 
         assert seen["present"], "the env-supplied wheel must be staged for the build"
         assert not (context / wheel.name).exists()
+
+    @patch("nemo_agents_plugin.container.builder.docker_build")
+    def test_latest_resolves_the_newest_wheel_in_dist(
+        self, mock_build: MagicMock, fabric_agent_config: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from nemo_agents_plugin.container import builder
+        from nemo_agents_plugin.container.template import WHEEL_ENV, WHEEL_LATEST
+
+        dist = tmp_path / "dist"
+        dist.mkdir()
+        older = dist / "nemo_platform-0.4.0.post1-py3-none-any.whl"
+        newer = dist / "nemo_platform-0.4.0.post2-py3-none-any.whl"
+        older.write_bytes(b"old")
+        newer.write_bytes(b"new")
+        os.utime(older, (1, 1))
+        os.utime(newer, (2, 2))
+        monkeypatch.setattr(builder, "_source_checkout_dist_dir", lambda: dist)
+        monkeypatch.setenv(WHEEL_ENV, WHEEL_LATEST)
+        context = fabric_agent_config.parent
+        seen: dict[str, bool] = {}
+        mock_build.side_effect = lambda **kwargs: seen.setdefault("present", (context / newer.name).exists())
+
+        builder.build_fabric_agent_image(fabric_agent_config, skip_validation=True, agent_author="x")
+
+        assert seen["present"], "LATEST must stage the most recently built wheel"
+
+    @patch("nemo_agents_plugin.container.builder.docker_build")
+    def test_an_existing_path_named_latest_is_not_treated_as_the_sentinel(
+        self, mock_build: MagicMock, fabric_agent_config: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from nemo_agents_plugin.container import builder
+        from nemo_agents_plugin.container.template import WHEEL_ENV, WHEEL_LATEST
+
+        literal = tmp_path / WHEEL_LATEST
+        literal.write_bytes(b"wheel")
+        monkeypatch.setenv(WHEEL_ENV, str(literal))
+
+        with pytest.raises(ValueError, match="not a wheel"):
+            builder.build_fabric_agent_image(fabric_agent_config, skip_validation=True, agent_author="x")
+
+    def test_latest_without_a_source_checkout_says_so(
+        self, fabric_agent_config: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from nemo_agents_plugin.container import builder
+        from nemo_agents_plugin.container.template import WHEEL_ENV, WHEEL_LATEST
+
+        monkeypatch.setattr(builder, "_source_checkout_dist_dir", lambda: None)
+        monkeypatch.setenv(WHEEL_ENV, WHEEL_LATEST)
+
+        with pytest.raises(ValueError, match="needs a source checkout"):
+            builder.build_fabric_agent_image(fabric_agent_config, skip_validation=True, agent_author="x")
+
+    def test_latest_with_an_empty_dist_names_the_build_command(
+        self, fabric_agent_config: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from nemo_agents_plugin.container import builder
+        from nemo_agents_plugin.container.template import WHEEL_ENV, WHEEL_LATEST
+
+        dist = tmp_path / "dist"
+        dist.mkdir()
+        monkeypatch.setattr(builder, "_source_checkout_dist_dir", lambda: dist)
+        monkeypatch.setenv(WHEEL_ENV, WHEEL_LATEST)
+
+        with pytest.raises(ValueError, match="uv build --package nemo-platform"):
+            builder.build_fabric_agent_image(fabric_agent_config, skip_validation=True, agent_author="x")
 
     @pytest.mark.parametrize(
         ("filename", "create", "match"),

--- a/plugins/nemo-agents/tests/unit/test_container.py
+++ b/plugins/nemo-agents/tests/unit/test_container.py
@@ -2834,6 +2834,47 @@ class TestFabricWheelInstall:
         assert seen["present"], "LATEST must stage the most recently built wheel"
 
     @patch("nemo_agents_plugin.container.builder.docker_build")
+    def test_latest_ignores_wheels_from_other_packages(
+        self, mock_build: MagicMock, fabric_agent_config: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from nemo_agents_plugin.container import builder
+        from nemo_agents_plugin.container.template import WHEEL_ENV, WHEEL_LATEST
+
+        dist = tmp_path / "dist"
+        dist.mkdir()
+        ours = dist / "nemo_platform-0.4.0-py3-none-any.whl"
+        theirs = dist / "nemo_evaluator-9.9.9-py3-none-any.whl"
+        ours.write_bytes(b"ours")
+        theirs.write_bytes(b"theirs")
+        os.utime(ours, (1, 1))
+        os.utime(theirs, (2, 2))
+        monkeypatch.setattr(builder, "_source_checkout_dist_dir", lambda: dist)
+        monkeypatch.setenv(WHEEL_ENV, WHEEL_LATEST)
+        context = fabric_agent_config.parent
+        seen: dict[str, bool] = {}
+        mock_build.side_effect = lambda **kwargs: seen.setdefault("present", (context / ours.name).exists())
+
+        builder.build_fabric_agent_image(fabric_agent_config, skip_validation=True, agent_author="x")
+
+        assert seen["present"], "a newer wheel from another package must not win the sort"
+        assert not (context / theirs.name).exists()
+
+    def test_latest_with_only_other_packages_wheels_names_the_build_command(
+        self, fabric_agent_config: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from nemo_agents_plugin.container import builder
+        from nemo_agents_plugin.container.template import WHEEL_ENV, WHEEL_LATEST
+
+        dist = tmp_path / "dist"
+        dist.mkdir()
+        (dist / "nemo_evaluator-9.9.9-py3-none-any.whl").write_bytes(b"theirs")
+        monkeypatch.setattr(builder, "_source_checkout_dist_dir", lambda: dist)
+        monkeypatch.setenv(WHEEL_ENV, WHEEL_LATEST)
+
+        with pytest.raises(ValueError, match="no nemo-platform wheels"):
+            builder.build_fabric_agent_image(fabric_agent_config, skip_validation=True, agent_author="x")
+
+    @patch("nemo_agents_plugin.container.builder.docker_build")
     def test_an_existing_path_named_latest_is_not_treated_as_the_sentinel(
         self, mock_build: MagicMock, fabric_agent_config: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/plugins/nemo-agents/tests/unit/test_container.py
+++ b/plugins/nemo-agents/tests/unit/test_container.py
@@ -2871,8 +2871,11 @@ class TestFabricWheelInstall:
         monkeypatch.setattr(builder, "_source_checkout_dist_dir", lambda: dist)
         monkeypatch.setenv(WHEEL_ENV, WHEEL_LATEST)
 
-        with pytest.raises(ValueError, match="no nemo-platform wheels"):
+        with pytest.raises(ValueError) as raised:
             builder.build_fabric_agent_image(fabric_agent_config, skip_validation=True, agent_author="x")
+
+        assert "no nemo-platform wheels" in str(raised.value)
+        assert "uv build --package nemo-platform" in str(raised.value)
 
     @patch("nemo_agents_plugin.container.builder.docker_build")
     def test_an_existing_path_named_latest_is_not_treated_as_the_sentinel(
@@ -2913,6 +2916,32 @@ class TestFabricWheelInstall:
 
         with pytest.raises(ValueError, match="uv build --package nemo-platform"):
             builder.build_fabric_agent_image(fabric_agent_config, skip_validation=True, agent_author="x")
+
+    @patch("nemo_agents_plugin.container.builder.docker_build")
+    def test_a_supplied_dockerfile_does_not_resolve_latest(
+        self, mock_build: MagicMock, fabric_agent_config: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from nemo_agents_plugin.container import builder
+        from nemo_agents_plugin.container.template import WHEEL_ENV, WHEEL_LATEST
+
+        def explode() -> Path:
+            raise AssertionError("LATEST must not be resolved for a --dockerfile build")
+
+        monkeypatch.setattr(builder, "resolve_latest_wheel", explode)
+        monkeypatch.setenv(WHEEL_ENV, WHEEL_LATEST)
+        dockerfile = tmp_path / "Dockerfile"
+        dockerfile.write_text("FROM scratch\n")
+        notices: list[str] = []
+
+        builder.build_fabric_agent_image(
+            fabric_agent_config,
+            dockerfile=dockerfile,
+            skip_validation=True,
+            agent_author="x",
+            on_progress=notices.append,
+        )
+
+        assert any(WHEEL_ENV in line and "ignoring" in line for line in notices)
 
     @pytest.mark.parametrize(
         ("filename", "create", "match"),

--- a/services/core/jobs/src/nmp/core/jobs/controllers/backends/subprocess.py
+++ b/services/core/jobs/src/nmp/core/jobs/controllers/backends/subprocess.py
@@ -62,6 +62,8 @@ SUBPROCESS_INHERITED_ENV_ALLOWLIST = frozenset(
     {
         "PATH",
         "VIRTUAL_ENV",
+        # A path on the build host, so operator-set like the rest of this list.
+        "NEMO_AGENTS_WHEEL",
     }
 )
 

--- a/services/core/jobs/tests/controllers/test_subprocess_backend.py
+++ b/services/core/jobs/tests/controllers/test_subprocess_backend.py
@@ -173,7 +173,11 @@ def test_schedule_passes_the_agent_wheel_through(mock_nmp_client, tmp_path, mock
     backend = _subprocess_backend(mock_nmp_client, tmp_path, mock_platform_config)
     step = _step_with_command(
         test_step_pending,
-        ["/bin/sh", "-c", 'test "$NEMO_AGENTS_WHEEL" = "/dist/nemo_platform.whl"'],
+        [
+            "/bin/sh",
+            "-c",
+            'test "$NEMO_AGENTS_WHEEL" = "/dist/nemo_platform.whl" && test -z "${SECRET_TOKEN+x}"',
+        ],
     )
 
     with (

--- a/services/core/jobs/tests/controllers/test_subprocess_backend.py
+++ b/services/core/jobs/tests/controllers/test_subprocess_backend.py
@@ -169,6 +169,31 @@ def test_schedule_uses_allowlisted_host_environment(mock_nmp_client, tmp_path, m
     assert metadata.process.wait(timeout=5) == 0
 
 
+def test_schedule_passes_the_agent_wheel_through(mock_nmp_client, tmp_path, mock_platform_config, test_step_pending):
+    backend = _subprocess_backend(mock_nmp_client, tmp_path, mock_platform_config)
+    step = _step_with_command(
+        test_step_pending,
+        ["/bin/sh", "-c", 'test "$NEMO_AGENTS_WHEEL" = "/dist/nemo_platform.whl"'],
+    )
+
+    with (
+        patch.dict(
+            os.environ,
+            {"PATH": "/bin", "NEMO_AGENTS_WHEEL": "/dist/nemo_platform.whl", "SECRET_TOKEN": "do-not-leak"},
+            clear=True,
+        ),
+        patch("nmp.core.jobs.controllers.backends.subprocess.create_otel_logger", return_value=None),
+    ):
+        update = backend.schedule(step.step_spec.executor, step)
+
+    assert update.status == PlatformJobStatus.PENDING
+    metadata = backend._process_registry.get(
+        SubprocessProcessKey(step.workspace, step.job, str(step.attempt_id), step.name)
+    )
+    assert metadata is not None
+    assert metadata.process.wait(timeout=5) == 0
+
+
 def test_schedule_preserves_uds_otlp_metadata_in_runtime_env(mock_nmp_client, tmp_path, test_step_pending):
     platform_config = PlatformConfig(  # type: ignore[abstract]
         service_discovery={"files": "unix:///tmp/nemo-platform.sock"},


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Packaging a Fabric agent from a source checkout worked, but took six steps and a platform restart. This makes it two: build a wheel, package.

The version carries the commit, so every commit invalidates the wheel and the path had to be retyped. And the path could not simply be exported — the subprocess job inherits only `PATH` and `VIRTUAL_ENV`, so it had to go through the jobs execution profile, which meant a restart and a config incantation whose nesting delimiter is a single underscore (`__` silently does nothing).

Before:

```bash
uv build --package nemo-platform --wheel --out-dir dist
pkill -f "nemo services run"
export NMP_JOBS_EXECUTOR_DEFAULTS_SUBPROCESS_ENV="{\"NEMO_AGENTS_WHEEL\":\"$(pwd)/dist/nemo_platform-0.4.0.post245.dev0+49ce01e9fa-py3-none-any.whl\"}"
uv run nemo services run --service-group all --controllers jobs --port 8080
```

After, once per machine:

```bash
export NEMO_AGENTS_WHEEL=LATEST
uv run nemo services run --service-group all --controllers jobs --port 8080
```

then `uv build --package nemo-platform --wheel --out-dir dist` whenever the image should catch up to the tree.

## Related Issue

ASTD-535

## Changes

- `controllers/backends/subprocess.py`: `NEMO_AGENTS_WHEEL` joins `SUBPROCESS_INHERITED_ENV_ALLOWLIST`, so exporting it before `nemo services run` reaches the packaging job.
- `container/template.py`: `WHEEL_LATEST` sentinel.
- `container/builder.py`: `NEMO_AGENTS_WHEEL=LATEST` resolves the newest `nemo_platform-*.whl` in the checkout's `dist`; a version mismatch against the host emits a warning.
- `README`: the shortened recipe.

### Notes for reviewers

- **The allowlist entry does not widen what a caller controls.** Worth spelling out, since this touches a security-relevant list.

  The subprocess backend runs a job step as a plain host process, so without intervention the child inherits the platform server's whole environment — whatever the operator exported before `nemo services run`. It is therefore built deny-by-default rather than inherited:

  ```python
  env = {name: value for name, value in os.environ.items() if name in SUBPROCESS_INHERITED_ENV_ALLOWLIST}
  env.update(self._execution_profile_config.env)
  ...
  ```

  Layers 1 and 2 there are operator-controlled; `spec.environment`, applied last, is caller-controlled. `NEMO_AGENTS_WHEEL` must never reach that last layer, because the packaging job installs whatever wheel it names — a caller-supplied path would be a file-read primitive aimed at the platform host. `PackageAgentInput` is `extra="forbid"` with no environment field, so that door stays shut.

  This change adds one name to layer 1 only. It lets an operator say "builds on this box use this wheel" from their own shell, and the value is a path rather than a credential, so it is not the class of thing the allowlist exists to contain.

- **A wheel path works on any install; `LATEST` does not.** The explicit-path branch has no checkout dependency — an air-gapped host with a prebuilt wheel, or one pinning an unpublished release candidate, can use it. `LATEST` locates `dist` by walking up from `nemo_agents_plugin`'s own location, not from `cwd`, because the packaging job runs with an unrelated working directory. That resolves only for a source checkout, and otherwise fails with a message naming the alternative rather than silently doing nothing.

- **`LATEST` considers only `nemo_platform-*.whl`.** A shared `dist` holding another package's newer wheel would otherwise win the sort and then fail the distribution check with a confusing message. Two tests pin it: a newer foreign wheel must not win, and a `dist` of only foreign wheels must say no nemo-platform wheel was found.

- **An existing path is checked before the sentinel**, so a file genuinely named `LATEST` can never be shadowed by it.

- **A version mismatch warns rather than fails, for any wheel.** Requiring the wheel's version to equal `contract_version` looks obviously right and is wrong: the installed metadata lags HEAD, so it would reject a wheel the user had just built.

  ```
  installed contract_version : 0.4.0.post245.dev0+6d8a59d870   # stamped before a rebase
  freshly built wheel        : 0.4.0.post245.dev0+49ce01e9fa   # stamped at HEAD
  ```

  Observed while reproducing this. Supplying a wheel already lifts the version guard and installs it *instead of* the pin, so the pin never has to resolve — the mismatch is real but tolerable, and worth naming both versions in the job log rather than refusing. The warning is not scoped to the sentinel: the mismatch is equally real for an explicitly-passed wheel. Say so if you would rather it were, it is a one-line guard.

### Rejected

- **Building the wheel on demand** when the job detects a source checkout. It would remove every step, and the staleness objection to auto-detection does not apply to it. Rejected anyway: a job that shells out to build the platform it is running from is a lot of implicit behaviour in a code path whose failures are already hard to read.
- **Auto-detecting `dist/*.whl` with no opt-in**, already rejected in ASTD-523 — a stale wheel silently baked into an image is a bad way to lose an afternoon. `LATEST` is the opt-in form of the same idea, which is what makes it acceptable.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

| Command | Result |
|---|---|
| `uv run pytest plugins/nemo-agents/tests/unit` | 1595 passed; 2 failed, both `test_port_allocation.py`, which `bind()`s a socket and is blocked by the local sandbox — unrelated, and failing on `main` |
| `uv run pytest services/core/jobs/tests/controllers/test_subprocess_backend.py` | 20 passed |
| `uv run pytest .../test_container.py .../test_subprocess_backend.py` after the comment trim | 210 passed |
| `uv run ruff check` / `ruff format --check` on changed files | All checks passed |
| `uv run --frozen ty check` on changed files | All checks passed |

**Every new test was checked against a deliberately broken build**, so none of them are decorative:

| Reverted | Result |
|---|---|
| the `LATEST` branch in `build_fabric_agent_image` | 3 of the 4 original `LATEST` tests fail |
| the `nemo_platform-*.whl` glob filter | both foreign-wheel tests fail |
| `NEMO_AGENTS_WHEEL` from the allowlist | `test_schedule_passes_the_agent_wheel_through` fails |

**`services/core/jobs/tests` has 12 pre-existing failures**, including `test_config.py::test_backend_registry_configuration`. I stashed this branch and ran the suite clean to confirm: the same 12 fail without these changes, and this branch takes it from 491 passed to 492. Not introduced here, but worth its own look.

Blocked pre-commit hooks, both environmental and neither related to this change:

- **`uv-lock`** — requires exactly uv 0.9.14 on `PATH`; this machine has 0.9.30. No dependency files are touched here.
- **`helm-docs`** — the binary is not installed locally. No Helm files are touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Fabric image builds can select the newest checkout wheel using `NEMO_AGENTS_WHEEL=LATEST`.
  - Explicit wheel paths take precedence over automatic selection.
  - Platform-triggered subprocess builds preserve the wheel selection setting.
  - Builds warn when the selected wheel’s contract version differs from the host version.

- **Bug Fixes**
  - Improved guidance when wheel sources are missing or invalid.
  - Custom Dockerfile builds ignore the wheel selection setting.

- **Documentation**
  - Documented wheel selection, precedence, version handling, and environment inheritance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->