### PR TITLE
refactor(customizer): migrate jobs SDK to typed clients

### DIFF
--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -9107,7 +9107,6 @@ nemo customization automodel [OPTIONS] COMMAND [ARGS]...
 **Commands:**
 
 * `explain`: Show input/output schemas.
-* `run`
 * `submit`
 
 ##### nemo customization automodel explain
@@ -9124,22 +9123,6 @@ nemo customization automodel explain [OPTIONS]
 
 * `--profile`: Annotate the bundle with this profile. Profile metadata lands in MR 1.4b.
 * `--cluster`: Accepted for forward compatibility; unused in MR 1.4a.
-
-**Help:**
-
-* `--help, -h`: Show this message and exit.
-
-##### nemo customization automodel run
-
-**Usage:**
-
-```shell
-nemo customization automodel run [OPTIONS] [JOB_JSON]
-```
-
-**Arguments:**
-
-* `<JOB_JSON>`: Path to Automodel job JSON (AutomodelJobInput schema).
 
 **Help:**
 
@@ -9187,7 +9170,6 @@ nemo customization rl [OPTIONS] COMMAND [ARGS]...
 **Commands:**
 
 * `explain`: Show input/output schemas.
-* `run`
 * `submit`
 
 ##### nemo customization rl explain
@@ -9204,22 +9186,6 @@ nemo customization rl explain [OPTIONS]
 
 * `--profile`: Annotate the bundle with this profile. Profile metadata lands in MR 1.4b.
 * `--cluster`: Accepted for forward compatibility; unused in MR 1.4a.
-
-**Help:**
-
-* `--help, -h`: Show this message and exit.
-
-##### nemo customization rl run
-
-**Usage:**
-
-```shell
-nemo customization rl run [OPTIONS] [JOB_JSON]
-```
-
-**Arguments:**
-
-* `<JOB_JSON>`: Path to NeMo-RL job JSON (RlJobInput schema).
 
 **Help:**
 
@@ -9267,7 +9233,6 @@ nemo customization unsloth [OPTIONS] COMMAND [ARGS]...
 **Commands:**
 
 * `explain`: Show input/output schemas.
-* `run`
 * `submit`
 
 ##### nemo customization unsloth explain
@@ -9284,22 +9249,6 @@ nemo customization unsloth explain [OPTIONS]
 
 * `--profile`: Annotate the bundle with this profile. Profile metadata lands in MR 1.4b.
 * `--cluster`: Accepted for forward compatibility; unused in MR 1.4a.
-
-**Help:**
-
-* `--help, -h`: Show this message and exit.
-
-##### nemo customization unsloth run
-
-**Usage:**
-
-```shell
-nemo customization unsloth run [OPTIONS] [JOB_JSON]
-```
-
-**Arguments:**
-
-* `<JOB_JSON>`: Path to Unsloth job JSON (UnslothJobInput schema).
 
 **Help:**
 

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/client/client.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/client/client.py
@@ -28,7 +28,7 @@ from contextlib import asynccontextmanager, contextmanager
 from datetime import timezone
 from functools import cache
 from pathlib import Path
-from typing import Any, Self, TypeVar, cast, get_args, get_origin, overload
+from typing import Any, Generic, Self, TypeVar, cast, get_args, get_origin, overload
 from urllib.parse import quote
 
 import httpx
