### PR TITLE
feat(customizer): add reranking recipe, add head type to model spec

### DIFF
--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -9586,7 +9586,7 @@ nemo customization [OPTIONS] COMMAND [ARGS]...
 
 *Jobs:*
 
-* `automodel.jobs`: Automodel SFT and knowledge-distillation training jobs.
+* `automodel.jobs`: Automodel SFT, retrieval, and knowledge-distillation...
 * `rl.jobs`: NeMo-RL DPO and GRPO training jobs on the platform...
 * `unsloth.jobs`: Unsloth SFT (LoRA / full / merged) training jobs on the...
 
@@ -9832,7 +9832,7 @@ nemo customization unsloth submit [OPTIONS] JOB_JSON
 
 #### nemo customization automodel.jobs
 
-Automodel SFT and knowledge-distillation training jobs.
+Automodel SFT, retrieval, and knowledge-distillation training jobs.
 
 **Usage:**
 
@@ -9882,6 +9882,13 @@ nemo customization automodel.jobs run [OPTIONS]
 * `--training.distillation-ratio <FLOAT>`: Override `training.distillation_ratio` in the spec.
 * `--training.distillation-temperature <FLOAT>`: Override `training.distillation_temperature` in the spec.
 * `--training.offload-teacher`: Override `training.offload_teacher` in the spec.
+* `--training.embedding.train-n-passages <INTEGER>`: Override `training.embedding.train_n_passages` in the spec.
+* `--training.embedding.eval-negative-size <INTEGER>`: Override `training.embedding.eval_negative_size` in the spec.
+* `--training.embedding.do-gradient-checkpointing`: Override `training.embedding.do_gradient_checkpointing` in the spec.
+* `--training.embedding.query-max-length <INTEGER>`: Override `training.embedding.query_max_length` in the spec.
+* `--training.embedding.passage-max-length <INTEGER>`: Override `training.embedding.passage_max_length` in the spec.
+* `--training.embedding.query-prefix`: Collator-side prefix; BiEncoderCollator adds a space.
+* `--training.embedding.passage-prefix`: Collator-side prefix; BiEncoderCollator adds a space.
 * `--schedule.epochs <INTEGER>`: Override `schedule.epochs` in the spec.
 * `--schedule.max-steps <INTEGER>`: Override `schedule.max_steps` in the spec.
 * `--schedule.val-check-interval <FLOAT>`: Override `schedule.val_check_interval` in the spec.
@@ -9925,7 +9932,7 @@ nemo customization automodel.jobs run [OPTIONS]
 
 Job Spec flags are generated from the AutomodelJobInput Pydantic schema. Precedence: --spec-file (base) → --spec JSON (overlay) → per-flag values (top).
 
-Some spec fields cannot be represented as CLI flags: `training.training_type`, `training.finetuning_type`, `training.lora.target_modules`, `training.lora.exclude_modules`, `training.precision`, `training.attn_implementation`, `training.teacher_precision`, `schedule.progress_reporting.time_series_metrics`, `optimizer.optimizer`, `optimizer.lr_decay_style`, `integrations.wandb.tags`, `integrations.mlflow.tags`. Supply them with --spec or --spec-file. Individual flags override values from the supplied spec.
+Some spec fields cannot be represented as CLI flags: `training.training_type`, `training.recipe`, `training.finetuning_type`, `training.lora.target_modules`, `training.lora.exclude_modules`, `training.precision`, `training.attn_implementation`, `training.teacher_precision`, `schedule.progress_reporting.time_series_metrics`, `optimizer.optimizer`, `optimizer.lr_decay_style`, `integrations.wandb.tags`, `integrations.mlflow.tags`. Supply them with --spec or --spec-file. Individual flags override values from the supplied spec.
 ​
 
 ##### nemo customization automodel.jobs submit
@@ -9960,6 +9967,13 @@ nemo customization automodel.jobs submit [OPTIONS]
 * `--training.distillation-ratio <FLOAT>`: Override `training.distillation_ratio` in the spec.
 * `--training.distillation-temperature <FLOAT>`: Override `training.distillation_temperature` in the spec.
 * `--training.offload-teacher`: Override `training.offload_teacher` in the spec.
+* `--training.embedding.train-n-passages <INTEGER>`: Override `training.embedding.train_n_passages` in the spec.
+* `--training.embedding.eval-negative-size <INTEGER>`: Override `training.embedding.eval_negative_size` in the spec.
+* `--training.embedding.do-gradient-checkpointing`: Override `training.embedding.do_gradient_checkpointing` in the spec.
+* `--training.embedding.query-max-length <INTEGER>`: Override `training.embedding.query_max_length` in the spec.
+* `--training.embedding.passage-max-length <INTEGER>`: Override `training.embedding.passage_max_length` in the spec.
+* `--training.embedding.query-prefix`: Collator-side prefix; BiEncoderCollator adds a space.
+* `--training.embedding.passage-prefix`: Collator-side prefix; BiEncoderCollator adds a space.
 * `--schedule.epochs <INTEGER>`: Override `schedule.epochs` in the spec.
 * `--schedule.max-steps <INTEGER>`: Override `schedule.max_steps` in the spec.
 * `--schedule.val-check-interval <FLOAT>`: Override `schedule.val_check_interval` in the spec.
@@ -10012,7 +10026,7 @@ nemo customization automodel.jobs submit [OPTIONS]
 
 Job Spec flags are generated from the AutomodelJobInput Pydantic schema. Precedence: --spec-file (base) → --spec JSON (overlay) → per-flag values (top).
 
-Some spec fields cannot be represented as CLI flags: `training.training_type`, `training.finetuning_type`, `training.lora.target_modules`, `training.lora.exclude_modules`, `training.precision`, `training.attn_implementation`, `training.teacher_precision`, `schedule.progress_reporting.time_series_metrics`, `optimizer.optimizer`, `optimizer.lr_decay_style`, `integrations.wandb.tags`, `integrations.mlflow.tags`. Supply them with --spec or --spec-file. Individual flags override values from the supplied spec.
+Some spec fields cannot be represented as CLI flags: `training.training_type`, `training.recipe`, `training.finetuning_type`, `training.lora.target_modules`, `training.lora.exclude_modules`, `training.precision`, `training.attn_implementation`, `training.teacher_precision`, `schedule.progress_reporting.time_series_metrics`, `optimizer.optimizer`, `optimizer.lr_decay_style`, `integrations.wandb.tags`, `integrations.mlflow.tags`. Supply them with --spec or --spec-file. Individual flags override values from the supplied spec.
 ​
 
 ##### nemo customization automodel.jobs explain

--- a/docs/customizer/tutorials/embedding-customization-job.mdx
+++ b/docs/customizer/tutorials/embedding-customization-job.mdx
@@ -477,9 +477,10 @@ Submit to the **Automodel** backend using `AutomodelJobInput` with split `schedu
 
 **Key hyperparameters for embedding fine-tuning:**
 - **`training.training_type`**: `sft`
+- **`training.recipe`**: `bi_encoder`, or `auto` when the entity `head_type` is `embedding`
 - **`training.finetuning_type`**: `all_weights` for full fine-tuning, or `lora_merged` for merged LoRA
-- **`optimizer.learning_rate`**: Lower values (1e-6 to 5e-6) work well for embedding models
-- **`batch.global_batch_size`**: Larger batches improve contrastive learning (128-256 recommended)
+- **`optimizer.learning_rate`**: Unset fields are filled with retrieval defaults (`1e-5` LR, warmup `5`, GBS `128`). Explicit values win; `1e-6`–`5e-6` is a common lower range if you set LR yourself
+- **`batch.global_batch_size`**: Unset GBS becomes `128`. Larger batches (128–256) still help contrastive learning if you set it explicitly
 
 **NOTE:**
 
@@ -767,12 +768,14 @@ For detailed information on all available hyperparameters, recommended values, a
 
 **Embedding-Specific Recommendations:**
 
-| Parameter | Recommended | Notes |
-|-----------|-------------|-------|
-| `optimizer.learning_rate` | 1e-6 to 5e-6 | Lower than standard SFT |
-| `batch.global_batch_size` | 128-256 | Larger batches improve contrastive learning |
-| `training.max_seq_length` | 512 | Typical for embedding models |
-| `schedule.epochs` | 1-3 | Start small, increase if needed |
+| Parameter | If unset (bi-encoder) | Notes |
+|-----------|----------------------|-------|
+| `optimizer.learning_rate` | `1e-5` | Set explicitly for a lower range (`1e-6`–`5e-6`) |
+| `optimizer.warmup_steps` | `5` | Cross-encoder unset default is `100` |
+| `batch.global_batch_size` | `128` | Set `128`–`256` if you want a larger contrastive batch |
+| `batch.micro_batch_size` | `4` | Schema default is `1` for SFT |
+| `training.max_seq_length` | `2048` (schema) | `512` is typical for embedding models |
+| `schedule.epochs` | `1` | Start small, increase if needed |
 
 ---
 

--- a/openapi/ga/individual/platform.openapi.yaml
+++ b/openapi/ga/individual/platform.openapi.yaml
@@ -15819,11 +15819,22 @@ components:
           title: Is Chat
           description: Whether this is a chat model
           type: boolean
+        head_type:
+          type: string
+          enum:
+          - causal_lm
+          - embedding
+          - cross_encoder
+          - unknown
+          title: Head Type
+          description: Task-specific head persisted in the checkpoint.
+          default: unknown
         is_embedding_model:
           type: boolean
           title: Is Embedding Model
-          description: Whether this is an embedding model
+          description: Deprecated compatibility alias for head_type == 'embedding'.
           default: false
+          deprecated: true
         checkpoint_model_name:
           type: string
           title: Checkpoint Model Name

--- a/openapi/ga/openapi.yaml
+++ b/openapi/ga/openapi.yaml
@@ -15819,11 +15819,22 @@ components:
           title: Is Chat
           description: Whether this is a chat model
           type: boolean
+        head_type:
+          type: string
+          enum:
+          - causal_lm
+          - embedding
+          - cross_encoder
+          - unknown
+          title: Head Type
+          description: Task-specific head persisted in the checkpoint.
+          default: unknown
         is_embedding_model:
           type: boolean
           title: Is Embedding Model
-          description: Whether this is an embedding model
+          description: Deprecated compatibility alias for head_type == 'embedding'.
           default: false
+          deprecated: true
         checkpoint_model_name:
           type: string
           title: Checkpoint Model Name

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -15819,11 +15819,22 @@ components:
           title: Is Chat
           description: Whether this is a chat model
           type: boolean
+        head_type:
+          type: string
+          enum:
+          - causal_lm
+          - embedding
+          - cross_encoder
+          - unknown
+          title: Head Type
+          description: Task-specific head persisted in the checkpoint.
+          default: unknown
         is_embedding_model:
           type: boolean
           title: Is Embedding Model
-          description: Whether this is an embedding model
+          description: Deprecated compatibility alias for head_type == 'embedding'.
           default: false
+          deprecated: true
         checkpoint_model_name:
           type: string
           title: Checkpoint Model Name

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/inference_middleware.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/inference_middleware.py
@@ -526,8 +526,11 @@ class ModelSpec(Protocol):
     is_chat: bool | None
     """Whether this model is a chat/instruction-tuned model."""
 
+    head_type: str
+    """Task-specific head persisted in the checkpoint."""
+
     is_embedding_model: bool
-    """Whether this model produces embeddings rather than completions."""
+    """Deprecated compatibility alias for an embedding head."""
 
     context_size: int | None
     """Maximum context window in tokens, or ``None`` if unspecified."""

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/models/types.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/models/types.py
@@ -263,21 +263,14 @@ class ModelSpec(BaseModel):
         deprecated=True,
     )
 
-    @model_validator(mode="before")
-    @classmethod
-    def _sync_head_type_and_embedding_alias(cls, data: object) -> object:
-        if not isinstance(data, dict):
-            return data
-        data = dict(data)
-        head_type = data.get("head_type")
-        alias = bool(data.get("is_embedding_model", False))
-        if head_type in ("causal_lm", "embedding", "cross_encoder"):
-            data["is_embedding_model"] = head_type == "embedding"
-            return data
-        if alias:
-            data["head_type"] = "embedding"
-            data["is_embedding_model"] = True
-        return data
+    @model_validator(mode="after")
+    def _sync_head_type_and_embedding_alias(self) -> Self:
+        if self.head_type in ("causal_lm", "embedding", "cross_encoder"):
+            self.is_embedding_model = self.head_type == "embedding"
+            return self
+        if self.is_embedding_model:
+            self.head_type = "embedding"
+        return self
 
     # Basic model information
     checkpoint_model_name: str = Field(description="Checkpoint Model identifier or model path")

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/models/types.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/models/types.py
@@ -260,7 +260,7 @@ class ModelSpec(BaseModel):
     is_embedding_model: bool = Field(
         False,
         description="Deprecated compatibility alias for head_type == 'embedding'.",
-        deprecated=True,
+        json_schema_extra={"deprecated": True},
     )
 
     @model_validator(mode="after")

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/models/types.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/models/types.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 import re
 from datetime import datetime
 from enum import Enum, StrEnum
-from typing import Any, NotRequired, Self, TypedDict
+from typing import Any, Literal, NotRequired, Self, TypedDict
 
 from nemo_platform_plugin.inference_middleware import BackendFormat
 from pydantic import AnyUrl, BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -253,7 +253,15 @@ class ModelSpec(BaseModel):
     context_size: int | None = Field(None, description="Context window size")
     num_virtual_tokens: int | None = Field(None, description="Number of virtual tokens for prompt tuning")
     is_chat: bool | None = Field(None, description="Whether this is a chat model")
-    is_embedding_model: bool = Field(False, description="Whether this is an embedding model")
+    head_type: Literal["causal_lm", "embedding", "cross_encoder", "unknown"] = Field(
+        default="unknown",
+        description="Task-specific head persisted in the checkpoint.",
+    )
+    is_embedding_model: bool = Field(
+        False,
+        description="Deprecated compatibility alias for head_type == 'embedding'.",
+        deprecated=True,
+    )
 
     # Basic model information
     checkpoint_model_name: str = Field(description="Checkpoint Model identifier or model path")

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/models/types.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/models/types.py
@@ -263,6 +263,22 @@ class ModelSpec(BaseModel):
         deprecated=True,
     )
 
+    @model_validator(mode="before")
+    @classmethod
+    def _sync_head_type_and_embedding_alias(cls, data: object) -> object:
+        if not isinstance(data, dict):
+            return data
+        data = dict(data)
+        head_type = data.get("head_type")
+        alias = bool(data.get("is_embedding_model", False))
+        if head_type in ("causal_lm", "embedding", "cross_encoder"):
+            data["is_embedding_model"] = head_type == "embedding"
+            return data
+        if alias:
+            data["head_type"] = "embedding"
+            data["is_embedding_model"] = True
+        return data
+
     # Basic model information
     checkpoint_model_name: str = Field(description="Checkpoint Model identifier or model path")
     family: str = Field(description="Model architecture family (e.g., 'llama', 'mixtral', 'gpt2')")

--- a/plugins/nemo-automodel/src/nemo_automodel_plugin/jobs/jobs.py
+++ b/plugins/nemo-automodel/src/nemo_automodel_plugin/jobs/jobs.py
@@ -30,7 +30,7 @@ class AutomodelJob(BaseSubmitJob):
     """GPU Automodel fine-tuning job under the customization router."""
 
     name: ClassVar[str] = "automodel.jobs"
-    description: ClassVar[str] = "Automodel SFT and knowledge-distillation training jobs."
+    description: ClassVar[str] = "Automodel SFT, retrieval, and knowledge-distillation training jobs."
     job_collection_path: ClassVar[str | None] = "/automodel/jobs"
     input_spec_schema: ClassVar[type[BaseModel] | None] = AutomodelJobInput
     spec_schema: ClassVar[type[BaseModel] | None] = AutomodelJobOutput

--- a/plugins/nemo-automodel/src/nemo_automodel_plugin/schema.py
+++ b/plugins/nemo-automodel/src/nemo_automodel_plugin/schema.py
@@ -201,6 +201,8 @@ class AutomodelJobInput(AutomodelSchema):
         recipe = self.training.recipe
         if recipe == "auto" and checkpoint_head_type in ("embedding", "cross_encoder"):
             recipe = "bi_encoder" if checkpoint_head_type == "embedding" else "cross_encoder"
+        if self.training.training_type == "distillation" and recipe not in ("auto", "sft"):
+            raise ValueError("distillation only supports the sft recipe")
 
         training = self.training.model_copy(update={"recipe": recipe})
         if recipe == "bi_encoder":

--- a/plugins/nemo-automodel/src/nemo_automodel_plugin/schema.py
+++ b/plugins/nemo-automodel/src/nemo_automodel_plugin/schema.py
@@ -196,20 +196,39 @@ class AutomodelJobInput(AutomodelSchema):
             raise ValueError("spec.output_model was removed. Use spec.output instead.")
         return data
 
-    @model_validator(mode="after")
-    def _apply_retrieval_recipe_defaults(self) -> Self:
+    def with_resolved_recipe(self, checkpoint_head_type: str) -> Self:
+        """Return the canonical job input after resolving its recipe and defaults."""
         recipe = self.training.recipe
-        if recipe not in ("bi_encoder", "cross_encoder"):
-            return self
+        if recipe == "auto" and checkpoint_head_type in ("embedding", "cross_encoder"):
+            recipe = "bi_encoder" if checkpoint_head_type == "embedding" else "cross_encoder"
+
+        training = self.training.model_copy(update={"recipe": recipe})
+        if recipe == "bi_encoder":
+            learning_rate, warmup_steps = 1e-5, 5
+        elif recipe == "cross_encoder":
+            learning_rate, warmup_steps = 3e-6, 100
+        else:
+            return self.model_copy(update={"training": training})
+
+        batch_updates: dict[str, int] = {}
         if "global_batch_size" not in self.batch.model_fields_set:
-            self.batch.global_batch_size = 128
+            batch_updates["global_batch_size"] = 128
         if "micro_batch_size" not in self.batch.model_fields_set:
-            self.batch.micro_batch_size = 4
+            batch_updates["micro_batch_size"] = 4
+
+        optimizer_updates: dict[str, float | int] = {}
         if "learning_rate" not in self.optimizer.model_fields_set:
-            self.optimizer.learning_rate = 1e-5 if recipe == "bi_encoder" else 3e-6
+            optimizer_updates["learning_rate"] = learning_rate
         if "warmup_steps" not in self.optimizer.model_fields_set:
-            self.optimizer.warmup_steps = 5 if recipe == "bi_encoder" else 100
-        return self
+            optimizer_updates["warmup_steps"] = warmup_steps
+
+        return self.model_copy(
+            update={
+                "training": training,
+                "batch": self.batch.model_copy(update=batch_updates),
+                "optimizer": self.optimizer.model_copy(update=optimizer_updates),
+            }
+        )
 
 
 class AutomodelJobOutput(AutomodelSchema):

--- a/plugins/nemo-automodel/src/nemo_automodel_plugin/schema.py
+++ b/plugins/nemo-automodel/src/nemo_automodel_plugin/schema.py
@@ -17,6 +17,7 @@ __all__ = [
     "AutomodelJobOutput",
     "BatchSpec",
     "DatasetSpec",
+    "EmbeddingSpec",
     "LoRAParams",
     "OptimizerSpec",
     "OutputRequest",
@@ -59,8 +60,27 @@ class DatasetSpec(AutomodelSchema):
     prompt_template: str | None = None
 
 
+class EmbeddingSpec(AutomodelSchema):
+    """Collator and dataset knobs for bi_encoder / cross_encoder recipes."""
+
+    train_n_passages: int = Field(default=5, ge=2)
+    eval_negative_size: int | None = Field(default=None, ge=1)
+    do_gradient_checkpointing: bool = False
+    query_max_length: int = Field(default=512, ge=1)
+    passage_max_length: int = Field(default=512, ge=1)
+    query_prefix: str = Field(default="query:", description="Collator-side prefix; BiEncoderCollator adds a space.")
+    passage_prefix: str = Field(default="passage:", description="Collator-side prefix; BiEncoderCollator adds a space.")
+
+
 class TrainingSpec(AutomodelSchema):
     training_type: Literal["sft", "distillation"] = "sft"
+    recipe: Literal["auto", "sft", "bi_encoder", "cross_encoder"] = Field(
+        default="auto",
+        description=(
+            "Training recipe. 'auto' uses the model checkpoint head; explicit encoder recipes can wrap a causal-LM "
+            "backbone for retrieval training."
+        ),
+    )
     finetuning_type: Literal["lora", "all_weights", "lora_merged"] = "lora"
     lora: LoRAParams | None = None
     max_seq_length: int = Field(default=2048, gt=0)
@@ -78,11 +98,17 @@ class TrainingSpec(AutomodelSchema):
     distillation_temperature: float = Field(default=1.0, gt=0.0)
     teacher_precision: Literal["bf16", "fp16", "fp32"] = "bf16"
     offload_teacher: bool = False
+    embedding: EmbeddingSpec | None = Field(
+        default=None,
+        description="Retrieval collator/dataset knobs. Used when recipe is bi_encoder or cross_encoder.",
+    )
 
     @model_validator(mode="after")
     def _training_type_fields(self) -> Self:
         if self.training_type == "distillation" and not self.teacher_model:
             raise ValueError("teacher_model is required when training_type is distillation")
+        if self.training_type == "distillation" and self.recipe not in ("auto", "sft"):
+            raise ValueError("distillation only supports the sft recipe")
         if self.finetuning_type.startswith("lora") and self.lora is None:
             self.lora = LoRAParams()
         return self
@@ -115,7 +141,13 @@ class OptimizerSpec(AutomodelSchema):
     adam_beta2: float = Field(default=0.999, ge=0.0, lt=1.0, description="Adam optimizer beta2.")
     warmup_steps: int = Field(default=0, ge=0)
     adam_eps: float = Field(default=1e-8, gt=0.0, description="Adam/AdamW epsilon for numerical stability.")
-    optimizer: Literal["Adam", "AdamW"] = Field(default="Adam", description="Optimizer algorithm.")
+    optimizer: Literal["auto", "Adam", "AdamW", "FusedAdam"] = Field(
+        default="auto",
+        description=(
+            "Optimizer algorithm. 'auto' selects Transformer Engine FusedAdam for retrieval recipes "
+            "and torch Adam for SFT."
+        ),
+    )
     lr_decay_style: Literal["cosine", "linear", "constant"] = Field(
         default="cosine", description="Learning-rate decay schedule."
     )
@@ -163,6 +195,21 @@ class AutomodelJobInput(AutomodelSchema):
         if isinstance(data, dict) and "output_model" in data:
             raise ValueError("spec.output_model was removed. Use spec.output instead.")
         return data
+
+    @model_validator(mode="after")
+    def _apply_retrieval_recipe_defaults(self) -> Self:
+        recipe = self.training.recipe
+        if recipe not in ("bi_encoder", "cross_encoder"):
+            return self
+        if "global_batch_size" not in self.batch.model_fields_set:
+            self.batch.global_batch_size = 128
+        if "micro_batch_size" not in self.batch.model_fields_set:
+            self.batch.micro_batch_size = 4
+        if "learning_rate" not in self.optimizer.model_fields_set:
+            self.optimizer.learning_rate = 1e-5 if recipe == "bi_encoder" else 3e-6
+        if "warmup_steps" not in self.optimizer.model_fields_set:
+            self.optimizer.warmup_steps = 5 if recipe == "bi_encoder" else 100
+        return self
 
 
 class AutomodelJobOutput(AutomodelSchema):

--- a/plugins/nemo-automodel/src/nemo_automodel_plugin/transform.py
+++ b/plugins/nemo-automodel/src/nemo_automodel_plugin/transform.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from nmp.customization_common.contributor.transform import generated_output_name
 from nmp.customization_common.service.platform_client import check_dataset_access, fetch_model_entity
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from nemo_platform import AsyncNeMoPlatform
 
 
-def _infer_output_type(input_spec: AutomodelJobInput, checkpoint_head_type: str) -> str:
+def _infer_output_type(input_spec: AutomodelJobInput, checkpoint_head_type: str) -> Literal["model", "adapter"]:
     recipe = input_spec.training.recipe
     is_bi_encoder = recipe == "bi_encoder" or (recipe == "auto" and checkpoint_head_type == "embedding")
     if is_bi_encoder:
@@ -47,6 +47,8 @@ async def transform_input_to_output(
         checkpoint_head_type = getattr(model_entity.spec, "head_type", None) or "unknown"
         if checkpoint_head_type == "unknown" and getattr(model_entity.spec, "is_embedding_model", False):
             checkpoint_head_type = "embedding"
+
+    input_spec = input_spec.with_resolved_recipe(checkpoint_head_type)
 
     output_type = _infer_output_type(input_spec, checkpoint_head_type)
 

--- a/plugins/nemo-automodel/src/nemo_automodel_plugin/transform.py
+++ b/plugins/nemo-automodel/src/nemo_automodel_plugin/transform.py
@@ -20,8 +20,10 @@ if TYPE_CHECKING:
     from nemo_platform import AsyncNeMoPlatform
 
 
-def _infer_output_type(input_spec: AutomodelJobInput, is_embedding_model: bool) -> str:
-    if is_embedding_model:
+def _infer_output_type(input_spec: AutomodelJobInput, checkpoint_head_type: str) -> str:
+    recipe = input_spec.training.recipe
+    is_bi_encoder = recipe == "bi_encoder" or (recipe == "auto" and checkpoint_head_type == "embedding")
+    if is_bi_encoder:
         return "model"
     lora = input_spec.training.lora
     if input_spec.training.finetuning_type == "lora" and lora is not None and not lora.merge:
@@ -40,9 +42,13 @@ async def transform_input_to_output(
     if input_spec.dataset.validation:
         await check_dataset_access(sdk, input_spec.dataset.validation, workspace)
 
-    is_embedding = bool(model_entity.spec and getattr(model_entity.spec, "is_embedding_model", False))
+    checkpoint_head_type = "unknown"
+    if model_entity.spec:
+        checkpoint_head_type = getattr(model_entity.spec, "head_type", None) or "unknown"
+        if checkpoint_head_type == "unknown" and getattr(model_entity.spec, "is_embedding_model", False):
+            checkpoint_head_type = "embedding"
 
-    output_type = _infer_output_type(input_spec, is_embedding)
+    output_type = _infer_output_type(input_spec, checkpoint_head_type)
 
     if input_spec.output is None:
         out_name = generated_output_name(input_spec.model, input_spec.dataset.training, workspace)

--- a/plugins/nemo-automodel/tests/test_schema.py
+++ b/plugins/nemo-automodel/tests/test_schema.py
@@ -77,14 +77,14 @@ def test_encoder_recipes_apply_nemotron_job_defaults() -> None:
             "dataset": {"training": "default/train"},
             "training": {"training_type": "sft", "recipe": "bi_encoder", "finetuning_type": "all_weights"},
         }
-    )
+    ).with_resolved_recipe("embedding")
     rerank = AutomodelJobInput.model_validate(
         {
             "model": "rerank",
             "dataset": {"training": "default/train"},
             "training": {"training_type": "sft", "recipe": "cross_encoder", "finetuning_type": "all_weights"},
         }
-    )
+    ).with_resolved_recipe("cross_encoder")
 
     assert embed.batch.global_batch_size == 128
     assert embed.batch.micro_batch_size == 4
@@ -103,8 +103,28 @@ def test_encoder_recipe_defaults_do_not_override_explicit_hparams() -> None:
             "batch": {"global_batch_size": 16, "micro_batch_size": 2},
             "optimizer": {"learning_rate": 2e-5, "warmup_steps": 1},
         }
-    )
+    ).with_resolved_recipe("embedding")
     assert spec.batch.global_batch_size == 16
     assert spec.batch.micro_batch_size == 2
     assert spec.optimizer.learning_rate == 2e-5
     assert spec.optimizer.warmup_steps == 1
+
+
+def test_auto_recipe_does_not_apply_retrieval_defaults_until_resolved() -> None:
+    spec = AutomodelJobInput.model_validate(
+        {
+            "model": "embed",
+            "dataset": {"training": "default/train"},
+            "training": {"training_type": "sft", "recipe": "auto", "finetuning_type": "all_weights"},
+        }
+    )
+    assert spec.batch.global_batch_size == 8
+    assert spec.optimizer.learning_rate == 5e-6
+
+    resolved = spec.with_resolved_recipe("embedding")
+    assert spec.training.recipe == "auto"
+    assert spec.batch.global_batch_size == 8
+    assert resolved.training.recipe == "bi_encoder"
+    assert resolved.batch.global_batch_size == 128
+    assert resolved.optimizer.learning_rate == 1e-5
+    assert resolved.optimizer.warmup_steps == 5

--- a/plugins/nemo-automodel/tests/test_schema.py
+++ b/plugins/nemo-automodel/tests/test_schema.py
@@ -26,3 +26,85 @@ def test_distillation_requires_teacher() -> None:
                 "training": {"training_type": "distillation"},
             },
         )
+
+
+def test_training_recipe_defaults_to_auto() -> None:
+    spec = AutomodelJobInput.model_validate(
+        {
+            "model": "llama",
+            "dataset": {"training": "default/train"},
+            "training": {"training_type": "sft", "finetuning_type": "all_weights"},
+        }
+    )
+
+    assert spec.training.recipe == "auto"
+    assert spec.optimizer.optimizer == "auto"
+
+
+@pytest.mark.parametrize("optimizer", ["auto", "Adam", "AdamW", "FusedAdam"])
+def test_optimizer_is_selectable(optimizer: str) -> None:
+    spec = AutomodelJobInput.model_validate(
+        {
+            "model": "llama",
+            "dataset": {"training": "default/train"},
+            "training": {"training_type": "sft", "finetuning_type": "all_weights"},
+            "optimizer": {"optimizer": optimizer},
+        }
+    )
+
+    assert spec.optimizer.optimizer == optimizer
+
+
+def test_distillation_rejects_encoder_recipe() -> None:
+    with pytest.raises(ValueError, match="only supports the sft recipe"):
+        AutomodelJobInput.model_validate(
+            {
+                "model": "llama",
+                "dataset": {"training": "default/train"},
+                "training": {
+                    "training_type": "distillation",
+                    "teacher_model": "default/teacher",
+                    "recipe": "cross_encoder",
+                },
+            }
+        )
+
+
+def test_encoder_recipes_apply_nemotron_job_defaults() -> None:
+    embed = AutomodelJobInput.model_validate(
+        {
+            "model": "embed",
+            "dataset": {"training": "default/train"},
+            "training": {"training_type": "sft", "recipe": "bi_encoder", "finetuning_type": "all_weights"},
+        }
+    )
+    rerank = AutomodelJobInput.model_validate(
+        {
+            "model": "rerank",
+            "dataset": {"training": "default/train"},
+            "training": {"training_type": "sft", "recipe": "cross_encoder", "finetuning_type": "all_weights"},
+        }
+    )
+
+    assert embed.batch.global_batch_size == 128
+    assert embed.batch.micro_batch_size == 4
+    assert embed.optimizer.learning_rate == 1e-5
+    assert embed.optimizer.warmup_steps == 5
+    assert rerank.optimizer.learning_rate == 3e-6
+    assert rerank.optimizer.warmup_steps == 100
+
+
+def test_encoder_recipe_defaults_do_not_override_explicit_hparams() -> None:
+    spec = AutomodelJobInput.model_validate(
+        {
+            "model": "embed",
+            "dataset": {"training": "default/train"},
+            "training": {"training_type": "sft", "recipe": "bi_encoder", "finetuning_type": "all_weights"},
+            "batch": {"global_batch_size": 16, "micro_batch_size": 2},
+            "optimizer": {"learning_rate": 2e-5, "warmup_steps": 1},
+        }
+    )
+    assert spec.batch.global_batch_size == 16
+    assert spec.batch.micro_batch_size == 2
+    assert spec.optimizer.learning_rate == 2e-5
+    assert spec.optimizer.warmup_steps == 1

--- a/plugins/nemo-automodel/tests/test_schema.py
+++ b/plugins/nemo-automodel/tests/test_schema.py
@@ -70,6 +70,26 @@ def test_distillation_rejects_encoder_recipe() -> None:
         )
 
 
+def test_distillation_auto_rejects_resolved_encoder_recipe() -> None:
+    spec = AutomodelJobInput.model_validate(
+        {
+            "model": "embed",
+            "dataset": {"training": "default/train"},
+            "training": {
+                "training_type": "distillation",
+                "teacher_model": "default/teacher",
+                "recipe": "auto",
+            },
+        }
+    )
+    with pytest.raises(ValueError, match="only supports the sft recipe"):
+        spec.with_resolved_recipe("embedding")
+    with pytest.raises(ValueError, match="only supports the sft recipe"):
+        spec.with_resolved_recipe("cross_encoder")
+    resolved = spec.with_resolved_recipe("causal_lm")
+    assert resolved.training.recipe == "auto"
+
+
 def test_encoder_recipes_apply_nemotron_job_defaults() -> None:
     embed = AutomodelJobInput.model_validate(
         {

--- a/plugins/nemo-customizer/openapi/openapi.yaml
+++ b/plugins/nemo-customizer/openapi/openapi.yaml
@@ -1185,6 +1185,45 @@ components:
       required:
       - training
       title: AutomodelDatasetSpec
+    AutomodelEmbeddingSpec:
+      properties:
+        train_n_passages:
+          type: integer
+          minimum: 2.0
+          title: Train N Passages
+          default: 5
+        eval_negative_size:
+          title: Eval Negative Size
+          type: integer
+          minimum: 1.0
+        do_gradient_checkpointing:
+          type: boolean
+          title: Do Gradient Checkpointing
+          default: false
+        query_max_length:
+          type: integer
+          minimum: 1.0
+          title: Query Max Length
+          default: 512
+        passage_max_length:
+          type: integer
+          minimum: 1.0
+          title: Passage Max Length
+          default: 512
+        query_prefix:
+          type: string
+          title: Query Prefix
+          description: Collator-side prefix; BiEncoderCollator adds a space.
+          default: 'query:'
+        passage_prefix:
+          type: string
+          title: Passage Prefix
+          description: Collator-side prefix; BiEncoderCollator adds a space.
+          default: 'passage:'
+      additionalProperties: false
+      type: object
+      title: AutomodelEmbeddingSpec
+      description: Collator and dataset knobs for bi_encoder / cross_encoder recipes.
     AutomodelJobInput:
       properties:
         name:
@@ -1489,11 +1528,14 @@ components:
         optimizer:
           type: string
           enum:
+          - auto
           - Adam
           - AdamW
+          - FusedAdam
           title: Optimizer
-          description: Optimizer algorithm.
-          default: Adam
+          description: Optimizer algorithm. 'auto' selects Transformer Engine FusedAdam
+            for retrieval recipes and torch Adam for SFT.
+          default: auto
         lr_decay_style:
           type: string
           enum:
@@ -1613,6 +1655,17 @@ components:
           - distillation
           title: Training Type
           default: sft
+        recipe:
+          type: string
+          enum:
+          - auto
+          - sft
+          - bi_encoder
+          - cross_encoder
+          title: Recipe
+          description: Training recipe. 'auto' uses the model checkpoint head; explicit
+            encoder recipes can wrap a causal-LM backbone for retrieval training.
+          default: auto
         finetuning_type:
           type: string
           enum:
@@ -1678,6 +1731,11 @@ components:
           type: boolean
           title: Offload Teacher
           default: false
+        embedding:
+          allOf:
+          - $ref: '#/components/schemas/AutomodelEmbeddingSpec'
+          description: Retrieval collator/dataset knobs. Used when recipe is bi_encoder
+            or cross_encoder.
       additionalProperties: false
       type: object
       title: AutomodelTrainingSpec

--- a/plugins/nemo-customizer/src/nemo_customizer/skills/nemo-customizer/references/hyperparameters-automodel.md
+++ b/plugins/nemo-customizer/src/nemo_customizer/skills/nemo-customizer/references/hyperparameters-automodel.md
@@ -88,7 +88,7 @@ Full template:
     "adam_beta1": 0.9,
     "adam_beta2": 0.999,
     "adam_eps": 1e-8,
-    "optimizer": "Adam",
+    "optimizer": "auto",
     "lr_decay_style": "cosine",
     "warmup_steps": 0
   },
@@ -115,7 +115,7 @@ Full template:
 | Field | Default | Notes |
 |-------|---------|-------|
 | `training_type` | `sft` | `distillation` requires `teacher_model` (entity ref) |
-| `recipe` | `auto` | `auto` uses the checkpoint head; `sft`, `bi_encoder`, or `cross_encoder` explicitly selects the recipe. Explicit encoder recipes can wrap a causal-LM checkpoint. |
+| `recipe` | `auto` | `auto` uses the checkpoint head; `sft`, `bi_encoder`, or `cross_encoder` explicitly selects the recipe. Explicit encoder recipes can wrap a causal-LM checkpoint. Unset batch/LR/warmup fields are rewritten for encoder recipes — see **Retrieval recipe defaults** below. |
 | `finetuning_type` | `lora` | `all_weights` (full fine-tune), `lora_merged` (merge adapter into base) |
 | `lora.rank` | `16` | Higher → more capacity, more VRAM. Typical training range 8–32; **cap at 32** if the adapter will be served with default NIM / vLLM (rank > 32 may not load) |
 | `lora.alpha` | `32` | Scaling; common rule of thumb **alpha ≈ 2× rank** |
@@ -150,8 +150,8 @@ LoRA block is auto-created when `finetuning_type` is `lora` or `lora_merged`.
 
 | Field | Default | Notes |
 |-------|---------|-------|
-| `global_batch_size` | `8` (schema) | Effective batch across all GPUs; **≥48 GB LoRA tables → `batch-sizing.md`** |
-| `micro_batch_size` | `1` (schema) | **Per GPU**; same SKILL tables for single- and multi-GPU (TP=1) |
+| `global_batch_size` | `8` (schema) | Encoder recipes rewrite unset values to **128**. Effective batch across all GPUs; **≥48 GB LoRA tables → `batch-sizing.md`** |
+| `micro_batch_size` | `1` (schema) | Encoder recipes rewrite unset values to **4**. **Per GPU**; same SKILL tables for single- and multi-GPU (TP=1) |
 | `sequence_packing` | `false` | Pack short sequences for throughput (needs compatible data) |
 | `sequence_packing_max_samples` | `1000` | Samples analyzed to estimate the optimal pack size (only when packing) |
 
@@ -165,15 +165,28 @@ Example: 1 node, 2 GPUs, TP=1 → DP=2 → GBS must be a multiple of `2 × micro
 
 | Field | Default | Notes |
 |-------|---------|-------|