@@ -70,6 +70,7 @@ from nemo_platform_plugin.client.types import (
 from pydantic import BaseModel, TypeAdapter, ValidationError
 
 ModelT = TypeVar("ModelT", bound=BaseModel)
+HttpClientT = TypeVar("HttpClientT", httpx.Client, httpx.AsyncClient)
 
 logger = logging.getLogger(__name__)
 
@@ -127,12 +128,6 @@ def _resolve_implicit_workload_auth(
         base_url=base_url,
         subject_token_file=Path(subject_token_file),
     )
-
-
-# Instance-dict slot holding lazily discovered plugin SDK resources. Each
-# resource is bound to the client that built it, so ``with_options()`` drops
-# this slot on the clone rather than handing out originals.
-_RESOURCE_CACHE_ATTR = "_discovered_resources"
 
 
 @cache
@@ -339,7 +334,7 @@ class _InferenceNamespace:
     through a synchronous ``send()``.
     """
 
-    def __init__(self, client: "BaseNemoClient") -> None:
+    def __init__(self, client: NemoClient | AsyncNemoClient) -> None:
         self._client = client
 
     def _models_client(self) -> NemoClient | AsyncNemoClient:
@@ -347,7 +342,7 @@ class _InferenceNamespace:
 
         if isinstance(self._client, AsyncNemoClient):
             return AsyncModelsClient.from_client(self._client)
-        return ModelsClient.from_client(cast(NemoClient, self._client))
+        return ModelsClient.from_client(self._client)
 
     @property
     def providers(self) -> NemoClient | AsyncNemoClient:
@@ -367,15 +362,17 @@ class _InferenceNamespace:
 
         if isinstance(self._client, AsyncNemoClient):
             return AsyncVirtualModelsClient.from_client(self._client)
-        return VirtualModelsClient.from_client(cast(NemoClient, self._client))
+        return VirtualModelsClient.from_client(self._client)
 
 
-class BaseNemoClient:
+class BaseNemoClient(Generic[HttpClientT]):
     """Shared logic for sync and async NeMo clients.
 
     Handles URL construction and request serialisation.
     Subclasses provide the actual HTTP transport (sync or async).
     """
+
+    _http: HttpClientT
 
     def __init__(
         self,
@@ -404,9 +401,9 @@ class BaseNemoClient:
     def _client(self) -> httpx.Client | httpx.AsyncClient:
         """Underlying httpx transport.
 
-        Plugin SDK resources access ``platform._client`` to make raw HTTP
-        calls. Exposing it here lets them work with NemoClient after the
-        Stainless SDK is retired.
+        Legacy plugin SDK resources access ``NeMoPlatform._client`` to make raw
+        HTTP calls. Exposing the same transport property here lets those
+        resources work with ``NemoClient`` while they migrate.
         """
         return self._http
 
@@ -414,30 +411,6 @@ class BaseNemoClient:
     def default_headers(self) -> dict[str, str]:
         """Default headers sent with every request."""
         return self._default_headers or {}
-
-    def __getattr__(self, name: str) -> Any:
-        """Delegate unknown attributes to plugin SDK discovery.
-
-        Mirrors NeMoPlatform.__getattr__: discovers plugin SDK resources
-        via entry points and instantiates them with self as the platform.
-        This handles sdk.auditor, sdk.evaluator, sdk.agents, sdk.iron_swarm,
-        sdk.anonymizer, sdk.customizer, and any other plugin-level resource
-        not covered by the convenience properties.
-        """
-        from nemo_platform_plugin.discovery import discover_sdk
-
-        resources = discover_sdk().get(name)
-        if resources is None:
-            raise AttributeError(f"'{type(self).__name__}' object has no attribute {name!r}")
-
-        resource_cls = resources.async_resource if isinstance(self, AsyncNemoClient) else resources.sync_resource
-        if resource_cls is None:
-            raise AttributeError(f"'{type(self).__name__}' object has no attribute {name!r}")
-
-        cache = self.__dict__.setdefault(_RESOURCE_CACHE_ATTR, {})
-        if name not in cache:
-            cache[name] = resource_cls(self)
-        return cache[name]
 
     @property
     def workspace(self) -> str | None:
@@ -510,10 +483,6 @@ class BaseNemoClient:
             client.with_options(timeout=300).update_fileset(...)
         """
         clone = copy.copy(self)
-        # Discovered resources are bound to the client that created them, so a
-        # shallow copy must not inherit them: the clone re-resolves each one
-        # against itself and picks up the overrides below.
-        clone.__dict__.pop(_RESOURCE_CACHE_ATTR, None)
         if headers:
             clone._default_headers = {**self._default_headers, **headers}
         if retry is not None:
@@ -620,7 +589,7 @@ class BaseNemoClient:
         return self._resource_client(IronSwarmClient, AsyncIronSwarmClient)
 
     @property
-    def inference(self) -> _InferenceNamespace:
+    def inference(self: NemoClient | AsyncNemoClient) -> _InferenceNamespace:
         return _InferenceNamespace(self)
 
     def _resolve_query_params(self, request: PreparedRequest) -> dict[str, str | int | bool] | None:
@@ -638,7 +607,7 @@ class BaseNemoClient:
         return filtered or None
 
 
-class NemoClient(BaseNemoClient):
+class NemoClient(BaseNemoClient[httpx.Client]):
     """Sync HTTP client for NeMo Platform APIs."""
 
     _auth: TokenProvider | None
@@ -902,7 +871,7 @@ class NemoClient(BaseNemoClient):
         return fetch
 
 
-class AsyncNemoClient(BaseNemoClient):
+class AsyncNemoClient(BaseNemoClient[httpx.AsyncClient]):
     """Async HTTP client for NeMo Platform APIs.
 
     Async twin of :class:`NemoClient`.

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/customization_contributor.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/customization_contributor.py
@@ -5,8 +5,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, ClassVar, Protocol, runtime_checkable
+from typing import ClassVar, Protocol, runtime_checkable
 
 import typer
 from nemo_platform_plugin.service import RouterSpec
@@ -16,12 +17,17 @@ class CustomizationContributorDiscoveryError(RuntimeError):
     """Raised when customization contributor discovery fails."""
 
 
+CustomizationSDKResourceFactory = Callable[..., object]
+
+
 @dataclass(frozen=True, slots=True)
 class CustomizationContributorSDKResources:
     """Sync/async resource classes mounted under ``client.customization.<name>``."""
 
-    sync_resource: type[Any] | None = None
-    async_resource: type[Any] | None = None
+    # The customization hub owns the concrete context type and validates the
+    # constructed resource shape before exposing a contributor SDK resource.
+    sync_resource: CustomizationSDKResourceFactory | None = None
+    async_resource: CustomizationSDKResourceFactory | None = None
 
     def __post_init__(self) -> None:
         if self.sync_resource is None and self.async_resource is None:
@@ -50,9 +56,10 @@ class CustomizationContributor(Protocol):
         """Return SDK resource classes for ``client.customization.<name>``.
 
         Return :class:`CustomizationContributorSDKResources` with sync and/or async
-        resource classes (each accepts a :class:`~nemo_platform.NeMoPlatform` or
-        :class:`~nemo_platform.AsyncNeMoPlatform` in ``__init__``). Return ``None``
-        when the backend has no Python SDK surface. Do not register a separate
-        ``nemo.sdk`` entry point — the customization hub composes contributors.
+        resource classes. The Customizer hub owns the top-level
+        ``client.customization`` SDK entry and passes each backend resource a
+        typed Customizer SDK context containing the typed Customizer client, the
+        typed Jobs client, and the active workspace. Do not register a separate
+        ``nemo.sdk`` entry point; the Customizer hub composes contributors.
         """
         ...

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/sdk.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/sdk.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Generic, TypeVar
+from typing import Generic, TypeVar
 
 from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
 
@@ -17,17 +17,14 @@ AsyncResourceT = TypeVar("AsyncResourceT")
 
 @dataclass(frozen=True, slots=True)
 class NemoPluginSDKResources(Generic[SyncResourceT, AsyncResourceT]):
-    """Container for plugin SDK resources exposed on platform clients.
+    """Container for plugin SDK resources exposed on legacy platform SDK owners.
 
-    Each factory is called with the client that owns the namespace: the legacy
-    ``NeMoPlatform`` / ``AsyncNeMoPlatform`` SDK, or ``NemoClient`` /
-    ``AsyncNemoClient`` when the caller uses the typed client. Both expose the
-    ``_client`` and ``default_headers`` surface plugin resources rely on, so
-    the factory parameter is deliberately left open.
+    Typed clients should expose resources through explicit typed APIs instead
+    of consuming this dynamic legacy ``nemo.sdk`` entry-point surface.
     """
 
-    sync_resource: Callable[[Any], SyncResourceT] | None = None
-    async_resource: Callable[[Any], AsyncResourceT] | None = None
+    sync_resource: Callable[[NeMoPlatform], SyncResourceT] | None = None
+    async_resource: Callable[[AsyncNeMoPlatform], AsyncResourceT] | None = None
 
     def __post_init__(self) -> None:
         if self.sync_resource is None and self.async_resource is None:

--- a/packages/nemo_platform_plugin/tests/client/test_client_resources.py
+++ b/packages/nemo_platform_plugin/tests/client/test_client_resources.py
@@ -1,13 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for discovered plugin resources, clone isolation, and transport auth.
+"""Tests for typed resource dispatch and transport auth.
 
-Covers three behaviours that only surface through the compatibility layer:
+Covers two behaviours that only surface through the compatibility layer:
 
 - ``sdk.inference.*`` must hand back a resource client matching the owning
   client's sync/async flavour.
-- ``with_options()`` clones must not reuse resources bound to the original.
 - Raw calls through the exposed ``_client`` transport must stay authenticated.
 """
 
@@ -18,27 +17,6 @@ import pytest
 from nemo_platform_plugin.client.client import AsyncNemoClient, NemoClient
 
 BASE = "http://test:8000"
-
-
-class _Resource:
-    """Stand-in for a discovered plugin SDK resource."""
-
-    def __init__(self, platform: object) -> None:
-        self.platform = platform
-
-
-@pytest.fixture
-def discovered(monkeypatch: pytest.MonkeyPatch):
-    """Register a fake ``thing`` resource on the plugin SDK discovery surface."""
-
-    class Resources:
-        sync_resource = _Resource
-        async_resource = _Resource
-
-    monkeypatch.setattr(
-        "nemo_platform_plugin.discovery.discover_sdk",
-        lambda: {"thing": Resources()},
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -154,44 +132,8 @@ def test_convenience_properties_return_async_clients_for_async_client() -> None:
         assert isinstance(resource._http, httpx.AsyncClient)
 
 
-# ---------------------------------------------------------------------------
-# with_options() clone isolation
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.parametrize("client_factory", [NemoClient, AsyncNemoClient])
-def test_with_options_does_not_reuse_cached_resources(client_factory, discovered) -> None:
-    client = client_factory(base_url=BASE)
-    original = client.thing
-
-    clone = client.with_headers({"X-Trace": "1"})
-
-    assert clone.thing is not original
-    assert clone.thing.platform is clone
-    assert original.platform is client
-
-
-@pytest.mark.parametrize("client_factory", [NemoClient, AsyncNemoClient])
-def test_cloned_resource_sees_overridden_options(client_factory, discovered) -> None:
-    """The whole point of the clone: overrides must reach the resource."""
-    client = client_factory(base_url=BASE)
-    _ = client.thing  # prime the cache before cloning
-
-    clone = client.with_headers({"X-Trace": "1"})
-
-    assert clone.thing.platform.default_headers == {"X-Trace": "1"}
-    assert client.thing.platform.default_headers == {}
-
-
-@pytest.mark.parametrize("client_factory", [NemoClient, AsyncNemoClient])
-def test_resource_is_cached_within_one_client(client_factory, discovered) -> None:
-    client = client_factory(base_url=BASE)
-
-    assert client.thing is client.thing
-
-
-@pytest.mark.parametrize("client_factory", [NemoClient, AsyncNemoClient])
-def test_unknown_attribute_still_raises(client_factory, discovered) -> None:
+def test_unknown_attribute_still_raises(client_factory) -> None:
     client = client_factory(base_url=BASE)
 
     with pytest.raises(AttributeError, match="nope"):
@@ -204,7 +146,7 @@ def test_unknown_attribute_still_raises(client_factory, discovered) -> None:
 
 
 def test_raw_client_calls_are_authenticated() -> None:
-    """Plugin resources using platform._client bypass send() but keep auth."""
+    """Plugin resources using owner._client bypass send() but keep auth."""
     seen: list[httpx.Request] = []
 
     def handler(request: httpx.Request) -> httpx.Response:

--- a/packages/nemo_platform_plugin/tests/test_discovery.py
+++ b/packages/nemo_platform_plugin/tests/test_discovery.py
@@ -81,6 +81,10 @@ def _make_cli_cls() -> type[_MinimalPluginCLI]:
     return _MinimalPluginCLI
 
 
+def _make_sdk_resource(_owner: object) -> object:
+    return object()
+
+
 class _MinimalPluginJob(NemoJob):
     name = "test-job"
     description = "A test job"
@@ -523,14 +527,14 @@ class TestDiscoverSDK:
         mock_eps.assert_called_once_with(group="nemo.sdk")
 
     def test_accepts_sync_only_container(self) -> None:
-        container = NemoPluginSDKResources(sync_resource=object)  # ty: ignore[invalid-argument-type]
+        container = NemoPluginSDKResources(sync_resource=_make_sdk_resource)
         ep = _make_ep("example", container)
         with patch("nemo_platform_plugin.discovery.entry_points", return_value=[ep]):
             result = discover_sdk()
         assert result["example"] is container
 
     def test_accepts_async_only_container(self) -> None:
-        container = NemoPluginSDKResources(async_resource=object)  # ty: ignore[invalid-argument-type]
+        container = NemoPluginSDKResources(async_resource=_make_sdk_resource)
         ep = _make_ep("example", container)
         with patch("nemo_platform_plugin.discovery.entry_points", return_value=[ep]):
             result = discover_sdk()
@@ -542,7 +546,7 @@ class TestDiscoverSDK:
 
     def test_skips_entry_that_is_not_a_container(self) -> None:
         bad = _make_ep("bad", SimpleNamespace(sync_resource=object))
-        good = _make_ep("good", NemoPluginSDKResources(sync_resource=object))  # ty: ignore[invalid-argument-type]
+        good = _make_ep("good", NemoPluginSDKResources(sync_resource=_make_sdk_resource))
         with patch("nemo_platform_plugin.discovery.entry_points", return_value=[bad, good]):
             result = discover_sdk()
         assert "bad" not in result

--- a/packages/nmp_customization_common/src/nmp/customization_common/cli/overrides.py
+++ b/packages/nmp_customization_common/src/nmp/customization_common/cli/overrides.py
@@ -3,18 +3,18 @@
 
 """Shared CLI override machinery for customization contributor plugins.
 
-After the platform's ``_add_run_command`` / ``_add_submit_command`` register the
-default verbs, both backends swap in the same shapes:
+After the platform's ``_add_submit_command`` registers the default submit verb,
+Customizer backends swap in the same shape:
 
 - ``submit`` → positional ``JOB_JSON`` argument plus standard submit flags;
   loads + validates the JSON (via the backend's ``load_job_json``), then
   delegates to the original ``submit`` callback with ``--spec`` set.
-- ``run`` → hard-fails with a "submit-only" message (these backends run
-  remotely in a container, not locally).
+- any pre-existing generated ``run`` command is removed; Customizer jobs are
+  submitted to the platform, not executed through local CLI scheduling.
 - ``explain`` → unchanged.
 
-Only the backend's ``load_job_json``, the ``JOB_JSON`` help text, and the
-run-disabled message differ; everything else is shared here.
+Only the backend's ``load_job_json`` and the ``JOB_JSON`` help text differ;
+everything else is shared here.
 """
 
 from collections.abc import Callable
@@ -30,15 +30,14 @@ def apply_job_cli_overrides(
     *,
     load_job_json: LoadJobJson,
     job_json_help: str,
-    run_disabled_message: str,
 ) -> None:
-    """Drop the default ``run``/``submit`` verbs, then re-register the overrides.
+    """Drop generated ``run``/``submit`` verbs, then re-register submit.
 
     Order matters: drop first, then re-register. Typer iterates
     ``registered_commands`` in insertion order, so stale entries would route
     users back to the auto-generated shapes.
     """
-    _replace_job_run_disabled(group, job_json_help, run_disabled_message)
+    _drop_command(group, "run")
     _replace_job_submit(group, load_job_json, job_json_help)
 
 
@@ -51,19 +50,6 @@ def _pluck_callback(group: typer.Typer, verb: str) -> Callable[..., None]:
 
 def _drop_command(group: typer.Typer, name: str) -> None:
     group.registered_commands = [c for c in group.registered_commands if c.name != name]
-
-
-def _replace_job_run_disabled(group: typer.Typer, job_json_help: str, run_disabled_message: str) -> None:
-    """Replace ``run`` with a hard-fail explainer (these backends are submit-only)."""
-    _drop_command(group, "run")
-
-    @group.command("run")
-    def run(
-        _typer_ctx: typer.Context,
-        _job_json: Path | None = typer.Argument(None, metavar="JOB_JSON", help=job_json_help),
-    ) -> None:
-        typer.secho(run_disabled_message, err=True, fg=typer.colors.RED)
-        raise typer.Exit(code=1)
 
 
 def _replace_job_submit(group: typer.Typer, load_job_json: LoadJobJson, job_json_help: str) -> None:

--- a/packages/nmp_customization_common/src/nmp/customization_common/contributor/base.py
+++ b/packages/nmp_customization_common/src/nmp/customization_common/contributor/base.py
@@ -42,7 +42,7 @@ class BaseContributor:
         raise NotImplementedError
 
     def apply_cli_overrides(self, app: typer.Typer) -> None:
-        """Apply backend-specific submit/run CLI overrides. Overridden per backend."""
+        """Apply backend-specific submit CLI overrides. Overridden per backend."""
         raise NotImplementedError
 
     @property
@@ -86,17 +86,15 @@ class BaseContributor:
         ]
 
     def get_cli(self) -> typer.Typer:
-        """Compose run/submit/explain verbs, then apply backend-specific overrides."""
+        """Compose submit/explain verbs, then apply backend-specific overrides."""
         from nemo_platform_plugin.commands import (
             _add_explain_command,
-            _add_run_command,
             _add_submit_command,
         )
         from nemo_platform_plugin.scheduler import NemoJobScheduler
 
         app = typer.Typer(name=self.name, help=self.cli_help, no_args_is_help=True)
         scheduler = NemoJobScheduler()
-        _add_run_command(app, self.job_cls, scheduler)
         _add_submit_command(app, self.job_cls, scheduler)
         _add_explain_command(app, self.job_cls, scheduler)
         self.apply_cli_overrides(app)

--- a/packages/nmp_customization_common/src/nmp/customization_common/sdk/client.py
+++ b/packages/nmp_customization_common/src/nmp/customization_common/sdk/client.py
@@ -1,309 +1,422 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Parametrized customization jobs-collection SDK client.
+"""Parametrized typed SDK resources for Customizer backend job collections.
 
-Both the unsloth and automodel contributor plugins expose an identical
-``client.customization.<backend>`` SDK namespace — a jobs collection whose only
-backend-specific variable is the route segment (``unsloth`` / ``automodel``).
-This module collapses the three previously-duplicated SDK files
-(``http_utils`` / ``job_resources`` / ``resources``) into one factory.
+Automodel, Unsloth, and RL expose the same public SDK shape:
+``client.customization.<backend>.jobs``. The only backend-specific value is
+the route segment under ``/apis/customization/v2/workspaces/{workspace}``.
 
-Each plugin keeps a thin ``nemo_<svc>_plugin/sdk/resources.py`` shim that calls
-:func:`make_customization_sdk` and re-exports ``<Svc>Customization`` /
-``Async<Svc>Customization`` — the symbols the ``nemo-customizer`` SDK hub imports
-by string.
+This module keeps that shared shape in one factory instead of duplicating
+``resources.py`` implementations in each backend plugin. The backend plugins
+remain thin shims that call :func:`make_customization_sdk` and re-export the
+``<Backend>Customization`` / ``Async<Backend>Customization`` symbols imported
+by the ``nemo-customizer`` SDK hub.
+
+Route-specific create/list/retrieve calls delegate to the typed Customizer
+client in this package. Operations already owned by the Jobs service should
+delegate to ``nemo_platform_plugin.jobs.client.JobsClient`` instead of being
+reimplemented here.
 """
 
-from typing import Any, ClassVar
-from urllib.parse import quote, urljoin
+from __future__ import annotations
 
-from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
-from nemo_platform_plugin.jobs.schemas import PlatformJobStatusResponse
+from dataclasses import dataclass
+from typing import Any, ClassVar
+
+from nemo_platform_plugin.client.client import AsyncNemoClient, NemoClient
+from nemo_platform_plugin.client.method import method
+from nemo_platform_plugin.client.response import AsyncNemoPaginatedResponse, NemoPaginatedResponse, NemoResponse
+from nemo_platform_plugin.client.types import CursorPagination
+from nemo_platform_plugin.jobs.client import AsyncJobsClient, JobsClient
+from nemo_platform_plugin.jobs.schemas import (
+    PlatformJobLog,
+    PlatformJobStatusResponse,
+)
+from nemo_platform_plugin.jobs.types import JobLogsQueryParams
+from nmp.customization_common.sdk import endpoints
+from nmp.customization_common.sdk.types import (
+    CustomizationJob,
+    CustomizationJobCreateRequest,
+    ListCustomizationJobsQueryParams,
+)
 from pydantic import BaseModel
 
-PlatformClient = NeMoPlatform | AsyncNeMoPlatform
 
-_API_PREFIX = "/apis/customization"
-
-
-# --------------------------------------------------------------------------- #
-# URL / payload helpers
-# --------------------------------------------------------------------------- #
-def base_url(source: str) -> str:
-    """Return the normalized base URL for a raw URL string."""
-    return source.rstrip("/")
+class _CustomizationMethods:
+    get_customization_health = method(endpoints.get_customization_health)
+    create_customization_job = method(endpoints.create_customization_job)
+    list_customization_jobs = method(endpoints.list_customization_jobs)
+    get_customization_job = method(endpoints.get_customization_job)
 
 
-def resolve_workspace(platform: PlatformClient, workspace: str | None, strict: bool = False) -> str:
-    """Return the explicit, platform, or default workspace for customization routes."""
-    resolved = workspace or platform.workspace
-    if resolved is None:
-        if strict:
-            raise ValueError("workspace must be provided when the client has no default workspace")
-        return "default"
-    return resolved
+class CustomizationClient(_CustomizationMethods, NemoClient):
+    """Sync typed client for the Customizer router SDK surface."""
 
 
-def _join_url(root: str, relative_path: str) -> str:
-    """Join a root URL and a relative path using URL parsing rules."""
-    return urljoin(f"{base_url(root)}/", relative_path.lstrip("/"))
+class AsyncCustomizationClient(_CustomizationMethods, AsyncNemoClient):
+    """Async typed client for the Customizer router SDK surface."""
 
 
-def url(platform: PlatformClient, path: str, workspace: str | None = None) -> str:
-    """Build a full customization plugin API URL for the provided route path."""
-    resolved_path = path.format(workspace=quote(resolve_workspace(platform, workspace), safe=""))
-    return _join_url(str(platform.base_url), f"{_API_PREFIX}/{resolved_path}")
+@dataclass(frozen=True, slots=True)
+class CustomizationSDKContext:
+    """Typed sync clients shared by one Customizer SDK namespace."""
+
+    customization: CustomizationClient
+    jobs: JobsClient
+    workspace: str | None
 
 
-def jobs_collection_url(platform: PlatformClient, backend: str, workspace: str | None = None) -> str:
-    """URL for the backend's jobs collection in a workspace."""
-    return url(platform, f"v2/workspaces/{{workspace}}/{backend}/jobs", workspace)
+@dataclass(frozen=True, slots=True)
+class AsyncCustomizationSDKContext:
+    """Typed async clients shared by one Customizer SDK namespace."""
+
+    customization: AsyncCustomizationClient
+    jobs: AsyncJobsClient
+    workspace: str | None
 
 
-def job_url(platform: PlatformClient, backend: str, job_name: str, workspace: str | None = None) -> str:
-    """URL for a single backend job."""
-    return _join_url(jobs_collection_url(platform, backend, workspace), quote(job_name, safe=""))
+def make_customization_sdk_context(client: NemoClient) -> CustomizationSDKContext:
+    """Build the typed sync clients used by Customizer backend SDK resources."""
+    return CustomizationSDKContext(
+        customization=CustomizationClient.from_client(client),
+        jobs=JobsClient.from_client(client),
+        workspace=client.workspace,
+    )
 
 
-def platform_default_headers(platform: PlatformClient) -> dict[str, str]:
-    """Return string-valued default platform headers for direct HTTP calls."""
-    return {str(key): value for key, value in platform.default_headers.items() if isinstance(value, str)}
+def make_async_customization_sdk_context(client: AsyncNemoClient) -> AsyncCustomizationSDKContext:
+    """Build the typed async clients used by Customizer backend SDK resources."""
+    return AsyncCustomizationSDKContext(
+        customization=AsyncCustomizationClient.from_client(client),
+        jobs=AsyncJobsClient.from_client(client),
+        workspace=client.workspace,
+    )
 
 
-def create_job_payload(spec: BaseModel) -> dict[str, Any]:
-    """Serialize a job creation request body."""
-    return {"spec": spec.model_dump(mode="json")}
+def _spec_payload(spec: BaseModel | dict[str, Any]) -> dict[str, Any]:
+    if isinstance(spec, BaseModel):
+        return spec.model_dump(mode="json")
+    return spec
 
 
-def _job_status_path(root: str, backend: str, workspace: str, job_name: str) -> str:
-    encoded_workspace = quote(workspace, safe="")
-    encoded_job = quote(job_name, safe="")
-    return f"{base_url(root)}/apis/customization/v2/workspaces/{encoded_workspace}/{backend}/jobs/{encoded_job}"
+def _create_request(
+    spec: BaseModel | dict[str, Any],
+    *,
+    name: str | None,
+    description: str | None,
+    project: str | None,
+    profile: str | None,
+    options: dict[str, Any] | None,
+    ownership: dict[str, Any] | None,
+    custom_fields: dict[str, Any] | None,
+    output_location: str | None,
+) -> CustomizationJobCreateRequest:
+    body: dict[str, Any] = {"spec": _spec_payload(spec)}
+    for key, value in (
+        ("name", name),
+        ("description", description),
+        ("project", project),
+        ("profile", profile),
+        ("options", options),
+        ("ownership", ownership),
+        ("custom_fields", custom_fields),
+        ("output_location", output_location),
+    ):
+        if value is not None:
+            body[key] = value
+    return CustomizationJobCreateRequest.model_validate(body)
 
 
-# --------------------------------------------------------------------------- #
-# Job records / resources
-# --------------------------------------------------------------------------- #
-class JobRecord(BaseModel):
-    """Minimal job record returned by the customization jobs API."""
-
-    name: str
-    workspace: str
-    status: str | None = None
-    spec: dict[str, Any] | None = None
-
-
-class JobResource:
-    """Sync handle for one submitted job."""
-
-    def __init__(
-        self,
-        backend: str,
-        job: JobRecord,
-        http_client: Any,
-        base_url: str,
-        workspace: str,
-        headers: dict[str, str],
-    ) -> None:
-        self._backend = backend
-        self.job = job
-        self._http_client = http_client
-        self._base_url = base_url
-        self._workspace = workspace
-        self._headers = headers
-
-    def get_status(self) -> PlatformJobStatusResponse:
-        """Fetch current job status."""
-        response = self._http_client.get(
-            _job_status_path(self._base_url, self._backend, self._workspace, self.job.name),
-            headers=self._headers,
-        )
-        response.raise_for_status()
-        return PlatformJobStatusResponse.model_validate(response.json())
+def _list_jobs_query_params(
+    *,
+    page: int | None,
+    page_size: int | None,
+    sort: str | None,
+    filter: str | None,
+) -> ListCustomizationJobsQueryParams | None:
+    query_params: ListCustomizationJobsQueryParams = {}
+    if page is not None:
+        query_params["page"] = page
+    if page_size is not None:
+        query_params["page_size"] = page_size
+    if sort is not None:
+        query_params["sort"] = sort
+    if filter is not None:
+        query_params["filter"] = filter
+    return query_params or None
 
 
-class AsyncJobResource:
-    """Async handle for one submitted job."""
-
-    def __init__(
-        self,
-        backend: str,
-        job: JobRecord,
-        http_client: Any,
-        base_url: str,
-        workspace: str,
-        headers: dict[str, str],
-    ) -> None:
-        self._backend = backend
-        self.job = job
-        self._http_client = http_client
-        self._base_url = base_url
-        self._workspace = workspace
-        self._headers = headers
-
-    async def get_status(self) -> PlatformJobStatusResponse:
-        """Fetch current job status."""
-        response = await self._http_client.get(
-            _job_status_path(self._base_url, self._backend, self._workspace, self.job.name),
-            headers=self._headers,
-        )
-        response.raise_for_status()
-        return PlatformJobStatusResponse.model_validate(response.json())
+def _job_logs_query_params(
+    *,
+    limit: int | None,
+    page_cursor: str | None,
+    attempt_id: int | None,
+    step_id: str | None,
+    task_id: str | None,
+) -> JobLogsQueryParams | None:
+    query_params: JobLogsQueryParams = {}
+    if limit is not None:
+        query_params["limit"] = limit
+    if page_cursor is not None:
+        query_params["page_cursor"] = page_cursor
+    if attempt_id is not None:
+        query_params["attempt_id"] = attempt_id
+    if step_id is not None:
+        query_params["step_id"] = step_id
+    if task_id is not None:
+        query_params["task_id"] = task_id
+    return query_params or None
 
 
-# --------------------------------------------------------------------------- #
-# Jobs collection + customization namespaces (parametrized by backend)
-# --------------------------------------------------------------------------- #
-class _JobsResourceBase:
-    backend: ClassVar[str]
-    record_schema: ClassVar[type[JobRecord]] = JobRecord
-
-    _platform: PlatformClient
-    # Sync subclass holds an httpx.Client, async holds an httpx.AsyncClient; typed
-    # Any so the shared sync/async method bodies (await vs no-await) both check.
-    _http_client: Any
-
-    def __init__(self, platform: PlatformClient) -> None:
-        self._platform = platform
-        self._http_client = platform._client
-
-    def _new_record(self, payload: Any) -> JobRecord:
-        return self.record_schema.model_validate(payload)
-
-
-class JobsResource(_JobsResourceBase):
+class JobsResource:
     """Sync SDK namespace at ``client.customization.<backend>.jobs``."""
+
+    backend: ClassVar[str]
+
+    def __init__(self, context: CustomizationSDKContext) -> None:
+        self._customization = context.customization
+        self._jobs = context.jobs
 
     def create(
         self,
-        spec: BaseModel,
+        spec: BaseModel | dict[str, Any],
         workspace: str | None = None,
         name: str | None = None,
-    ) -> JobResource:
-        """Submit a training job to the platform GPU cluster."""
-        body: dict[str, Any] = create_job_payload(spec)
-        if name is not None:
-            body["name"] = name
-        response = self._http_client.post(
-            jobs_collection_url(self._platform, self.backend, workspace),
-            json=body,
-            headers=platform_default_headers(self._platform),
+        *,
+        description: str | None = None,
+        project: str | None = None,
+        profile: str | None = None,
+        options: dict[str, Any] | None = None,
+        ownership: dict[str, Any] | None = None,
+        custom_fields: dict[str, Any] | None = None,
+        output_location: str | None = None,
+    ) -> NemoResponse[CustomizationJob]:
+        """Submit a training job through the Customizer backend route."""
+        body = _create_request(
+            spec,
+            name=name,
+            description=description,
+            project=project,
+            profile=profile,
+            options=options,
+            ownership=ownership,
+            custom_fields=custom_fields,
+            output_location=output_location,
         )
-        response.raise_for_status()
-        resolved_ws = resolve_workspace(self._platform, workspace)
-        return JobResource(
+        return self._customization.create_customization_job(
+            workspace=workspace,
             backend=self.backend,
-            job=self._new_record(response.json()),
-            http_client=self._http_client,
-            base_url=base_url(str(self._platform.base_url)),
-            workspace=resolved_ws,
-            headers=platform_default_headers(self._platform),
+            body=body,
         )
 
-    def get_job_resource(self, job_name: str, workspace: str | None = None) -> JobResource:
-        """Get a resource handle for an existing job."""
-        resolved_ws = resolve_workspace(self._platform, workspace)
-        response = self._http_client.get(
-            job_url(self._platform, self.backend, job_name, resolved_ws),
-            headers=platform_default_headers(self._platform),
-        )
-        response.raise_for_status()
-        return JobResource(
+    def list(
+        self,
+        *,
+        workspace: str | None = None,
+        page: int | None = None,
+        page_size: int | None = None,
+        sort: str | None = None,
+        filter: str | None = None,
+    ) -> NemoPaginatedResponse[CustomizationJob]:
+        """List backend jobs through the Customizer route."""
+        return self._customization.list_customization_jobs(
+            workspace=workspace,
             backend=self.backend,
-            job=self._new_record(response.json()),
-            http_client=self._http_client,
-            base_url=base_url(str(self._platform.base_url)),
-            workspace=resolved_ws,
-            headers=platform_default_headers(self._platform),
+            query_params=_list_jobs_query_params(
+                page=page,
+                page_size=page_size,
+                sort=sort,
+                filter=filter,
+            ),
+        )
+
+    def retrieve(self, name: str, *, workspace: str | None = None) -> NemoResponse[CustomizationJob]:
+        """Retrieve one backend job through the Customizer route."""
+        return self._customization.get_customization_job(
+            workspace=workspace,
+            backend=self.backend,
+            name=name,
+        )
+
+    def get_job_resource(self, job_name: str, workspace: str | None = None) -> NemoResponse[CustomizationJob]:
+        """Compatibility alias for ``retrieve``; returns the typed response."""
+        return self.retrieve(job_name, workspace=workspace)
+
+    def get_status(self, name: str, *, workspace: str | None = None) -> NemoResponse[PlatformJobStatusResponse]:
+        """Fetch current job status from the core Jobs service."""
+        return self._jobs.get_job_status(name=name, workspace=workspace)
+
+    def get_logs(
+        self,
+        name: str,
+        *,
+        workspace: str | None = None,
+        limit: int | None = None,
+        page_cursor: str | None = None,
+        attempt_id: int | None = None,
+        step_id: str | None = None,
+        task_id: str | None = None,
+    ) -> NemoPaginatedResponse[PlatformJobLog, CursorPagination]:
+        """Fetch job logs from the core Jobs service."""
+        return self._jobs.list_job_logs(
+            name=name,
+            workspace=workspace,
+            query_params=_job_logs_query_params(
+                limit=limit,
+                page_cursor=page_cursor,
+                attempt_id=attempt_id,
+                step_id=step_id,
+                task_id=task_id,
+            ),
         )
 
 
-class AsyncJobsResource(_JobsResourceBase):
+class AsyncJobsResource:
     """Async SDK namespace at ``client.customization.<backend>.jobs``."""
+
+    backend: ClassVar[str]
+
+    def __init__(self, context: AsyncCustomizationSDKContext) -> None:
+        self._customization = context.customization
+        self._jobs = context.jobs
 
     async def create(
         self,
-        spec: BaseModel,
+        spec: BaseModel | dict[str, Any],
         workspace: str | None = None,
         name: str | None = None,
-    ) -> AsyncJobResource:
-        """Submit a training job to the platform GPU cluster."""
-        body: dict[str, Any] = create_job_payload(spec)
-        if name is not None:
-            body["name"] = name
-        response = await self._http_client.post(
-            jobs_collection_url(self._platform, self.backend, workspace),
-            json=body,
-            headers=platform_default_headers(self._platform),
+        *,
+        description: str | None = None,
+        project: str | None = None,
+        profile: str | None = None,
+        options: dict[str, Any] | None = None,
+        ownership: dict[str, Any] | None = None,
+        custom_fields: dict[str, Any] | None = None,
+        output_location: str | None = None,
+    ) -> NemoResponse[CustomizationJob]:
+        """Submit a training job through the Customizer backend route."""
+        body = _create_request(
+            spec,
+            name=name,
+            description=description,
+            project=project,
+            profile=profile,
+            options=options,
+            ownership=ownership,
+            custom_fields=custom_fields,
+            output_location=output_location,
         )
-        response.raise_for_status()
-        resolved_ws = resolve_workspace(self._platform, workspace)
-        return AsyncJobResource(
+        return await self._customization.create_customization_job(
+            workspace=workspace,
             backend=self.backend,
-            job=self._new_record(response.json()),
-            http_client=self._http_client,
-            base_url=base_url(str(self._platform.base_url)),
-            workspace=resolved_ws,
-            headers=platform_default_headers(self._platform),
+            body=body,
         )
 
-    async def get_job_resource(self, job_name: str, workspace: str | None = None) -> AsyncJobResource:
-        """Get a resource handle for an existing job."""
-        resolved_ws = resolve_workspace(self._platform, workspace)
-        response = await self._http_client.get(
-            job_url(self._platform, self.backend, job_name, resolved_ws),
-            headers=platform_default_headers(self._platform),
-        )
-        response.raise_for_status()
-        return AsyncJobResource(
+    async def list(
+        self,
+        *,
+        workspace: str | None = None,
+        page: int | None = None,
+        page_size: int | None = None,
+        sort: str | None = None,
+        filter: str | None = None,
+    ) -> AsyncNemoPaginatedResponse[CustomizationJob]:
+        """List backend jobs through the Customizer route."""
+        return await self._customization.list_customization_jobs(
+            workspace=workspace,
             backend=self.backend,
-            job=self._new_record(response.json()),
-            http_client=self._http_client,
-            base_url=base_url(str(self._platform.base_url)),
-            workspace=resolved_ws,
-            headers=platform_default_headers(self._platform),
+            query_params=_list_jobs_query_params(
+                page=page,
+                page_size=page_size,
+                sort=sort,
+                filter=filter,
+            ),
+        )
+
+    async def retrieve(self, name: str, *, workspace: str | None = None) -> NemoResponse[CustomizationJob]:
+        """Retrieve one backend job through the Customizer route."""
+        return await self._customization.get_customization_job(
+            workspace=workspace,
+            backend=self.backend,
+            name=name,
+        )
+
+    async def get_job_resource(self, job_name: str, workspace: str | None = None) -> NemoResponse[CustomizationJob]:
+        """Compatibility alias for ``retrieve``; returns the typed response."""
+        return await self.retrieve(job_name, workspace=workspace)
+
+    async def get_status(self, name: str, *, workspace: str | None = None) -> NemoResponse[PlatformJobStatusResponse]:
+        """Fetch current job status from the core Jobs service."""
+        return await self._jobs.get_job_status(name=name, workspace=workspace)
+
+    async def get_logs(
+        self,
+        name: str,
+        *,
+        workspace: str | None = None,
+        limit: int | None = None,
+        page_cursor: str | None = None,
+        attempt_id: int | None = None,
+        step_id: str | None = None,
+        task_id: str | None = None,
+    ) -> AsyncNemoPaginatedResponse[PlatformJobLog, CursorPagination]:
+        """Fetch job logs from the core Jobs service."""
+        return await self._jobs.list_job_logs(
+            name=name,
+            workspace=workspace,
+            query_params=_job_logs_query_params(
+                limit=limit,
+                page_cursor=page_cursor,
+                attempt_id=attempt_id,
+                step_id=step_id,
+                task_id=task_id,
+            ),
         )
 
 
-class _CustomizationBase:
+class CustomizationBackendResource:
     backend: ClassVar[str]
-    jobs_resource_cls: ClassVar[type[_JobsResourceBase]]
+    jobs_resource_cls: ClassVar[type[JobsResource]]
 
-    def __init__(self, platform: PlatformClient) -> None:
-        self.jobs = self.jobs_resource_cls(platform)
+    def __init__(self, context: CustomizationSDKContext) -> None:
+        self.jobs: JobsResource
+        self.jobs = self.jobs_resource_cls(context)
+
+
+class AsyncCustomizationBackendResource:
+    backend: ClassVar[str]
+    jobs_resource_cls: ClassVar[type[AsyncJobsResource]]
+
+    def __init__(self, context: AsyncCustomizationSDKContext) -> None:
+        self.jobs: AsyncJobsResource
+        self.jobs = self.jobs_resource_cls(context)
 
 
 def make_customization_sdk(
     backend: str,
-    record_schema: type[JobRecord] = JobRecord,
-) -> tuple[type[_CustomizationBase], type[_CustomizationBase]]:
-    """Build the sync + async ``<Backend>Customization`` SDK namespace classes.
-
-    Returns a ``(sync_cls, async_cls)`` tuple. Each class takes a platform client
-    and exposes ``.jobs`` — matching the shape the ``nemo-customizer`` SDK hub
-    instantiates as ``client.customization.<backend>``.
-    """
+) -> tuple[type[CustomizationBackendResource], type[AsyncCustomizationBackendResource]]:
+    """Build the sync + async ``<Backend>Customization`` SDK namespace classes."""
     title = backend.capitalize()
 
     sync_jobs = type(
         f"{title}JobsResource",
         (JobsResource,),
-        {"backend": backend, "record_schema": record_schema},
+        {"backend": backend},
     )
     async_jobs = type(
         f"Async{title}JobsResource",
         (AsyncJobsResource,),
-        {"backend": backend, "record_schema": record_schema},
+        {"backend": backend},
     )
     sync_cls = type(
         f"{title}Customization",
-        (_CustomizationBase,),
+        (CustomizationBackendResource,),
         {"backend": backend, "jobs_resource_cls": sync_jobs},
     )
     async_cls = type(
         f"Async{title}Customization",
-        (_CustomizationBase,),
+        (AsyncCustomizationBackendResource,),
         {"backend": backend, "jobs_resource_cls": async_jobs},
     )
     return sync_cls, async_cls

--- a/packages/nmp_customization_common/src/nmp/customization_common/sdk/endpoints.py
+++ b/packages/nmp_customization_common/src/nmp/customization_common/sdk/endpoints.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Typed endpoint definitions for the Customizer SDK routes."""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+
+from nemo_platform_plugin.client.endpoint import get, post
+from nemo_platform_plugin.client.types import Paginated
+from nmp.customization_common.sdk.types import (
+    CustomizationHealthResponse,
+    CustomizationJob,
+    CustomizationJobCreateRequest,
+    ListCustomizationJobsQueryParams,
+)
+
+
+@get("/apis/customization/v2/healthz")
+@abstractmethod
+def get_customization_health() -> CustomizationHealthResponse: ...
+
+
+@post("/apis/customization/v2/workspaces/{workspace}/{backend}/jobs")
+@abstractmethod
+def create_customization_job(
+    *,
+    workspace: str | None = None,
+    backend: str,
+    body: CustomizationJobCreateRequest,
+) -> CustomizationJob: ...
+
+
+@get("/apis/customization/v2/workspaces/{workspace}/{backend}/jobs")
+@abstractmethod
+def list_customization_jobs(
+    *,
+    workspace: str | None = None,
+    backend: str,
+    query_params: ListCustomizationJobsQueryParams | None = None,
+) -> Paginated[CustomizationJob]: ...
+
+
+@get("/apis/customization/v2/workspaces/{workspace}/{backend}/jobs/{name}")
+@abstractmethod
+def get_customization_job(
+    *,
+    workspace: str | None = None,
+    backend: str,
+    name: str,
+) -> CustomizationJob: ...

--- a/packages/nmp_customization_common/src/nmp/customization_common/sdk/types.py
+++ b/packages/nmp_customization_common/src/nmp/customization_common/sdk/types.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Typed DTOs for the Customizer SDK routes."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, NotRequired, Self, TypedDict
+
+from nemo_platform_plugin.jobs.schemas import PlatformJobStatus
+from nemo_platform_plugin.jobs.types import validate_output_location
+from pydantic import BaseModel, Field, field_validator
+
+
+class CustomizationHealthResponse(BaseModel):
+    """Health payload returned by the Customizer router."""
+
+    plugin: str
+    status: str
+    contributors: list[str] = Field(default_factory=list)
+
+
+class CustomizationJobCreateRequest(BaseModel):
+    """Body accepted by each customization backend job collection."""
+
+    name: str | None = None
+    description: str | None = None
+    project: str | None = None
+    spec: dict[str, Any]
+    profile: str | None = None
+    options: dict[str, Any] | None = None
+    ownership: dict[str, Any] | None = None
+    custom_fields: dict[str, Any] | None = None
+    output_location: str | None = None
+
+    _validate_output_location = field_validator("output_location")(validate_output_location)
+
+
+class CustomizationJob(BaseModel):
+    """Backend-specific Customizer job response."""
+
+    id: str | None = None
+    name: str
+    description: str | None = None
+    project: str | None = None
+    workspace: str | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+    spec: dict[str, Any] = Field(default_factory=dict)
+    status: PlatformJobStatus | None = None
+    status_details: dict[str, Any] | None = None
+    error_details: dict[str, Any] | None = None
+    ownership: dict[str, Any] | None = None
+    custom_fields: dict[str, Any] | None = None
+
+    @property
+    def job(self) -> Self:
+        """Compatibility alias for the pre-typed-SDK job handle shape."""
+        return self
+
+
+class ListCustomizationJobsQueryParams(TypedDict, total=False):
+    page: NotRequired[int]
+    page_size: NotRequired[int]
+    sort: NotRequired[str]
+    filter: NotRequired[str]
+
+
+__all__ = [
+    "CustomizationHealthResponse",
+    "CustomizationJob",
+    "CustomizationJobCreateRequest",
+    "ListCustomizationJobsQueryParams",
+]

--- a/packages/nmp_customization_common/tests/sdk/test_client.py
+++ b/packages/nmp_customization_common/tests/sdk/test_client.py
@@ -1,0 +1,355 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import get_origin
+
+import httpx
+from nemo_platform_plugin.client.types import Paginated, PreparedRequest
+from nemo_platform_plugin.jobs.schemas import PlatformJobStatus, PlatformJobStatusResponse
+from pydantic import BaseModel
+
+
+class _Spec(BaseModel):
+    model: str
+
+
+def _status_response(status: PlatformJobStatus = PlatformJobStatus.COMPLETED) -> PlatformJobStatusResponse:
+    now = datetime.now(timezone.utc)
+    return PlatformJobStatusResponse(
+        id="job-id",
+        name="job-a",
+        status=status,
+        status_details={},
+        error_details=None,
+        steps=[],
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def test_create_customization_job_endpoint_shape() -> None:
+    from nmp.customization_common.sdk import endpoints
+    from nmp.customization_common.sdk.types import CustomizationJob, CustomizationJobCreateRequest
+
+    body = CustomizationJobCreateRequest(
+        name="job-a",
+        spec={"model": "default/qwen"},
+        profile="gpu",
+        options={"kubernetes": {"priority": "normal"}},
+    )
+
+    prepared = endpoints.create_customization_job(
+        workspace="team-a",
+        backend="automodel",
+        body=body,
+    )
+
+    assert isinstance(prepared, PreparedRequest)
+    assert prepared.method == "POST"
+    assert prepared.path_template == "/apis/customization/v2/workspaces/{workspace}/{backend}/jobs"
+    assert prepared.path_params == {"workspace": "team-a", "backend": "automodel"}
+    assert isinstance(prepared.content, bytes)
+    assert json.loads(prepared.content) == {
+        "name": "job-a",
+        "spec": {"model": "default/qwen"},
+        "profile": "gpu",
+        "options": {"kubernetes": {"priority": "normal"}},
+    }
+    assert prepared.response_type is CustomizationJob
+
+
+def test_customization_job_preserves_legacy_job_alias() -> None:
+    from nmp.customization_common.sdk.types import CustomizationJob
+
+    job = CustomizationJob(name="job-a", spec={"model": "default/qwen"})
+
+    assert job.job is job
+
+
+def test_list_customization_jobs_endpoint_shape() -> None:
+    from nmp.customization_common.sdk import endpoints
+
+    prepared = endpoints.list_customization_jobs(
+        workspace="team-a",
+        backend="unsloth",
+        query_params={"page": 2, "page_size": 25, "sort": "-created_at", "filter": '{"status":"completed"}'},
+    )
+
+    assert prepared.method == "GET"
+    assert prepared.path_template == "/apis/customization/v2/workspaces/{workspace}/{backend}/jobs"
+    assert prepared.path_params == {"workspace": "team-a", "backend": "unsloth"}
+    assert prepared.query_params == {
+        "page": 2,
+        "page_size": 25,
+        "sort": "-created_at",
+        "filter": '{"status":"completed"}',
+    }
+    assert get_origin(prepared.response_type) is Paginated
+
+
+def test_get_customization_job_endpoint_shape() -> None:
+    from nmp.customization_common.sdk import endpoints
+    from nmp.customization_common.sdk.types import CustomizationJob
+
+    prepared = endpoints.get_customization_job(
+        workspace="team-a",
+        backend="rl",
+        name="job-a",
+    )
+
+    assert prepared.method == "GET"
+    assert prepared.path_template == "/apis/customization/v2/workspaces/{workspace}/{backend}/jobs/{name}"
+    assert prepared.path_params == {
+        "workspace": "team-a",
+        "backend": "rl",
+        "name": "job-a",
+    }
+    assert prepared.response_type is CustomizationJob
+
+
+def test_jobs_resource_create_delegates_to_typed_customization_client() -> None:
+    from nemo_platform_plugin.client.client import NemoClient
+    from nmp.customization_common.sdk.client import make_customization_sdk, make_customization_sdk_context
+    from nmp.customization_common.sdk.types import CustomizationJob
+
+    captured: list[httpx.Request] = []
+    returned = CustomizationJob(
+        id="job-id",
+        name="job-a",
+        workspace="team-a",
+        spec={"model": "default/qwen"},
+        status=PlatformJobStatus.CREATED,
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(201, json=returned.model_dump(mode="json"))
+
+    owner = NemoClient(
+        base_url="http://nmp.test",
+        workspace="team-a",
+        http_client=httpx.Client(transport=httpx.MockTransport(handler)),
+    )
+    Customization, _AsyncCustomization = make_customization_sdk("automodel")
+    resource = Customization(make_customization_sdk_context(owner))
+    response = resource.jobs.create(
+        spec=_Spec(model="default/qwen"),
+        workspace="team-a",
+        name="job-a",
+        profile="gpu",
+        options={"docker": {"network": "bridge"}},
+    )
+
+    assert response.data() == returned
+    assert len(captured) == 1
+    assert captured[0].method == "POST"
+    assert str(captured[0].url) == "http://nmp.test/apis/customization/v2/workspaces/team-a/automodel/jobs"
+    assert json.loads(captured[0].content) == {
+        "name": "job-a",
+        "spec": {"model": "default/qwen"},
+        "profile": "gpu",
+        "options": {"docker": {"network": "bridge"}},
+    }
+
+
+def test_jobs_resource_get_status_uses_core_jobs_client() -> None:
+    from nemo_platform_plugin.client.client import NemoClient
+    from nmp.customization_common.sdk.client import make_customization_sdk, make_customization_sdk_context
+
+    status = _status_response()
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, json=status.model_dump(mode="json"))
+
+    owner = NemoClient(
+        base_url="http://nmp.test",
+        workspace="team-a",
+        http_client=httpx.Client(transport=httpx.MockTransport(handler)),
+    )
+    Customization, _AsyncCustomization = make_customization_sdk("automodel")
+    resource = Customization(make_customization_sdk_context(owner))
+
+    assert resource.jobs.get_status("job-a", workspace="team-a").data() == status
+    assert len(captured) == 1
+    assert str(captured[0].url) == "http://nmp.test/apis/jobs/v2/workspaces/team-a/jobs/job-a/status"
+
+
+def test_jobs_resource_get_logs_uses_core_jobs_client() -> None:
+    from nemo_platform_plugin.client.client import NemoClient
+    from nmp.customization_common.sdk.client import make_customization_sdk, make_customization_sdk_context
+
+    now = datetime.now(timezone.utc)
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "data": [
+                    {
+                        "timestamp": now.isoformat(),
+                        "job": "job-a",
+                        "job_step": "train",
+                        "job_task": "task-1",
+                        "message": "hello",
+                    }
+                ],
+                "total": 1,
+                "next_page": None,
+                "prev_page": None,
+            },
+        )
+
+    owner = NemoClient(
+        base_url="http://nmp.test",
+        workspace="team-a",
+        http_client=httpx.Client(transport=httpx.MockTransport(handler)),
+    )
+    Customization, _AsyncCustomization = make_customization_sdk("automodel")
+    resource = Customization(make_customization_sdk_context(owner))
+
+    page = resource.jobs.get_logs(
+        "job-a",
+        workspace="team-a",
+        limit=50,
+        page_cursor="cursor-1",
+        attempt_id=3,
+        step_id="train",
+        task_id="task-1",
+    ).page()
+
+    assert page.items[0].message == "hello"
+    assert page.metadata == {"total": 1, "next_page": None, "prev_page": None}
+    assert len(captured) == 1
+    assert str(captured[0].url) == (
+        "http://nmp.test/apis/jobs/v2/workspaces/team-a/jobs/job-a/logs"
+        "?limit=50&page_cursor=cursor-1&attempt_id=3&step_id=train&task_id=task-1"
+    )
+
+
+def test_sync_customization_resource_accepts_typed_nemo_client_owner() -> None:
+    from nemo_platform_plugin.client.client import NemoClient
+    from nmp.customization_common.sdk.client import (
+        CustomizationClient,
+        make_customization_sdk,
+        make_customization_sdk_context,
+    )
+    from nmp.customization_common.sdk.types import CustomizationJob
+
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(
+            201,
+            json={
+                "id": "job-id",
+                "name": "job-a",
+                "workspace": "team-a",
+                "spec": {"model": "default/qwen"},
+                "status": "created",
+            },
+        )
+
+    owner = NemoClient(
+        base_url="http://nmp.test",
+        workspace="team-a",
+        http_client=httpx.Client(transport=httpx.MockTransport(handler)),
+    )
+    Customization, _AsyncCustomization = make_customization_sdk("automodel")
+
+    response = Customization(make_customization_sdk_context(owner)).jobs.create(
+        spec={"model": "default/qwen"},
+        name="job-a",
+    )
+
+    assert isinstance(response.data(), CustomizationJob)
+    assert str(captured[0].url) == "http://nmp.test/apis/customization/v2/workspaces/team-a/automodel/jobs"
+    assert isinstance(CustomizationClient.from_client(owner), CustomizationClient)
+
+
+async def test_async_customization_resource_accepts_typed_nemo_client_owner() -> None:
+    from nemo_platform_plugin.client.client import AsyncNemoClient
+    from nemo_platform_plugin.client.response import AsyncNemoPaginatedResponse, NemoResponse
+    from nmp.customization_common.sdk.client import (
+        AsyncCustomizationClient,
+        make_async_customization_sdk_context,
+        make_customization_sdk,
+    )
+    from nmp.customization_common.sdk.types import CustomizationJob
+
+    captured: list[httpx.Request] = []
+    returned = CustomizationJob(
+        id="job-id",
+        name="job-a",
+        workspace="team-a",
+        spec={"model": "default/qwen"},
+        status=PlatformJobStatus.CREATED,
+    )
+    returned_payload = returned.model_dump(mode="json")
+    status = _status_response()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        path = request.url.path
+        if request.method == "POST" and path == "/apis/customization/v2/workspaces/team-a/automodel/jobs":
+            return httpx.Response(201, json=returned_payload)
+        if request.method == "GET" and path == "/apis/customization/v2/workspaces/team-a/automodel/jobs":
+            return httpx.Response(
+                200,
+                json={
+                    "data": [returned_payload],
+                    "pagination": {
+                        "page": 1,
+                        "page_size": 100,
+                        "current_page_size": 1,
+                        "total_pages": 1,
+                        "total_results": 1,
+                    },
+                },
+            )
+        if request.method == "GET" and path == "/apis/customization/v2/workspaces/team-a/automodel/jobs/job-a":
+            return httpx.Response(200, json=returned_payload)
+        if request.method == "GET" and path == "/apis/jobs/v2/workspaces/team-a/jobs/job-a/status":
+            return httpx.Response(200, json=status.model_dump(mode="json"))
+        return httpx.Response(404, request=request, json={"detail": "unexpected request"})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http_client:
+        owner = AsyncNemoClient(
+            base_url="http://nmp.test",
+            workspace="team-a",
+            http_client=http_client,
+        )
+        _Customization, AsyncCustomization = make_customization_sdk("automodel")
+        resource = AsyncCustomization(make_async_customization_sdk_context(owner))
+
+        create_response = await resource.jobs.create(
+            spec={"model": "default/qwen"},
+            name="job-a",
+        )
+        list_response = await resource.jobs.list(workspace="team-a")
+        retrieve_response = await resource.jobs.retrieve("job-a", workspace="team-a")
+        status_response = await resource.jobs.get_status("job-a", workspace="team-a")
+
+        assert isinstance(create_response, NemoResponse)
+        assert create_response.data() == returned
+        assert isinstance(list_response, AsyncNemoPaginatedResponse)
+        assert list_response.page().items[0] == returned
+        assert isinstance(retrieve_response, NemoResponse)
+        assert retrieve_response.data() == returned
+        assert isinstance(status_response, NemoResponse)
+        assert status_response.data() == status
+        assert isinstance(AsyncCustomizationClient.from_client(owner), AsyncCustomizationClient)
+    assert [str(request.url) for request in captured] == [
+        "http://nmp.test/apis/customization/v2/workspaces/team-a/automodel/jobs",
+        "http://nmp.test/apis/customization/v2/workspaces/team-a/automodel/jobs",
+        "http://nmp.test/apis/customization/v2/workspaces/team-a/automodel/jobs/job-a",
+        "http://nmp.test/apis/jobs/v2/workspaces/team-a/jobs/job-a/status",
+    ]

--- a/plugins/nemo-automodel/README.md
+++ b/plugins/nemo-automodel/README.md
@@ -22,12 +22,6 @@ nemo customization automodel submit path/to/job.json -w acme-corp
 nemo customization automodel submit path/to/job.json --cluster my-cluster
 ```
 
-`run` is registered but **always fails** — Automodel training is submit-only (platform API / Docker GPU jobs), not local subprocess execution:
-
-```bash
-nemo customization automodel run path/to/job.json   # exits with error
-```
-
 Other customization backends may still use `nemo customization <backend> jobs submit ...`.
 
 Job JSON uses the simplified `AutomodelJobInput` schema (see `nemo_automodel_plugin/schema.py`). Submit posts to `/apis/customization/v2/workspaces/{workspace}/automodel/jobs`.

--- a/plugins/nemo-automodel/src/nemo_automodel_plugin/cli/inputs.py
+++ b/plugins/nemo-automodel/src/nemo_automodel_plugin/cli/inputs.py
@@ -5,7 +5,7 @@
 
 The override machinery is shared in :mod:`nmp.customization_common.cli.overrides`; this
 module supplies the Automodel specifics: the ``AutomodelJobInput`` schema (via
-``load_job_json``), the ``JOB_JSON`` help text, and the run-disabled message.
+``load_job_json``) and the ``JOB_JSON`` help text.
 """
 
 import json
@@ -17,10 +17,6 @@ from nmp.customization_common.cli.overrides import apply_job_cli_overrides
 from nemo_automodel_plugin.schema import AutomodelJobInput
 
 _JOB_JSON_HELP = "Path to Automodel job JSON (AutomodelJobInput schema)."
-_RUN_DISABLED_MESSAGE = (
-    "Automodel does not support local run. Submit to the platform API instead:\n"
-    "  nemo customization automodel submit <job.json> -w <workspace>"
-)
 
 
 def load_job_json(path: Path) -> str:
@@ -31,10 +27,9 @@ def load_job_json(path: Path) -> str:
 
 
 def apply_automodel_job_cli_overrides(group: typer.Typer) -> None:
-    """Flat ``automodel`` CLI: ``submit JOB.json``; ``run`` is disabled."""
+    """Flat ``automodel`` CLI: ``submit JOB.json``."""
     apply_job_cli_overrides(
         group,
         load_job_json=load_job_json,
         job_json_help=_JOB_JSON_HELP,
-        run_disabled_message=_RUN_DISABLED_MESSAGE,
     )

--- a/plugins/nemo-automodel/src/nemo_automodel_plugin/cli/main.py
+++ b/plugins/nemo-automodel/src/nemo_automodel_plugin/cli/main.py
@@ -13,7 +13,7 @@ from nemo_automodel_plugin.jobs.jobs import AutomodelJob
 
 
 class AutomodelContributorCLI:
-    """Passed to ``add_job_commands`` to override job submit/run with job-file args."""
+    """Passed to ``add_job_commands`` to override job submit with job-file args."""
 
     def update_job_cli(self, job_cls: type[NemoJob], group: typer.Typer) -> None:
         if job_cls is AutomodelJob:

--- a/plugins/nemo-automodel/tests/test_cli.py
+++ b/plugins/nemo-automodel/tests/test_cli.py
@@ -105,12 +105,14 @@ def test_cli_submit_accepts_job_json_file(monkeypatch: pytest.MonkeyPatch) -> No
     assert submitted["spec"]["model"] == "default/qwen3-1.7b"
 
 
-def test_cli_run_is_disabled() -> None:
+def test_cli_help_lists_submit_and_explain_only() -> None:
     automodel_cli = AutomodelContributor().get_cli()
     runner = CliRunner()
-    result = runner.invoke(automodel_cli, ["run", str(FIXTURES / "minimal_sft_lora.json")])
-    assert result.exit_code == 1
-    assert "does not support local run" in result.stderr
+    result = runner.invoke(automodel_cli, ["--help"])
+    assert result.exit_code == 0
+    assert "submit" in result.stdout
+    assert "explain" in result.stdout
+    assert "run" not in result.stdout
 
 
 def test_cli_expose_input_and_output_schemas() -> None:

--- a/plugins/nemo-automodel/tests/test_contributor.py
+++ b/plugins/nemo-automodel/tests/test_contributor.py
@@ -3,21 +3,33 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+from typing import Protocol, runtime_checkable
+
 from fastapi import FastAPI
 from nemo_automodel_plugin.contributor import AutomodelContributor
+
+
+@runtime_checkable
+class _RouteWithPath(Protocol):
+    path: str
+
+
+@runtime_checkable
+class _RouteWithEffectiveCandidates(Protocol):
+    def effective_candidates(self) -> Iterable[object]: ...
 
 
 def _route_paths(app: FastAPI) -> set[str]:
     """Collect all route paths, compatible with FastAPI 0.138+ _IncludedRouter."""
     paths: set[str] = set()
-    queue = list(app.routes)
+    queue: list[object] = list(app.routes)
     while queue:
         route = queue.pop()
-        if hasattr(route, "path"):
+        if isinstance(route, _RouteWithPath):
             paths.add(route.path)
-        fn = getattr(route, "effective_candidates", None)
-        if callable(fn):
-            queue.extend(fn())  # type: ignore[arg-type]
+        if isinstance(route, _RouteWithEffectiveCandidates):
+            queue.extend(route.effective_candidates())
     return paths
 
 
@@ -38,7 +50,7 @@ def test_contributor_get_cli_exposes_flat_verbs() -> None:
     assert isinstance(cli, typer.Typer)
     assert cli.info.name == "automodel"
     assert not any(g.name == "jobs" for g in cli.registered_groups)
-    assert {cmd.name for cmd in cli.registered_commands} >= {"run", "submit", "explain"}
+    assert {cmd.name for cmd in cli.registered_commands} == {"submit", "explain"}
 
 
 def test_contributor_exposes_sdk_resources() -> None:

--- a/plugins/nemo-customizer/docs/CUSTOMIZATION.md
+++ b/plugins/nemo-customizer/docs/CUSTOMIZATION.md
@@ -12,7 +12,7 @@ Implement `CustomizationContributor`:
 - `name` — must match the entry-point key (e.g. `automodel`)
 - `get_routers()` — `RouterSpec` list with a **unique** prefix under `v2/workspaces/{workspace}/<backend>/`
 - `get_cli()` — optional `typer.Typer` mounted at `nemo customization <name>`
-- `get_sdk_resources()` — optional sync/async resource classes for `client.customization.<name>` (do not register a separate `nemo.sdk` entry point; **`nemo-customizer-plugin`** owns `nemo.sdk` → `customization` and composes backends)
+- `get_sdk_resources()` — optional sync/async resource classes for `client.customization.<name>`; the Customizer hub constructs them with a typed Customizer SDK context that contains the typed Customizer client, typed Jobs client, and active workspace (do not register a separate `nemo.sdk` entry point; the Customizer hub owns `nemo.sdk` → `customization` and composes backends)
 
 ## pyproject.toml
 

--- a/plugins/nemo-customizer/openapi/openapi.yaml
+++ b/plugins/nemo-customizer/openapi/openapi.yaml
@@ -3407,7 +3407,7 @@ components:
       - model
       - dataset
       title: UnslothJobInput
-      description: POST body / CLI JSON for ``nemo customization unsloth run``.
+      description: POST body / CLI JSON for ``nemo customization unsloth submit``.
     UnslothJobOutput:
       properties:
         name:

--- a/plugins/nemo-customizer/pyproject.toml
+++ b/plugins/nemo-customizer/pyproject.toml
@@ -8,7 +8,6 @@ readme = "README.md"
 requires-python = ">=3.11,<3.15"
 dependencies = [
     "nemo-platform-plugin",
-    "nemo-platform",
     "pydantic>=2.10.6",
     "typer>=0.12.5",
 ]
@@ -38,7 +37,6 @@ packages = ["src/nemo_customizer"]
 
 [tool.uv.sources]
 nemo-platform-plugin = { workspace = true }
-nemo-platform = { workspace = true }
 
 
 [dependency-groups]

--- a/plugins/nemo-customizer/src/nemo_customizer/sdk/resources.py
+++ b/plugins/nemo-customizer/src/nemo_customizer/sdk/resources.py
@@ -1,21 +1,40 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Customization SDK hub — composes contributor backends under ``client.customization``."""
+"""Customization SDK hub — composes contributor backends for the customization namespace."""
 
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable, Mapping
+from types import MappingProxyType
+from typing import Self, TypeVar
 
 from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
-from nemo_platform_plugin.customization_contributor import CustomizationContributor
+from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.client.client import AsyncNemoClient, NemoClient
+from nemo_platform_plugin.customization_contributor import (
+    CustomizationContributor,
+    CustomizationContributorSDKResources,
+    CustomizationSDKResourceFactory,
+)
 from nemo_platform_plugin.discovery import discover_customization_contributors
 from nemo_platform_plugin.sdk import NemoPluginSDKResources
-from nmp.customization_common.sdk.client import platform_default_headers, url
+from nmp.customization_common.sdk.client import (
+    AsyncCustomizationBackendResource,
+    AsyncCustomizationClient,
+    AsyncCustomizationSDKContext,
+    CustomizationBackendResource,
+    CustomizationClient,
+    CustomizationSDKContext,
+    make_async_customization_sdk_context,
+    make_customization_sdk_context,
+)
 
 logger = logging.getLogger(__name__)
 
-_HEALTHZ_PATH = "v2/healthz"
+ContextT = TypeVar("ContextT", CustomizationSDKContext, AsyncCustomizationSDKContext)
+ResourceT = TypeVar("ResourceT", CustomizationBackendResource, AsyncCustomizationBackendResource)
 
 
 def _coerce_health_payload(payload: object) -> dict[str, object]:
@@ -25,66 +44,141 @@ def _coerce_health_payload(payload: object) -> dict[str, object]:
 
 
 def _mount_contributor_sdk_resources(
-    target: object,
-    platform: NeMoPlatform | AsyncNeMoPlatform,
+    context: ContextT,
     contributors: dict[str, CustomizationContributor],
-    *,
-    async_: bool,
-) -> None:
+    resource_selector: Callable[
+        [CustomizationContributorSDKResources],
+        CustomizationSDKResourceFactory | None,
+    ],
+    resource_type: type[ResourceT],
+) -> dict[str, ResourceT]:
+    resources: dict[str, ResourceT] = {}
     for key in sorted(contributors.keys()):
         contributor = contributors[key]
         sdk_resources = contributor.get_sdk_resources()
         if sdk_resources is None:
             continue
-        resource_cls = sdk_resources.async_resource if async_ else sdk_resources.sync_resource
+        resource_cls = resource_selector(sdk_resources)
         if resource_cls is None:
             continue
         try:
-            setattr(target, key, resource_cls(platform))
+            resource = resource_cls(context)
         except ImportError:
             logger.warning(
                 "Customization contributor %r is installed but SDK resources are unavailable",
                 key,
             )
+            continue
+        if not isinstance(resource, resource_type):
+            raise TypeError(f"Customization contributor {key!r} SDK resource must be a {resource_type.__name__}")
+        resources[key] = resource
+    return resources
+
+
+def _missing_resource_attribute(owner: object, name: str) -> AttributeError:
+    return AttributeError(f"'{type(owner).__name__}' object has no attribute {name!r}")
+
+
+def _require_resource_attribute(
+    owner: object,
+    name: str,
+    resource: ResourceT | None,
+) -> ResourceT:
+    if resource is None:
+        raise _missing_resource_attribute(owner, name)
+    return resource
 
 
 class Customization:
-    """Sync SDK namespace mounted as ``client.customization``."""
+    """Sync customization SDK namespace."""
 
-    def __init__(self, platform: NeMoPlatform) -> None:
-        self._platform = platform
+    def __init__(self, context: CustomizationSDKContext) -> None:
+        self._customization_client: CustomizationClient = context.customization
         contributors = discover_customization_contributors()
-        _mount_contributor_sdk_resources(self, platform, contributors, async_=False)
+        self._contributor_resources: dict[str, CustomizationBackendResource] = _mount_contributor_sdk_resources(
+            context,
+            contributors,
+            lambda resources: resources.sync_resource,
+            CustomizationBackendResource,
+        )
+        self.contributors: Mapping[str, CustomizationBackendResource] = MappingProxyType(self._contributor_resources)
+        self._automodel: CustomizationBackendResource | None = self._contributor_resources.get("automodel")
+        self._rl: CustomizationBackendResource | None = self._contributor_resources.get("rl")
+        self._unsloth: CustomizationBackendResource | None = self._contributor_resources.get("unsloth")
+
+    @classmethod
+    def from_client(cls, client: NemoClient) -> Self:
+        return cls(make_customization_sdk_context(client))
+
+    @classmethod
+    def from_platform(cls, platform: NeMoPlatform) -> Self:
+        return cls.from_client(client_from_platform(platform, NemoClient))
+
+    @property
+    def automodel(self) -> CustomizationBackendResource:
+        return _require_resource_attribute(self, "automodel", self._automodel)
+
+    @property
+    def rl(self) -> CustomizationBackendResource:
+        return _require_resource_attribute(self, "rl", self._rl)
+
+    @property
+    def unsloth(self) -> CustomizationBackendResource:
+        return _require_resource_attribute(self, "unsloth", self._unsloth)
 
     def plugin_status(self) -> dict[str, object]:
         """Return customization router health, including the registered contributors."""
-        response = self._platform._client.get(
-            url(self._platform, _HEALTHZ_PATH),
-            headers=platform_default_headers(self._platform),
+        return _coerce_health_payload(
+            self._customization_client.get_customization_health().data().model_dump(mode="json")
         )
-        response.raise_for_status()
-        return _coerce_health_payload(response.json())
 
 
 class AsyncCustomization:
-    """Async SDK namespace mounted as ``client.customization``."""
+    """Async customization SDK namespace."""
 
-    def __init__(self, platform: AsyncNeMoPlatform) -> None:
-        self._platform = platform
+    def __init__(self, context: AsyncCustomizationSDKContext) -> None:
+        self._customization_client: AsyncCustomizationClient = context.customization
         contributors = discover_customization_contributors()
-        _mount_contributor_sdk_resources(self, platform, contributors, async_=True)
+        self._contributor_resources: dict[str, AsyncCustomizationBackendResource] = _mount_contributor_sdk_resources(
+            context,
+            contributors,
+            lambda resources: resources.async_resource,
+            AsyncCustomizationBackendResource,
+        )
+        self.contributors: Mapping[str, AsyncCustomizationBackendResource] = MappingProxyType(
+            self._contributor_resources
+        )
+        self._automodel: AsyncCustomizationBackendResource | None = self._contributor_resources.get("automodel")
+        self._rl: AsyncCustomizationBackendResource | None = self._contributor_resources.get("rl")
+        self._unsloth: AsyncCustomizationBackendResource | None = self._contributor_resources.get("unsloth")
+
+    @classmethod
+    def from_client(cls, client: AsyncNemoClient) -> Self:
+        return cls(make_async_customization_sdk_context(client))
+
+    @classmethod
+    def from_platform(cls, platform: AsyncNeMoPlatform) -> Self:
+        return cls.from_client(client_from_platform(platform, AsyncNemoClient))
+
+    @property
+    def automodel(self) -> AsyncCustomizationBackendResource:
+        return _require_resource_attribute(self, "automodel", self._automodel)
+
+    @property
+    def rl(self) -> AsyncCustomizationBackendResource:
+        return _require_resource_attribute(self, "rl", self._rl)
+
+    @property
+    def unsloth(self) -> AsyncCustomizationBackendResource:
+        return _require_resource_attribute(self, "unsloth", self._unsloth)
 
     async def plugin_status(self) -> dict[str, object]:
         """Return customization router health, including the registered contributors."""
-        response = await self._platform._client.get(
-            url(self._platform, _HEALTHZ_PATH),
-            headers=platform_default_headers(self._platform),
-        )
-        response.raise_for_status()
-        return _coerce_health_payload(response.json())
+        response = await self._customization_client.get_customization_health()
+        return _coerce_health_payload(response.data().model_dump(mode="json"))
 
 
-customization_sdk_resources = NemoPluginSDKResources(
-    sync_resource=Customization,
-    async_resource=AsyncCustomization,
+customization_sdk_resources = NemoPluginSDKResources[Customization, AsyncCustomization](
+    sync_resource=Customization.from_platform,
+    async_resource=AsyncCustomization.from_platform,
 )

--- a/plugins/nemo-customizer/src/nemo_customizer/skills/nemo-customizer/SKILL.md
+++ b/plugins/nemo-customizer/src/nemo_customizer/skills/nemo-customizer/SKILL.md
@@ -64,7 +64,7 @@ allowed-tools: [Bash, Read, Grep]
 
 # NeMo Customizer
 
-End-to-end **SFT + LoRA** (automodel/unsloth), **DPO**, and **GRPO** (rl) on NeMo Platform. Three backend plugins ship in this repo — all are **`submit`-only** (local `run` is hard-disabled on each):
+End-to-end **SFT + LoRA** (automodel/unsloth), **DPO**, and **GRPO** (rl) on NeMo Platform. Three backend plugins ship in this repo — all are **`submit`-only** and expose no local `run` verb:
 
 | Backend | Verb | Trains | Where it runs | Pick when |
 |---------|------|--------|---------------|-----------|
@@ -155,8 +155,8 @@ For **`automodel`/`unsloth`**, training never runs inside the `nemo` CLI process
     ```
 
     Poll until healthy (`curl -sf http://127.0.0.1:8080/health/ready` or retry `nemo jobs list-execution-profiles -f json`), then continue the workflow. Do not start services without asking.
-    - ⚠️ **This default start is a DOCKER-runtime platform — fine for single-node `automodel`/`unsloth`.** It is **NOT** valid for **`rl`**: rl needs `platform.runtime: kubernetes` with a `kubernetes_job` execution backend. Starting this default and submitting rl will fail the runtime gate. For rl, configure/point at a Kubernetes-runtime platform instead — see `references/rl-kubernetes-runtime.md`. Never start or reuse a docker-runtime platform for rl.
-- **All backends are `submit` only** — `nemo customization <plugin> run …` hard-fails with a pointer to `submit` (automodel, unsloth, and rl each disable local `run`). Do not improvise verbs or pass `--venv`.
+    - ⚠️ **This default start is a DOCKER-runtime platform — valid for single-node `automodel`/`unsloth` only.** It is **NOT** valid for **`rl`**: rl needs `platform.runtime: kubernetes` with a `kubernetes_job` execution backend. Starting this default and submitting rl will fail the runtime gate. For rl, configure/point at a Kubernetes-runtime platform instead — see `references/rl-kubernetes-runtime.md`. Never start or reuse a docker-runtime platform for rl.
+- **All backends are `submit` only** — use `nemo customization <plugin> submit …`; automodel, unsloth, and rl expose no local `run` verb. Do not improvise verbs or pass `--venv`.
 - **Test fixtures are not the schema.** `tests/fixtures/*.json` are smoke-test inputs: they carry whatever made a test cheap, exercise one path rather than the field set, and nothing fails when the schema gains a field they never set. Read one for where a block sits in the payload — never for which fields exist, what a default is, or what a sensible value looks like, and never conclude a field is unsupported because a fixture omits it. Authoritative, in order: `nemo customization <plugin> explain` (the installed build's live schema), then the schema source files in `references/hyperparameters.md` § **Source of truth**, then this skill. When a fixture and `explain` disagree, the fixture is stale — say so rather than following it.
 - **Never set `max_steps` together with `epochs`** (automodel + unsloth; rl has the same caveat — see **rl (DPO / GRPO) gotchas**). `max_steps` is a global cap and stops mid-epoch. Every fixture in this repo sets it so a smoke test finishes in a minute — the most-copied wrong value here. Unsloth's schema enforces this as a hard mutex; automodel allows both but the result is surprising.
 - **Job done (all backends) = top-level `status`** in `completed` | `error` | `cancelled`. Steps can all be `completed` while the job is still `active` (upload, entity registration). `status_details.phase` may stay `training` with `progress_pct: 100` for a long time — keep polling. `poll_customization_job.sh` works for any job id (`automodel-…`, `unsloth-…`, or `rl-…`); it exits **1** on `error` or `cancelled`.
@@ -372,7 +372,7 @@ bash plugins/nemo-customizer/src/nemo_customizer/skills/nemo-customizer/scripts/
 
 Read `<job-id>` from the `"name"` field in submit stdout (JSON). **Do not use `2>&1`** before `json.load` — warnings on stderr break parsing; see Gotchas. Optional interval override: append seconds (e.g. `… 30`). Or poll manually: `nemo jobs get-status unsloth-<job-id>` every 30–60s. If submit fails on an unknown profile, re-list execution profiles and pass `--profile <name>` on submit (default is `gpu`).
 
-If you try `nemo customization unsloth run …`, the CLI hard-fails with a pointer to `submit`.
+Use `submit` for Unsloth jobs; the contributor CLI exposes no local `run` verb.
 
 ## Fast path — rl (GRPO)
 
@@ -532,7 +532,7 @@ bash plugins/nemo-customizer/src/nemo_customizer/skills/nemo-customizer/scripts/
 
 **Do not** derive the job id by picking the newest `rl-*` from `nemo jobs list` — a concurrent job or an earlier failed submit selects the wrong one. If `/tmp/rl-submit.json` does not parse, the submit result is unknown: stop and inspect it (re-submitting risks a duplicate job).
 
-**Do not use `2>&1`** before `json.load` — warnings on stderr break parsing; see Gotchas. Or poll manually: `nemo jobs get-status rl-<job-id>` every 30–60s. If submit fails on an unknown profile, re-list execution profiles and pass `--profile <name>`. `nemo customization rl run …` is disabled (no local execution — it provisions a Ray cluster); `nemo customization rl explain` prints the live schema.
+**Do not use `2>&1`** before `json.load` — warnings on stderr break parsing; see Gotchas. Or poll manually: `nemo jobs get-status rl-<job-id>` every 30–60s. If submit fails on an unknown profile, re-list execution profiles and pass `--profile <name>`. `nemo customization rl explain` prints the live schema.
 
 ## Defaults
 

--- a/plugins/nemo-customizer/src/nemo_customizer/skills/nemo-customizer/references/troubleshooting.md
+++ b/plugins/nemo-customizer/src/nemo_customizer/skills/nemo-customizer/references/troubleshooting.md
@@ -104,7 +104,7 @@ Same rule for `nemo jobs list-execution-profiles -f json`: parse stdout only; us
 
 ## Verb is backend-specific (both submit-only)
 
-- **Automodel** and **Unsloth** both use **`submit` only**. `nemo customization <plugin> run …` hard-fails with a pointer to `submit`.
+- **Automodel**, **Unsloth**, and **RL** use **`submit` only**. Use `nemo customization <plugin> submit …`; these backends expose no local `run` verb.
 - Dataset refs in job JSON: `default/<fileset>` (automodel: `dataset.training` / `dataset.validation`; unsloth: `dataset.path` / optional `dataset.validation_path`).
 
 ## Gated HuggingFace models
@@ -285,7 +285,6 @@ Set `jobs.executors.docker.launcher_tool_path` in `~/.nemo/config.yaml` to the *
 
 | Error / symptom | Cause | Fix |
 |-----------------|-------|-----|
-| `Unsloth does not support local run` | Used `run` instead of `submit` | `nemo customization unsloth submit <job.json> -w <workspace>` |
 | `Unsloth training requires platform.runtime: docker` | Platform not configured for Docker GPU jobs | Start platform with Docker runtime and a GPU execution profile |
 | Unknown execution profile | Default `gpu` profile missing or wrong | Re-list profiles; pass `--profile <exact-name>` on submit |
 | Missing `nmp-unsloth-training` image / `Failed to pull image` / `manifest unknown` | Image not on the **platform host's** Docker daemon | **Remote platform** (`NMP_BASE_URL` not localhost): tell user to build on the target — **do not** `docker build` locally. **Local platform**: build on same host; see **Missing training images** above and `docker/unsloth/README.md` |
@@ -307,7 +306,7 @@ Shared:
 | Upload | `nemo files upload <local> <fileset> --workspace default --remote-path train.jsonl` |
 | List files | `nemo files list <fileset> --workspace default` |
 | Create model | `nemo models create <name> --workspace default --exist-ok --input-data '<json>'` |
-| Poll job | `nemo jobs get-status <automodel\|unsloth>-<job-id>` |
+| Poll job | `nemo jobs get-status <automodel\|unsloth\|rl>-<job-id>` |
 
 Automodel:
 
@@ -324,6 +323,5 @@ Unsloth:
 | Submit | `nemo customization unsloth submit <job.json> --workspace default [--profile P] [--cluster C]` |
 | Status | `nemo jobs get-status unsloth-<job-id>` |
 | Live schema | `nemo customization unsloth explain` |
-| Run (disabled) | `nemo customization unsloth run …` → hard-fails; use `submit` |
 
 All backends return a job id from `submit` — poll until top-level status is terminal (`completed`, `error`, or `cancelled`).

--- a/plugins/nemo-customizer/tests/test_sdk.py
+++ b/plugins/nemo-customizer/tests/test_sdk.py
@@ -3,22 +3,28 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import patch
 
+import httpx
 import pytest
-from nemo_automodel_plugin.sdk.resources import AutomodelCustomization
+from nemo_automodel_plugin.sdk.resources import AsyncAutomodelCustomization, AutomodelCustomization
 from nemo_customizer.sdk.resources import (
     AsyncCustomization,
     Customization,
+    _coerce_health_payload,
     customization_sdk_resources,
 )
+from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
 from nemo_platform_plugin.customization_contributor import CustomizationContributorSDKResources
 from nemo_platform_plugin.sdk import NemoPluginSDKResources
 
 
 class _AutomodelContributorStub:
     def get_sdk_resources(self) -> CustomizationContributorSDKResources:
-        return CustomizationContributorSDKResources(sync_resource=AutomodelCustomization)
+        return CustomizationContributorSDKResources(
+            sync_resource=AutomodelCustomization,
+            async_resource=AsyncAutomodelCustomization,
+        )
 
 
 class _ContributorWithoutSdk:
@@ -26,97 +32,230 @@ class _ContributorWithoutSdk:
         return None
 
 
+class _InvalidCustomizationResource:
+    def __init__(self, _context: object) -> None:
+        pass
+
+
+class _InvalidContributorStub:
+    def get_sdk_resources(self) -> CustomizationContributorSDKResources:
+        return CustomizationContributorSDKResources(sync_resource=_InvalidCustomizationResource)
+
+
+def _recording_customization_transport() -> tuple[httpx.MockTransport, list[httpx.Request]]:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.method == "POST" and request.url.path == "/apis/customization/v2/workspaces/team-a/automodel/jobs":
+            return httpx.Response(
+                201,
+                request=request,
+                json={
+                    "id": "job-id",
+                    "name": "job-a",
+                    "workspace": "team-a",
+                    "spec": {"model": "default/qwen"},
+                    "status": "created",
+                },
+            )
+        return httpx.Response(404, request=request, json={"detail": "unexpected request"})
+
+    return httpx.MockTransport(handler), requests
+
+
 def test_customization_sdk_resources_entry_point_shape() -> None:
     assert isinstance(customization_sdk_resources, NemoPluginSDKResources)
-    assert customization_sdk_resources.sync_resource is Customization
-    assert customization_sdk_resources.async_resource is AsyncCustomization
+    sync_resource = customization_sdk_resources.sync_resource
+    async_resource = customization_sdk_resources.async_resource
+    assert sync_resource is not None
+    assert async_resource is not None
+
+    platform = NeMoPlatform(base_url="http://localhost:8000", workspace="default")
+    with patch(
+        "nemo_customizer.sdk.resources.discover_customization_contributors",
+        return_value={},
+    ):
+        assert isinstance(sync_resource(platform), Customization)
 
 
 def test_customization_composes_automodel_when_contributor_present() -> None:
-    platform = MagicMock()
-    platform._client = MagicMock()
-    platform.workspace = "default"
-    platform.base_url = "http://localhost:8000"
-    platform.default_headers = {}
+    from nemo_platform_plugin.client.client import NemoClient
+
+    client = NemoClient(base_url="http://localhost:8000", workspace="default")
 
     with patch(
         "nemo_customizer.sdk.resources.discover_customization_contributors",
         return_value={"automodel": _AutomodelContributorStub()},
     ):
-        customization = Customization(platform)
+        customization = Customization.from_client(client)
 
-    assert hasattr(customization, "automodel")
-    assert hasattr(customization.automodel, "jobs")
+    assert customization.automodel.jobs is not None
 
 
 def test_customization_skips_contributors_without_sdk() -> None:
-    platform = MagicMock()
-    platform._client = MagicMock()
-    platform.workspace = "default"
-    platform.base_url = "http://localhost:8000"
-    platform.default_headers = {}
+    from nemo_platform_plugin.client.client import NemoClient
+
+    client = NemoClient(base_url="http://localhost:8000", workspace="default")
 
     with patch(
         "nemo_customizer.sdk.resources.discover_customization_contributors",
         return_value={"noop": _ContributorWithoutSdk()},
     ):
-        customization = Customization(platform)
+        customization = Customization.from_client(client)
 
-    assert not hasattr(customization, "noop")
+    assert "noop" not in customization.contributors
 
 
-def _health_platform() -> MagicMock:
-    platform = MagicMock()
-    platform.workspace = "default"
-    platform.base_url = "http://localhost:8000"
-    platform.default_headers = {}
-    return platform
+def test_customization_composes_contributor_resources_on_typed_nemo_client() -> None:
+    from nemo_platform_plugin.client.client import NemoClient
+
+    client = NemoClient(base_url="http://localhost:8000", workspace="default")
+
+    with patch(
+        "nemo_customizer.sdk.resources.discover_customization_contributors",
+        return_value={"automodel": _AutomodelContributorStub()},
+    ):
+        customization = Customization.from_client(client)
+
+    assert customization.automodel.jobs is not None
+
+
+def test_customization_accepts_legacy_nemo_platform_owner() -> None:
+    transport, requests = _recording_customization_transport()
+    platform = NeMoPlatform(
+        base_url="http://localhost:8000",
+        workspace="team-a",
+        http_client=httpx.Client(transport=transport),
+    )
+
+    with patch(
+        "nemo_customizer.sdk.resources.discover_customization_contributors",
+        return_value={"automodel": _AutomodelContributorStub()},
+    ):
+        response = Customization.from_platform(platform).automodel.jobs.create(
+            spec={"model": "default/qwen"},
+            name="job-a",
+        )
+
+    assert response.data().name == "job-a"
+    assert len(requests) == 1
+    assert requests[0].method == "POST"
+    assert str(requests[0].url) == "http://localhost:8000/apis/customization/v2/workspaces/team-a/automodel/jobs"
+
+
+def test_customization_keeps_dynamic_contributors_in_mapping() -> None:
+    from nemo_platform_plugin.client.client import NemoClient
+
+    client = NemoClient(base_url="http://localhost:8000", workspace="default")
+
+    with patch(
+        "nemo_customizer.sdk.resources.discover_customization_contributors",
+        return_value={"third_party": _AutomodelContributorStub()},
+    ):
+        customization = Customization.from_client(client)
+
+    assert "third_party" not in customization.__dict__
+    assert customization.contributors["third_party"].jobs is not None
+
+
+def test_customization_rejects_contributor_resource_without_jobs() -> None:
+    from nemo_platform_plugin.client.client import NemoClient
+
+    client = NemoClient(base_url="http://localhost:8000", workspace="default")
+
+    with (
+        patch(
+            "nemo_customizer.sdk.resources.discover_customization_contributors",
+            return_value={"invalid": _InvalidContributorStub()},
+        ),
+        pytest.raises(TypeError, match="must be a CustomizationBackendResource"),
+    ):
+        Customization.from_client(client)
 
 
 def test_plugin_status_hits_versioned_hub_healthz() -> None:
-    platform = _health_platform()
-    response = MagicMock()
-    response.json.return_value = {"plugin": "customization", "status": "ok", "contributors": ["automodel"]}
-    platform._client.get.return_value = response
+    import httpx
+    from nemo_platform_plugin.client.client import NemoClient
+
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json={"plugin": "customization", "status": "ok", "contributors": ["automodel"]},
+        )
+
+    client = NemoClient(
+        base_url="http://localhost:8000",
+        workspace="default",
+        http_client=httpx.Client(transport=httpx.MockTransport(handler)),
+    )
 
     with patch(
         "nemo_customizer.sdk.resources.discover_customization_contributors",
         return_value={},
     ):
-        status = Customization(platform).plugin_status()
+        status = Customization.from_client(client).plugin_status()
 
-    called_url = platform._client.get.call_args.args[0]
-    assert called_url == "http://localhost:8000/apis/customization/v2/healthz"
+    assert requests[0].method == "GET"
+    assert str(requests[0].url) == "http://localhost:8000/apis/customization/v2/healthz"
     assert status["contributors"] == ["automodel"]
 
 
 def test_plugin_status_rejects_non_object_payload() -> None:
-    platform = _health_platform()
-    response = MagicMock()
-    response.json.return_value = ["not", "an", "object"]
-    platform._client.get.return_value = response
-
-    with patch(
-        "nemo_customizer.sdk.resources.discover_customization_contributors",
-        return_value={},
-    ):
-        resource = Customization(platform)
     with pytest.raises(TypeError):
-        resource.plugin_status()
+        _coerce_health_payload(["not", "an", "object"])
 
 
 async def test_async_plugin_status_hits_versioned_hub_healthz() -> None:
-    platform = _health_platform()
-    response = MagicMock()
-    response.json.return_value = {"plugin": "customization", "status": "ok", "contributors": []}
-    platform._client.get = AsyncMock(return_value=response)
+    from nemo_platform_plugin.client.client import AsyncNemoClient
+
+    requests: list[httpx.Request] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json={"plugin": "customization", "status": "ok", "contributors": []},
+        )
+
+    client = AsyncNemoClient(
+        base_url="http://localhost:8000",
+        workspace="default",
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
 
     with patch(
         "nemo_customizer.sdk.resources.discover_customization_contributors",
         return_value={},
     ):
-        status = await AsyncCustomization(platform).plugin_status()
+        status = await AsyncCustomization.from_client(client).plugin_status()
 
-    called_url = platform._client.get.call_args.args[0]
-    assert called_url == "http://localhost:8000/apis/customization/v2/healthz"
+    assert requests[0].method == "GET"
+    assert str(requests[0].url) == "http://localhost:8000/apis/customization/v2/healthz"
     assert status["status"] == "ok"
+
+
+async def test_async_customization_accepts_legacy_nemo_platform_owner() -> None:
+    transport, requests = _recording_customization_transport()
+    platform = AsyncNeMoPlatform(
+        base_url="http://localhost:8000",
+        workspace="team-a",
+        http_client=httpx.AsyncClient(transport=transport),
+    )
+
+    with patch(
+        "nemo_customizer.sdk.resources.discover_customization_contributors",
+        return_value={"automodel": _AutomodelContributorStub()},
+    ):
+        response = await AsyncCustomization.from_platform(platform).automodel.jobs.create(
+            spec={"model": "default/qwen"},
+            name="job-a",
+        )
+
+    assert response.data().name == "job-a"
+    assert len(requests) == 1
+    assert requests[0].method == "POST"
+    assert str(requests[0].url) == "http://localhost:8000/apis/customization/v2/workspaces/team-a/automodel/jobs"

--- a/plugins/nemo-iron-swarm/tests/unit/test_operator_env.py
+++ b/plugins/nemo-iron-swarm/tests/unit/test_operator_env.py
@@ -161,7 +161,7 @@ def test_write_operator_env_never_creates_a_world_readable_file(tmp_path: Path) 
 # ── run job env injection ────────────────────────────────────────────────
 
 
-def test_run_job_injects_operator_env_without_overriding_shell(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_run_job_injects_operator_env_when_shell_env_absent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     plugin_config = _config(tmp_path)
     plugin_config.venv_path.mkdir(parents=True)
     plugin_config.iron_swarm_bin.parent.mkdir(parents=True, exist_ok=True)
@@ -170,6 +170,7 @@ def test_run_job_injects_operator_env_without_overriding_shell(tmp_path: Path, m
     plugin_config.garak_python.touch()
     plugin_config.operator_env_file.write_text(f"{INFERENCE_API_KEY_ENVVAR}=from-dotenv\n", encoding="utf-8")
 
+    monkeypatch.delenv(INFERENCE_API_KEY_ENVVAR, raising=False)
     monkeypatch.setattr("nemo_iron_swarm_plugin.jobs.run.IronSwarmConfig.get", lambda: plugin_config)
     monkeypatch.setattr("nemo_iron_swarm_plugin.jobs._common.sys.stdin.isatty", lambda: False)
 
@@ -201,7 +202,8 @@ def test_run_job_does_not_override_explicit_shell_env(tmp_path: Path, monkeypatc
     plugin_config.garak_python.touch()
     plugin_config.operator_env_file.write_text(f"{INFERENCE_API_KEY_ENVVAR}=from-dotenv\n", encoding="utf-8")
 
-    monkeypatch.setenv(INFERENCE_API_KEY_ENVVAR, "from-shell")
+    shell_value = "from-shell-sentinel"
+    monkeypatch.setenv(INFERENCE_API_KEY_ENVVAR, shell_value)
     monkeypatch.setattr("nemo_iron_swarm_plugin.jobs.run.IronSwarmConfig.get", lambda: plugin_config)
     monkeypatch.setattr("nemo_iron_swarm_plugin.jobs._common.sys.stdin.isatty", lambda: False)
 
@@ -221,7 +223,8 @@ def test_run_job_does_not_override_explicit_shell_env(tmp_path: Path, monkeypatc
     monkeypatch.setattr(job, "report_progress", lambda *a, **k: None)
     job.run({"config": str(manifest)}, ctx=ctx, sdk=None)
 
-    assert captured["env"][INFERENCE_API_KEY_ENVVAR] == "from-shell"
+    assert captured["env"][INFERENCE_API_KEY_ENVVAR] == shell_value
+    assert os.environ[INFERENCE_API_KEY_ENVVAR] == shell_value
 
 
 # ── missing_secrets ──────────────────────────────────────────────────────

--- a/plugins/nemo-rl/README.md
+++ b/plugins/nemo-rl/README.md
@@ -13,9 +13,9 @@ Thin contributor layer only — the heavy compile glue and container tasks live 
 ## Surfaces
 
 - **CLI:** `nemo customization rl submit <job.json> -w <workspace>` (submit-only;
-  `run` is disabled — there is no local execution).
+  there is no local `run` verb or local execution path).
 - **REST:** `POST /apis/customization/v2/workspaces/{workspace}/rl/jobs`
-- **SDK:** `client.customization.rl.jobs.create(...)`
+- **SDK:** `client.customization.rl.jobs.create(...).data()`
 
 ## Constraints
 

--- a/plugins/nemo-rl/src/nemo_rl_plugin/cli/inputs.py
+++ b/plugins/nemo-rl/src/nemo_rl_plugin/cli/inputs.py
@@ -5,7 +5,7 @@
 
 The override machinery is shared in :mod:`nmp.customization_common.cli.overrides`;
 this module supplies the RL specifics: the ``RlJobInput`` schema (via
-``load_job_json``), the ``JOB_JSON`` help text, and the run-disabled message.
+``load_job_json``) and the ``JOB_JSON`` help text.
 """
 
 import json
@@ -17,11 +17,6 @@ from nmp.customization_common.cli.overrides import apply_job_cli_overrides
 from nemo_rl_plugin.schema import RlJobInput
 
 _JOB_JSON_HELP = "Path to NeMo-RL job JSON (RlJobInput schema)."
-_RUN_DISABLED_MESSAGE = (
-    "NeMo-RL does not support local run (it provisions a Ray cluster on the remote Kubernetes cluster). "
-    "Submit to the platform API instead:\n"
-    "  nemo customization rl submit <job.json> -w <workspace>"
-)
 
 
 def load_job_json(path: Path) -> str:
@@ -32,10 +27,9 @@ def load_job_json(path: Path) -> str:
 
 
 def apply_rl_job_cli_overrides(group: typer.Typer) -> None:
-    """Flat ``rl`` CLI: ``submit JOB.json``; ``run`` is disabled."""
+    """Flat ``rl`` CLI: ``submit JOB.json``."""
     apply_job_cli_overrides(
         group,
         load_job_json=load_job_json,
         job_json_help=_JOB_JSON_HELP,
-        run_disabled_message=_RUN_DISABLED_MESSAGE,
     )

--- a/plugins/nemo-rl/src/nemo_rl_plugin/cli/main.py
+++ b/plugins/nemo-rl/src/nemo_rl_plugin/cli/main.py
@@ -18,7 +18,7 @@ from nemo_rl_plugin.jobs.jobs import RlJob
 
 
 class RlContributorCLI:
-    """Passed to ``add_job_commands`` to override run/submit with job-file args."""
+    """Passed to ``add_job_commands`` to override submit with job-file args."""
 
     def update_job_cli(self, job_cls: type[NemoJob], group: typer.Typer) -> None:
         if job_cls is RlJob:

--- a/plugins/nemo-unsloth/README.md
+++ b/plugins/nemo-unsloth/README.md
@@ -7,7 +7,7 @@ Unsloth GPU fine-tuning **customization contributor** for NeMo Platform.
 
 Registered under `nemo.customization.contributors` (key `unsloth`) — the `nemo-customizer-plugin` hub composes it under `/apis/customization/v2/workspaces/{workspace}/unsloth/` (HTTP) and `client.customization.unsloth.*` (SDK), and mounts the CLI at `nemo customization unsloth ...`.
 
-Unsloth is **submit-only**: training executes remotely on the platform's GPU cluster as a 4-step container job (download → train → upload → model-entity), mirroring `nemo-automodel-plugin`. The plugin itself stays lightweight — heavy ML deps (`unsloth`, `trl`, `transformers`, `peft`, `accelerate`, `bitsandbytes`, `torch`) live only inside the `nmp-unsloth-training` container image. `run` is hard-disabled — use `submit`.
+Unsloth is **submit-only**: training executes remotely on the platform's GPU cluster as a 4-step container job (download → train → upload → model-entity), mirroring `nemo-automodel-plugin`. The plugin itself stays lightweight — heavy ML deps (`unsloth`, `trl`, `transformers`, `peft`, `accelerate`, `bitsandbytes`, `torch`) live only inside the `nmp-unsloth-training` container image.
 
 ## Install
 
@@ -52,7 +52,6 @@ What happens after submit:
 ```bash
 nemo customization unsloth --help
 nemo customization unsloth submit JOB_JSON -w WORKSPACE [--profile P] [--cluster C] [-o k=v]
-nemo customization unsloth run ...      # hard-fails: Unsloth is submit-only
 nemo customization unsloth explain      # prints schemas
 ```
 

--- a/plugins/nemo-unsloth/src/nemo_unsloth_plugin/cli/inputs.py
+++ b/plugins/nemo-unsloth/src/nemo_unsloth_plugin/cli/inputs.py
@@ -5,7 +5,7 @@
 
 The override machinery is shared in :mod:`nmp.customization_common.cli.overrides`; this
 module supplies the Unsloth specifics: the ``UnslothJobInput`` schema (via
-``load_job_json``), the ``JOB_JSON`` help text, and the run-disabled message.
+``load_job_json``) and the ``JOB_JSON`` help text.
 """
 
 import json
@@ -17,10 +17,6 @@ from nmp.customization_common.cli.overrides import apply_job_cli_overrides
 from nemo_unsloth_plugin.schema import UnslothJobInput
 
 _JOB_JSON_HELP = "Path to Unsloth job JSON (UnslothJobInput schema)."
-_RUN_DISABLED_MESSAGE = (
-    "Unsloth does not support local run. Submit to the platform API instead:\n"
-    "  nemo customization unsloth submit <job.json> -w <workspace>"
-)
 
 
 def load_job_json(path: Path) -> str:
@@ -31,10 +27,9 @@ def load_job_json(path: Path) -> str:
 
 
 def apply_unsloth_job_cli_overrides(group: typer.Typer) -> None:
-    """Flat ``unsloth`` CLI: ``submit JOB.json``; ``run`` is disabled."""
+    """Flat ``unsloth`` CLI: ``submit JOB.json``."""
     apply_job_cli_overrides(
         group,
         load_job_json=load_job_json,
         job_json_help=_JOB_JSON_HELP,
-        run_disabled_message=_RUN_DISABLED_MESSAGE,
     )

--- a/plugins/nemo-unsloth/src/nemo_unsloth_plugin/cli/main.py
+++ b/plugins/nemo-unsloth/src/nemo_unsloth_plugin/cli/main.py
@@ -19,7 +19,7 @@ from nemo_unsloth_plugin.jobs.jobs import UnslothJob
 
 
 class UnslothContributorCLI:
-    """Passed to ``add_job_commands`` to override run/submit with job-file args."""
+    """Passed to ``add_job_commands`` to override submit with job-file args."""
 
     def update_job_cli(self, job_cls: type[NemoJob], group: typer.Typer) -> None:
         if job_cls is UnslothJob:

--- a/plugins/nemo-unsloth/src/nemo_unsloth_plugin/schema.py
+++ b/plugins/nemo-unsloth/src/nemo_unsloth_plugin/schema.py
@@ -68,7 +68,7 @@ class OutputRequest(UnslothSchema):
 
 
 class UnslothJobInput(UnslothSchema):
-    """POST body / CLI JSON for ``nemo customization unsloth run``."""
+    """POST body / CLI JSON for ``nemo customization unsloth submit``."""
 
     name: str | None = None
     model: ModelLoadSpec

--- a/plugins/nemo-unsloth/tests/test_cli.py
+++ b/plugins/nemo-unsloth/tests/test_cli.py
@@ -3,16 +3,16 @@
 
 """Tests for the Unsloth CLI overrides (``apply_unsloth_job_cli_overrides``).
 
-Pins the post-2026 submit-only contract: ``submit`` accepts a positional
-``JOB_JSON`` and delegates to the auto-generated callback with ``--spec``
-set to the validated JSON; ``run`` hard-fails with an "use submit"
-message.
+Pins the post-2026 submit-only contract: generated ``run`` is removed, while
+``submit`` accepts a positional ``JOB_JSON`` and delegates to the auto-generated
+callback with ``--spec`` set to the validated JSON.
 """
 
 from __future__ import annotations
 
 import json
 import re
+from dataclasses import dataclass
 from pathlib import Path
 
 import httpx
@@ -34,16 +34,19 @@ def _plain(text: str) -> str:
 
 
 def _build_app() -> typer.Typer:
-    """Build a Typer app with the contributor's overridden run/submit/explain."""
+    """Build a generated Typer app, then apply the contributor overrides."""
     from nemo_platform_plugin.commands import (
         _add_explain_command,
-        _add_run_command,
         _add_submit_command,
     )
 
     app = typer.Typer(no_args_is_help=True)
+
+    @app.command("run")
+    def generated_run() -> None:
+        raise AssertionError("Customizer overrides should remove generated run commands")
+
     scheduler = NemoJobScheduler()
-    _add_run_command(app, UnslothJob, scheduler)
     _add_submit_command(app, UnslothJob, scheduler)
     _add_explain_command(app, UnslothJob, scheduler)
     apply_unsloth_job_cli_overrides(app)
@@ -56,6 +59,13 @@ def _minimal_payload() -> dict[str, object]:
         "dataset": {"path": "default/my-dataset"},
         "schedule": {"max_steps": 60},
     }
+
+
+@dataclass
+class _SubmittedCall:
+    workspace: str | None = None
+    spec: dict[str, object] | None = None
+    base_url: str | None = None
 
 
 class TestLoadJobJson:
@@ -82,18 +92,16 @@ class TestSubmitPath:
         assert path == "/apis/customization/v2/workspaces/acme-corp/unsloth/jobs"
 
 
-class TestRunHardFail:
-    def test_run_exits_1_with_submit_pointer(self, tmp_path: Path) -> None:
-        path = tmp_path / "job.json"
-        path.write_text(json.dumps(_minimal_payload()))
-
+class TestCommandRegistration:
+    def test_help_lists_submit_and_explain_only(self) -> None:
         app = _build_app()
         runner = CliRunner()
-        result = runner.invoke(app, ["run", str(path)])
-        assert result.exit_code == 1
+        result = runner.invoke(app, ["--help"])
+        assert result.exit_code == 0
         plain = _plain(result.output)
         assert "submit" in plain
-        assert "does not support local run" in plain
+        assert "explain" in plain
+        assert "run" not in plain
 
 
 class TestSubmitOverride:
@@ -110,12 +118,12 @@ class TestSubmitOverride:
 
     def test_submit_delegates_with_validated_spec(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """``submit JOB.json -w ws`` forwards workspace + base-url to submit_remote."""
-        submitted: dict[str, object] = {}
+        submitted = _SubmittedCall()
 
         def fake_submit_remote(
             _scheduler,
             _job_cls: type,
-            spec_data: dict,
+            spec_data: dict[str, object],
             base_url: str | None,
             workspace: str,
             profile: str | None = None,
@@ -124,9 +132,9 @@ class TestSubmitOverride:
             http_client: httpx.Client | None = None,
             headers: dict[str, str] | None = None,
         ) -> dict:
-            submitted["workspace"] = workspace
-            submitted["spec"] = spec_data
-            submitted["base_url"] = base_url
+            submitted.workspace = workspace
+            submitted.spec = spec_data
+            submitted.base_url = base_url
             return {"id": "job-99"}
 
         monkeypatch.setattr(
@@ -156,10 +164,13 @@ class TestSubmitOverride:
         )
 
         assert result.exit_code == 0, result.stdout + result.stderr
-        assert submitted["workspace"] == "acme-corp"
-        assert submitted["base_url"] == "https://nmp.test"
+        assert submitted.workspace == "acme-corp"
+        assert submitted.base_url == "https://nmp.test"
         # Raw input shape — to_spec runs inside the (mocked-out) submit_remote.
-        assert submitted["spec"]["model"]["name"] == "unsloth/Qwen2.5-0.5B-Instruct"
+        spec = submitted.spec
+        assert spec is not None
+        captured_input = UnslothJobInput.model_validate(spec)
+        assert captured_input.model.name == "unsloth/Qwen2.5-0.5B-Instruct"
 
 
 class TestExplain:

--- a/plugins/nemo-unsloth/tests/test_contributor.py
+++ b/plugins/nemo-unsloth/tests/test_contributor.py
@@ -9,8 +9,8 @@ Pin the contract the customization-router hub depends on:
 - ``get_routers`` returns the jobs router under the right prefix, with
   ``@path_rule`` authz stamped on the generated job routes (the platform
   derives the policy from those rules — there is no ``get_authz_contribution``).
-- ``get_cli`` exposes ``run`` / ``submit`` / ``explain`` and the submit
-  group accepts the ``JOB_JSON`` positional. ``run`` hard-fails.
+- ``get_cli`` exposes ``submit`` / ``explain`` and the submit group accepts the
+  ``JOB_JSON`` positional.
 """
 
 from __future__ import annotations
@@ -18,6 +18,7 @@ from __future__ import annotations
 import re
 
 import pytest
+from nemo_platform_plugin.customization_contributor import CustomizationContributor
 from typer.testing import CliRunner
 
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
@@ -28,17 +29,17 @@ def _plain(text: str) -> str:
 
 
 @pytest.fixture
-def contributor() -> object:
+def contributor() -> CustomizationContributor:
     from nemo_unsloth_plugin.contributor import UnslothContributor
 
     return UnslothContributor()
 
 
 class TestIdentity:
-    def test_name(self, contributor: object) -> None:
+    def test_name(self, contributor: CustomizationContributor) -> None:
         assert contributor.name == "unsloth"
 
-    def test_dependencies_match_submit_path(self, contributor: object) -> None:
+    def test_dependencies_match_submit_path(self, contributor: CustomizationContributor) -> None:
         # Remote container submit needs the same set of platform services
         # automodel needs: workspace/auth, jobs API, secrets, files + models.
         for required in ("entities", "auth", "jobs", "files", "secrets", "models"):
@@ -46,7 +47,7 @@ class TestIdentity:
 
 
 class TestAuthz:
-    def test_job_routes_carry_unsloth_path_rules(self, contributor: object) -> None:
+    def test_job_routes_carry_unsloth_path_rules(self, contributor: CustomizationContributor) -> None:
         """Authz is derived from ``@path_rule`` on the generated job routes
         (permission namespace ``customization.unsloth.jobs`` from
         ``AuthzScope("customization").child(name, "jobs")``), not a separate
@@ -74,7 +75,7 @@ class TestAuthz:
 
 
 class TestRouters:
-    def test_returns_jobs_router_spec(self, contributor: object) -> None:
+    def test_returns_jobs_router_spec(self, contributor: CustomizationContributor) -> None:
         specs = ()
         try:
             specs = contributor.get_routers()
@@ -91,36 +92,26 @@ class TestRouters:
 
 
 class TestCLI:
-    def test_cli_root_help_lists_three_verbs(self, contributor: object) -> None:
+    def test_cli_root_help_lists_submit_and_explain_only(self, contributor: CustomizationContributor) -> None:
         try:
             cli = contributor.get_cli()
         except ImportError as exc:
             pytest.skip(f"CLI deps unavailable in this env: {exc}")
+        assert cli is not None
         runner = CliRunner()
         result = runner.invoke(cli, ["--help"])
         assert result.exit_code == 0
         plain = _plain(result.output)
-        assert "run" in plain
         assert "submit" in plain
         assert "explain" in plain
+        assert "run" not in plain
 
-    def test_run_hard_fails(self, contributor: object) -> None:
+    def test_submit_help_shows_job_json_positional(self, contributor: CustomizationContributor) -> None:
         try:
             cli = contributor.get_cli()
         except ImportError as exc:
             pytest.skip(f"CLI deps unavailable in this env: {exc}")
-        runner = CliRunner()
-        result = runner.invoke(cli, ["run"])
-        assert result.exit_code == 1
-        plain = _plain(result.output)
-        assert "does not support local run" in plain
-        assert "submit" in plain
-
-    def test_submit_help_shows_job_json_positional(self, contributor: object) -> None:
-        try:
-            cli = contributor.get_cli()
-        except ImportError as exc:
-            pytest.skip(f"CLI deps unavailable in this env: {exc}")
+        assert cli is not None
         runner = CliRunner()
         result = runner.invoke(cli, ["submit", "--help"])
         assert result.exit_code == 0, result.output
@@ -132,7 +123,7 @@ class TestCLI:
 
 
 class TestSDK:
-    def test_exposes_sdk_resources(self, contributor: object) -> None:
+    def test_exposes_sdk_resources(self, contributor: CustomizationContributor) -> None:
         from nemo_unsloth_plugin.sdk.resources import AsyncUnslothCustomization, UnslothCustomization
 
         sdk = contributor.get_sdk_resources()

--- a/uv.lock
+++ b/uv.lock
@@ -4332,7 +4332,6 @@ name = "nemo-customizer-plugin"
 version = "0.0.0"
 source = { editable = "plugins/nemo-customizer" }
 dependencies = [
-    { name = "nemo-platform", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-platform-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "pydantic", extra = ["email"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "typer", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -4348,7 +4347,6 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "nemo-platform", editable = "packages/nemo_platform" },
     { name = "nemo-platform-plugin", editable = "packages/nemo_platform_plugin" },
     { name = "pydantic", specifier = ">=2.10.6" },
     { name = "typer", specifier = ">=0.12.5" },


### PR DESCRIPTION
## TL;DR

Migrates the Customizer jobs SDK for Automodel, Unsloth, and RL onto typed `NemoClient` endpoint resources while preserving the `client.customization.<backend>.jobs` namespace. The Customizer CLI now exposes only `submit` and `explain` for these remote training backends instead of registering a local `run` command that could only fail.

## Details

This adds typed Customizer endpoint definitions and DTOs for health, job create/list/retrieve, then rewires the shared backend SDK factory to build sync/async Customizer contexts from `NemoClient` / `AsyncNemoClient`. Customizer-owned calls return typed `NemoResponse` or paginated responses, and status/log helpers delegate to the core Jobs SDK so lifecycle data comes from the canonical Jobs service routes.

The Customizer hub now passes a typed context to contributor SDK resources, so Automodel, Unsloth, and RL share one implementation path. The `nemo-customizer-plugin` no longer depends directly on `nemo-platform`; it relies on `nemo-platform-plugin` client resources.

For the CLI, Customizer contributors no longer register a generated `run` verb. The backend commands remain submit-only with `nemo customization <backend> submit JOB_JSON`, and the docs, skill guidance, and focused tests were updated to reflect that `run` is not part of the Customizer training surface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added typed synchronous and asynchronous customization SDK clients for creating, listing, retrieving, and monitoring jobs.
  - Added pagination, health checks, workspace-aware operations, and contributor resource access through SDK context.

- **CLI**
  - Customization backends now provide `submit` and `explain`; local `run` commands are no longer available.

- **Documentation**
  - Updated CLI, SDK, schema, and troubleshooting guidance for submit-only workflows and current job responses.

- **Tests**
  - Expanded coverage for SDK operations, endpoints, pagination, health checks, async behavior, and CLI availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->