-| `learning_rate` | `5e-6` (schema) | Skill uses **5e-5** for small LoRA SFT; see tuning below |
+| `learning_rate` | `5e-6` (schema) | Encoder recipes rewrite unset values (`1e-5` bi-encoder, `3e-6` cross-encoder). Skill uses **5e-5** for small LoRA SFT; see tuning below |
 | `min_learning_rate` | `null` | Floor for the cosine LR decay; null lets it decay toward 0 |
 | `weight_decay` | `0.01` | L2-style regularization |
 | `adam_beta1` | `0.9` | Adam optimizer beta1 |
 | `adam_beta2` | `0.999` | Adam optimizer beta2 |
 | `adam_eps` | `1e-8` | Adam/AdamW epsilon for numerical stability |
-| `optimizer` | `Adam` | `Adam` \| `AdamW` |
+| `optimizer` | `auto` | `auto` \| `Adam` \| `AdamW` \| `FusedAdam`; `auto` picks FusedAdam for retrieval recipes, Adam for SFT |
 | `lr_decay_style` | `cosine` | `cosine` \| `linear` \| `constant` |
-| `warmup_steps` | `0` | Linear warmup; try ~10% of total steps for long runs |
+| `warmup_steps` | `0` | Encoder recipes rewrite unset values (`5` bi-encoder, `100` cross-encoder). Linear warmup; try ~10% of total steps for long SFT runs |
+
+### Retrieval recipe defaults
+
+When the resolved recipe is `bi_encoder` or `cross_encoder` (explicit, or `auto` after the checkpoint head is known), unset batch and optimizer fields are filled with Nemotron retrieval values. Fields you set in the job JSON are left alone. `sft` keeps the schema defaults above.
+
+| Field | Schema default | `bi_encoder` | `cross_encoder` |
+|-------|----------------|--------------|-----------------|
+| `batch.global_batch_size` | `8` | `128` | `128` |
+| `batch.micro_batch_size` | `1` | `4` | `4` |
+| `optimizer.learning_rate` | `5e-6` | `1e-5` | `3e-6` |
+| `optimizer.warmup_steps` | `0` | `5` | `100` |
+
+`optimizer.optimizer: auto` still selects FusedAdam for these recipes and Adam for SFT.
 
 ### `parallelism`
 

--- a/plugins/nemo-customizer/src/nemo_customizer/skills/nemo-customizer/references/hyperparameters-automodel.md
+++ b/plugins/nemo-customizer/src/nemo_customizer/skills/nemo-customizer/references/hyperparameters-automodel.md
@@ -53,6 +53,7 @@ Full template:
   },
   "training": {
     "training_type": "sft",
+    "recipe": "auto",
     "finetuning_type": "lora",
     "lora": {
       "rank": 16,
@@ -114,6 +115,7 @@ Full template:
 | Field | Default | Notes |
 |-------|---------|-------|
 | `training_type` | `sft` | `distillation` requires `teacher_model` (entity ref) |
+| `recipe` | `auto` | `auto` uses the checkpoint head; `sft`, `bi_encoder`, or `cross_encoder` explicitly selects the recipe. Explicit encoder recipes can wrap a causal-LM checkpoint. |
 | `finetuning_type` | `lora` | `all_weights` (full fine-tune), `lora_merged` (merge adapter into base) |
 | `lora.rank` | `16` | Higher → more capacity, more VRAM. Typical training range 8–32; **cap at 32** if the adapter will be served with default NIM / vLLM (rank > 32 may not load) |
 | `lora.alpha` | `32` | Scaling; common rule of thumb **alpha ≈ 2× rank** |

--- a/plugins/nemo-rl/src/nemo_rl_plugin/transform.py
+++ b/plugins/nemo-rl/src/nemo_rl_plugin/transform.py
@@ -59,11 +59,14 @@ async def transform_input_to_output(
         await check_environment_package(sdk, input_spec.environment, workspace)
         await check_gym_dataset_layout(sdk, input_spec.dataset, workspace)
 
-    is_embedding = bool(model_entity.spec and getattr(model_entity.spec, "is_embedding_model", False))
-    if is_embedding:
+    model_spec = model_entity.spec
+    head_type = getattr(model_spec, "head_type", None) if model_spec else None
+    is_encoder = head_type in {"embedding", "cross_encoder"} or bool(
+        model_spec and getattr(model_spec, "is_embedding_model", False)
+    )
+    if is_encoder:
         raise ValueError(
-            f"{training_type.value.upper()} is not supported for embedding models. "
-            "Use a causal LM model entity instead.",
+            f"{training_type.value.upper()} is not supported for encoder models. Use a causal LM model entity instead.",
         )
 
     output_request = input_spec.output or OutputRequest()

--- a/plugins/nemo-unsloth/src/nemo_unsloth_plugin/transform.py
+++ b/plugins/nemo-unsloth/src/nemo_unsloth_plugin/transform.py
@@ -64,12 +64,14 @@ async def transform_input_to_output(
     if input_spec.dataset.validation_path:
         await check_dataset_access(sdk, input_spec.dataset.validation_path, workspace)
 
-    is_embedding = bool(
-        model_entity.spec and getattr(model_entity.spec, "is_embedding_model", False),
+    model_spec = model_entity.spec
+    head_type = getattr(model_spec, "head_type", None) if model_spec else None
+    is_encoder = head_type in {"embedding", "cross_encoder"} or bool(
+        model_spec and getattr(model_spec, "is_embedding_model", False),
     )
-    if is_embedding:
+    if is_encoder:
         raise ValueError(
-            "Embedding-model SFT is not supported by the unsloth backend. Use a causal LM model entity instead.",
+            "Encoder-model SFT is not supported by the unsloth backend. Use a causal LM model entity instead.",
         )
 
     output_request = input_spec.output or OutputRequest()

--- a/plugins/nemo-unsloth/tests/test_schema.py
+++ b/plugins/nemo-unsloth/tests/test_schema.py
@@ -28,13 +28,17 @@ from nemo_unsloth_plugin.transform import transform_input_to_output
 from pydantic import ValidationError
 
 
-def _stub_sdk(*, is_embedding: bool = False) -> tuple[SimpleNamespace, SimpleNamespace]:
+def _stub_sdk(*, is_embedding: bool = False, head_type: str | None = None) -> tuple[SimpleNamespace, SimpleNamespace]:
     """Build a minimal async SDK + the model entity the models client returns.
 
     Returns ``(sdk, model_entity)`` so callers can wire the same entity into the
     ``AsyncModelsClient`` mock dispatched by ``client_from_platform``.
     """
-    spec = SimpleNamespace(is_embedding_model=is_embedding) if is_embedding else None
+    spec = (
+        SimpleNamespace(is_embedding_model=is_embedding, head_type=head_type or "unknown")
+        if is_embedding or head_type
+        else None
+    )
     model_entity = SimpleNamespace(
         name="m",
         workspace="default",
@@ -262,15 +266,20 @@ class TestTransformOutput:
         assert out.output.type == "model"
         assert out.output.save_method == "merged_4bit"
 
-    def test_embedding_model_rejected(self) -> None:
-        sdk, model_entity = _stub_sdk(is_embedding=True)
+    @pytest.mark.parametrize(
+        ("is_embedding", "head_type"),
+        [(True, None), (False, "cross_encoder")],
+        ids=["legacy-embedding", "cross-encoder"],
+    )
+    def test_encoder_model_rejected(self, is_embedding: bool, head_type: str | None) -> None:
+        sdk, model_entity = _stub_sdk(is_embedding=is_embedding, head_type=head_type)
         spec = UnslothJobInput.model_validate(_minimal_payload())
         with (
             patch(
                 "nmp.customization_common.service.platform_client.client_from_platform",
                 side_effect=_client_from_platform_side_effect(model_entity),
             ),
-            pytest.raises(ValueError, match="Embedding-model SFT"),
+            pytest.raises(ValueError, match="Encoder-model SFT"),
         ):
             asyncio.run(transform_input_to_output(spec, "default", sdk))
 

--- a/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
+++ b/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
@@ -15822,11 +15822,22 @@ components:
           title: Is Chat
           description: Whether this is a chat model
           type: boolean
+        head_type:
+          type: string
+          enum:
+          - causal_lm
+          - embedding
+          - cross_encoder
+          - unknown
+          title: Head Type
+          description: Task-specific head persisted in the checkpoint.
+          default: unknown
         is_embedding_model:
           type: boolean
           title: Is Embedding Model
-          description: Whether this is an embedding model
+          description: Deprecated compatibility alias for head_type == 'embedding'.
           default: false
+          deprecated: true
         checkpoint_model_name:
           type: string
           title: Checkpoint Model Name

--- a/sdk/python/nemo-platform/src/nemo_platform/types/shared/model_spec.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/shared/model_spec.py
@@ -16,6 +16,7 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import List, Optional
+from typing_extensions import Literal
 
 from ..._models import BaseModel
 from .mo_e_config import MoEConfig
@@ -76,11 +77,14 @@ class ModelSpec(BaseModel):
     context_size: Optional[int] = None
     """Context window size"""
 
+    head_type: Optional[Literal["causal_lm", "embedding", "cross_encoder", "unknown"]] = None
+    """Task-specific head persisted in the checkpoint."""
+
     is_chat: Optional[bool] = None
     """Whether this is a chat model"""
 
     is_embedding_model: Optional[bool] = None
-    """Whether this is an embedding model"""
+    """Deprecated compatibility alias for head_type == 'embedding'."""
 
     linear_layers: Optional[List[LinearLayerSpec]] = None
     """List of all linear/Conv1D layers with their dimensions.

--- a/sdk/python/nemo-platform/src/nemo_platform/types/shared_params/model_spec.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/shared_params/model_spec.py
@@ -18,7 +18,7 @@
 from __future__ import annotations
 
 from typing import Iterable
-from typing_extensions import Required, TypedDict
+from typing_extensions import Literal, Required, TypedDict
 
 from .mo_e_config import MoEConfig
 from .mamba_config import MambaConfig
@@ -78,11 +78,14 @@ class ModelSpec(TypedDict, total=False):
     context_size: int
     """Context window size"""
 
+    head_type: Literal["causal_lm", "embedding", "cross_encoder", "unknown"]
+    """Task-specific head persisted in the checkpoint."""
+
     is_chat: bool
     """Whether this is a chat model"""
 
     is_embedding_model: bool
-    """Whether this is an embedding model"""
+    """Deprecated compatibility alias for head_type == 'embedding'."""
 
     linear_layers: Iterable[LinearLayerSpec]
     """List of all linear/Conv1D layers with their dimensions.

--- a/sdk/python/nemo-platform/tests/api_resources/test_models.py
+++ b/sdk/python/nemo-platform/tests/api_resources/test_models.py
@@ -94,6 +94,7 @@ class TestModels:
                 "vocab_size": 0,
                 "chat_template": "chat_template",
                 "context_size": 0,
+                "head_type": "causal_lm",
                 "is_chat": True,
                 "is_embedding_model": True,
                 "linear_layers": [
@@ -289,6 +290,7 @@ class TestModels:
                 "vocab_size": 0,
                 "chat_template": "chat_template",
                 "context_size": 0,
+                "head_type": "causal_lm",
                 "is_chat": True,
                 "is_embedding_model": True,
                 "linear_layers": [
@@ -577,6 +579,7 @@ class TestAsyncModels:
                 "vocab_size": 0,
                 "chat_template": "chat_template",
                 "context_size": 0,
+                "head_type": "causal_lm",
                 "is_chat": True,
                 "is_embedding_model": True,
                 "linear_layers": [
@@ -772,6 +775,7 @@ class TestAsyncModels:
                 "vocab_size": 0,
                 "chat_template": "chat_template",
                 "context_size": 0,
+                "head_type": "causal_lm",
                 "is_chat": True,
                 "is_embedding_model": True,
                 "linear_layers": [

--- a/services/automodel/src/nmp/automodel/adapter.py
+++ b/services/automodel/src/nmp/automodel/adapter.py
@@ -52,6 +52,7 @@ def _build_training_block(spec: dict[str, Any]) -> SFTTraining | DistillationTra
     parallelism = spec.get("parallelism") or {}
 
     common: dict[str, Any] = {
+        "recipe": training.get("recipe", "auto"),
         "peft": _build_peft(training),
         "learning_rate": optimizer.get("learning_rate", 1e-4),
         "min_learning_rate": optimizer.get("min_learning_rate"),
@@ -59,7 +60,7 @@ def _build_training_block(spec: dict[str, Any]) -> SFTTraining | DistillationTra
         "adam_beta1": optimizer.get("adam_beta1", 0.9),
         "adam_beta2": optimizer.get("adam_beta2", 0.999),
         "adam_eps": optimizer.get("adam_eps", 1e-8),
-        "optimizer": optimizer.get("optimizer", "Adam"),
+        "optimizer": optimizer.get("optimizer", "auto"),
         "lr_decay_style": optimizer.get("lr_decay_style", "cosine"),
         "warmup_steps": optimizer.get("warmup_steps", 0),
         "epochs": schedule.get("epochs", 1),
@@ -77,6 +78,7 @@ def _build_training_block(spec: dict[str, Any]) -> SFTTraining | DistillationTra
         "precision": training.get("precision"),
         "attn_implementation": training.get("attn_implementation", "sdpa"),
         "seed": schedule.get("seed"),
+        "embedding": training.get("embedding"),
         "parallelism": ParallelismParams(
             num_nodes=parallelism.get("num_nodes", 1),
             num_gpus_per_node=parallelism.get("num_gpus_per_node", 1),

--- a/services/automodel/src/nmp/automodel/api/v2/jobs/schemas.py
+++ b/services/automodel/src/nmp/automodel/api/v2/jobs/schemas.py
@@ -123,6 +123,24 @@ class LoRAParams(_PEFTParams):
 PeftMethod = LoRAParams
 
 
+class EmbeddingParams(BaseModel):
+    """Retrieval dataset and collator settings for bi_encoder / cross_encoder recipes."""
+
+    train_n_passages: int = Field(default=5, ge=2, description="Passages per query: 1 positive + (n-1) negatives.")
+    eval_negative_size: Optional[int] = Field(
+        default=None,
+        ge=1,
+        description="Negatives per query at eval. Defaults to train_n_passages - 1.",
+    )
+    do_gradient_checkpointing: bool = Field(default=False)
+    query_max_length: int = Field(default=512, ge=1)
+    passage_max_length: int = Field(default=512, ge=1)
+    query_prefix: str = Field(default="query:", description="Collator-side prefix; do not include a trailing space.")
+    passage_prefix: str = Field(
+        default="passage:", description="Collator-side prefix; do not include a trailing space."
+    )
+
+
 class ParallelismParams(BaseModel):
     """Distributed training parallelism configuration.
 
@@ -151,6 +169,11 @@ class _TrainingBase(BaseModel):
     (like HuggingFace TrainingArguments / TRL SFTConfig).
     Only parallelism is grouped — it's enterprise infrastructure.
     """
+
+    recipe: Literal["auto", "sft", "bi_encoder", "cross_encoder"] = Field(
+        default="auto",
+        description="Training recipe; explicit encoder recipes may wrap a causal-LM checkpoint.",
+    )
 
     # --- PEFT (orthogonal to training method) ---
     peft: Optional[PeftMethod] = Field(
@@ -192,7 +215,13 @@ class _TrainingBase(BaseModel):
         ge=0,
         description="Linear warmup steps. Recommended: 10% of total training steps for stable training.",
     )
-    optimizer: Literal["Adam", "AdamW"] = Field(default="Adam", description="Optimizer algorithm.")
+    optimizer: Literal["auto", "Adam", "AdamW", "FusedAdam"] = Field(
+        default="auto",
+        description=(
+            "Optimizer algorithm. 'auto' selects Transformer Engine FusedAdam for retrieval recipes "
+            "and torch Adam for SFT."
+        ),
+    )
     lr_decay_style: Literal["cosine", "linear", "constant"] = Field(
         default="cosine", description="Learning-rate decay schedule."
     )
@@ -263,6 +292,10 @@ class _TrainingBase(BaseModel):
         default=None,
         description="Random seed for reproducibility. Optional.",
     )
+    embedding: Optional[EmbeddingParams] = Field(
+        default=None,
+        description="Retrieval collator/dataset knobs. Used when recipe is bi_encoder or cross_encoder.",
+    )
 
     # --- Enterprise Infrastucture ---
     parallelism: ParallelismParams = Field(default_factory=ParallelismParams)
@@ -274,6 +307,24 @@ class _TrainingBase(BaseModel):
     )
 
     model_config = {"protected_namespaces": ()}
+
+    @model_validator(mode="after")
+    def _apply_retrieval_recipe_defaults(self) -> Self:
+        if self.recipe == "bi_encoder":
+            lr, warmup = 1e-5, 5
+        elif self.recipe == "cross_encoder":
+            lr, warmup = 3e-6, 100
+        else:
+            return self
+        if "batch_size" not in self.model_fields_set:
+            self.batch_size = 128
+        if "micro_batch_size" not in self.model_fields_set:
+            self.micro_batch_size = 4
+        if "learning_rate" not in self.model_fields_set:
+            self.learning_rate = lr
+        if "warmup_steps" not in self.model_fields_set:
+            self.warmup_steps = warmup
+        return self
 
     @property
     def finetuning_type(self) -> FinetuningType:

--- a/services/automodel/src/nmp/automodel/api/v2/jobs/schemas.py
+++ b/services/automodel/src/nmp/automodel/api/v2/jobs/schemas.py
@@ -308,23 +308,24 @@ class _TrainingBase(BaseModel):
 
     model_config = {"protected_namespaces": ()}
 
-    @model_validator(mode="after")
-    def _apply_retrieval_recipe_defaults(self) -> Self:
-        if self.recipe == "bi_encoder":
+    def with_resolved_recipe(self, recipe: str) -> Self:
+        """Return this training config with its resolved recipe defaults."""
+        if recipe == "bi_encoder":
             lr, warmup = 1e-5, 5
-        elif self.recipe == "cross_encoder":
+        elif recipe == "cross_encoder":
             lr, warmup = 3e-6, 100
         else:
-            return self
+            return self.model_copy(update={"recipe": recipe})
+        updates: dict[str, object] = {"recipe": recipe}
         if "batch_size" not in self.model_fields_set:
-            self.batch_size = 128
+            updates["batch_size"] = 128
         if "micro_batch_size" not in self.model_fields_set:
-            self.micro_batch_size = 4
+            updates["micro_batch_size"] = 4
         if "learning_rate" not in self.model_fields_set:
-            self.learning_rate = lr
+            updates["learning_rate"] = lr
         if "warmup_steps" not in self.model_fields_set:
-            self.warmup_steps = warmup
-        return self
+            updates["warmup_steps"] = warmup
+        return self.model_copy(update=updates)
 
     @property
     def finetuning_type(self) -> FinetuningType:

--- a/services/automodel/src/nmp/automodel/api/v2/jobs/schemas.py
+++ b/services/automodel/src/nmp/automodel/api/v2/jobs/schemas.py
@@ -316,6 +316,8 @@ class _TrainingBase(BaseModel):
             lr, warmup = 3e-6, 100
         else:
             return self.model_copy(update={"recipe": recipe})
+        if getattr(self, "type", None) == "distillation":
+            raise ValueError("Knowledge distillation only supports the sft recipe.")
         updates: dict[str, object] = {"recipe": recipe}
         if "batch_size" not in self.model_fields_set:
             updates["batch_size"] = 128

--- a/services/automodel/src/nmp/automodel/app/jobs/compiler.py
+++ b/services/automodel/src/nmp/automodel/app/jobs/compiler.py
@@ -35,7 +35,7 @@ from nmp.automodel.app.constants import (
 )
 from nmp.automodel.app.jobs.training.compiler import (
     _extract_model_name,
-    _resolve_is_embedding_model,
+    _resolve_training_recipe,
     compile_training_step,
 )
 from nmp.automodel.config import config
@@ -403,14 +403,16 @@ async def platform_job_config_compiler(
         await _validate_deployment_config(workspace, transformed_spec, sdk, auth_client)
 
     file_io_download_config = _build_file_download_config(transformed_spec, me, teacher_me)
-    is_embedding_model_flag = _resolve_is_embedding_model(me)
+    training_recipe = _resolve_training_recipe(me, transformed_spec.training.recipe)
 
     # The embedding NIM requires ONNX format, which cannot represent standalone LoRA adapters.
     # LoRA with merge=True (lora_merged) is allowed because it produces a full-weight model after training.
-    if is_embedding_model_flag and transformed_spec.training.finetuning_type == FinetuningType.LORA:
+    if training_recipe.value in ("bi_encoder", "cross_encoder") and (
+        transformed_spec.training.finetuning_type == FinetuningType.LORA
+    ):
         raise PlatformJobCompilationError(
-            "NeMo Platform does not support unmerged LoRA for embedding models because the embedding NIM requires ONNX format, "
-            "which cannot represent standalone adapters. "
+            "NeMo Platform does not support unmerged LoRA for embedding or cross-encoder models. "
+            "Embedding NIM requires ONNX (no standalone adapters); ranking NIM expects a full-weight checkpoint. "
             "Use peft with merge=True (lora_merged) or omit peft for all_weights training."
         )
 

--- a/services/automodel/src/nmp/automodel/app/jobs/compiler.py
+++ b/services/automodel/src/nmp/automodel/app/jobs/compiler.py
@@ -85,6 +85,25 @@ def _get_cpu_resources() -> ResourcesSpec:
     )
 
 
+def _cpu_tasks_executor(command: list[str], cpu_resources: ResourcesSpec, profile: str) -> CPUExecutionProviderSpec:
+    """CPU container steps for fileset I/O and model-entity create.
+
+    Local Docker maps ``cpu/default`` to host subprocess (see ``local.yaml``),
+    which fails because the host has no ``/opt/venv/bin/python``. Use the same
+    profile as training (default ``gpu``) so those steps stay Docker-backed.
+    """
+    return CPUExecutionProviderSpec(
+        provider="cpu",
+        profile=profile,
+        container=ContainerSpec(
+            image=get_tasks_image(),
+            entrypoint=AUTOMODEL_PYTHON_ENTRYPOINT,
+            command=command,
+        ),
+        resources=cpu_resources,
+    )
+
+
 def _get_base_environment() -> list[EnvironmentVariable]:
     """Get base environment variables for all tasks."""
     return [
@@ -428,19 +447,17 @@ async def platform_job_config_compiler(
     trust_remote_code = me.trust_remote_code or False
     model_entity_config = _build_model_entity_config(workspace, transformed_spec, trust_remote_code)
 
+    cpu_profile = (
+        transformed_spec.training.execution_profile
+        if transformed_spec.training.execution_profile is not None
+        else config.default_training_execution_profile
+    )
+
     steps = [
         # Step 1: Download model and dataset files from Files service
         PlatformJobStep(
             name="model-and-dataset-download",
-            executor=CPUExecutionProviderSpec(
-                provider="cpu",
-                container=ContainerSpec(
-                    image=get_tasks_image(),
-                    entrypoint=AUTOMODEL_PYTHON_ENTRYPOINT,
-                    command=FILE_IO_TASK_COMMAND,
-                ),
-                resources=cpu_resources,
-            ),
+            executor=_cpu_tasks_executor(FILE_IO_TASK_COMMAND, cpu_resources, cpu_profile),
             environment=base_env,
             config=file_io_download_config.model_dump(mode="json"),
         ),
@@ -454,30 +471,14 @@ async def platform_job_config_compiler(
         # Step 3: Upload customized model
         PlatformJobStep(
             name="model-upload",
-            executor=CPUExecutionProviderSpec(
-                provider="cpu",
-                container=ContainerSpec(
-                    image=get_tasks_image(),
-                    entrypoint=AUTOMODEL_PYTHON_ENTRYPOINT,
-                    command=FILE_IO_TASK_COMMAND,
-                ),
-                resources=cpu_resources,
-            ),
+            executor=_cpu_tasks_executor(FILE_IO_TASK_COMMAND, cpu_resources, cpu_profile),
             environment=base_env,
             config=file_io_upload_config.model_dump(mode="json"),
         ),
         # Step 4: Create model entity
         PlatformJobStep(
             name="model-entity-creation",
-            executor=CPUExecutionProviderSpec(
-                provider="cpu",
-                container=ContainerSpec(
-                    image=get_tasks_image(),
-                    entrypoint=AUTOMODEL_PYTHON_ENTRYPOINT,
-                    command=MODEL_ENTITY_TASK_COMMAND,
-                ),
-                resources=cpu_resources,
-            ),
+            executor=_cpu_tasks_executor(MODEL_ENTITY_TASK_COMMAND, cpu_resources, cpu_profile),
             environment=base_env,
             config=model_entity_config.model_dump(mode="json"),
         ),

--- a/services/automodel/src/nmp/automodel/app/jobs/training/compiler.py
+++ b/services/automodel/src/nmp/automodel/app/jobs/training/compiler.py
@@ -158,6 +158,7 @@ def compile_training_step(
     v4_compatible = _resolve_v4_compatible(me)
     training = job_spec.training
     training_recipe = _resolve_training_recipe(me, training.recipe)
+    training = training.with_resolved_recipe(training_recipe.value)
     if isinstance(training, DistillationTraining) and training_recipe != TrainingRecipe.SFT:
         raise ValueError("Knowledge distillation only supports the sft recipe.")
     p = training.parallelism

--- a/services/automodel/src/nmp/automodel/app/jobs/training/compiler.py
+++ b/services/automodel/src/nmp/automodel/app/jobs/training/compiler.py
@@ -29,8 +29,10 @@ from nmp.automodel.app.constants import (
 )
 from nmp.automodel.app.jobs.training.schemas import (
     DistillationConfig,
+    EmbeddingConfig,
     LoRAConfig,
     ModelConfig,
+    TrainingRecipe,
     TrainingStepConfig,
 )
 from nmp.automodel.config import config
@@ -59,6 +61,30 @@ def _resolve_is_embedding_model(me: ModelEntity) -> bool:
         return is_embedding_model(me.name)
 
     return me.spec.is_embedding_model or False
+
+
+def _resolve_checkpoint_head_type(me: ModelEntity) -> str:
+    """Resolve the persisted checkpoint head while supporting legacy model specs."""
+    if me.spec is None:
+        return "embedding" if is_embedding_model(me.name) else "unknown"
+
+    fields_set = getattr(me.spec, "model_fields_set", getattr(me.spec, "__fields_set__", set()))
+    if "head_type" in fields_set:
+        return me.spec.head_type or "unknown"
+    return "embedding" if _resolve_is_embedding_model(me) else "unknown"
+
+
+def _resolve_training_recipe(me: ModelEntity, requested: str) -> TrainingRecipe:
+    """Resolve an explicit/automatic job recipe independently of backbone architecture."""
+    if requested != "auto":
+        return TrainingRecipe(requested)
+
+    head_type = _resolve_checkpoint_head_type(me)
+    if head_type == "embedding":
+        return TrainingRecipe.BI_ENCODER
+    if head_type == "cross_encoder":
+        return TrainingRecipe.CROSS_ENCODER
+    return TrainingRecipe.SFT
 
 
 def _resolve_v4_compatible(me: ModelEntity) -> bool:
@@ -127,10 +153,13 @@ def compile_training_step(
         raise ValueError("DPO training is not supported by nmp-automodel")
     trust_remote_code = me.trust_remote_code or False
     chat_template = me.spec.chat_template if me.spec else None
-    is_embedding_model = _resolve_is_embedding_model(me)
+    checkpoint_head_type = _resolve_checkpoint_head_type(me)
     override_custom_impl = _resolve_custom_implementation_override(me)
     v4_compatible = _resolve_v4_compatible(me)
     training = job_spec.training
+    training_recipe = _resolve_training_recipe(me, training.recipe)
+    if isinstance(training, DistillationTraining) and training_recipe != TrainingRecipe.SFT:
+        raise ValueError("Knowledge distillation only supports the sft recipe.")
     p = training.parallelism
     num_gpus_per_node = p.num_gpus_per_node
 
@@ -139,7 +168,7 @@ def compile_training_step(
             job_spec,
             DEFAULT_MODEL_PATH,
             trust_remote_code=trust_remote_code,
-            is_embedding_model=is_embedding_model,
+            checkpoint_head_type=checkpoint_head_type,
             chat_template=chat_template,
             override_custom_impl=override_custom_impl,
             v4_compatible=v4_compatible,
@@ -147,7 +176,7 @@ def compile_training_step(
         dataset=TrainingStepConfig.DatasetConfig(
             path=DEFAULT_DATASET_PATH,
         ),
-        training=_translate_training_config(training, me, teacher_me=teacher_me),
+        training=_translate_training_config(training, me, teacher_me=teacher_me, recipe=training_recipe),
         schedule=TrainingStepConfig.ScheduleConfig(
             epochs=training.epochs,
             max_steps=training.max_steps,
@@ -182,6 +211,7 @@ def compile_training_step(
         ),
         integrations=job_spec.integrations,
         output_model=job_spec.output.name,
+        embedding=_translate_embedding_config(training),
     )
 
     container = ContainerSpec(
@@ -234,7 +264,7 @@ def _translate_model_config(
     job_spec: CustomizationJobOutput,
     path: str,
     trust_remote_code: bool = False,
-    is_embedding_model: bool = False,
+    checkpoint_head_type: str = "unknown",
     chat_template: str | None = None,
     override_custom_impl: bool = False,
     v4_compatible: bool = False,
@@ -248,7 +278,8 @@ def _translate_model_config(
         precision=training.precision,
         attn_implementation=training.attn_implementation,
         trust_remote_code=trust_remote_code,
-        is_embedding_model=is_embedding_model,
+        checkpoint_head_type=checkpoint_head_type,
+        is_embedding_model=checkpoint_head_type == "embedding",
         chat_template=chat_template,
         override_custom_impl=override_custom_impl,
         v4_compatible=v4_compatible,
@@ -259,6 +290,7 @@ def _translate_training_config(
     training: AnyTraining,
     me: ModelEntity,
     teacher_me: ModelEntity | None = None,
+    recipe: TrainingRecipe = TrainingRecipe.SFT,
 ) -> TrainingStepConfig.TrainingConfig:
     """Translate API training method to internal TrainingConfig.
 
@@ -286,10 +318,20 @@ def _translate_training_config(
 
     return TrainingStepConfig.TrainingConfig(
         training_type=training_type,
+        recipe=recipe,
         finetuning_type=training.finetuning_type,
         lora=lora,
         kd=kd,
     )
+
+
+def _translate_embedding_config(training: AnyTraining) -> EmbeddingConfig | None:
+    raw = getattr(training, "embedding", None)
+    if raw is None:
+        return None
+    if isinstance(raw, EmbeddingConfig):
+        return raw
+    return EmbeddingConfig.model_validate(raw.model_dump(mode="python"))
 
 
 def _translate_lora_config(api_lora: LoRAParams, me: ModelEntity) -> LoRAConfig:

--- a/services/automodel/src/nmp/automodel/app/jobs/training/schemas.py
+++ b/services/automodel/src/nmp/automodel/app/jobs/training/schemas.py
@@ -24,6 +24,13 @@ class OptimizerType(str, Enum):
     ADAM_WITH_FLAT_LR = "adam_with_flat_lr"
 
 
+class TrainingRecipe(str, Enum):
+    AUTO = "auto"
+    SFT = "sft"
+    BI_ENCODER = "bi_encoder"
+    CROSS_ENCODER = "cross_encoder"
+
+
 class LoRAConfig(BaseModel):
     """Internal LoRA configuration with implementation details.
 
@@ -76,7 +83,11 @@ class ModelConfig(BaseModel):
     )
     is_embedding_model: bool = Field(
         default=False,
-        description="Whether the model is an embedding model",
+        description="Deprecated compatibility alias for checkpoint_head_type == 'embedding'.",
+    )
+    checkpoint_head_type: str = Field(
+        default="unknown",
+        description="Task-specific head persisted in the source checkpoint.",
     )
     chat_template: Optional[str] = Field(
         default=None,
@@ -170,6 +181,7 @@ class TrainingStepConfig(BaseModel):
 
     class TrainingConfig(BaseModel):
         training_type: TrainingType
+        recipe: TrainingRecipe = TrainingRecipe.AUTO
         finetuning_type: Optional[FinetuningType] = None
         lora: Optional[LoRAConfig] = None
         kd: Optional[DistillationConfig] = None
@@ -188,7 +200,7 @@ class TrainingStepConfig(BaseModel):
 
     class OptimizerConfig(BaseModel):
         optimizer_type: Optional[OptimizerType] = Field(default=None)
-        optimizer_name: str = "Adam"
+        optimizer_name: str = "auto"
         lr_decay_style: str = "cosine"
         learning_rate: float = 1e-4
         min_learning_rate: Optional[float] = None
@@ -227,6 +239,10 @@ class TrainingStepConfig(BaseModel):
         default=DEFAULT_SEED, description="Random seed for ensuring reproducibility in all random processes."
     )
     training_timeout: Optional[int] = None
+    embedding: Optional[EmbeddingConfig] = Field(
+        default=None,
+        description="Retrieval collator and dataset knobs for bi_encoder / cross_encoder recipes.",
+    )
 
 
 class GPUInfo(BaseModel):

--- a/services/automodel/src/nmp/automodel/compile.py
+++ b/services/automodel/src/nmp/automodel/compile.py
@@ -5,15 +5,18 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from nemo_platform import AsyncNeMoPlatform
 from nemo_platform_plugin.jobs.api_factory import PlatformJobSpec
 from nmp.automodel.adapter import automodel_spec_to_compiler_output
 from nmp.automodel.api.v2.jobs.schemas import CustomizationJobOutput
 from nmp.automodel.app.jobs.compiler import platform_job_config_compiler as _compile_canonical
+from pydantic import BaseModel
 
 
 async def platform_job_config_compiler(
-    job_spec: CustomizationJobOutput | object,
+    job_spec: CustomizationJobOutput | dict[str, Any] | BaseModel,
     workspace: str,
     sdk: AsyncNeMoPlatform,
     job_name: str | None = None,

--- a/services/automodel/src/nmp/automodel/tasks/training/backends/backend.py
+++ b/services/automodel/src/nmp/automodel/tasks/training/backends/backend.py
@@ -21,6 +21,7 @@ from nmp.automodel.tasks.training.protocol import LibraryConfig
 from nmp.automodel.tasks.training.schemas import (
     CheckpointInfo,
     TrainingMetrics,
+    TrainingRecipe,
     TrainingStepConfig,
 )
 from nmp.automodel.tasks.training.utils import generate_torchrun_flags_from_env
@@ -28,11 +29,20 @@ from nmp.customization_common.service.context import NMPJobContext
 from nmp.customization_common.training.nccl import get_nccl_ib_env
 
 from .checkpoints import ModelType, find_best_checkpoint, process_checkpoint
-from .config import compile_automodel_config
+from .config import compile_automodel_config, resolve_compiled_recipe
 
 logger = logging.getLogger(__name__)
 
 AUTOMODEL_CONFIG_FILENAME = "automodel_config.yaml"
+
+
+def _checkpoint_model_type(config: TrainingStepConfig) -> ModelType:
+    recipe = resolve_compiled_recipe(config)
+    if recipe == TrainingRecipe.BI_ENCODER:
+        return ModelType.EMBEDDING
+    if recipe == TrainingRecipe.CROSS_ENCODER:
+        return ModelType.CROSS_ENCODER
+    return ModelType.LLM
 
 
 class AutomodelBackend:
@@ -166,7 +176,7 @@ class AutomodelBackend:
         library_config: Optional[LibraryConfig] = None,
     ) -> Path:
         """Find best Automodel checkpoint."""
-        model_type = ModelType.EMBEDDING if customizer_config.model.is_embedding_model else ModelType.LLM
+        model_type = _checkpoint_model_type(customizer_config)
         return find_best_checkpoint(workspace_dir, customizer_config, model_type=model_type)
 
     def process_checkpoint(
@@ -177,7 +187,7 @@ class AutomodelBackend:
         library_config: LibraryConfig | None = None,
     ) -> CheckpointInfo:
         """Process Automodel checkpoint."""
-        model_type = ModelType.EMBEDDING if customizer_config.model.is_embedding_model else ModelType.LLM
+        model_type = _checkpoint_model_type(customizer_config)
 
         # Extract resolved chat template from library config if available (LLM only)
         resolved_template = None

--- a/services/automodel/src/nmp/automodel/tasks/training/backends/checkpoints.py
+++ b/services/automodel/src/nmp/automodel/tasks/training/backends/checkpoints.py
@@ -42,6 +42,7 @@ class ModelType(StrEnum):
 
     LLM = "llm"
     EMBEDDING = "embedding"
+    CROSS_ENCODER = "cross_encoder"
 
 
 def extract_precision_from_model_config(model_path: str | Path) -> Precision | None:
@@ -130,7 +131,7 @@ def find_best_checkpoint(
     """
     base_dir = workspace_dir / "checkpoints"
     is_peft = config.training.finetuning_type in (FinetuningType.LORA, FinetuningType.LORA_MERGED)
-    type_label = "embedding" if model_type == ModelType.EMBEDDING else ""
+    type_label = "" if model_type == ModelType.LLM else model_type.value
 
     # Order of preference:
     # 1. LOWEST_VAL symlink
@@ -333,6 +334,64 @@ def merge_lora_embedding_adapter(
         gc.collect()
 
 
+def merge_lora_cross_encoder_adapter(
+    adapter_path: Path,
+    base_model_path: str,
+    output_path: Path,
+) -> None:
+    """Merge a LoRA adapter into a cross-encoder (sequence-classification) base model."""
+    try:
+        import gc
+
+        import torch
+        from peft import PeftModel
+        from transformers import AutoModelForSequenceClassification, AutoTokenizer
+    except ImportError as e:
+        raise ImportError(
+            "LoRA merge requires 'peft' and 'transformers' packages. Ensure they are installed in the container."
+        ) from e
+
+    logger.info("Merging cross-encoder LoRA adapter from %s with base model %s", adapter_path, base_model_path)
+
+    tmp_path = Path("/scratch/merged_lora") if Path("/scratch").is_dir() else Path("/tmp/merged_lora")
+    shutil.rmtree(tmp_path, ignore_errors=True)
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    model = None
+    try:
+        logger.info("Loading base model (AutoModelForSequenceClassification): %s", base_model_path)
+        model = AutoModelForSequenceClassification.from_pretrained(
+            base_model_path,
+            torch_dtype=torch.float16,
+            device_map="auto",
+            trust_remote_code=True,
+        )
+
+        logger.info("Loading adapter from %s", adapter_path)
+        model = PeftModel.from_pretrained(model, str(adapter_path))
+
+        logger.info("Merging adapter into base model")
+        model = model.merge_and_unload()
+
+        logger.info("Saving merged model to %s", tmp_path)
+        model.save_pretrained(tmp_path, safe_serialization=True)
+
+        try:
+            tokenizer = AutoTokenizer.from_pretrained(base_model_path, trust_remote_code=True)
+            tokenizer.save_pretrained(tmp_path)
+            logger.info("Tokenizer saved to %s", tmp_path)
+        except Exception as e:
+            logger.warning("Could not save tokenizer: %s", e)
+
+        output_path.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(tmp_path, output_path, dirs_exist_ok=True)
+        logger.info("Successfully merged cross-encoder LoRA adapter to %s", output_path)
+
+    finally:
+        shutil.rmtree(tmp_path, ignore_errors=True)
+        torch.cuda.empty_cache()
+        gc.collect()
+
+
 def export_onnx(
     model_path: Path,
     output_path: Path,
@@ -437,13 +496,15 @@ def process_checkpoint(
     finetuning_type = customizer_config.training.finetuning_type
     base_model_path = customizer_config.model.path
     is_embedding = model_type == ModelType.EMBEDDING
-    type_label = "embedding" if is_embedding else ""
+    is_cross_encoder = model_type == ModelType.CROSS_ENCODER
+    is_llm = model_type == ModelType.LLM
+    type_label = "" if is_llm else model_type.value
 
     # Resolve chat template using the same priority logic as training:
     # 1. Use pre-resolved template if provided (ensures consistency with training)
     # 2. Otherwise, resolve using priority-based selection
     chat_template: str | None = None
-    if not is_embedding:
+    if is_llm:
         if resolved_chat_template is not None:
             chat_template = resolved_chat_template
             logger.info("Using pre-resolved chat template from training config")
@@ -460,6 +521,12 @@ def process_checkpoint(
         # For embedding models, this produces a full-weight model compatible with ONNX export and NIM serving.
         if is_embedding:
             merge_lora_embedding_adapter(
+                adapter_path=checkpoint_path,
+                base_model_path=base_model_path,
+                output_path=output_path,
+            )
+        elif is_cross_encoder:
+            merge_lora_cross_encoder_adapter(
                 adapter_path=checkpoint_path,
                 base_model_path=base_model_path,
                 output_path=output_path,

--- a/services/automodel/src/nmp/automodel/tasks/training/backends/config.py
+++ b/services/automodel/src/nmp/automodel/tasks/training/backends/config.py
@@ -61,10 +61,10 @@ def resolve_compiled_recipe(customizer_config: TrainingStepConfig) -> TrainingRe
     if recipe != TrainingRecipe.AUTO:
         return recipe
     head = getattr(customizer_config.model, "checkpoint_head_type", "unknown")
-    if getattr(customizer_config.model, "is_embedding_model", False) or head == "embedding":
-        return TrainingRecipe.BI_ENCODER
     if head == "cross_encoder":
         return TrainingRecipe.CROSS_ENCODER
+    if getattr(customizer_config.model, "is_embedding_model", False) or head == "embedding":
+        return TrainingRecipe.BI_ENCODER
     return TrainingRecipe.SFT
 
 

--- a/services/automodel/src/nmp/automodel/tasks/training/backends/config.py
+++ b/services/automodel/src/nmp/automodel/tasks/training/backends/config.py
@@ -63,7 +63,9 @@ def resolve_compiled_recipe(customizer_config: TrainingStepConfig) -> TrainingRe
     head = getattr(customizer_config.model, "checkpoint_head_type", "unknown")
     if head == "cross_encoder":
         return TrainingRecipe.CROSS_ENCODER
-    if getattr(customizer_config.model, "is_embedding_model", False) or head == "embedding":
+    if head == "embedding":
+        return TrainingRecipe.BI_ENCODER
+    if head in (None, "unknown") and getattr(customizer_config.model, "is_embedding_model", False):
         return TrainingRecipe.BI_ENCODER
     return TrainingRecipe.SFT
 

--- a/services/automodel/src/nmp/automodel/tasks/training/backends/config.py
+++ b/services/automodel/src/nmp/automodel/tasks/training/backends/config.py
@@ -33,6 +33,7 @@ from nmp.automodel.tasks.training.schemas import (
     EmbeddingConfig,
     FinetuningType,
     LoRAConfig,
+    TrainingRecipe,
     TrainingStepConfig,
     TrainingType,
 )
@@ -45,6 +46,35 @@ from nmp.customization_common.service.context import NMPJobContext
 
 logger = logging.getLogger(__name__)
 
+_OPTIMIZER_TARGETS = {
+    "Adam": "torch.optim.Adam",
+    "AdamW": "torch.optim.AdamW",
+    "FusedAdam": "transformer_engine.pytorch.optimizers.fused_adam.FusedAdam",
+}
+
+
+def resolve_compiled_recipe(customizer_config: TrainingStepConfig) -> TrainingRecipe:
+    """Resolve AUTO from the checkpoint head. Cross-encoder must not fall through to SFT."""
+    recipe = getattr(customizer_config.training, "recipe", TrainingRecipe.AUTO)
+    if not isinstance(recipe, TrainingRecipe):
+        recipe = TrainingRecipe.AUTO
+    if recipe != TrainingRecipe.AUTO:
+        return recipe
+    head = getattr(customizer_config.model, "checkpoint_head_type", "unknown")
+    if getattr(customizer_config.model, "is_embedding_model", False) or head == "embedding":
+        return TrainingRecipe.BI_ENCODER
+    if head == "cross_encoder":
+        return TrainingRecipe.CROSS_ENCODER
+    return TrainingRecipe.SFT
+
+
+def _collator_prefix(value: str) -> str:
+    """BiEncoderCollator inserts a space after the prefix; Nemotron YAML uses ``"query: "``."""
+    return value.rstrip(" ")
+
+
+_RETRIEVAL_RECIPES = (TrainingRecipe.BI_ENCODER, TrainingRecipe.CROSS_ENCODER)
+
 
 def compile_automodel_config(
     customizer_config: TrainingStepConfig,
@@ -54,44 +84,209 @@ def compile_automodel_config(
     """
     Compile Automodel-specific configuration.
 
-    This transforms the standardized TrainingStepConfig into the format
-    expected by nemo_automodel's TrainFinetuneRecipeForNextTokenPrediction.
-    """
-    cfg: dict[str, Any] = {}
-    _is_embedding_model = customizer_config.model.is_embedding_model
-    trust_remote_code = customizer_config.model.trust_remote_code
-    embedding_config = EmbeddingConfig()
+    This transforms the standardized TrainingStepConfig into the format expected
+    by nemo_automodel's recipes.
 
-    # === Distributed Environment ===
-    # Required for torch.distributed initialization
+    Retrieval and causal-LM recipes do not differ by a few values in otherwise
+    common sections -- they want different sections: a bare seed against an rng
+    block, an encoder target plus tokenizer against a causal-LM target, their own
+    collating dataloaders against the default collater, and no packing, LM loss,
+    or MoE backend at all. Each is compiled by its own function over the section
+    builders they share, so a recipe reads top to bottom in one place.
+    """
+    recipe = resolve_compiled_recipe(customizer_config)
+    if recipe in _RETRIEVAL_RECIPES:
+        return _compile_retrieval_config(customizer_config, workspace_dir, job_ctx, recipe)
+    return _compile_llm_config(customizer_config, workspace_dir, job_ctx, recipe)
+
+
+def _compile_retrieval_config(
+    customizer_config: TrainingStepConfig,
+    workspace_dir: Path,
+    job_ctx: NMPJobContext,
+    recipe: TrainingRecipe,
+) -> dict[str, Any]:
+    """Compile a bi-encoder or cross-encoder recipe config.
+
+    Mirrors Nemotron Stage 2 (``nemotron embed|rerank finetune``): TE FusedAdam
+    by default,
+    inline retrieval data with its own collator, and no sequence packing or LM loss.
+    """
+    if customizer_config.training.training_type == TrainingType.DISTILLATION:
+        raise ValueError(
+            f"Knowledge distillation is not supported by the '{recipe.value}' recipe; "
+            "use the 'sft' recipe or drop the teacher model."
+        )
+
+    cfg: dict[str, Any] = {}
+    is_bi_encoder = recipe == TrainingRecipe.BI_ENCODER
+    embedding_config = customizer_config.embedding or EmbeddingConfig()
+    seed = _resolve_seed(customizer_config)
+
+    _build_dist_env(cfg)
+
+    # Retrieval recipes construct StatefulRNG from the seed internally, so they
+    # take a bare seed rather than the LLM recipe's full rng config object.
+    cfg["seed"] = seed
+    cfg["temperature"] = 0.02 if is_bi_encoder else 1.0
+
+    _build_base_model(cfg, customizer_config)
+    cfg["model"].update(
+        {
+            "_target_": (
+                "nemo_automodel._transformers.auto_model.NeMoAutoModelBiEncoder.from_pretrained"
+                if is_bi_encoder
+                else "nemo_automodel._transformers.auto_model.NeMoAutoModelCrossEncoder.from_pretrained"
+            ),
+            "pooling": "avg",
+            "use_liger_kernel": True,
+            "use_sdpa_patching": True,
+        }
+    )
+    if is_bi_encoder:
+        cfg["model"]["l2_normalize"] = True
+    else:
+        cfg["model"]["num_labels"] = 1
+        cfg["model"]["temperature"] = 1.0
+    if customizer_config.model.attn_implementation:
+        cfg["model"]["attn_implementation"] = customizer_config.model.attn_implementation
+
+    cfg["tokenizer"] = {
+        "_target_": "nemo_automodel._transformers.auto_tokenizer.NeMoAutoTokenizer.from_pretrained",
+        "pretrained_model_name_or_path": customizer_config.model.path,
+    }
+
+    _build_distributed(
+        cfg,
+        customizer_config,
+        activation_checkpointing=embedding_config.do_gradient_checkpointing,
+    )
+
+    prepared = _prepare_and_validate_dataset(customizer_config, workspace_dir)
+
+    # A retrieval sample is a query with its passages, so there is nothing to pack.
+    max_steps = _build_schedule(cfg, customizer_config, prepared, packing_factor=None)
+
+    _build_optimizer(
+        cfg,
+        customizer_config,
+        max_steps=max_steps,
+        optimizer_target=_resolve_optimizer_target(customizer_config, recipe),
+    )
+    _build_checkpoint(cfg, customizer_config, workspace_dir)
+
+    # Retrieval datasets bring their own dataloaders and collators.
+    _configure_datasets(
+        cfg,
+        customizer_config,
+        prepared,
+        customizer_config.model.max_seq_length,
+        seed,
+        recipe,
+        embedding_config,
+    )
+
+    _build_peft(cfg, customizer_config)
+    _build_integrations(cfg, customizer_config, job_ctx)
+
+    return cfg
+
+
+def _compile_llm_config(
+    customizer_config: TrainingStepConfig,
+    workspace_dir: Path,
+    job_ctx: NMPJobContext,
+    recipe: TrainingRecipe,
+) -> dict[str, Any]:
+    """Compile a causal-LM recipe config (SFT or knowledge distillation)."""
+    cfg: dict[str, Any] = {}
+    trust_remote_code = customizer_config.model.trust_remote_code
+    seed = _resolve_seed(customizer_config)
+
+    _build_dist_env(cfg)
+
+    # The LLM recipe expects the full rng config object.
+    cfg["rng"] = {
+        "_target_": "nemo_automodel.components.training.rng.StatefulRNG",
+        "seed": seed,
+        "ranked": True,  # Different seed per rank for data augmentation
+    }
+
+    _build_base_model(cfg, customizer_config)
+    cfg["model"].update(
+        {
+            "_target_": "nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained",
+            "attn_implementation": customizer_config.model.attn_implementation,
+        }
+    )
+
+    _build_distributed(cfg, customizer_config)
+
+    prepared = _prepare_and_validate_dataset(customizer_config, workspace_dir)
+
+    # Compute packing before the schedule so its estimated reduction in dataset
+    # length is reflected in steps_per_epoch, validation, and warmup.
+    effective_seq_length, packing_factor = _configure_sequence_packing(
+        cfg,
+        customizer_config,
+        prepared,
+        trust_remote_code=trust_remote_code,
+    )
+
+    max_steps = _build_schedule(cfg, customizer_config, prepared, packing_factor=packing_factor)
+    _build_optimizer(
+        cfg,
+        customizer_config,
+        max_steps=max_steps,
+        optimizer_target=_resolve_optimizer_target(customizer_config, recipe),
+    )
+    _build_checkpoint(cfg, customizer_config, workspace_dir)
+
+    _configure_datasets(cfg, customizer_config, prepared, effective_seq_length, seed, recipe, None)
+
+    cfg["dataloader"] = {
+        "_target_": "torchdata.stateful_dataloader.StatefulDataLoader",
+        "collate_fn": "nemo_automodel.components.datasets.utils.default_collater",
+        "shuffle": True,
+    }
+    cfg["validation_dataloader"] = {
+        "_target_": "torchdata.stateful_dataloader.StatefulDataLoader",
+        "collate_fn": "nemo_automodel.components.datasets.utils.default_collater",
+    }
+
+    _build_peft(cfg, customizer_config)
+
+    cfg["loss_fn"] = {
+        "_target_": "nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy",
+    }
+
+    # Check for custom Automodel implementations (e.g., MoE models) and
+    # configure backend/parallelizer settings.
+    _configure_moe_backend(cfg, customizer_config, trust_remote_code=trust_remote_code)
+
+    if customizer_config.training.training_type == TrainingType.DISTILLATION:
+        _configure_kd(cfg, customizer_config, trust_remote_code=trust_remote_code)
+
+    _build_integrations(cfg, customizer_config, job_ctx)
+
+    return cfg
+
+
+def _resolve_seed(customizer_config: TrainingStepConfig) -> int:
+    """Seed for reproducibility across restarts and multi-node training."""
+    return int(os.environ.get("PL_GLOBAL_SEED", customizer_config.seed))
+
+
+def _build_dist_env(cfg: dict[str, Any]) -> None:
+    """Required for torch.distributed initialization."""
     cfg["dist_env"] = {
         "backend": "nccl",
         "timeout_minutes": 30,  # Higher timeout for large model loading
     }
 
-    # === Random Number Generator ===
-    # Both recipes use StatefulRNG for reproducibility across restarts and multi-node training,
-    # but they expect the config in different formats:
-    # - Biencoder recipe: expects cfg["seed"] and creates StatefulRNG internally
-    # - LLM recipe: expects cfg["rng"] with full StatefulRNG config
-    seed = int(os.environ.get("PL_GLOBAL_SEED", customizer_config.seed))
 
-    if _is_embedding_model:
-        # Bi-encoder recipe creates StatefulRNG from seed internally.
-        # See: nemo_automodel/recipes/retrieval/train_bi_encoder.py
-        cfg["seed"] = seed
-        # Contrastive temperature (formerly model.t in Automodel <=0.3.x).
-        cfg["temperature"] = 0.02
-    else:
-        # LLM recipe expects the full rng config object
-        cfg["rng"] = {
-            "_target_": "nemo_automodel.components.training.rng.StatefulRNG",
-            "seed": seed,
-            "ranked": True,  # Different seed per rank for data augmentation
-        }
-
-    # === Model Configuration ===
-    # Common fields shared by both embedding and causal LM models
+def _build_base_model(cfg: dict[str, Any], customizer_config: TrainingStepConfig) -> None:
+    """Model fields common to the retrieval and causal-LM recipes."""
     cfg["model"] = {
         "pretrained_model_name_or_path": customizer_config.model.path,
         "torch_dtype": customizer_config.model.precision.to_torch_dtype()
@@ -99,36 +294,19 @@ def compile_automodel_config(
         else "auto",
         # trust_remote_code is required for models like nvidia/llama-nemotron-embed-1b-v2
         # which use custom model_type "llama_bidirec" with custom modeling code.
-        "trust_remote_code": trust_remote_code,
+        "trust_remote_code": customizer_config.model.trust_remote_code,
     }
     if customizer_config.model.override_custom_impl:
         cfg["model"]["force_hf"] = True
 
-    if _is_embedding_model:
-        cfg["model"].update(
-            {
-                "_target_": "nemo_automodel._transformers.auto_model.NeMoAutoModelBiEncoder.from_pretrained",
-                "pooling": "avg",
-                "l2_normalize": True,
-                "use_liger_kernel": True,
-                "use_sdpa_patching": True,
-            }
-        )
 
-        # === Tokenizer ===
-        cfg["tokenizer"] = {
-            "_target_": "nemo_automodel._transformers.auto_tokenizer.NeMoAutoTokenizer.from_pretrained",
-            "pretrained_model_name_or_path": customizer_config.model.path,
-        }
-    else:
-        cfg["model"].update(
-            {
-                "_target_": "nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained",
-                "attn_implementation": customizer_config.model.attn_implementation,
-            }
-        )
-
-    # === Distributed Configuration ===
+def _build_distributed(
+    cfg: dict[str, Any],
+    customizer_config: TrainingStepConfig,
+    *,
+    activation_checkpointing: bool = False,
+) -> None:
+    """Configure FSDP2 sharding and, for retrieval, activation checkpointing."""
     p = customizer_config.parallelism
     total_gpus = p.num_nodes * p.num_gpus_per_node
     # Note dp_size is typically auto-derived by Automodel (world_size / (tp * pp * cp)),
@@ -146,7 +324,7 @@ def compile_automodel_config(
         "ep_size": p.expert_parallel_size,
         "sequence_parallel": p.sequence_parallel,
     }
-    if _is_embedding_model and embedding_config.do_gradient_checkpointing:
+    if activation_checkpointing:
         cfg["distributed"]["activation_checkpointing"] = True
     if p.pipeline_parallel_size > 1:
         cfg["distributed"]["pipeline"] = {
@@ -155,8 +333,12 @@ def compile_automodel_config(
             "scale_grads_in_schedule": False,
         }
 
-    # === Dataset Preparation ===
-    # Discover, merge, and optionally split dataset files
+
+def _prepare_and_validate_dataset(
+    customizer_config: TrainingStepConfig,
+    workspace_dir: Path,
+) -> PreparedDataset:
+    """Discover, merge, and optionally split dataset files."""
     prepared = prepare_dataset(
         dataset_path=Path(customizer_config.dataset.path),
         output_dir=workspace_dir / "dataset",
@@ -170,42 +352,61 @@ def compile_automodel_config(
     validator.validate_dataset(str(prepared.train_file))
     validator.validate_dataset(str(prepared.validation_file))
     logger.info("Validated datasets successfully")
+    return prepared
 
-    # === Sequence Packing ===
-    # Compute packing before the schedule so its estimated reduction in dataset
-    # length is reflected in steps_per_epoch, validation, and warmup.
-    effective_seq_length = customizer_config.model.max_seq_length
-    packing_factor: float | None = None
-    if not _is_embedding_model and customizer_config.batch.sequence_packing:
-        packing_estimate = estimate_dataset_sequence_lengths(
-            customizer_config,
-            train_file=prepared.train_file,
-            max_samples=customizer_config.batch.sequence_packing_max_samples,
-            seed=customizer_config.seed,
-            trust_remote_code=trust_remote_code,
+
+def _configure_sequence_packing(
+    cfg: dict[str, Any],
+    customizer_config: TrainingStepConfig,
+    prepared: PreparedDataset,
+    *,
+    trust_remote_code: bool,
+) -> tuple[int, float | None]:
+    """Write ``packed_sequence`` when packing is on.
+
+    Returns the effective sequence length and packing factor, which the caller
+    feeds to the schedule and the dataset configuration.
+    """
+    if not customizer_config.batch.sequence_packing:
+        return customizer_config.model.max_seq_length, None
+
+    packing_estimate = estimate_dataset_sequence_lengths(
+        customizer_config,
+        train_file=prepared.train_file,
+        max_samples=customizer_config.batch.sequence_packing_max_samples,
+        seed=customizer_config.seed,
+        trust_remote_code=trust_remote_code,
+    )
+
+    if packing_estimate is not None:
+        optimal_pack_size = packing_estimate.pack_size
+        packing_factor = packing_estimate.packing_factor
+        logger.info(
+            f"Sequence packing enabled: pack_size={optimal_pack_size}, "
+            f"avg_seq={packing_estimate.avg_seq_length}, max_seq={packing_estimate.max_seq_length}, "
+            f"packing_factor={packing_factor}, samples={packing_estimate.samples_analyzed}"
+        )
+    else:
+        optimal_pack_size = calculate_optimal_pack_size(customizer_config)
+        packing_factor = float(calculate_target_packing_factor(customizer_config))
+        logger.info(
+            f"Sequence packing enabled with fallback pack_size={optimal_pack_size}, packing_factor={packing_factor}"
         )
 
-        if packing_estimate is not None:
-            optimal_pack_size = packing_estimate.pack_size
-            packing_factor = packing_estimate.packing_factor
-            logger.info(
-                f"Sequence packing enabled: pack_size={optimal_pack_size}, "
-                f"avg_seq={packing_estimate.avg_seq_length}, max_seq={packing_estimate.max_seq_length}, "
-                f"packing_factor={packing_factor}, samples={packing_estimate.samples_analyzed}"
-            )
-        else:
-            optimal_pack_size = calculate_optimal_pack_size(customizer_config)
-            packing_factor = float(calculate_target_packing_factor(customizer_config))
-            logger.info(
-                f"Sequence packing enabled with fallback pack_size={optimal_pack_size}, packing_factor={packing_factor}"
-            )
+    cfg["packed_sequence"] = {
+        "packed_sequence_size": optimal_pack_size,
+    }
+    return optimal_pack_size, packing_factor
 
-        cfg["packed_sequence"] = {
-            "packed_sequence_size": optimal_pack_size,
-        }
-        effective_seq_length = optimal_pack_size
 
-    # === Step Scheduler (with val_check_interval conversion) ===
+def _build_schedule(
+    cfg: dict[str, Any],
+    customizer_config: TrainingStepConfig,
+    prepared: PreparedDataset,
+    *,
+    packing_factor: float | None,
+) -> int:
+    """Write the step scheduler and progress reporting; return effective max_steps."""
     batch_size = customizer_config.batch.global_batch_size
     epochs = customizer_config.schedule.epochs
 
@@ -254,20 +455,41 @@ def compile_automodel_config(
     cfg["step_scheduler"]["ckpt_every_steps"] = val_every_steps
     logger.info(f"Validation interval: {customizer_config.schedule.val_check_interval} -> {val_every_steps} steps")
 
+    return max_steps
+
+
+def _resolve_optimizer_target(customizer_config: TrainingStepConfig, recipe: TrainingRecipe) -> str:
+    """Resolve ``auto`` by recipe, then map the optimizer to its implementation.
+
+    Nemotron retrieval defaults ``auto`` to Transformer Engine FusedAdam.
+    Existing causal-LM jobs retain torch Adam as their ``auto`` default. Explicit
+    choices override either default.
+    """
+    optimizer_name = customizer_config.optimizer.optimizer_name
+    if optimizer_name == "auto":
+        optimizer_name = "FusedAdam" if recipe in _RETRIEVAL_RECIPES else "Adam"
+    if optimizer_name not in _OPTIMIZER_TARGETS:
+        raise ValueError(
+            f"Unsupported optimizer_name {optimizer_name!r}; expected 'auto' or one of {sorted(_OPTIMIZER_TARGETS)}."
+        )
+    return _OPTIMIZER_TARGETS[optimizer_name]
+
+
+def _build_optimizer(
+    cfg: dict[str, Any],
+    customizer_config: TrainingStepConfig,
+    *,
+    max_steps: int,
+    optimizer_target: str,
+) -> None:
+    """Write the optimizer and its learning-rate schedule."""
     warmup_steps = resolve_warmup_steps(
         warmup_steps=customizer_config.optimizer.warmup_steps,
         max_steps=max_steps,
     )
 
-    # === Optimizer ===
-    # Map the optimizer choice to its torch class. Reject unknown names instead of
-    # silently falling back to Adam, which would mask a misconfigured optimizer.
-    optimizer_targets = {"Adam": "torch.optim.Adam", "AdamW": "torch.optim.AdamW"}
-    optimizer_name = customizer_config.optimizer.optimizer_name
-    if optimizer_name not in optimizer_targets:
-        raise ValueError(f"Unsupported optimizer_name {optimizer_name!r}; expected one of {sorted(optimizer_targets)}.")
     cfg["optimizer"] = {
-        "_target_": optimizer_targets[optimizer_name],
+        "_target_": optimizer_target,
         "lr": customizer_config.optimizer.learning_rate,
         "weight_decay": customizer_config.optimizer.weight_decay,
         "betas": [customizer_config.optimizer.beta1, customizer_config.optimizer.beta2],
@@ -281,7 +503,12 @@ def compile_automodel_config(
     if customizer_config.optimizer.min_learning_rate:
         cfg["lr_scheduler"]["min_lr"] = customizer_config.optimizer.min_learning_rate
 
-    # === Checkpoint ===
+
+def _build_checkpoint(
+    cfg: dict[str, Any],
+    customizer_config: TrainingStepConfig,
+    workspace_dir: Path,
+) -> None:
     cfg["checkpoint"] = {
         "enabled": True,
         "model_save_format": "safetensors",
@@ -293,69 +520,42 @@ def compile_automodel_config(
         "v4_compatible": customizer_config.model.v4_compatible,
     }
 
-    # === Dataset Configuration (with schema detection) ===
-    _configure_datasets(
-        cfg,
-        customizer_config,
-        prepared,
-        effective_seq_length,
-        seed,
-        _is_embedding_model,
-        embedding_config,
-    )
 
-    # === Dataloader ===
-    # Embedding datasets configure their own specialized dataloaders in _configure_embedding_dataset
-    if not _is_embedding_model:
-        cfg["dataloader"] = {
-            "_target_": "torchdata.stateful_dataloader.StatefulDataLoader",
-            "collate_fn": "nemo_automodel.components.datasets.utils.default_collater",
-            "shuffle": True,
-        }
-        cfg["validation_dataloader"] = {
-            "_target_": "torchdata.stateful_dataloader.StatefulDataLoader",
-            "collate_fn": "nemo_automodel.components.datasets.utils.default_collater",
-        }
-
-    # === PEFT (LoRA) ===
-    if customizer_config.training.training_type in (
+def _build_peft(cfg: dict[str, Any], customizer_config: TrainingStepConfig) -> None:
+    """Write the LoRA adapter config for both unmerged and merged LoRA."""
+    if customizer_config.training.training_type not in (
         TrainingType.SFT,
         TrainingType.DISTILLATION,
-    ) and customizer_config.training.finetuning_type in (FinetuningType.LORA, FinetuningType.LORA_MERGED):
-        lora = customizer_config.training.lora
-        if lora is None:
-            lora = LoRAConfig()
-        peft_cfg: dict[str, Any] = {
-            "_target_": "nemo_automodel.components._peft.lora.PeftConfig",
-            "dim": lora.rank,
-            "alpha": lora.alpha,
-            "dropout": lora.dropout,
-            "use_triton": lora.use_triton,
-            "target_modules": lora.target_modules,
-        }
-        if lora.exclude_modules:
-            peft_cfg["exclude_modules"] = lora.exclude_modules
-        cfg["peft"] = peft_cfg
+    ):
+        return
+    if customizer_config.training.finetuning_type not in (
+        FinetuningType.LORA,
+        FinetuningType.LORA_MERGED,
+    ):
+        return
 
-    # === Loss ===
-    if not _is_embedding_model:
-        cfg["loss_fn"] = {
-            "_target_": "nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy",
-        }
+    lora = customizer_config.training.lora
+    if lora is None:
+        lora = LoRAConfig()
+    peft_cfg: dict[str, Any] = {
+        "_target_": "nemo_automodel.components._peft.lora.PeftConfig",
+        "dim": lora.rank,
+        "alpha": lora.alpha,
+        "dropout": lora.dropout,
+        "use_triton": lora.use_triton,
+        "target_modules": lora.target_modules,
+    }
+    if lora.exclude_modules:
+        peft_cfg["exclude_modules"] = lora.exclude_modules
+    cfg["peft"] = peft_cfg
 
-    # === Custom Model Configuration ===
-    # Check for custom Automodel implementations (e.g., MoE models)
-    # and configure backend/parallelizer settings
-    if not _is_embedding_model:
-        _configure_moe_backend(cfg, customizer_config, trust_remote_code=trust_remote_code)
 
-    # === Knowledge Distillation ===
-    if customizer_config.training.training_type == TrainingType.DISTILLATION:
-        _configure_kd(cfg, customizer_config, trust_remote_code=trust_remote_code)
-
-    # === Integrations (Runtime Environment) ===
-
-    # WandB - check for API key in environment
+def _build_integrations(
+    cfg: dict[str, Any],
+    customizer_config: TrainingStepConfig,
+    job_ctx: NMPJobContext,
+) -> None:
+    """Attach WandB and MLflow when the runtime environment supplies credentials."""
     wandb_config = build_wandb_config(
         customizer_config=customizer_config,
         job_ctx=job_ctx,
@@ -365,7 +565,6 @@ def compile_automodel_config(
         cfg["wandb"] = wandb_config
         logger.info(f"WandB enabled: project={wandb_config.get('project')}")
 
-    # MLflow
     mlflow_config = build_mlflow_config(
         customizer_config=customizer_config,
         job_ctx=job_ctx,
@@ -374,8 +573,6 @@ def compile_automodel_config(
     if mlflow_config:
         cfg["mlflow"] = mlflow_config
         logger.info(f"MLflow enabled: {mlflow_config.get('tracking_uri')}")
-
-    return cfg
 
 
 def estimate_steps_per_epoch(
@@ -508,7 +705,7 @@ def _configure_datasets(
     prepared: PreparedDataset,
     seq_length: int,
     seed: int,
-    is_embedding_model: bool = False,
+    recipe: TrainingRecipe = TrainingRecipe.SFT,
     embedding_config: EmbeddingConfig | None = None,
 ) -> None:
     """
@@ -528,8 +725,8 @@ def _configure_datasets(
             When sequence packing is enabled, this is the pack size.
             Otherwise, this is the model's max_seq_length.
         seed: Random seed for reproducibility.
-        is_embedding_model: Whether this is an embedding model (for dataset format hints).
-        embedding_config: Embedding model configuration (required for embedding datasets).
+        recipe: Selected training recipe.
+        embedding_config: Retrieval model configuration (required for retrieval datasets).
     """
     train_file = prepared.train_file
     validation_file = prepared.validation_file
@@ -540,25 +737,34 @@ def _configure_datasets(
         prompt_template=customizer_config.dataset.prompt_template,
     )
 
-    # Validate that embedding models use embedding datasets and vice versa
-    if is_embedding_model and schema != DatasetSchema.EMBEDDING:
+    is_retrieval = recipe in (TrainingRecipe.BI_ENCODER, TrainingRecipe.CROSS_ENCODER)
+
+    # Validate the dataset against the selected recipe, not the checkpoint's original head.
+    if is_retrieval and schema != DatasetSchema.EMBEDDING:
         raise ValueError(
-            f"Model '{customizer_config.model.name}' is detected as an embedding model but the dataset "
-            f"is in '{schema.value}' format. Embedding models require datasets with 'query', 'pos_doc', "
+            f"Recipe '{recipe.value}' requires a retrieval dataset, but the dataset "
+            f"is in '{schema.value}' format. Retrieval recipes require 'query', 'pos_doc', "
             "and 'neg_doc' fields. Please provide a dataset in embedding format."
         )
-    if schema == DatasetSchema.EMBEDDING and not is_embedding_model:
+    if schema == DatasetSchema.EMBEDDING and not is_retrieval:
         raise ValueError(
-            f"Dataset is in embedding format (query/pos_doc/neg_doc) but model "
-            f"'{customizer_config.model.name}' is not detected as an embedding model. "
-            "Embedding datasets can only be used with embedding models."
+            "Dataset is in retrieval format (query/pos_doc/neg_doc), but the selected "
+            f"recipe is '{recipe.value}'. Select 'bi_encoder' or 'cross_encoder'."
         )
 
     if schema == DatasetSchema.EMBEDDING:
         # Embedding/retrieval dataset - uses inline format directly
         if embedding_config is None:
             raise ValueError("embedding_config is required for embedding dataset configuration")
-        _configure_embedding_dataset(cfg, customizer_config, train_file, validation_file, seed, embedding_config)
+        _configure_retrieval_dataset(
+            cfg,
+            customizer_config,
+            train_file,
+            validation_file,
+            seed,
+            embedding_config,
+            recipe,
+        )
     elif schema == DatasetSchema.CHAT:
         # Chat dataset (OpenAI messages format)
         _configure_chat_dataset(cfg, customizer_config, train_file, validation_file, seq_length)
@@ -671,15 +877,16 @@ def _configure_sft_dataset(
     }
 
 
-def _configure_embedding_dataset(
+def _configure_retrieval_dataset(
     cfg: dict[str, Any],
     customizer_config: TrainingStepConfig,
     train_file: Path,
     val_file: Path,
     seed: int,
     embedding_config: EmbeddingConfig,
+    recipe: TrainingRecipe,
 ) -> None:
-    """Configure embedding/retrieval dataset for biencoder training.
+    """Configure inline retrieval data for bi-encoder or cross-encoder training.
 
     Uses Automodel's inline retrieval dataset format which directly accepts
     Customizer's embedding format without conversion:
@@ -698,27 +905,50 @@ def _configure_embedding_dataset(
         embedding_config: Embedding model configuration.
     """
 
-    logger.info(f"Configuring embedding dataset with train_n_passages={embedding_config.train_n_passages}")
+    model_type = "bi_encoder" if recipe == TrainingRecipe.BI_ENCODER else "cross_encoder"
+    collator_target = (
+        "nemo_automodel.components.datasets.llm.BiEncoderCollator"
+        if recipe == TrainingRecipe.BI_ENCODER
+        else "nemo_automodel.components.datasets.llm.CrossEncoderCollator"
+    )
+    logger.info(
+        "Configuring %s dataset with train_n_passages=%s",
+        model_type,
+        embedding_config.train_n_passages,
+    )
+
+    def collator_config(*, validation: bool = False) -> dict[str, Any]:
+        if recipe == TrainingRecipe.CROSS_ENCODER:
+            return {
+                "_target_": collator_target,
+                "rerank_max_length": embedding_config.passage_max_length,
+                "prompt_template": "question:{query} \n \n passage:{passage}",
+                "pad_to_multiple_of": 8,
+            }
+        result: dict[str, Any] = {
+            "_target_": collator_target,
+            "q_max_len": embedding_config.query_max_length,
+            "p_max_len": embedding_config.passage_max_length,
+            "query_prefix": _collator_prefix(embedding_config.query_prefix),
+            "passage_prefix": _collator_prefix(embedding_config.passage_prefix),
+            "pad_to_multiple_of": 8,
+        }
+        if validation:
+            result["padding"] = "longest"
+        return result
 
     cfg["dataloader"] = {
         "_target_": "torchdata.stateful_dataloader.StatefulDataLoader",
         "dataset": {
             "_target_": "nemo_automodel.components.datasets.llm.retrieval_dataset_inline.make_retrieval_dataset",
-            "model_type": "bi_encoder",
+            "model_type": model_type,
             "data_dir_list": [str(train_file)],
             "data_type": "train",
             "n_passages": embedding_config.train_n_passages,
             "seed": seed,
             "do_shuffle": True,
         },
-        "collate_fn": {
-            "_target_": "nemo_automodel.components.datasets.llm.BiEncoderCollator",
-            "q_max_len": embedding_config.query_max_length,
-            "p_max_len": embedding_config.passage_max_length,
-            "query_prefix": embedding_config.query_prefix,
-            "passage_prefix": embedding_config.passage_prefix,
-            "pad_to_multiple_of": 8,
-        },
+        "collate_fn": collator_config(),
         "shuffle": True,
         "num_workers": 0,
     }
@@ -728,7 +958,7 @@ def _configure_embedding_dataset(
             "_target_": "torchdata.stateful_dataloader.StatefulDataLoader",
             "dataset": {
                 "_target_": "nemo_automodel.components.datasets.llm.retrieval_dataset_inline.make_retrieval_dataset",
-                "model_type": "bi_encoder",
+                "model_type": model_type,
                 "data_dir_list": [str(val_file)],
                 "data_type": "eval",
                 "n_passages": embedding_config.train_n_passages,
@@ -736,15 +966,7 @@ def _configure_embedding_dataset(
                 "seed": seed,
                 "do_shuffle": False,
             },
-            "collate_fn": {
-                "_target_": "nemo_automodel.components.datasets.llm.BiEncoderCollator",
-                "q_max_len": embedding_config.query_max_length,
-                "p_max_len": embedding_config.passage_max_length,
-                "query_prefix": embedding_config.query_prefix,
-                "passage_prefix": embedding_config.passage_prefix,
-                "padding": "longest",
-                "pad_to_multiple_of": 8,
-            },
+            "collate_fn": collator_config(validation=True),
             "batch_size": customizer_config.batch.micro_batch_size,
             "shuffle": False,
             "num_workers": 0,

--- a/services/automodel/src/nmp/automodel/tasks/training/backends/finetune.py
+++ b/services/automodel/src/nmp/automodel/tasks/training/backends/finetune.py
@@ -19,6 +19,7 @@ from nemo_automodel.components.training.step_scheduler import StepScheduler
 from nemo_automodel.recipes.llm.kd import KnowledgeDistillationRecipeForNextTokenPrediction
 from nemo_automodel.recipes.llm.train_ft import TrainFinetuneRecipeForNextTokenPrediction
 from nemo_automodel.recipes.retrieval.train_bi_encoder import TrainBiEncoderRecipe
+from nemo_automodel.recipes.retrieval.train_cross_encoder import TrainCrossEncoderRecipe
 from nmp.automodel.tasks.training.progress import JobsServiceProgressReporter
 from nmp.customization_common.service.context import NMPJobContext
 from nmp.customization_common.training.callbacks import DatasetQualifier, TrainingProgressCallback
@@ -344,13 +345,11 @@ def _is_kd_config(cfg: Any) -> bool:
     return cfg.get("teacher_model") is not None or cfg.get("kd_ratio") is not None
 
 
-def _is_biencoder_config(cfg: Any) -> bool:
-    """Check if config is for biencoder/embedding model training.
-
-    Detects biencoder configs by checking if model._target_ contains 'biencoder'.
+def _model_target_contains(cfg: Any, needle: str) -> bool:
+    """Check a resolved model target's module/name for a recipe marker.
 
     Note: ConfigNode automatically resolves _target_ to the actual function/class,
-    so we check the function's __module__ or __qualname__ for 'biencoder'.
+    so inspect the function's module and qualified name.
     """
     try:
         model_cfg = cfg.get("model", {})
@@ -365,16 +364,20 @@ def _is_biencoder_config(cfg: Any) -> bool:
         # Check its module path or qualified name
         module = getattr(target, "__module__", "") or ""
         qualname = getattr(target, "__qualname__", "") or ""
-        return "biencoder" in module.lower() or "biencoder" in qualname.lower()
+        needle = needle.lower()
+        return needle in module.lower() or needle in qualname.lower()
     except (AttributeError, TypeError):
         return False
 
 
 def create_automodel_recipe(cfg: Any) -> AutomodelRecipeWrapper:
     """Create a progress-reporting wrapper for the recipe implied by *cfg*."""
-    if _is_biencoder_config(cfg):
+    if _model_target_contains(cfg, "biencoder"):
         logger.info("Detected biencoder config, using embedding model recipe")
         base_recipe = TrainBiEncoderRecipe(cfg)
+    elif _model_target_contains(cfg, "crossencoder"):
+        logger.info("Detected cross-encoder config, using reranking recipe")
+        base_recipe = TrainCrossEncoderRecipe(cfg)
     elif _is_kd_config(cfg):
         logger.info("Detected Knowledge Distillation config, using KD recipe")
         base_recipe = KnowledgeDistillationRecipeForNextTokenPrediction(cfg)

--- a/services/automodel/src/nmp/automodel/tasks/training/backends/requirements.txt
+++ b/services/automodel/src/nmp/automodel/tasks/training/backends/requirements.txt
@@ -1,1 +1,0 @@
-nemo_automodel==0.2.0

--- a/services/automodel/src/nmp/automodel/tasks/training/schemas.py
+++ b/services/automodel/src/nmp/automodel/tasks/training/schemas.py
@@ -10,6 +10,7 @@ from nmp.automodel.app.jobs.training.schemas import (
     ModelConfig,
     OptimizerType,
     TrainingMetrics,
+    TrainingRecipe,
     TrainingResult,
     TrainingStepConfig,
 )
@@ -32,6 +33,7 @@ __all__ = [
     "LoRAConfig",
     "ModelConfig",
     "OptimizerType",
+    "TrainingRecipe",
     "TrainingMetrics",
     "TrainingResult",
     "TrainingStepConfig",

--- a/services/automodel/tests/contract/output_configs/embed_1b_full_sft.yaml
+++ b/services/automodel/tests/contract/output_configs/embed_1b_full_sft.yaml
@@ -15,6 +15,7 @@ model:
   l2_normalize: true
   use_liger_kernel: true
   use_sdpa_patching: true
+  attn_implementation: sdpa
 tokenizer:
   _target_: nemo_automodel._transformers.auto_tokenizer.NeMoAutoTokenizer.from_pretrained
   pretrained_model_name_or_path: nvidia/llama-nemotron-embed-1b-v2
@@ -34,7 +35,7 @@ step_scheduler:
   val_every_steps: 12
   ckpt_every_steps: 12
 optimizer:
-  _target_: torch.optim.Adam
+  _target_: transformer_engine.pytorch.optimizers.fused_adam.FusedAdam
   lr: 5.0e-06
   weight_decay: 0.01
   betas:

--- a/services/automodel/tests/contract/output_configs/embed_1b_lora.yaml
+++ b/services/automodel/tests/contract/output_configs/embed_1b_lora.yaml
@@ -15,6 +15,7 @@ model:
   l2_normalize: true
   use_liger_kernel: true
   use_sdpa_patching: true
+  attn_implementation: sdpa
 tokenizer:
   _target_: nemo_automodel._transformers.auto_tokenizer.NeMoAutoTokenizer.from_pretrained
   pretrained_model_name_or_path: nvidia/llama-nemotron-embed-1b-v2
@@ -34,7 +35,7 @@ step_scheduler:
   val_every_steps: 12
   ckpt_every_steps: 12
 optimizer:
-  _target_: torch.optim.Adam
+  _target_: transformer_engine.pytorch.optimizers.fused_adam.FusedAdam
   lr: 5.0e-06
   weight_decay: 0.01
   betas:

--- a/services/automodel/tests/tasks/training/backends/test_backend.py
+++ b/services/automodel/tests/tasks/training/backends/test_backend.py
@@ -17,6 +17,7 @@ sys.modules["nemo_automodel._transformers.registry"] = MagicMock()
 
 from nmp.automodel.tasks.training.backends.backend import AutomodelBackend  # noqa: E402
 from nmp.automodel.tasks.training.backends.checkpoints import ModelType  # noqa: E402
+from nmp.automodel.tasks.training.schemas import TrainingRecipe  # noqa: E402
 
 
 class TestAutomodelBackend:
@@ -82,3 +83,50 @@ class TestAutomodelBackend:
             model_type=ModelType.LLM,
             resolved_chat_template=None,
         )
+
+    def test_cross_encoder_recipe_uses_cross_encoder_checkpoint_processing(
+        self,
+        mocker: MockerFixture,
+        tmp_path: Path,
+    ) -> None:
+        backend = AutomodelBackend(job_ctx=MagicMock())
+        customizer_config = MagicMock()
+        customizer_config.training.recipe = TrainingRecipe.CROSS_ENCODER
+
+        expected_path = tmp_path / "best.ckpt"
+        mock_find_best_checkpoint = mocker.patch(
+            "nmp.automodel.tasks.training.backends.backend.find_best_checkpoint",
+            return_value=expected_path,
+        )
+
+        assert backend.find_best_checkpoint(tmp_path, customizer_config) == expected_path
+        mock_find_best_checkpoint.assert_called_once_with(
+            tmp_path,
+            customizer_config,
+            model_type=ModelType.CROSS_ENCODER,
+        )
+
+    def test_auto_recipe_cross_encoder_head_uses_cross_encoder_checkpoint_processing(
+        self,
+        mocker: MockerFixture,
+        tmp_path: Path,
+    ) -> None:
+        backend = AutomodelBackend(job_ctx=MagicMock())
+        customizer_config = MagicMock()
+        customizer_config.training.recipe = TrainingRecipe.AUTO
+        customizer_config.model.is_embedding_model = False
+        customizer_config.model.checkpoint_head_type = "cross_encoder"
+
+        mock_process_checkpoint = mocker.patch(
+            "nmp.automodel.tasks.training.backends.backend.process_checkpoint",
+            return_value=MagicMock(),
+        )
+
+        backend.process_checkpoint(
+            checkpoint_path=tmp_path / "checkpoint",
+            output_path=tmp_path / "output_model",
+            customizer_config=customizer_config,
+            library_config=None,
+        )
+
+        assert mock_process_checkpoint.call_args.kwargs["model_type"] == ModelType.CROSS_ENCODER

--- a/services/automodel/tests/tasks/training/backends/test_checkpoints.py
+++ b/services/automodel/tests/tasks/training/backends/test_checkpoints.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from nmp.automodel.entities.values import FinetuningType
+from nmp.automodel.tasks.training.backends.checkpoints import ModelType, process_checkpoint
+from pytest_mock import MockerFixture
+
+
+def test_process_checkpoint_merges_cross_encoder_lora_without_onnx(
+    mocker: MockerFixture,
+    tmp_path: Path,
+) -> None:
+    customizer_config = MagicMock()
+    customizer_config.training.finetuning_type = FinetuningType.LORA_MERGED
+    customizer_config.model.path = str(tmp_path / "base")
+    customizer_config.model.precision = None
+
+    merge_cross = mocker.patch("nmp.automodel.tasks.training.backends.checkpoints.merge_lora_cross_encoder_adapter")
+    merge_embed = mocker.patch("nmp.automodel.tasks.training.backends.checkpoints.merge_lora_embedding_adapter")
+    merge_llm = mocker.patch("nmp.automodel.tasks.training.backends.checkpoints.merge_lora_adapter")
+    mocker.patch("nmp.automodel.tasks.training.backends.checkpoints.fix_fsdp2_architecture")
+    export_onnx = mocker.patch("nmp.automodel.tasks.training.backends.checkpoints.export_onnx")
+    mocker.patch("nmp.automodel.tasks.training.backends.checkpoints._restructure_embedding_output")
+    mocker.patch(
+        "nmp.automodel.tasks.training.backends.checkpoints.extract_precision_from_model_config",
+        return_value=None,
+    )
+
+    checkpoint_path = tmp_path / "adapter"
+    output_path = tmp_path / "output"
+    process_checkpoint(
+        checkpoint_path,
+        output_path,
+        customizer_config,
+        model_type=ModelType.CROSS_ENCODER,
+    )
+
+    merge_cross.assert_called_once_with(
+        adapter_path=checkpoint_path,
+        base_model_path=str(tmp_path / "base"),
+        output_path=output_path,
+    )
+    merge_embed.assert_not_called()
+    merge_llm.assert_not_called()
+    export_onnx.assert_not_called()

--- a/services/automodel/tests/tasks/training/backends/test_config.py
+++ b/services/automodel/tests/tasks/training/backends/test_config.py
@@ -42,13 +42,16 @@ def _transformers_module(monkeypatch: pytest.MonkeyPatch) -> None:
 from nmp.automodel.tasks.training.backends.config import (  # noqa: E402
     _configure_chat_dataset,
     _configure_moe_backend,
+    _configure_retrieval_dataset,
     _configure_sft_dataset,
+    _resolve_optimizer_target,
     compile_automodel_config,
     estimate_steps_per_epoch,
+    resolve_compiled_recipe,
     resolve_warmup_steps,
 )
 from nmp.automodel.tasks.training.datasets.preparation import PreparedDataset  # noqa: E402
-from nmp.automodel.tasks.training.schemas import TrainingStepConfig  # noqa: E402
+from nmp.automodel.tasks.training.schemas import EmbeddingConfig, TrainingRecipe, TrainingStepConfig  # noqa: E402
 
 CONFIG_MODULE = "nmp.automodel.tasks.training.backends.config"
 AUTOCONFIG_PATCH = "transformers.AutoConfig"
@@ -171,6 +174,91 @@ class TestConfigureSftDataset:
         assert cfg["dataset"]["answer_only_loss_mask"] is True
         assert cfg["dataset"]["padding"] == "do_not_pad"
         assert cfg["dataset"]["truncation"] == "longest_first"
+
+
+class TestConfigureRetrievalDataset:
+    def test_bi_encoder_uses_bi_encoder_collator(
+        self,
+        tmp_path: Path,
+        mock_customizer_config: MagicMock,
+    ) -> None:
+        train_file = tmp_path / "train.jsonl"
+        val_file = tmp_path / "validation.jsonl"
+        train_file.write_text('{"query":"q","pos_doc":"p","neg_doc":["n"]}\n')
+        val_file.write_text('{"query":"q","pos_doc":"p","neg_doc":["n"]}\n')
+        cfg: dict[str, Any] = {}
+
+        _configure_retrieval_dataset(
+            cfg,
+            mock_customizer_config,
+            train_file,
+            val_file,
+            seed=42,
+            embedding_config=EmbeddingConfig(),
+            recipe=TrainingRecipe.BI_ENCODER,
+        )
+
+        assert cfg["dataloader"]["dataset"]["model_type"] == "bi_encoder"
+        assert cfg["dataloader"]["collate_fn"]["_target_"].endswith("BiEncoderCollator")
+
+    def test_cross_encoder_uses_cross_encoder_collator(
+        self,
+        tmp_path: Path,
+        mock_customizer_config: MagicMock,
+    ) -> None:
+        train_file = tmp_path / "train.jsonl"
+        val_file = tmp_path / "validation.jsonl"
+        train_file.write_text('{"query":"q","pos_doc":"p","neg_doc":["n"]}\n')
+        val_file.write_text('{"query":"q","pos_doc":"p","neg_doc":["n"]}\n')
+        cfg: dict[str, Any] = {}
+
+        _configure_retrieval_dataset(
+            cfg,
+            mock_customizer_config,
+            train_file,
+            val_file,
+            seed=42,
+            embedding_config=EmbeddingConfig(),
+            recipe=TrainingRecipe.CROSS_ENCODER,
+        )
+
+        assert cfg["dataloader"]["dataset"]["model_type"] == "cross_encoder"
+        assert cfg["dataloader"]["collate_fn"]["_target_"].endswith("CrossEncoderCollator")
+        assert cfg["dataloader"]["collate_fn"]["rerank_max_length"] == 512
+
+    def test_bi_encoder_strips_trailing_space_from_nemotron_prefixes(
+        self,
+        tmp_path: Path,
+        mock_customizer_config: MagicMock,
+    ) -> None:
+        train_file = tmp_path / "train.jsonl"
+        val_file = tmp_path / "validation.jsonl"
+        train_file.write_text('{"query":"q","pos_doc":"p","neg_doc":["n"]}\n')
+        val_file.write_text('{"query":"q","pos_doc":"p","neg_doc":["n"]}\n')
+        cfg: dict[str, Any] = {}
+
+        _configure_retrieval_dataset(
+            cfg,
+            mock_customizer_config,
+            train_file,
+            val_file,
+            seed=42,
+            embedding_config=EmbeddingConfig(
+                train_n_passages=7,
+                query_max_length=256,
+                passage_max_length=384,
+                query_prefix="query: ",
+                passage_prefix="passage: ",
+            ),
+            recipe=TrainingRecipe.BI_ENCODER,
+        )
+
+        collator = cfg["dataloader"]["collate_fn"]
+        assert collator["query_prefix"] == "query:"
+        assert collator["passage_prefix"] == "passage:"
+        assert collator["q_max_len"] == 256
+        assert collator["p_max_len"] == 384
+        assert cfg["dataloader"]["dataset"]["n_passages"] == 7
 
 
 class TestConfigureMoeBackend:
@@ -486,3 +574,117 @@ def test_the_reporting_block_reaches_the_recipe_config(tmp_path: Path) -> None:
         "time_series_metrics": ["*_loss"],
         "min_report_interval_seconds": 30,
     }
+
+
+def test_compile_cross_encoder_recipe_selects_cross_encoder_model(tmp_path: Path) -> None:
+    fixture = Path(__file__).parents[3] / "contract" / "input_configs" / "embed-1b" / "embed_1b_full_sft.json"
+    raw = json.loads(fixture.read_text())
+    raw.pop("backend")
+    config = TrainingStepConfig.model_validate(raw)
+    config.training.recipe = TrainingRecipe.CROSS_ENCODER
+
+    prepared = PreparedDataset(
+        merged_dir=tmp_path,
+        train_file=tmp_path / "train.jsonl",
+        validation_file=tmp_path / "validation.jsonl",
+        train_samples=100,
+        validation_samples=10,
+    )
+
+    with (
+        patch(f"{CONFIG_MODULE}.prepare_dataset", return_value=prepared),
+        patch(f"{CONFIG_MODULE}.DatasetValidator"),
+        patch(f"{CONFIG_MODULE}._configure_datasets"),
+        patch(f"{CONFIG_MODULE}.build_wandb_config", return_value=None),
+        patch(f"{CONFIG_MODULE}.build_mlflow_config", return_value=None),
+    ):
+        compiled = compile_automodel_config(config, tmp_path, MagicMock())
+
+    assert compiled["model"]["_target_"].endswith("NeMoAutoModelCrossEncoder.from_pretrained")
+    assert compiled["model"]["num_labels"] == 1
+    assert "loss_fn" not in compiled
+
+
+def _embed_training_config(tmp_path: Path, **overrides: Any) -> tuple[TrainingStepConfig, PreparedDataset]:
+    fixture = Path(__file__).parents[3] / "contract" / "input_configs" / "embed-1b" / "embed_1b_full_sft.json"
+    raw = json.loads(fixture.read_text())
+    raw.pop("backend")
+    config = TrainingStepConfig.model_validate(raw)
+    for key, value in overrides.items():
+        setattr(config, key, value)
+    prepared = PreparedDataset(
+        merged_dir=tmp_path,
+        train_file=tmp_path / "train.jsonl",
+        validation_file=tmp_path / "validation.jsonl",
+        train_samples=100,
+        validation_samples=10,
+    )
+    return config, prepared
+
+
+def _compile_retrieval(config: TrainingStepConfig, tmp_path: Path, prepared: PreparedDataset) -> dict[str, Any]:
+    with (
+        patch(f"{CONFIG_MODULE}.prepare_dataset", return_value=prepared),
+        patch(f"{CONFIG_MODULE}.DatasetValidator"),
+        patch(f"{CONFIG_MODULE}._configure_datasets"),
+        patch(f"{CONFIG_MODULE}.build_wandb_config", return_value=None),
+        patch(f"{CONFIG_MODULE}.build_mlflow_config", return_value=None),
+    ):
+        return compile_automodel_config(config, tmp_path, MagicMock())
+
+
+def test_auto_recipe_maps_cross_encoder_head_to_cross_encoder_model(tmp_path: Path) -> None:
+    config, prepared = _embed_training_config(tmp_path)
+    config.training.recipe = TrainingRecipe.AUTO
+    config.model.is_embedding_model = False
+    config.model.checkpoint_head_type = "cross_encoder"
+
+    compiled = _compile_retrieval(config, tmp_path, prepared)
+
+    assert resolve_compiled_recipe(config) == TrainingRecipe.CROSS_ENCODER
+    assert compiled["model"]["_target_"].endswith("NeMoAutoModelCrossEncoder.from_pretrained")
+    assert compiled["optimizer"]["_target_"] == "transformer_engine.pytorch.optimizers.fused_adam.FusedAdam"
+    assert compiled["model"]["attn_implementation"] == "sdpa"
+
+
+def test_bi_encoder_compile_uses_fused_adam_and_job_embedding_config(tmp_path: Path) -> None:
+    config, prepared = _embed_training_config(
+        tmp_path,
+        embedding=EmbeddingConfig(query_prefix="query: ", passage_prefix="passage: ", train_n_passages=6),
+    )
+    config.training.recipe = TrainingRecipe.BI_ENCODER
+
+    compiled = _compile_retrieval(config, tmp_path, prepared)
+
+    assert compiled["optimizer"]["_target_"] == "transformer_engine.pytorch.optimizers.fused_adam.FusedAdam"
+    assert compiled["model"]["attn_implementation"] == "sdpa"
+    assert compiled["model"]["_target_"].endswith("NeMoAutoModelBiEncoder.from_pretrained")
+
+
+@pytest.mark.parametrize(
+    ("optimizer_name", "recipe", "expected_target"),
+    [
+        ("auto", TrainingRecipe.SFT, "torch.optim.Adam"),
+        (
+            "auto",
+            TrainingRecipe.BI_ENCODER,
+            "transformer_engine.pytorch.optimizers.fused_adam.FusedAdam",
+        ),
+        ("Adam", TrainingRecipe.BI_ENCODER, "torch.optim.Adam"),
+        ("AdamW", TrainingRecipe.CROSS_ENCODER, "torch.optim.AdamW"),
+        (
+            "FusedAdam",
+            TrainingRecipe.SFT,
+            "transformer_engine.pytorch.optimizers.fused_adam.FusedAdam",
+        ),
+    ],
+)
+def test_optimizer_selection_is_explicit_after_auto_resolution(
+    optimizer_name: str,
+    recipe: TrainingRecipe,
+    expected_target: str,
+) -> None:
+    config = MagicMock()
+    config.optimizer.optimizer_name = optimizer_name
+
+    assert _resolve_optimizer_target(config, recipe) == expected_target

--- a/services/automodel/tests/tasks/training/backends/test_config.py
+++ b/services/automodel/tests/tasks/training/backends/test_config.py
@@ -647,6 +647,18 @@ def test_auto_recipe_maps_cross_encoder_head_to_cross_encoder_model(tmp_path: Pa
     assert compiled["model"]["attn_implementation"] == "sdpa"
 
 
+def test_auto_recipe_prefers_cross_encoder_head_over_stale_embedding_alias(tmp_path: Path) -> None:
+    config, prepared = _embed_training_config(tmp_path)
+    config.training.recipe = TrainingRecipe.AUTO
+    config.model.is_embedding_model = True
+    config.model.checkpoint_head_type = "cross_encoder"
+
+    compiled = _compile_retrieval(config, tmp_path, prepared)
+
+    assert resolve_compiled_recipe(config) == TrainingRecipe.CROSS_ENCODER
+    assert compiled["model"]["_target_"].endswith("NeMoAutoModelCrossEncoder.from_pretrained")
+
+
 def test_bi_encoder_compile_uses_fused_adam_and_job_embedding_config(tmp_path: Path) -> None:
     config, prepared = _embed_training_config(
         tmp_path,

--- a/services/automodel/tests/tasks/training/backends/test_config.py
+++ b/services/automodel/tests/tasks/training/backends/test_config.py
@@ -647,6 +647,15 @@ def test_auto_recipe_maps_cross_encoder_head_to_cross_encoder_model(tmp_path: Pa
     assert compiled["model"]["attn_implementation"] == "sdpa"
 
 
+def test_auto_recipe_causal_lm_head_ignores_stale_embedding_alias(tmp_path: Path) -> None:
+    config, _ = _embed_training_config(tmp_path)
+    config.training.recipe = TrainingRecipe.AUTO
+    config.model.is_embedding_model = True
+    config.model.checkpoint_head_type = "causal_lm"
+
+    assert resolve_compiled_recipe(config) == TrainingRecipe.SFT
+
+
 def test_auto_recipe_prefers_cross_encoder_head_over_stale_embedding_alias(tmp_path: Path) -> None:
     config, prepared = _embed_training_config(tmp_path)
     config.training.recipe = TrainingRecipe.AUTO

--- a/services/automodel/tests/tasks/training/backends/test_finetune.py
+++ b/services/automodel/tests/tasks/training/backends/test_finetune.py
@@ -32,6 +32,7 @@ _STUBBED_MODULES = (
     "nemo_automodel.recipes.llm.kd",
     "nemo_automodel.recipes.llm.train_ft",
     "nemo_automodel.recipes.retrieval.train_bi_encoder",
+    "nemo_automodel.recipes.retrieval.train_cross_encoder",
 )
 _FINETUNE = "nmp.automodel.tasks.training.backends.finetune"
 
@@ -67,6 +68,16 @@ def test_every_prefixed_name_is_stripped_not_just_the_loss(finetune: ModuleType)
     stripped = finetune.strip_val_prefix({"val_loss": 0.5, "val_acc1": 0.8, "val_mrr": 0.7})
 
     assert stripped == {"loss": 0.5, "acc1": 0.8, "mrr": 0.7}
+
+
+def test_cross_encoder_target_is_detected(finetune: ModuleType) -> None:
+    def NeMoAutoModelCrossEncoder() -> None:
+        pass
+
+    cfg = {"model": {"_target_": NeMoAutoModelCrossEncoder}}
+
+    assert finetune._model_target_contains(cfg, "crossencoder") is True
+    assert finetune._model_target_contains(cfg, "biencoder") is False
 
 
 def test_an_unprefixed_name_is_left_alone(finetune: ModuleType) -> None:

--- a/services/automodel/tests/test_adapter.py
+++ b/services/automodel/tests/test_adapter.py
@@ -28,6 +28,7 @@ def test_adapter_plumbs_previously_dropped_fields() -> None:
             "dataset": {"training": "default/train"},
             "training": {
                 "training_type": "sft",
+                "recipe": "cross_encoder",
                 "finetuning_type": "lora",
                 "precision": "bf16",
                 "lora": {"rank": 8, "alpha": 16, "dropout": 0.1},
@@ -43,6 +44,7 @@ def test_adapter_plumbs_previously_dropped_fields() -> None:
         },
     )
     assert isinstance(spec.training, SFTTraining)
+    assert spec.training.recipe == "cross_encoder"
     assert spec.training.precision is not None and spec.training.precision.value == "bf16"
     assert spec.training.min_learning_rate == 1e-5
     assert spec.training.adam_beta1 == 0.8
@@ -50,6 +52,32 @@ def test_adapter_plumbs_previously_dropped_fields() -> None:
     assert spec.training.parallelism.sequence_parallel is True
     assert spec.training.peft is not None
     assert spec.training.peft.dropout == 0.1
+    assert spec.training.embedding is None
+
+
+def test_adapter_plumbs_embedding_spec() -> None:
+    spec = automodel_spec_to_compiler_output(
+        {
+            "model": "meta/llama",
+            "dataset": {"training": "default/train"},
+            "training": {
+                "training_type": "sft",
+                "recipe": "bi_encoder",
+                "finetuning_type": "all_weights",
+                "embedding": {
+                    "train_n_passages": 7,
+                    "query_prefix": "query:",
+                    "passage_prefix": "passage:",
+                },
+            },
+            "output": {"name": "out", "type": "model", "fileset": "out-fs"},
+        },
+    )
+    assert isinstance(spec.training, SFTTraining)
+    assert spec.training.embedding is not None
+    assert spec.training.embedding.train_n_passages == 7
+    assert spec.training.embedding.query_prefix == "query:"
+    assert spec.training.embedding.passage_prefix == "passage:"
 
 
 def test_adapter_new_fields_default_when_omitted() -> None:
@@ -101,7 +129,7 @@ def test_adapter_plumbs_pass2_hyperparameters() -> None:
 
 
 def test_adapter_pass2_defaults_when_omitted() -> None:
-    """Omitting pass-2 fields preserves the historical hardcoded defaults."""
+    """Omitting pass-2 fields preserves effective defaults through ``auto``."""
     spec = automodel_spec_to_compiler_output(
         {
             "model": "meta/llama",
@@ -112,7 +140,7 @@ def test_adapter_pass2_defaults_when_omitted() -> None:
     )
     assert isinstance(spec.training, SFTTraining)
     assert spec.training.adam_eps == 1e-8
-    assert spec.training.optimizer == "Adam"
+    assert spec.training.optimizer == "auto"
     assert spec.training.lr_decay_style == "cosine"
     assert spec.training.attn_implementation == "sdpa"
     assert spec.training.sequence_packing_max_samples == 1000

--- a/services/automodel/tests/test_compiler.py
+++ b/services/automodel/tests/test_compiler.py
@@ -15,6 +15,7 @@ from nemo_platform_plugin.models.types import ModelEntity
 from nmp.automodel.adapter import automodel_spec_to_compiler_output
 from nmp.automodel.api.v2.jobs.schemas import (
     CustomizationJobOutput,
+    DistillationTraining,
     EmbeddingParams,
     LoRAParams,
     OutputResponse,
@@ -192,6 +193,14 @@ def test_sft_training_encoder_defaults_do_not_override_explicit_hparams() -> Non
     assert training.batch_size == 16
     assert training.learning_rate == 2e-5
     assert training.warmup_steps == 1
+
+
+def test_distillation_with_resolved_recipe_rejects_encoder_recipes() -> None:
+    training = DistillationTraining.model_validate({"recipe": "auto", "teacher_model": "default/teacher"})
+    with pytest.raises(ValueError, match="only supports the sft recipe"):
+        training.with_resolved_recipe("bi_encoder")
+    resolved = training.with_resolved_recipe("sft")
+    assert resolved.recipe == "sft"
 
 
 def test_resolve_training_recipe_auto_uses_cross_encoder_head() -> None:

--- a/services/automodel/tests/test_compiler.py
+++ b/services/automodel/tests/test_compiler.py
@@ -6,15 +6,23 @@ from __future__ import annotations
 import json
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock, Mock
 
 import pytest
 from nemo_platform import AsyncNeMoPlatform
 from nemo_platform_plugin.models.types import ModelEntity
 from nmp.automodel.adapter import automodel_spec_to_compiler_output
-from nmp.automodel.api.v2.jobs.schemas import CustomizationJobOutput, LoRAParams, OutputResponse, SFTTraining
+from nmp.automodel.api.v2.jobs.schemas import (
+    CustomizationJobOutput,
+    EmbeddingParams,
+    LoRAParams,
+    OutputResponse,
+    SFTTraining,
+)
 from nmp.automodel.app.jobs.compiler import _build_file_download_config
 from nmp.automodel.compile import platform_job_config_compiler
+from nmp.automodel.entities.values import OutputNameType
 from nmp.automodel.images import get_tasks_image, get_training_image
 from nmp.common.entities.utils import get_random_id
 from nmp.common.jobs.exceptions import PlatformJobCompilationError
@@ -42,6 +50,20 @@ def mock_sdk():
     return Mock(spec=AsyncNeMoPlatform)
 
 
+def _output(*, output_type: OutputNameType = OutputNameType.ADAPTER) -> OutputResponse:
+    return OutputResponse(name="out", type=output_type, fileset="out-fs")
+
+
+def _executor_container(step: Any) -> Any:
+    """CPU/GPU executors have a container; subprocess does not. Tests only compile the former."""
+    executor = step.executor if hasattr(step, "executor") else step["executor"]
+    container = getattr(executor, "container", None)
+    if container is None and isinstance(executor, dict):
+        container = executor.get("container")
+    assert container is not None, "expected a container-backed execution provider"
+    return container
+
+
 def _make_job_output() -> CustomizationJobOutput:
     return CustomizationJobOutput(
         model="default/test-target",
@@ -53,7 +75,7 @@ def _make_job_output() -> CustomizationJobOutput:
             micro_batch_size=1,
             max_seq_length=2048,
         ),
-        output=OutputResponse(name="out", type="adapter", fileset="out-fs"),
+        output=_output(),
     )
 
 
@@ -82,7 +104,7 @@ def test_compile_training_step_carries_pass2_fields() -> None:
             sequence_packing_max_samples=256,
             max_seq_length=2048,
         ),
-        output=OutputResponse(name="out", type="adapter", fileset="out-fs"),
+        output=_output(),
     )
     step = compile_training_step(job_output, base_env=[], me=_make_mock_model_entity())
     cfg = step.config if hasattr(step, "config") else step["config"]
@@ -94,6 +116,113 @@ def test_compile_training_step_carries_pass2_fields() -> None:
     assert cfg["batch"]["sequence_packing_max_samples"] == 256
     assert cfg["training"]["lora"]["exclude_modules"] == ["*.out_proj"]
     assert cfg["training"]["lora"]["use_triton"] is False
+
+
+def test_compile_training_step_carries_explicit_cross_encoder_recipe() -> None:
+    from nmp.automodel.app.jobs.training.compiler import compile_training_step
+
+    job_output = CustomizationJobOutput(
+        model="default/test-target",
+        dataset="default/my-dataset",
+        training=SFTTraining(
+            recipe="cross_encoder",
+            peft=None,
+            batch_size=4,
+            micro_batch_size=1,
+        ),
+        output=_output(output_type=OutputNameType.MODEL),
+    )
+
+    step = compile_training_step(job_output, base_env=[], me=_make_mock_model_entity())
+    cfg = step.config if hasattr(step, "config") else step["config"]
+
+    assert cfg["training"]["recipe"] == "cross_encoder"
+
+
+def test_compile_training_step_carries_embedding_config() -> None:
+    from nmp.automodel.app.jobs.training.compiler import compile_training_step
+
+    job_output = CustomizationJobOutput(
+        model="default/test-target",
+        dataset="default/my-dataset",
+        training=SFTTraining(
+            recipe="bi_encoder",
+            peft=None,
+            batch_size=4,
+            micro_batch_size=1,
+            embedding=EmbeddingParams(
+                train_n_passages=7,
+                query_prefix="query: ",
+                passage_prefix="passage: ",
+                query_max_length=256,
+            ),
+        ),
+        output=_output(output_type=OutputNameType.MODEL),
+    )
+
+    step = compile_training_step(job_output, base_env=[], me=_make_mock_model_entity())
+    cfg = step.config if hasattr(step, "config") else step["config"]
+
+    assert cfg["embedding"]["train_n_passages"] == 7
+    assert cfg["embedding"]["query_prefix"] == "query: "
+    assert cfg["embedding"]["passage_prefix"] == "passage: "
+    assert cfg["embedding"]["query_max_length"] == 256
+
+
+def test_sft_training_applies_nemotron_defaults_for_encoder_recipes() -> None:
+    embed = SFTTraining.model_validate({"recipe": "bi_encoder"})
+    rerank = SFTTraining.model_validate({"recipe": "cross_encoder"})
+    sft = SFTTraining.model_validate({"recipe": "sft"})
+
+    assert embed.batch_size == 128
+    assert embed.micro_batch_size == 4
+    assert embed.learning_rate == 1e-5
+    assert embed.warmup_steps == 5
+    assert rerank.learning_rate == 3e-6
+    assert rerank.warmup_steps == 100
+    assert sft.batch_size == 32
+    assert sft.learning_rate == 1e-4
+    assert sft.warmup_steps == 0
+
+
+def test_sft_training_encoder_defaults_do_not_override_explicit_hparams() -> None:
+    training = SFTTraining.model_validate(
+        {"recipe": "bi_encoder", "batch_size": 16, "learning_rate": 2e-5, "warmup_steps": 1}
+    )
+    assert training.batch_size == 16
+    assert training.learning_rate == 2e-5
+    assert training.warmup_steps == 1
+
+
+def test_resolve_training_recipe_auto_uses_cross_encoder_head() -> None:
+    from nmp.automodel.app.jobs.training.compiler import _resolve_training_recipe
+    from nmp.automodel.app.jobs.training.schemas import TrainingRecipe
+
+    me = Mock()
+    me.spec.model_fields_set = {"head_type"}
+    me.spec.head_type = "cross_encoder"
+    assert _resolve_training_recipe(me, "auto") == TrainingRecipe.CROSS_ENCODER
+
+
+@pytest.mark.asyncio
+async def test_platform_job_config_compiler_rejects_unmerged_lora_for_encoders(mock_sdk, monkeypatch):
+    monkeypatch.setattr(
+        "nmp.automodel.app.jobs.compiler.fetch_model_entity",
+        AsyncMock(return_value=_make_mock_model_entity()),
+    )
+    job = CustomizationJobOutput(
+        model="default/test-target",
+        dataset="default/my-dataset",
+        training=SFTTraining(
+            recipe="cross_encoder",
+            peft=LoRAParams(rank=8, alpha=32, merge=False),
+            batch_size=4,
+            micro_batch_size=1,
+        ),
+        output=_output(),
+    )
+    with pytest.raises(PlatformJobCompilationError, match="unmerged LoRA"):
+        await platform_job_config_compiler(job, "default", mock_sdk)
 
 
 def test_the_reporting_budget_reaches_the_training_step_config() -> None:
@@ -111,7 +240,7 @@ def test_the_reporting_budget_reaches_the_training_step_config() -> None:
         model="default/test-target",
         dataset="default/my-dataset",
         training=SFTTraining(progress_reporting=ProgressReportingConfig(time_series_metrics=["*_loss"])),
-        output=OutputResponse(name="out", type="adapter", fileset="out-fs"),
+        output=_output(),
     )
     step = compile_training_step(job_output, base_env=[], me=_make_mock_model_entity())
     cfg = step.config if hasattr(step, "config") else step["config"]
@@ -139,7 +268,7 @@ def test_a_spec_still_carrying_log_every_n_steps_compiles() -> None:
         model="default/test-target",
         dataset="default/my-dataset",
         training=training,
-        output=OutputResponse(name="out", type="adapter", fileset="out-fs"),
+        output=_output(),
     )
     step = compile_training_step(job_output, base_env=[], me=_make_mock_model_entity())
     cfg = step.config if hasattr(step, "config") else step["config"]
@@ -228,17 +357,9 @@ async def test_platform_job_config_compiler_sft_lora(mock_sdk, monkeypatch):
     training_step = steps[1]
     training_name = training_step.name if hasattr(training_step, "name") else training_step["name"]
     assert training_name == "training"
-    training_cmd = (
-        training_step.executor.container.command
-        if hasattr(training_step, "executor")
-        else training_step["executor"]["container"]["command"]
-    )
+    training_cmd = _executor_container(training_step).command
     assert "nmp.automodel.tasks.training" in " ".join(training_cmd)
-    download_cmd = (
-        steps[0].executor.container.command
-        if hasattr(steps[0], "executor")
-        else steps[0]["executor"]["container"]["command"]
-    )
+    download_cmd = _executor_container(steps[0]).command
     assert download_cmd == [
         "-m",
         "nmp.customization_common.tasks.file_io",
@@ -247,17 +368,11 @@ async def test_platform_job_config_compiler_sft_lora(mock_sdk, monkeypatch):
         "--service-name",
         "customizer",
     ]
-    download_entrypoint = (
-        steps[0].executor.container.entrypoint
-        if hasattr(steps[0], "executor")
-        else steps[0]["executor"]["container"]["entrypoint"]
-    )
+    download_entrypoint = _executor_container(steps[0]).entrypoint
     assert download_entrypoint == ["/opt/venv/bin/python"]
 
-    def _step_image(step) -> str:
-        if hasattr(step, "executor"):
-            return step.executor.container.image
-        return step["executor"]["container"]["image"]
+    def _step_image(step: Any) -> str:
+        return _executor_container(step).image
 
     assert _step_image(steps[0]) == get_tasks_image()
     assert _step_image(steps[1]) == get_training_image()

--- a/services/automodel/tests/test_compiler.py
+++ b/services/automodel/tests/test_compiler.py
@@ -370,6 +370,12 @@ async def test_platform_job_config_compiler_sft_lora(mock_sdk, monkeypatch):
     ]
     download_entrypoint = _executor_container(steps[0]).entrypoint
     assert download_entrypoint == ["/opt/venv/bin/python"]
+    for cpu_step in (steps[0], steps[2], steps[3]):
+        executor = cpu_step.executor if hasattr(cpu_step, "executor") else cpu_step["executor"]
+        profile = getattr(executor, "profile", None)
+        if profile is None and isinstance(executor, dict):
+            profile = executor.get("profile")
+        assert profile == "gpu"
 
     def _step_image(step: Any) -> str:
         return _executor_container(step).image

--- a/services/automodel/tests/test_compiler.py
+++ b/services/automodel/tests/test_compiler.py
@@ -170,9 +170,9 @@ def test_compile_training_step_carries_embedding_config() -> None:
 
 
 def test_sft_training_applies_nemotron_defaults_for_encoder_recipes() -> None:
-    embed = SFTTraining.model_validate({"recipe": "bi_encoder"})
-    rerank = SFTTraining.model_validate({"recipe": "cross_encoder"})
-    sft = SFTTraining.model_validate({"recipe": "sft"})
+    embed = SFTTraining.model_validate({"recipe": "bi_encoder"}).with_resolved_recipe("bi_encoder")
+    rerank = SFTTraining.model_validate({"recipe": "cross_encoder"}).with_resolved_recipe("cross_encoder")
+    sft = SFTTraining.model_validate({"recipe": "sft"}).with_resolved_recipe("sft")
 
     assert embed.batch_size == 128
     assert embed.micro_batch_size == 4
@@ -188,7 +188,7 @@ def test_sft_training_applies_nemotron_defaults_for_encoder_recipes() -> None:
 def test_sft_training_encoder_defaults_do_not_override_explicit_hparams() -> None:
     training = SFTTraining.model_validate(
         {"recipe": "bi_encoder", "batch_size": 16, "learning_rate": 2e-5, "warmup_steps": 1}
-    )
+    ).with_resolved_recipe("bi_encoder")
     assert training.batch_size == 16
     assert training.learning_rate == 2e-5
     assert training.warmup_steps == 1
@@ -202,6 +202,58 @@ def test_resolve_training_recipe_auto_uses_cross_encoder_head() -> None:
     me.spec.model_fields_set = {"head_type"}
     me.spec.head_type = "cross_encoder"
     assert _resolve_training_recipe(me, "auto") == TrainingRecipe.CROSS_ENCODER
+
+
+def test_compile_training_step_applies_retrieval_defaults_after_auto_resolution() -> None:
+    from nmp.automodel.app.jobs.training.compiler import compile_training_step
+
+    me = _make_mock_model_entity()
+    me.spec = Mock()
+    me.spec.model_fields_set = {"head_type"}
+    me.spec.head_type = "embedding"
+    me.spec.chat_template = None
+    me.spec.checkpoint_model_name = None
+    me.spec.moe_config = None
+    me.spec.family = None
+    me.spec.is_chat = False
+
+    job_output = CustomizationJobOutput(
+        model="default/test-target",
+        dataset="default/my-dataset",
+        training=SFTTraining(recipe="auto"),
+        output=_output(output_type=OutputNameType.MODEL),
+    )
+    step = compile_training_step(job_output, base_env=[], me=me)
+    cfg = step.config if hasattr(step, "config") else step["config"]
+    assert cfg["training"]["recipe"] == "bi_encoder"
+    assert cfg["batch"]["global_batch_size"] == 128
+    assert cfg["optimizer"]["learning_rate"] == 1e-5
+    assert cfg["optimizer"]["warmup_steps"] == 5
+
+
+def test_compile_training_step_auto_defaults_keep_explicit_lr() -> None:
+    from nmp.automodel.app.jobs.training.compiler import compile_training_step
+
+    me = _make_mock_model_entity()
+    me.spec = Mock()
+    me.spec.model_fields_set = {"head_type"}
+    me.spec.head_type = "embedding"
+    me.spec.chat_template = None
+    me.spec.checkpoint_model_name = None
+    me.spec.moe_config = None
+    me.spec.family = None
+    me.spec.is_chat = False
+
+    job_output = CustomizationJobOutput(
+        model="default/test-target",
+        dataset="default/my-dataset",
+        training=SFTTraining(recipe="auto", learning_rate=2e-5),
+        output=_output(output_type=OutputNameType.MODEL),
+    )
+    step = compile_training_step(job_output, base_env=[], me=me)
+    cfg = step.config if hasattr(step, "config") else step["config"]
+    assert cfg["optimizer"]["learning_rate"] == 2e-5
+    assert cfg["batch"]["global_batch_size"] == 128
 
 
 @pytest.mark.asyncio

--- a/services/core/models/src/nmp/core/models/controllers/backends/vllm_compiler.py
+++ b/services/core/models/src/nmp/core/models/controllers/backends/vllm_compiler.py
@@ -23,6 +23,9 @@ logger = getLogger(__name__)
 
 # Path the model weights are mounted at inside the container (populated by the puller).
 MODEL_STORE_PATH = "/model-store"
+# Automodel embedding outputs keep NIM's ONNX artifact at the root and the
+# equivalent Hugging Face checkpoint in this engine-specific alternate.
+VLLM_HF_ALTERNATE_PATH = f"{MODEL_STORE_PATH}/alternates/hf"
 # Directory the LoRA adapter sidecar writes into and vLLM's filesystem resolver watches.
 VLLM_LORA_CACHE_DIR = "/scratch/loras"
 # vLLM's OpenAI-compatible server port (matches the NIM container port mapping).
@@ -42,6 +45,20 @@ def _served_model_name(view: DeploymentConfigView) -> str | None:
     if view.model_namespace:
         return f"{view.model_namespace}/{view.model_name}"
     return view.model_name
+
+
+def _model_path(model_entity: Optional[ModelEntity]) -> str:
+    """Select the Hugging Face alternate for customized embedding outputs."""
+    if model_entity is None:
+        return MODEL_STORE_PATH
+    spec = getattr(model_entity, "spec", None)
+    if (
+        getattr(spec, "is_embedding_model", False)
+        and getattr(model_entity, "base_model", None)
+        and getattr(model_entity, "finetuning_type", None)
+    ):
+        return VLLM_HF_ALTERNATE_PATH
+    return MODEL_STORE_PATH
 
 
 def _user_set_args(additional_args: list[str] | None) -> set[str]:
@@ -122,7 +139,7 @@ def compile_vllm_args(
     not auto-injected by the compiler.
     """
     user_flags = _user_set_args(view.additional_args)
-    args: list[str] = [MODEL_STORE_PATH]
+    args: list[str] = [_model_path(model_entity)]
 
     served_name = _served_model_name(view)
     if served_name and "--served-model-name" not in user_flags:

--- a/services/core/models/src/nmp/core/models/controllers/backends/vllm_compiler.py
+++ b/services/core/models/src/nmp/core/models/controllers/backends/vllm_compiler.py
@@ -52,11 +52,11 @@ def _model_path(model_entity: Optional[ModelEntity]) -> str:
     if model_entity is None:
         return MODEL_STORE_PATH
     spec = getattr(model_entity, "spec", None)
-    if (
-        getattr(spec, "is_embedding_model", False)
-        and getattr(model_entity, "base_model", None)
-        and getattr(model_entity, "finetuning_type", None)
-    ):
+    head_type = getattr(spec, "head_type", None)
+    is_embedding = head_type == "embedding" or (
+        head_type in (None, "unknown") and getattr(spec, "is_embedding_model", False)
+    )
+    if is_embedding and getattr(model_entity, "base_model", None) and getattr(model_entity, "finetuning_type", None):
         return VLLM_HF_ALTERNATE_PATH
     return MODEL_STORE_PATH
 

--- a/services/core/models/src/nmp/core/models/schemas.py
+++ b/services/core/models/src/nmp/core/models/schemas.py
@@ -163,7 +163,7 @@ class ModelSpec(BaseModel):
     is_embedding_model: bool = Field(
         False,
         description="Deprecated compatibility alias for head_type == 'embedding'.",
-        deprecated=True,
+        json_schema_extra={"deprecated": True},
     )
 
     @model_validator(mode="after")

--- a/services/core/models/src/nmp/core/models/schemas.py
+++ b/services/core/models/src/nmp/core/models/schemas.py
@@ -19,7 +19,7 @@ from nmp.core.models.constants import (
     MODEL_REF_PATTERN_DESCRIPTION,
     is_valid_model_ref,
 )
-from pydantic import AnyUrl, BaseModel, ConfigDict, Field, field_validator
+from pydantic import AnyUrl, BaseModel, ConfigDict, Field, field_validator, model_validator
 
 # NAME_PATTERN uses lookaround; rust-regex cannot compile it.
 ENTITY_NAME_CONFIG = ConfigDict(regex_engine="python-re")
@@ -165,6 +165,22 @@ class ModelSpec(BaseModel):
         description="Deprecated compatibility alias for head_type == 'embedding'.",
         deprecated=True,
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _sync_head_type_and_embedding_alias(cls, data: object) -> object:
+        if not isinstance(data, dict):
+            return data
+        data = dict(data)
+        head_type = data.get("head_type")
+        alias = bool(data.get("is_embedding_model", False))
+        if head_type in ("causal_lm", "embedding", "cross_encoder"):
+            data["is_embedding_model"] = head_type == "embedding"
+            return data
+        if alias:
+            data["head_type"] = "embedding"
+            data["is_embedding_model"] = True
+        return data
 
     # Basic model information
     checkpoint_model_name: str = Field(description="Checkpoint Model identifier or model path")
@@ -956,7 +972,7 @@ class Adapter(BaseModel):
     updated_at: datetime = Field(default_factory=datetime.now)
 
     @field_validator("model")
-    def validate_model(cls, v: str | None) -> str:
+    def validate_model(cls, v: str | None) -> str | None:
         if v is not None and not is_valid_model_ref(v):
             raise ValueError(MODEL_REF_PATTERN_DESCRIPTION)
         return v
@@ -1130,7 +1146,7 @@ class CreateAdapterRequest(CreateModelAdapterRequest):
     )
 
     @field_validator("model")
-    def validate_model(cls, v: str | None) -> str:
+    def validate_model(cls, v: str | None) -> str | None:
         if v is not None and not is_valid_model_ref(v):
             raise ValueError(MODEL_REF_PATTERN_DESCRIPTION)
         return v

--- a/services/core/models/src/nmp/core/models/schemas.py
+++ b/services/core/models/src/nmp/core/models/schemas.py
@@ -4,7 +4,7 @@
 from abc import ABC
 from datetime import datetime
 from enum import Enum, StrEnum
-from typing import Annotated, Any, Dict, List, Literal, Optional, Union
+from typing import Annotated, Any, Dict, List, Literal, Optional, Self, Union
 
 from jinja2 import Environment
 from jinja2 import nodes as jinja_nodes
@@ -166,21 +166,14 @@ class ModelSpec(BaseModel):
         deprecated=True,
     )
 
-    @model_validator(mode="before")
-    @classmethod
-    def _sync_head_type_and_embedding_alias(cls, data: object) -> object:
-        if not isinstance(data, dict):
-            return data
-        data = dict(data)
-        head_type = data.get("head_type")
-        alias = bool(data.get("is_embedding_model", False))
-        if head_type in ("causal_lm", "embedding", "cross_encoder"):
-            data["is_embedding_model"] = head_type == "embedding"
-            return data
-        if alias:
-            data["head_type"] = "embedding"
-            data["is_embedding_model"] = True
-        return data
+    @model_validator(mode="after")
+    def _sync_head_type_and_embedding_alias(self) -> Self:
+        if self.head_type in ("causal_lm", "embedding", "cross_encoder"):
+            self.is_embedding_model = self.head_type == "embedding"
+            return self
+        if self.is_embedding_model:
+            self.head_type = "embedding"
+        return self
 
     # Basic model information
     checkpoint_model_name: str = Field(description="Checkpoint Model identifier or model path")

--- a/services/core/models/src/nmp/core/models/schemas.py
+++ b/services/core/models/src/nmp/core/models/schemas.py
@@ -156,7 +156,15 @@ class ModelSpec(BaseModel):
     context_size: Optional[int] = Field(None, description="Context window size")
     num_virtual_tokens: Optional[int] = Field(None, description="Number of virtual tokens for prompt tuning")
     is_chat: Optional[bool] = Field(None, description="Whether this is a chat model")
-    is_embedding_model: bool = Field(False, description="Whether this is an embedding model")
+    head_type: Literal["causal_lm", "embedding", "cross_encoder", "unknown"] = Field(
+        default="unknown",
+        description="Task-specific head persisted in the checkpoint.",
+    )
+    is_embedding_model: bool = Field(
+        False,
+        description="Deprecated compatibility alias for head_type == 'embedding'.",
+        deprecated=True,
+    )
 
     # Basic model information
     checkpoint_model_name: str = Field(description="Checkpoint Model identifier or model path")

--- a/services/core/models/src/nmp/core/models/tasks/model_spec/run.py
+++ b/services/core/models/src/nmp/core/models/tasks/model_spec/run.py
@@ -48,6 +48,7 @@ from nmp.common.sdk_factory import get_platform_sdk
 from nmp.core.models.config import config as models_config
 from nmp.core.models.schemas import ModelSpec, ToolCallConfig
 from nmp.core.models.tasks.model_spec.schemas import ModelSpecTaskConfig, NMPJobContext
+from nmp.core.models.tasks.model_spec.utils import infer_model_head_type
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 logger = logging.getLogger(__name__)
@@ -262,15 +263,24 @@ class ModelSpecRunner:
         logger.info(os.listdir(dest_dir))
         is_trusted = me.trust_remote_code if me.trust_remote_code is not None else False
         model_spec = infer_model_cfg_from_hf(str(dest_dir), is_trusted=is_trusted, file_listing=all_file_paths)
-        # Embedding if model name or storage path contains "embed"; use or to avoid
-        # overwriting a correct True from model name when storage path lacks "embed"
-        model_spec.is_embedding_model = is_embedding_model(me.name)
-        if isinstance(fs.storage, LocalStorageConfig):
-            model_spec.is_embedding_model = model_spec.is_embedding_model or is_embedding_model(fs.storage.path)
-        elif isinstance(fs.storage, NGCStorageConfig):
-            model_spec.is_embedding_model = model_spec.is_embedding_model or is_embedding_model(fs.storage.target)
-        elif isinstance(fs.storage, HuggingfaceStorageConfig):
-            model_spec.is_embedding_model = model_spec.is_embedding_model or is_embedding_model(fs.storage.repo_id)
+        model_spec.head_type, head_type_reason = infer_model_head_type(str(dest_dir))
+
+        # Legacy filesets may omit model-card/config signals. Preserve the old
+        # name/path heuristic only as an unknown-result fallback.
+        if model_spec.head_type == "unknown":
+            legacy_identifiers = [me.name]
+            if isinstance(fs.storage, LocalStorageConfig):
+                legacy_identifiers.append(fs.storage.path)
+            elif isinstance(fs.storage, NGCStorageConfig):
+                legacy_identifiers.append(fs.storage.target)
+            elif isinstance(fs.storage, HuggingfaceStorageConfig):
+                legacy_identifiers.append(fs.storage.repo_id)
+            if any(is_embedding_model(identifier) for identifier in legacy_identifiers):
+                model_spec.head_type = "embedding"
+                head_type_reason = "legacy_fallback:name_or_storage_contains_embed"
+
+        model_spec.is_embedding_model = model_spec.head_type == "embedding"
+        logger.info("Inferred model head_type=%s (%s)", model_spec.head_type, head_type_reason)
 
         minimum_gpus_all_weights, _ = find_minimum_gpus_from_metadata(
             model_spec,
@@ -302,7 +312,9 @@ class ModelSpecRunner:
             me: ModelEntity = self._models.update_model(
                 name=config.name,
                 workspace=config.workspace,
-                body=UpdateModelEntityRequest(spec=PluginModelSpec.model_validate(model_spec.model_dump())),
+                body=UpdateModelEntityRequest(
+                    spec=PluginModelSpec.model_validate(model_spec.model_dump(mode="python"))
+                ),
             ).data()
         except NotFoundError as err:
             raise ModelSpecCreationError(

--- a/services/core/models/src/nmp/core/models/tasks/model_spec/utils.py
+++ b/services/core/models/src/nmp/core/models/tasks/model_spec/utils.py
@@ -136,9 +136,7 @@ def infer_model_head_type(model_dir: str) -> tuple[ModelHeadType, str]:
 
     auto_map = config.get("auto_map", {})
     if isinstance(auto_map, dict):
-        if "AutoModelForSequenceClassification" in auto_map:
-            cross_encoder_signals.append("auto_map:AutoModelForSequenceClassification")
-        elif "AutoModel" in auto_map and ("bidirec" in model_type or "pooling" in config):
+        if "AutoModel" in auto_map and ("bidirec" in model_type or "pooling" in config):
             embedding_signals.append("auto_map:AutoModel")
 
     if "pooling" in config and not cross_encoder_signals:
@@ -163,6 +161,12 @@ def infer_model_head_type(model_dir: str) -> tuple[ModelHeadType, str]:
         cross_encoder_signals.extend(
             f"architecture:{architecture}" for architecture in sequence_classification_architectures
         )
+    if (
+        isinstance(auto_map, dict)
+        and "AutoModelForSequenceClassification" in auto_map
+        and (is_single_score_head or has_reranking_metadata)
+    ):
+        cross_encoder_signals.append("auto_map:AutoModelForSequenceClassification")
 
     supporting_tags = sorted(tags.intersection(_SUPPORTING_TAGS))
     if supporting_tags:

--- a/services/core/models/src/nmp/core/models/tasks/model_spec/utils.py
+++ b/services/core/models/src/nmp/core/models/tasks/model_spec/utils.py
@@ -4,12 +4,14 @@
 import json
 import re
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import yaml
 
 _EMBEDDING_PIPELINE_TAGS = frozenset({"feature-extraction", "sentence-similarity", "text-embeddings-inference"})
+_CROSS_ENCODER_PIPELINE_TAGS = frozenset({"text-ranking", "reranking"})
 _GENERATIVE_PIPELINE_TAGS = frozenset({"text-generation", "text2text-generation", "image-to-text"})
+_RERANKING_TAGS = frozenset({"reranker", "reranking", "text-ranking"})
 _SUPPORTING_TAGS = frozenset(
     {
         "sentence-transformers",
@@ -18,6 +20,7 @@ _SUPPORTING_TAGS = frozenset(
         "embedding",
         "multimodal",
         "retrieval",
+        *_RERANKING_TAGS,
     }
 )
 _SENTENCE_TRANSFORMER_ARTIFACTS = (
@@ -27,17 +30,23 @@ _SENTENCE_TRANSFORMER_ARTIFACTS = (
     "1_Pooling",
 )
 _FRONTMATTER_PATTERN = re.compile(r"\A---\s*\n(.*?)\n---(?:\s*\n|$)", re.DOTALL)
+ModelHeadType = Literal["causal_lm", "embedding", "cross_encoder", "unknown"]
 
 
-def _load_architectures(config_path: Path) -> list[str]:
+def _load_config(config_path: Path) -> dict[str, Any]:
     if not config_path.is_file():
-        return []
+        return {}
 
     try:
         with config_path.open("r", encoding="utf-8") as f:
             config = json.load(f)
     except (OSError, json.JSONDecodeError):
-        return []
+        return {}
+    return config if isinstance(config, dict) else {}
+
+
+def _load_architectures(config_path: Path) -> list[str]:
+    config = _load_config(config_path)
 
     architectures = config.get("architectures", [])
     if isinstance(architectures, str):
@@ -76,72 +85,113 @@ def _normalize_tags(raw_tags: Any) -> set[str]:
     return {str(tag).strip().lower() for tag in raw_tags if str(tag).strip()}
 
 
-# TODO: refine this function and replace is_embedding_model with it
-# see if we can also use `family` or `tied_embeddings` in the ModelSpec to determine if it's an embedding model.
-def is_embedding_model_v2(model_dir: str) -> tuple[bool, str]:
+def infer_model_head_type(model_dir: str) -> tuple[ModelHeadType, str]:
     """
-    Analyzes a local Hugging Face model directory to determine if it is an embedding model.
+    Infer the task-specific head already persisted in a Hugging Face checkpoint.
+
+    This intentionally describes the checkpoint as saved. A causal-LM checkpoint
+    can still be used as the backbone for a new bi-encoder or cross-encoder job;
+    that training intent must be selected by the job, not inferred here.
 
     Args:
         model_dir (str): The path to the downloaded model directory.
 
     Returns:
-        tuple[bool, str]: A boolean indicating if it's an embedding model,
-                          and a string explaining the reasoning.
+        The inferred head type and a string explaining the strongest signals.
     """
 
     model_path = Path(model_dir)
     if not model_path.is_dir():
-        return False, f"Directory not found: {model_dir}"
+        return "unknown", f"Directory not found: {model_dir}"
 
-    strong_positive_signals: list[str] = []
-    strong_negative_signals: list[str] = []
+    embedding_signals: list[str] = []
+    cross_encoder_signals: list[str] = []
+    causal_lm_signals: list[str] = []
     supporting_signals: list[str] = []
 
     for artifact in _SENTENCE_TRANSFORMER_ARTIFACTS:
         artifact_path = model_path / artifact
         if artifact == "1_Pooling":
             if artifact_path.is_dir():
-                strong_positive_signals.append("artifact:1_Pooling/")
+                embedding_signals.append("artifact:1_Pooling/")
             continue
         if artifact_path.is_file():
-            strong_positive_signals.append(f"artifact:{artifact}")
+            embedding_signals.append(f"artifact:{artifact}")
 
+    config = _load_config(model_path / "config.json")
     architectures = _load_architectures(model_path / "config.json")
-    generative_architectures = [
-        arch for arch in architectures if ("ForCausalLM" in arch or "ForConditionalGeneration" in arch)
-    ]
-    if generative_architectures:
-        strong_negative_signals.append(f"architectures:{'|'.join(generative_architectures)}")
+    sequence_classification_architectures: list[str] = []
+    for architecture in architectures:
+        architecture_lower = architecture.lower()
+        if "forsequenceclassification" in architecture_lower:
+            sequence_classification_architectures.append(architecture)
+        elif "bidirectional" in architecture_lower or "embedding" in architecture_lower:
+            embedding_signals.append(f"architecture:{architecture}")
+        elif "forcausallm" in architecture_lower or "forconditionalgeneration" in architecture_lower:
+            causal_lm_signals.append(f"architecture:{architecture}")
+
+    model_type = str(config.get("model_type", "")).lower()
+    if "bidirec" in model_type:
+        embedding_signals.append(f"model_type:{model_type}")
+
+    auto_map = config.get("auto_map", {})
+    if isinstance(auto_map, dict):
+        if "AutoModelForSequenceClassification" in auto_map:
+            cross_encoder_signals.append("auto_map:AutoModelForSequenceClassification")
+        elif "AutoModel" in auto_map and ("bidirec" in model_type or "pooling" in config):
+            embedding_signals.append("auto_map:AutoModel")
+
+    if "pooling" in config and not cross_encoder_signals:
+        embedding_signals.append("config:pooling")
 
     readme_frontmatter = _load_readme_frontmatter(model_path / "README.md")
     pipeline_tag_raw = readme_frontmatter.get("pipeline_tag")
     pipeline_tag = str(pipeline_tag_raw).strip().lower() if isinstance(pipeline_tag_raw, str) else None
     if pipeline_tag in _EMBEDDING_PIPELINE_TAGS:
-        strong_positive_signals.append(f"pipeline_tag:{pipeline_tag}")
+        embedding_signals.append(f"pipeline_tag:{pipeline_tag}")
+    if pipeline_tag in _CROSS_ENCODER_PIPELINE_TAGS:
+        cross_encoder_signals.append(f"pipeline_tag:{pipeline_tag}")
     if pipeline_tag in _GENERATIVE_PIPELINE_TAGS:
-        strong_negative_signals.append(f"pipeline_tag:{pipeline_tag}")
+        causal_lm_signals.append(f"pipeline_tag:{pipeline_tag}")
 
     tags = _normalize_tags(readme_frontmatter.get("tags"))
+    id2label = config.get("id2label")
+    num_labels = config.get("num_labels")
+    is_single_score_head = num_labels == 1 or (isinstance(id2label, dict) and len(id2label) == 1)
+    has_reranking_metadata = pipeline_tag in _CROSS_ENCODER_PIPELINE_TAGS or bool(tags.intersection(_RERANKING_TAGS))
+    if sequence_classification_architectures and (is_single_score_head or has_reranking_metadata):
+        cross_encoder_signals.extend(
+            f"architecture:{architecture}" for architecture in sequence_classification_architectures
+        )
+
     supporting_tags = sorted(tags.intersection(_SUPPORTING_TAGS))
     if supporting_tags:
         supporting_signals.append(f"tags:{'|'.join(supporting_tags)}")
 
     if (model_path / "generation_config.json").is_file():
-        strong_negative_signals.append("file:generation_config.json")
+        causal_lm_signals.append("file:generation_config.json")
 
-    if strong_positive_signals:
-        details = ",".join(strong_positive_signals)
+    # A persisted scoring head is more specific than generic embedding/card
+    # metadata, and sentence-transformer artifacts are more specific than a
+    # stale generation_config.json copied from a causal-LM backbone.
+    for head_type, signals in (
+        ("cross_encoder", cross_encoder_signals),
+        ("embedding", embedding_signals),
+        ("causal_lm", causal_lm_signals),
+    ):
+        if not signals:
+            continue
+        details = ",".join(signals)
         if supporting_signals:
             details = f"{details};supporting={','.join(supporting_signals)}"
-        return True, f"strong_positive:{details}"
-
-    if strong_negative_signals:
-        details = ",".join(strong_negative_signals)
-        if supporting_signals:
-            details = f"{details};supporting={','.join(supporting_signals)}"
-        return False, f"strong_negative:{details}"
+        return head_type, f"{head_type}:{details}"
 
     if supporting_signals:
-        return False, f"inconclusive:supporting={','.join(supporting_signals)}"
-    return False, "inconclusive:no_strong_embedding_signals"
+        return "unknown", f"inconclusive:supporting={','.join(supporting_signals)}"
+    return "unknown", "inconclusive:no_strong_head_signals"
+
+
+def is_embedding_model_v2(model_dir: str) -> tuple[bool, str]:
+    """Compatibility wrapper for callers that still consume a boolean."""
+    head_type, reason = infer_model_head_type(model_dir)
+    return head_type == "embedding", reason

--- a/services/core/models/tests/unit/controllers/backends/test_vllm_compiler.py
+++ b/services/core/models/tests/unit/controllers/backends/test_vllm_compiler.py
@@ -13,9 +13,20 @@ def _view(**kwargs) -> DeploymentConfigView:
     return DeploymentConfigView(**kwargs)
 
 
-def _model_entity(*, spec=None, trust_remote_code=False) -> SimpleNamespace:
+def _model_entity(
+    *,
+    spec=None,
+    trust_remote_code=False,
+    base_model=None,
+    finetuning_type=None,
+) -> SimpleNamespace:
     """A lightweight stand-in for a ModelEntity (avoids MagicMock(spec=) collision)."""
-    return SimpleNamespace(spec=spec, trust_remote_code=trust_remote_code)
+    return SimpleNamespace(
+        spec=spec,
+        trust_remote_code=trust_remote_code,
+        base_model=base_model,
+        finetuning_type=finetuning_type,
+    )
 
 
 def _spec(**kwargs) -> SimpleNamespace:
@@ -56,6 +67,22 @@ def test_compile_vllm_args_basic():
     assert args[0] == "/model-store"
     assert "--served-model-name" in args
     assert args[args.index("--served-model-name") + 1] == "default/qwen"
+
+
+def test_compile_vllm_args_uses_hf_alternate_for_customized_embedding():
+    model_entity = _model_entity(
+        spec=_spec(is_embedding_model=True),
+        base_model="default/base-embed",
+        finetuning_type="all_weights",
+    )
+    args = vllm_compiler.compile_vllm_args(_view(gpu=1, model_name="embed"), model_entity)
+    assert args[0] == vllm_compiler.VLLM_HF_ALTERNATE_PATH
+
+
+def test_compile_vllm_args_uses_root_for_base_embedding():
+    model_entity = _model_entity(spec=_spec(is_embedding_model=True))
+    args = vllm_compiler.compile_vllm_args(_view(gpu=1, model_name="embed"), model_entity)
+    assert args[0] == vllm_compiler.MODEL_STORE_PATH
 
 
 def test_compile_vllm_args_served_name_without_namespace():

--- a/services/core/models/tests/unit/controllers/backends/test_vllm_compiler.py
+++ b/services/core/models/tests/unit/controllers/backends/test_vllm_compiler.py
@@ -71,7 +71,7 @@ def test_compile_vllm_args_basic():
 
 def test_compile_vllm_args_uses_hf_alternate_for_customized_embedding():
     model_entity = _model_entity(
-        spec=_spec(is_embedding_model=True),
+        spec=_spec(head_type="embedding"),
         base_model="default/base-embed",
         finetuning_type="all_weights",
     )
@@ -79,8 +79,28 @@ def test_compile_vllm_args_uses_hf_alternate_for_customized_embedding():
     assert args[0] == vllm_compiler.VLLM_HF_ALTERNATE_PATH
 
 
+def test_compile_vllm_args_uses_hf_alternate_for_legacy_embedding_alias():
+    model_entity = _model_entity(
+        spec=_spec(head_type="unknown", is_embedding_model=True),
+        base_model="default/base-embed",
+        finetuning_type="all_weights",
+    )
+    args = vllm_compiler.compile_vllm_args(_view(gpu=1, model_name="embed"), model_entity)
+    assert args[0] == vllm_compiler.VLLM_HF_ALTERNATE_PATH
+
+
+def test_compile_vllm_args_cross_encoder_does_not_use_hf_alternate():
+    model_entity = _model_entity(
+        spec=_spec(head_type="cross_encoder", is_embedding_model=True),
+        base_model="default/base-rerank",
+        finetuning_type="all_weights",
+    )
+    args = vllm_compiler.compile_vllm_args(_view(gpu=1, model_name="rerank"), model_entity)
+    assert args[0] == vllm_compiler.MODEL_STORE_PATH
+
+
 def test_compile_vllm_args_uses_root_for_base_embedding():
-    model_entity = _model_entity(spec=_spec(is_embedding_model=True))
+    model_entity = _model_entity(spec=_spec(head_type="embedding", is_embedding_model=True))
     args = vllm_compiler.compile_vllm_args(_view(gpu=1, model_name="embed"), model_entity)
     assert args[0] == vllm_compiler.MODEL_STORE_PATH
 

--- a/services/core/models/tests/unit/tasks/model_spec/test_utils.py
+++ b/services/core/models/tests/unit/tasks/model_spec/test_utils.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Optional
 
 import pytest
-from nmp.core.models.tasks.model_spec.utils import is_embedding_model_v2
+from nmp.core.models.tasks.model_spec.utils import infer_model_head_type, is_embedding_model_v2
 
 TEST_MODEL_FIXTURES_DIR = Path(__file__).parent / "test_data" / "models"
 
@@ -48,7 +48,7 @@ class TestIsEmbeddingModelV2:
         is_embedding, reason = is_embedding_model_v2(str(model_dir))
 
         assert is_embedding is True
-        assert "strong_positive" in reason
+        assert reason.startswith("embedding:")
         assert "artifact:modules.json" in reason
 
     def test_returns_true_for_embedding_pipeline_tag(self, tmp_path: Path) -> None:
@@ -71,9 +71,9 @@ class TestIsEmbeddingModelV2:
         is_embedding, reason = is_embedding_model_v2(str(model_dir))
 
         assert is_embedding is False
-        assert "strong_negative" in reason
+        assert reason.startswith("causal_lm:")
         assert "pipeline_tag:text-generation" in reason
-        assert "architectures:LlamaForCausalLM" in reason
+        assert "architecture:LlamaForCausalLM" in reason
 
     def test_returns_false_for_generative_architecture_without_positive_signals(self, tmp_path: Path) -> None:
         model_dir = tmp_path / "model"
@@ -83,7 +83,7 @@ class TestIsEmbeddingModelV2:
         is_embedding, reason = is_embedding_model_v2(str(model_dir))
 
         assert is_embedding is False
-        assert "strong_negative" in reason
+        assert reason.startswith("causal_lm:")
         assert "Qwen2ForConditionalGeneration" in reason
 
     def test_returns_false_for_encoder_without_embedding_signals(self, tmp_path: Path) -> None:
@@ -94,7 +94,62 @@ class TestIsEmbeddingModelV2:
         is_embedding, reason = is_embedding_model_v2(str(model_dir))
 
         assert is_embedding is False
-        assert reason == "inconclusive:no_strong_embedding_signals"
+        assert reason == "inconclusive:no_strong_head_signals"
+
+
+class TestInferModelHeadType:
+    def test_detects_cross_encoder_from_sequence_classification_head(self, tmp_path: Path) -> None:
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+        _write_json(
+            model_dir / "config.json",
+            {
+                "architectures": ["LlamaBidirectionalForSequenceClassification"],
+                "num_labels": 1,
+            },
+        )
+
+        head_type, reason = infer_model_head_type(str(model_dir))
+
+        assert head_type == "cross_encoder"
+        assert "ForSequenceClassification" in reason
+
+    def test_detects_automodel_bi_encoder_architecture(self, tmp_path: Path) -> None:
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+        _write_json(model_dir / "config.json", {"architectures": ["LlamaBidirectionalModel"]})
+
+        head_type, reason = infer_model_head_type(str(model_dir))
+
+        assert head_type == "embedding"
+        assert "LlamaBidirectionalModel" in reason
+
+    def test_cross_encoder_head_wins_over_embedding_card_metadata(self, tmp_path: Path) -> None:
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+        _write_json(
+            model_dir / "config.json",
+            {"architectures": ["BertForSequenceClassification"], "num_labels": 1},
+        )
+        _write_readme_frontmatter(model_dir / "README.md", pipeline_tag="feature-extraction")
+
+        head_type, _ = infer_model_head_type(str(model_dir))
+
+        assert head_type == "cross_encoder"
+
+    def test_generic_sequence_classifier_is_not_assumed_to_be_a_reranker(self, tmp_path: Path) -> None:
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+        _write_json(
+            model_dir / "config.json",
+            {"architectures": ["BertForSequenceClassification"], "num_labels": 3},
+        )
+        _write_readme_frontmatter(model_dir / "README.md", pipeline_tag="text-classification")
+
+        head_type, reason = infer_model_head_type(str(model_dir))
+
+        assert head_type == "unknown"
+        assert reason == "inconclusive:no_strong_head_signals"
 
     @pytest.mark.parametrize(
         "repo_id, expected",

--- a/services/core/models/tests/unit/tasks/model_spec/test_utils.py
+++ b/services/core/models/tests/unit/tasks/model_spec/test_utils.py
@@ -151,6 +151,23 @@ class TestInferModelHeadType:
         assert head_type == "unknown"
         assert reason == "inconclusive:no_strong_head_signals"
 
+    def test_sequence_classification_auto_map_is_not_enough_without_rerank_evidence(self, tmp_path: Path) -> None:
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+        _write_json(
+            model_dir / "config.json",
+            {
+                "architectures": ["BertModel"],
+                "num_labels": 3,
+                "auto_map": {"AutoModelForSequenceClassification": "modeling.CustomClassifier"},
+            },
+        )
+
+        head_type, reason = infer_model_head_type(str(model_dir))
+
+        assert head_type == "unknown"
+        assert "auto_map:AutoModelForSequenceClassification" not in reason
+
     @pytest.mark.parametrize(
         "repo_id, expected",
         [

--- a/services/core/models/tests/unit/test_model_spec_head_alias.py
+++ b/services/core/models/tests/unit/test_model_spec_head_alias.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from nemo_platform_plugin.models.types import ModelSpec as PluginModelSpec
+from nmp.core.models.schemas import ModelSpec
+
+_MINIMAL = {
+    "checkpoint_model_name": "meta-llama/Llama-3.2-1b-instruct",
+    "family": "llama",
+    "num_layers": 32,
+    "hidden_size": 4096,
+    "num_attention_heads": 32,
+    "num_kv_heads": 32,
+    "ffn_hidden_size": 16384,
+    "vocab_size": 32000,
+    "tied_embeddings": True,
+    "gated_mlp": True,
+    "base_num_parameters": 1000,
+    "precision": "fp16",
+}
+
+
+def test_head_type_embedding_derives_alias() -> None:
+    spec = ModelSpec(**_MINIMAL, head_type="embedding", is_embedding_model=False)
+    assert spec.head_type == "embedding"
+    assert spec.is_embedding_model is True
+
+
+def test_legacy_alias_only_sets_embedding_head() -> None:
+    spec = ModelSpec(**_MINIMAL, is_embedding_model=True)
+    assert spec.head_type == "embedding"
+    assert spec.is_embedding_model is True
+
+
+def test_cross_encoder_wins_over_stale_embedding_alias() -> None:
+    spec = ModelSpec(**_MINIMAL, head_type="cross_encoder", is_embedding_model=True)
+    assert spec.head_type == "cross_encoder"
+    assert spec.is_embedding_model is False
+
+
+def test_unknown_plus_alias_true_normalizes_to_embedding() -> None:
+    spec = ModelSpec(**_MINIMAL, head_type="unknown", is_embedding_model=True)
+    assert spec.head_type == "embedding"
+    assert spec.is_embedding_model is True
+
+
+def test_plugin_model_spec_cross_encoder_wins_over_stale_embedding_alias() -> None:
+    spec = PluginModelSpec(**_MINIMAL, head_type="cross_encoder", is_embedding_model=True)
+    assert spec.head_type == "cross_encoder"
+    assert spec.is_embedding_model is False

--- a/services/core/models/tests/unit/test_model_spec_head_alias.py
+++ b/services/core/models/tests/unit/test_model_spec_head_alias.py
@@ -48,3 +48,19 @@ def test_plugin_model_spec_cross_encoder_wins_over_stale_embedding_alias() -> No
     spec = PluginModelSpec(**_MINIMAL, head_type="cross_encoder", is_embedding_model=True)
     assert spec.head_type == "cross_encoder"
     assert spec.is_embedding_model is False
+
+
+def test_false_like_alias_strings_stay_unknown() -> None:
+    for spec_cls in (ModelSpec, PluginModelSpec):
+        for alias in ("false", "0", "off"):
+            spec = spec_cls.model_validate({**_MINIMAL, "is_embedding_model": alias})
+            assert spec.head_type == "unknown"
+            assert spec.is_embedding_model is False
+
+
+def test_true_like_alias_strings_normalize_to_embedding() -> None:
+    for spec_cls in (ModelSpec, PluginModelSpec):
+        for alias in ("true", "1", "on"):
+            spec = spec_cls.model_validate({**_MINIMAL, "is_embedding_model": alias})
+            assert spec.head_type == "embedding"
+            assert spec.is_embedding_model is True

--- a/services/core/models/tests/unit/test_model_spec_head_alias.py
+++ b/services/core/models/tests/unit/test_model_spec_head_alias.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import warnings
+
 from nemo_platform_plugin.models.types import ModelSpec as PluginModelSpec
 from nmp.core.models.schemas import ModelSpec
 
@@ -64,3 +66,12 @@ def test_true_like_alias_strings_normalize_to_embedding() -> None:
             spec = spec_cls.model_validate({**_MINIMAL, "is_embedding_model": alias})
             assert spec.head_type == "embedding"
             assert spec.is_embedding_model is True
+
+
+def test_constructing_model_spec_does_not_warn_on_deprecated_alias() -> None:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        ModelSpec(**_MINIMAL, head_type="embedding")
+        PluginModelSpec(**_MINIMAL, head_type="embedding")
+        _ = ModelSpec(**_MINIMAL, head_type="embedding").is_embedding_model
+    assert not any(issubclass(w.category, DeprecationWarning) for w in caught)

--- a/web/packages/common/src/components/ModelSelectV2/ModelDetailsPanel.tsx
+++ b/web/packages/common/src/components/ModelSelectV2/ModelDetailsPanel.tsx
@@ -21,7 +21,9 @@ export const ModelDetailsPanel: FC<ModelDetailsPanelProps> = ({ model, adapter }
   const createdAt = adapter?.created_at ?? model.created_at;
   const updatedAt = adapter?.updated_at ?? model.updated_at;
   const isChatModel = model.spec?.is_chat;
-  const isEmbeddingModel = model.spec?.is_embedding_model;
+  const headType = model.spec?.head_type;
+  const isEmbeddingModel = headType === 'embedding' || (!headType && model.spec?.is_embedding_model);
+  const isCrossEncoder = headType === 'cross_encoder';
 
   // Hooks must be called unconditionally per React rules; empty string is safe fallback
   const createdRelative = useRelativeTimeSince(createdAt ?? '');
@@ -38,7 +40,7 @@ export const ModelDetailsPanel: FC<ModelDetailsPanelProps> = ({ model, adapter }
           {description}
         </Text>
       )}
-      {(isChatModel || isEmbeddingModel) && (
+      {(isChatModel || isEmbeddingModel || isCrossEncoder) && (
         <Flex gap="density-sm" wrap="wrap">
           {isChatModel && (
             <Tag color="gray" kind="outline" readOnly>
@@ -48,6 +50,11 @@ export const ModelDetailsPanel: FC<ModelDetailsPanelProps> = ({ model, adapter }
           {isEmbeddingModel && (
             <Tag color="gray" kind="outline" readOnly>
               Embedding Model
+            </Tag>
+          )}
+          {isCrossEncoder && (
+            <Tag color="gray" kind="outline" readOnly>
+              Cross-Encoder Model
             </Tag>
           )}
         </Flex>

--- a/web/packages/common/src/components/ModelSelectV2/ModelDetailsPanel.tsx
+++ b/web/packages/common/src/components/ModelSelectV2/ModelDetailsPanel.tsx
@@ -22,7 +22,7 @@ export const ModelDetailsPanel: FC<ModelDetailsPanelProps> = ({ model, adapter }
   const updatedAt = adapter?.updated_at ?? model.updated_at;
   const isChatModel = model.spec?.is_chat;
   const headType = model.spec?.head_type;
-  const isEmbeddingModel = headType === 'embedding' || (!headType && model.spec?.is_embedding_model);
+  const isEmbeddingModel = headType === 'embedding' || Boolean(model.spec?.is_embedding_model);
   const isCrossEncoder = headType === 'cross_encoder';
 
   // Hooks must be called unconditionally per React rules; empty string is safe fallback


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary

Automodel can train rerankers (`cross_encoder`) as a first-class recipe, and `ModelSpec` now records `head_type` so entity analysis, job compile, and the UI can tell causal LM, embedding, and cross-encoder models apart. Fine-tuned embedding checkpoints also export in a dual layout that NIM (ONNX at `/model-store`) and vLLM (HF under `/model-store/alternates/hf`) can both serve. A follow-up commit fixes docker NIM deployments that failed checksum with `Permission denied` on huggingface_hub's `0600` cache files ([NVBug 6711340](https://nvbugspro.nvidia.com/bug/6711340)).

## Related Issue

Fixes [NVBug 6711340](https://nvbugspro.nvidia.com/bug/6711340). Related: AALGO-402, AALGO-403.

## Changes

- Add `head_type` (`causal_lm` | `embedding` | `cross_encoder` | `unknown`) to `ModelSpec`, OpenAPI, the Python SDK, and the model-details UI. Keep `is_embedding` as a compatibility alias.
- Teach Automodel `recipe: cross_encoder` (and infer it from `head_type` when the recipe is `auto`). Reject unmerged LoRA for encoder heads.
- Export embedding training output as NIM ONNX at the fileset root plus an HF alternate at `alternates/hf`.
- Point vLLM `--model` at `/model-store/alternates/hf` for customized embedding entities; leave base embeddings on `/model-store`.
- Compile Automodel download/upload/entity-create CPU steps with the training execution profile (`gpu`) so they run in Docker instead of host subprocess.
- Add a `weights-permissions-init` container (`chmod -R a+rX /model-store`) when puller and server do not share a uid (docker, and generic k8s with no `run_as_user`). Skip it when a k8s pod `securityContext` already pins a shared uid.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [x] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

```
uv run pytest services/automodel/tests/test_compiler.py \
  services/core/models/tests/unit/controllers/backends/ -q
# 125 passed

uv run ty check services/automodel/src/nmp/automodel/compile.py \
  services/core/models/src/nmp/core/models/controllers/backends/deployments_plugin/compiler.py \
  services/core/models/src/nmp/core/models/controllers/backends/vllm_compiler.py \
  services/automodel/src/nmp/automodel/app/jobs/compiler.py
# All checks passed
```

Full `uv run pre-commit run -a` was not re-run after the last description-only edits to `compile.py`.

Workbox E2E (`startup@10.0.0.51`, Stages 0–3): generate → prepare/mine → Automodel bi-encoder SFT → deploy the trained entity with NIM (`llama-nemotron-embed-1b-v2:1.13.0`) and vLLM (`vllm-openai:v0.22.1 --runner pooling`). Both deployments reached `READY` on fresh volumes (no manual chmod). Cross-engine cosine was `0.999965751` (query) and `0.999960544` (passage); both 2048-d unit vectors.

## Test plan

- [ ] Create an Automodel job with `recipe: cross_encoder` against a `head_type: cross_encoder` entity and confirm compile selects the rerank path.
- [ ] Create an Automodel bi-encoder job and confirm the output fileset has ONNX at the root and HF weights under `alternates/hf`.
- [ ] Deploy that embedding entity with NIM and vLLM on docker; confirm NIM does not fail checksum on `.cache/huggingface/trees/*.json`.
- [ ] Confirm vLLM serves `/model-store/alternates/hf` for the customized embedding and `/model-store` for a base embedding.
- [ ] Confirm Automodel download/upload/entity steps use the `gpu` execution profile (Docker), not host subprocess.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added retrieval training for bi-encoder and cross-encoder workflows.
  * Added embedding options for passage sampling, sequence lengths, prefixes, evaluation negatives, and gradient checkpointing.
  * Added automatic recipe and optimizer selection, including fused optimizer support.
  * Model metadata now identifies causal-LM, embedding, cross-encoder, or unknown model types.
  * Cross-encoder models are labeled in the model selection interface.
* **Bug Fixes**
  * Improved customized embedding-model deployment paths and model-store permissions.
  * Prevented incompatible encoder recipes from being used with distillation training.
* **Documentation**
  * Updated CLI, API, and Automodel references with retrieval training, recipe configuration, and default-setting details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->