### PR TITLE
ci: release prepared container candidates

### DIFF
--- a/.github/scripts/release-plan.cjs
+++ b/.github/scripts/release-plan.cjs
@@ -3,6 +3,7 @@
 
 // Release plan parsing is independent of the GitHub Actions runtime.
 const SEMVER_CORE_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+const RELEASE_SERIES_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
 // ECMA-compatible SemVer 2.0.0 pattern from https://semver.org/.
 const SEMVER_PATTERN = new RegExp(
   "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)" +
@@ -38,10 +39,32 @@ function selectArtifacts(value, allowedArtifacts, label, inputName) {
   return allowedArtifacts.filter((artifact) => requestedIds.has(artifact.id));
 }
 
+function deriveNextReleaseVersion(releaseSeries, tags) {
+  const match = RELEASE_SERIES_PATTERN.exec(releaseSeries);
+  if (!match) {
+    throw new Error(
+      "Stable releases require a MAJOR.MINOR release series, for example 0.5.",
+    );
+  }
+
+  const [, major, minor] = match;
+  const latestPatch = tags.reduce((latest, tag) => {
+    const tagMatch = SEMVER_CORE_PATTERN.exec(tag);
+    if (!tagMatch || tagMatch[1] !== major || tagMatch[2] !== minor) {
+      return latest;
+    }
+    return Math.max(latest, Number(tagMatch[3]));
+  }, -1);
+
+  return `${releaseSeries}.${latestPatch + 1}`;
+}
+
 async function resolveReleasePlan({
   env,
   context,
   getCommit,
+  getTags,
+  sourceBelongsToBranch,
   now = () => new Date(),
 }) {
   const allWheels = JSON.parse(env.RELEASE_WHEELS_JSON);
@@ -58,7 +81,10 @@ async function resolveReleasePlan({
     ? (inputs["helm-version"] ?? "").trim()
     : "";
   let sourceSha = isManual ? (inputs["source-sha"] ?? "").trim() : context.sha;
-  const version = releaseType === "stable" ? (inputs.version ?? "").trim() : "";
+  const releaseSeries =
+    releaseType === "stable" ? (inputs["release-series"] ?? "").trim() : "";
+  const releaseBranch = releaseSeries ? `release/${releaseSeries}` : "";
+  let version = "";
 
   if (releaseType === "stable") {
     if (!/^[0-9a-f]{40}$/i.test(sourceSha)) {
@@ -66,8 +92,13 @@ async function resolveReleasePlan({
         "Stable releases require an exact 40-character source SHA.",
       );
     }
-    if (!SEMVER_CORE_PATTERN.test(version)) {
-      throw new Error("Stable releases require a MAJOR.MINOR.PATCH version.");
+    version = deriveNextReleaseVersion(releaseSeries, await getTags());
+    if (
+      !(await sourceBelongsToBranch(sourceSha.toLowerCase(), releaseBranch))
+    ) {
+      throw new Error(
+        `Source SHA ${sourceSha} does not belong to ${releaseBranch}.`,
+      );
     }
   } else {
     if (sourceSha && !/^[0-9a-f]{40}$/i.test(sourceSha)) {
@@ -149,6 +180,8 @@ async function resolveReleasePlan({
   return {
     releaseType,
     releaseScope,
+    releaseSeries,
+    releaseBranch,
     sourceSha,
     version,
     releaseLabel,
@@ -165,4 +198,4 @@ async function resolveReleasePlan({
   };
 }
 
-module.exports = { resolveReleasePlan };
+module.exports = { deriveNextReleaseVersion, resolveReleasePlan };

--- a/.github/scripts/release-plan.cjs
+++ b/.github/scripts/release-plan.cjs
@@ -180,7 +180,6 @@ async function resolveReleasePlan({
   return {
     releaseType,
     releaseScope,
-    releaseSeries,
     releaseBranch,
     sourceSha,
     version,

--- a/.github/scripts/release-qualification.cjs
+++ b/.github/scripts/release-qualification.cjs
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+async function requireReleaseQualification({
+  github,
+  repository,
+  sourceSha,
+  releaseBranch,
+  version,
+}) {
+  const [owner, repo, extra] = repository.split("/");
+  if (!owner || !repo || extra) {
+    throw new Error("Release qualification repository is not configured.");
+  }
+
+  let deployments;
+  try {
+    deployments = await github.paginate(github.rest.repos.listDeployments, {
+      owner,
+      repo,
+      environment: "release-qualified",
+      per_page: 100,
+    });
+  } catch {
+    throw new Error(
+      "Unable to verify release qualification. Ensure the release token has Deployments read access.",
+    );
+  }
+
+  const deployment = deployments.find(
+    ({ payload }) =>
+      payload?.platform_ref === sourceSha &&
+      payload?.release_branch === releaseBranch &&
+      payload?.release_version === version,
+  );
+
+  if (deployment) {
+    try {
+      const { data: statuses } = await github.rest.repos.listDeploymentStatuses(
+        {
+          owner,
+          repo,
+          deployment_id: deployment.id,
+          per_page: 1,
+        },
+      );
+      if (statuses[0]?.state === "success") {
+        return;
+      }
+    } catch {
+      throw new Error(
+        "Unable to verify release qualification. Ensure the release token has Deployments read access.",
+      );
+    }
+  }
+
+  throw new Error(
+    `Source SHA ${sourceSha} is not release-qualified for ${releaseBranch} version ${version}. ` +
+      "Wait for the release-branch container build, nSpect registration, and NGC publishing MR update to succeed, then retry.",
+  );
+}
+
+module.exports = { requireReleaseQualification };

--- a/.github/scripts/release-qualification.cjs
+++ b/.github/scripts/release-qualification.cjs
@@ -36,15 +36,23 @@ async function requireReleaseQualification({
 
   if (deployment) {
     try {
-      const { data: statuses } = await github.rest.repos.listDeploymentStatuses(
+      const statuses = await github.paginate(
+        github.rest.repos.listDeploymentStatuses,
         {
           owner,
           repo,
           deployment_id: deployment.id,
-          per_page: 1,
+          per_page: 100,
         },
       );
-      if (statuses[0]?.state === "success") {
+      const latestStatus = [...statuses]
+        .sort(
+          (left, right) =>
+            left.created_at.localeCompare(right.created_at) ||
+            left.id - right.id,
+        )
+        .at(-1);
+      if (latestStatus?.state === "success") {
         return;
       }
     } catch {

--- a/.github/scripts/tests/release-plan.test.cjs
+++ b/.github/scripts/tests/release-plan.test.cjs
@@ -56,7 +56,6 @@ test("resolves a stable Helm-only release", async () => {
   });
 
   assert.equal(plan.sourceSha, SHA);
-  assert.equal(plan.releaseSeries, "1.2");
   assert.equal(plan.releaseBranch, "release/1.2");
   assert.equal(plan.releaseLabel, "1.2.3");
   assert.equal(plan.includeHelm, true);

--- a/.github/scripts/tests/release-plan.test.cjs
+++ b/.github/scripts/tests/release-plan.test.cjs
@@ -5,7 +5,10 @@
 const assert = require("node:assert/strict");
 const test = require("node:test");
 
-const { resolveReleasePlan } = require("../release-plan.cjs");
+const {
+  deriveNextReleaseVersion,
+  resolveReleasePlan,
+} = require("../release-plan.cjs");
 
 const WHEELS = [
   {
@@ -38,19 +41,66 @@ test("resolves a stable Helm-only release", async () => {
     context: manualContext({
       "release-type": "stable",
       "release-scope": "helm",
+      "release-series": "1.2",
       "source-sha": SHA.toUpperCase(),
-      version: "1.2.3",
       "helm-version": "1.2.3-rc.1+build.9",
     }),
     getCommit: async () =>
       assert.fail("stable releases do not resolve a default branch commit"),
+    getTags: async () => ["1.2.0", "1.2.1", "1.2.2", "2.0.0-rc1"],
+    sourceBelongsToBranch: async (sha, branch) => {
+      assert.equal(sha, SHA);
+      assert.equal(branch, "release/1.2");
+      return true;
+    },
   });
 
   assert.equal(plan.sourceSha, SHA);
+  assert.equal(plan.releaseSeries, "1.2");
+  assert.equal(plan.releaseBranch, "release/1.2");
   assert.equal(plan.releaseLabel, "1.2.3");
   assert.equal(plan.includeHelm, true);
   assert.deepEqual(plan.wheelIds, []);
   assert.deepEqual(plan.containerIds, []);
+});
+
+test("derives the first patch in a release series", () => {
+  assert.equal(
+    deriveNextReleaseVersion("0.5", ["0.4.9", "0.5.0-rc1", "v0.5.0"]),
+    "0.5.0",
+  );
+});
+
+test("derives the patch after the latest stable tag", () => {
+  assert.equal(
+    deriveNextReleaseVersion("0.5", ["0.5.1", "1.5.9", "0.5.7", "0.5.3"]),
+    "0.5.8",
+  );
+});
+
+test("rejects an invalid release series", () => {
+  assert.throws(
+    () => deriveNextReleaseVersion("0.5.1", []),
+    /MAJOR.MINOR release series/,
+  );
+});
+
+test("rejects a stable source outside the release branch", async () => {
+  await assert.rejects(
+    resolveReleasePlan({
+      env: environment(),
+      context: manualContext({
+        "release-type": "stable",
+        "release-scope": "containers",
+        "release-series": "0.5",
+        "source-sha": SHA,
+      }),
+      getCommit: async () => assert.fail("stable releases use an exact SHA"),
+      getTags: async () => [],
+      sourceBelongsToBranch: async () => false,
+    }),
+    new RegExp(`Source SHA ${SHA} does not belong to release/0.5`),
+  );
 });
 
 test("resolves a custom nightly release and uses the supplied clock", async () => {

--- a/.github/scripts/tests/release-qualification.test.cjs
+++ b/.github/scripts/tests/release-qualification.test.cjs
@@ -14,19 +14,28 @@ const REQUEST = {
   version: "0.5.1",
 };
 
-function githubClient(deployments, statuses = [{ state: "success" }]) {
+function githubClient(
+  deployments,
+  statuses = [{ id: 1, state: "success", created_at: "2026-09-01T00:00:00Z" }],
+) {
+  const listDeployments = () => {};
+  const listDeploymentStatuses = () => {};
+
   return {
-    paginate: async (_method, request) => {
-      assert.equal(request.environment, "release-qualified");
-      return deployments;
+    paginate: async (method, request) => {
+      if (method === listDeployments) {
+        assert.equal(request.environment, "release-qualified");
+        return deployments;
+      }
+
+      assert.equal(method, listDeploymentStatuses);
+      assert.equal(request.deployment_id, 42);
+      return statuses;
     },
     rest: {
       repos: {
-        listDeployments: () => {},
-        listDeploymentStatuses: async (request) => {
-          assert.equal(request.deployment_id, 42);
-          return { data: statuses };
-        },
+        listDeployments,
+        listDeploymentStatuses,
       },
     },
   };
@@ -99,7 +108,40 @@ test("rejects a non-success qualification", async () => {
             },
           },
         ],
-        [{ state: "inactive" }],
+        [{ id: 1, state: "inactive", created_at: "2026-09-01T00:00:00Z" }],
+      ),
+    }),
+    /is not release-qualified/,
+  );
+});
+
+test("uses the newest deployment status", async () => {
+  await assert.rejects(
+    requireReleaseQualification({
+      ...REQUEST,
+      github: githubClient(
+        [
+          {
+            id: 42,
+            payload: {
+              platform_ref: SOURCE_SHA,
+              release_branch: "release/0.5",
+              release_version: "0.5.1",
+            },
+          },
+        ],
+        [
+          {
+            id: 1,
+            state: "success",
+            created_at: "2026-09-01T00:00:00Z",
+          },
+          {
+            id: 2,
+            state: "inactive",
+            created_at: "2026-09-02T00:00:00Z",
+          },
+        ],
       ),
     }),
     /is not release-qualified/,

--- a/.github/scripts/tests/release-qualification.test.cjs
+++ b/.github/scripts/tests/release-qualification.test.cjs
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { requireReleaseQualification } = require("../release-qualification.cjs");
+
+const SOURCE_SHA = "a".repeat(40);
+const REQUEST = {
+  repository: "private-owner/private-repo",
+  sourceSha: SOURCE_SHA,
+  releaseBranch: "release/0.5",
+  version: "0.5.1",
+};
+
+function githubClient(deployments, statuses = [{ state: "success" }]) {
+  return {
+    paginate: async (_method, request) => {
+      assert.equal(request.environment, "release-qualified");
+      return deployments;
+    },
+    rest: {
+      repos: {
+        listDeployments: () => {},
+        listDeploymentStatuses: async (request) => {
+          assert.equal(request.deployment_id, 42);
+          return { data: statuses };
+        },
+      },
+    },
+  };
+}
+
+test("accepts the exact successful release qualification", async () => {
+  await requireReleaseQualification({
+    ...REQUEST,
+    github: githubClient([
+      {
+        id: 42,
+        payload: {
+          platform_ref: SOURCE_SHA,
+          release_branch: "release/0.5",
+          release_version: "0.5.1",
+        },
+      },
+    ]),
+  });
+});
+
+test("rejects a missing release qualification", async () => {
+  await assert.rejects(
+    requireReleaseQualification({
+      ...REQUEST,
+      github: githubClient([]),
+    }),
+    /is not release-qualified/,
+  );
+});
+
+for (const [name, payload] of [
+  ["SHA", { platform_ref: "b".repeat(40) }],
+  ["branch", { release_branch: "release/0.6" }],
+  ["version", { release_version: "0.5.0" }],
+]) {
+  test(`rejects a qualification with the wrong ${name}`, async () => {
+    await assert.rejects(
+      requireReleaseQualification({
+        ...REQUEST,
+        github: githubClient([
+          {
+            id: 42,
+            payload: {
+              platform_ref: SOURCE_SHA,
+              release_branch: "release/0.5",
+              release_version: "0.5.1",
+              ...payload,
+            },
+          },
+        ]),
+      }),
+      /is not release-qualified/,
+    );
+  });
+}
+
+test("rejects a non-success qualification", async () => {
+  await assert.rejects(
+    requireReleaseQualification({
+      ...REQUEST,
+      github: githubClient(
+        [
+          {
+            id: 42,
+            payload: {
+              platform_ref: SOURCE_SHA,
+              release_branch: "release/0.5",
+              release_version: "0.5.1",
+            },
+          },
+        ],
+        [{ state: "inactive" }],
+      ),
+    }),
+    /is not release-qualified/,
+  );
+});
+
+test("sanitizes private API failures", async () => {
+  const github = githubClient([]);
+  github.paginate = async () => {
+    throw new Error("private-owner/private-repo is forbidden");
+  };
+
+  await assert.rejects(
+    requireReleaseQualification({ ...REQUEST, github }),
+    (error) => {
+      assert.match(error.message, /Deployments read access/);
+      assert.doesNotMatch(error.message, /private-owner|private-repo/);
+      return true;
+    },
+  );
+});

--- a/.github/workflows/dispatch.yaml
+++ b/.github/workflows/dispatch.yaml
@@ -19,10 +19,34 @@ jobs:
     name: Notify CI consumer
     runs-on: ubuntu-latest
     steps:
+      - name: Check out workflow revision
+        if: startsWith(github.ref_name, 'release/')
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Derive next release version
+        if: startsWith(github.ref_name, 'release/')
+        id: release-version
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { deriveNextReleaseVersion } = require("./.github/scripts/release-plan.cjs");
+            const tags = await github.paginate(github.rest.repos.listTags, {
+              ...context.repo,
+              per_page: 100,
+            });
+            const releaseSeries = context.ref.replace("refs/heads/release/", "");
+            core.setOutput(
+              "version",
+              deriveNextReleaseVersion(releaseSeries, tags.map(({ name }) => name)),
+            );
+
       - name: Send completion event
         env:
           GH_TOKEN: ${{ secrets.CI_DISPATCH_TOKEN }}
           DISPATCH_REPO: ${{ secrets.CI_DISPATCH_REPO }}
+          RELEASE_VERSION: ${{ steps.release-version.outputs.version }}
         shell: bash
         run: |
           set -euo pipefail
@@ -30,7 +54,7 @@ jobs:
           release_version=""
           if [[ "${GITHUB_REF_NAME}" == release/* ]]; then
             event_type="release-branch-updated"
-            release_version="${GITHUB_REF_NAME#release/}"
+            release_version="${RELEASE_VERSION}"
           fi
 
           jq -n \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -150,7 +150,6 @@ jobs:
     outputs:
       release_type: ${{ steps.plan.outputs.release_type }}
       release_scope: ${{ steps.plan.outputs.release_scope }}
-      release_branch: ${{ steps.plan.outputs.release_branch }}
       source_sha: ${{ steps.plan.outputs.source_sha }}
       version: ${{ steps.plan.outputs.version }}
       release_label: ${{ steps.plan.outputs.release_label }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,8 +26,8 @@ on:
         required: false
         type: string
         default: ""
-      version:
-        description: "Stable SemVer core release version, for example 1.0.0."
+      release-series:
+        description: "Stable release series in MAJOR.MINOR format, for example 0.5."
         required: false
         type: string
         default: ""
@@ -130,7 +130,7 @@ env:
     ]
   RELEASE_HELM_ID: nemo-platform
   RELEASE_HELM_PATH: k8s/helm
-  RELEASE_HELM_REGISTRY: nvcr.io/0921617854601259/nemo-platform
+  RELEASE_HELM_REGISTRY: nvcr.io/0921617854601259/nemo-platform-dev
   STABLE_IMAGE_REGISTRY: nvcr.io/nvidia/nemo-platform
   RELEASE_PUBLISH_NIGHTLY_WHEELS: "false"
   RELEASE_NIGHTLY_WHEEL_INDEX: https://pypi.nvidia.com
@@ -150,6 +150,7 @@ jobs:
     outputs:
       release_type: ${{ steps.plan.outputs.release_type }}
       release_scope: ${{ steps.plan.outputs.release_scope }}
+      release_branch: ${{ steps.plan.outputs.release_branch }}
       source_sha: ${{ steps.plan.outputs.source_sha }}
       version: ${{ steps.plan.outputs.version }}
       release_label: ${{ steps.plan.outputs.release_label }}
@@ -192,10 +193,25 @@ jobs:
                 });
                 return commit.sha;
               },
+              getTags: async () => {
+                const tags = await github.paginate(github.rest.repos.listTags, {
+                  ...context.repo,
+                  per_page: 100,
+                });
+                return tags.map(({name}) => name);
+              },
+              sourceBelongsToBranch: async (sourceSha, releaseBranch) => {
+                const {data: comparison} = await github.rest.repos.compareCommitsWithBasehead({
+                  ...context.repo,
+                  basehead: `${sourceSha}...${releaseBranch}`,
+                });
+                return comparison.status === "ahead" || comparison.status === "identical";
+              },
             });
             const outputs = {
               release_type: plan.releaseType,
               release_scope: plan.releaseScope,
+              release_branch: plan.releaseBranch,
               source_sha: plan.sourceSha,
               version: plan.version,
               release_label: plan.releaseLabel,
@@ -215,6 +231,28 @@ jobs:
             Object.entries(outputs).forEach(([name, value]) => core.setOutput(name, value));
             core.info(`Planned ${plan.releaseType} release ${plan.releaseLabel} from ${plan.sourceSha}`);
 
+      - name: Verify exact container SHA is release-qualified
+        if: >-
+          steps.plan.outputs.release_type == 'stable' &&
+          steps.plan.outputs.has_containers == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          QUALIFICATION_REPOSITORY: ${{ secrets.CI_DISPATCH_REPO }}
+          SOURCE_SHA: ${{ steps.plan.outputs.source_sha }}
+          RELEASE_BRANCH: ${{ steps.plan.outputs.release_branch }}
+          RELEASE_VERSION: ${{ steps.plan.outputs.version }}
+        with:
+          github-token: ${{ secrets.CI_DISPATCH_TOKEN }}
+          script: |
+            const { requireReleaseQualification } = require("./.github/scripts/release-qualification.cjs");
+            await requireReleaseQualification({
+              github,
+              repository: process.env.QUALIFICATION_REPOSITORY,
+              sourceSha: process.env.SOURCE_SHA,
+              releaseBranch: process.env.RELEASE_BRANCH,
+              version: process.env.RELEASE_VERSION,
+            });
+
       - name: Checkout selected source
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -223,7 +261,8 @@ jobs:
           fetch-tags: true
           persist-credentials: false
 
-      - name: Ensure selected source is an ancestor of this workflow revision
+      - name: Ensure nightly source is an ancestor of this workflow revision
+        if: steps.plan.outputs.release_type != 'stable'
         shell: bash
         env:
           SOURCE_SHA: ${{ steps.plan.outputs.source_sha }}
@@ -445,6 +484,8 @@ jobs:
               client_payload: {
                 version: process.env.RELEASE_VERSION,
                 source_sha: process.env.SOURCE_SHA,
+                source_team: "nemo-platform-dev",
+                container_version: process.env.SOURCE_SHA,
                 source_run_url: process.env.SOURCE_RUN_URL,
                 wheel_ids: JSON.parse(process.env.WHEEL_IDS),
                 container_ids: JSON.parse(process.env.CONTAINER_IDS),
@@ -496,11 +537,12 @@ jobs:
               },
             });
 
-  dispatch-container-stage:
-    name: Dispatch container builds
+  dispatch-nightly-container-builds:
+    name: Dispatch nightly container builds
     needs: plan-release
     if: >-
       needs.plan-release.outputs.has_containers == 'true' &&
+      needs.plan-release.outputs.release_type == 'nightly' &&
       needs.plan-release.outputs.dry_run != 'true'
     runs-on: ubuntu-latest
     steps:
@@ -694,7 +736,7 @@ jobs:
       - plan-release
       - dispatch-release-registration
       - dispatch-wheel-stage
-      - dispatch-container-stage
+      - dispatch-nightly-container-builds
       - stage-helm
     if: >-
       !cancelled() &&
@@ -832,7 +874,7 @@ jobs:
       - plan-release
       - dispatch-release-registration
       - dispatch-wheel-stage
-      - dispatch-container-stage
+      - dispatch-nightly-container-builds
       - stage-helm
     if: >-
       !cancelled() &&

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -10,13 +10,18 @@ workflow so contributors can see and validate every releasable artifact in one
 place.
 
 Anyone with permission to run repository workflows can start a release. A
-stable release requires a specific source commit and version; a nightly can use
-the default branch head.
+stable release requires a release series and a specific source commit; a
+nightly can use the default branch head.
 
 ## Before starting a stable release
 
-Choose the exact 40-character commit SHA and the `MAJOR.MINOR.PATCH` version
-to release. The source must contain the desired generated SDKs. If the API
+Choose the `MAJOR.MINOR` release series and exact 40-character commit SHA to
+release. The SHA must belong to the corresponding `release/MAJOR.MINOR` branch.
+The workflow derives the next patch version from stable Git tags.
+
+When releasing containers, the selected SHA must already have completed the
+release-branch container build, nSpect registration, and NGC publishing MR
+update. The source must also contain the desired generated SDKs. If the API
 surface changed since the last SDK update, update the SDKs before releasing:
 
 ```bash
@@ -55,11 +60,11 @@ and select **Run workflow**. The form shows the allowed custom artifact IDs.
 | --- | --- |
 | `release-type` | `nightly` by default. Select `stable` for a full release. |
 | `source-sha` | Required for stable releases. Optional for nightlies; a normal nightly with no SHA uses the current default-branch head. A dry-run nightly with no SHA uses the workflow commit so a branch can be validated. |
-| `version` | Required for stable releases. Enter the `MAJOR.MINOR.PATCH` release version. |
+| `release-series` | Required for stable releases. Enter `MAJOR.MINOR`; the workflow derives the next patch version from stable Git tags. |
 | `release-scope` | `all` by default. Select `wheels`, `containers`, `helm`, or `custom` for a subset. |
 | `wheel-ids`, `container-ids` | Comma-separated IDs used only with `release-scope: custom`. Each ID must be in the catalog above; duplicates and empty entries fail validation. |
 | `include-helm` | Includes the Helm chart in a custom release. |
-| `helm-version` | Optional exact SemVer Helm chart version for stable Helm-only releases. The stable release label still comes from `version`. |
+| `helm-version` | Optional exact SemVer Helm chart version for stable Helm-only releases. The stable release label still comes from the derived version. |
 | `update-ngc-metadata` | Also runs the reusable NGC metadata workflow for `nemo-platform` and `nemo-platform-dev`. It checks out the workflow ref, normally `main`. |
 | `send-notifications` | Sends Slack start and final-status notifications. Defaults to `true`. |
 | `dry-run` | Validates the selected source and packages the selected Helm chart, but does not publish, dispatch external work, poll, create a GitHub release, or signal deployment. The start notification intentionally still runs when notifications are enabled. |
@@ -69,10 +74,10 @@ Examples:
 | Goal | Inputs |
 | --- | --- |
 | Scheduled-style nightly | Leave `release-type` as `nightly` and use the default `all` scope. |
-| Stable full release | `release-type: stable`, `source-sha: <40-character SHA>`, `version: <MAJOR.MINOR.PATCH>`, `release-scope: all`. |
+| Stable full release | `release-type: stable`, `release-series: <MAJOR.MINOR>`, `source-sha: <40-character SHA>`, `release-scope: all`. |
 | One container | `release-scope: custom`, `container-ids: nmp-customizer-tasks`. |
 | Helm-only validation | `release-scope: helm`, `dry-run: true`. |
-| Stable Helm-only chart override | `release-type: stable`, `source-sha: <40-character SHA>`, `version: 0.1.0`, `release-scope: helm`, `helm-version: 0.1.0+helmfix1`. |
+| Stable Helm-only chart override | `release-type: stable`, `release-series: 0.1`, `source-sha: <40-character SHA>`, `release-scope: helm`, `helm-version: 0.1.0+helmfix1`. |
 
 Nightlies also run automatically Monday through Friday at 8:00 PM
 America/Los_Angeles.
@@ -80,15 +85,18 @@ America/Los_Angeles.
 ## What the workflow does
 
 1. Resolves the source, release label, selected artifacts, wheel version, and
-   Helm chart version. Stable versions use the supplied release version.
-   Nightly labels use `nightly-<UTC timestamp>` and the wheel version is
-   resolved by `.github/scripts/stamp_sdk_version.py`.
-2. Checks out the selected source and validates the selected wheel paths,
-   Docker Bake targets, and NGC overview files.
+   Helm chart version. Stable versions use the next patch version derived from
+   stable Git tags. Nightly labels use `nightly-<UTC timestamp>` and the wheel
+   version is resolved by `.github/scripts/stamp_sdk_version.py`.
+2. Verifies the stable source belongs to its release branch. When containers
+   are selected, it also verifies that exact SHA and derived version are marked
+   `release-qualified`. It then checks out the source and validates the selected
+   wheel paths, Docker Bake targets, and NGC overview files.
 3. Optionally synchronizes NGC metadata, when requested on a non-dry-run.
-4. Dispatches wheel, container, and stable-release registration work to the
-   configured internal release repository. The selected source SHA, release
-   type, version, and selected IDs are passed with the dispatch.
+4. Dispatches wheel builds, nightly container builds, and stable-release
+   registration work to the configured internal release repository. Stable
+   containers reuse the exact-SHA development images prepared by the release
+   branch instead of rebuilding them.
 5. Packages the Helm chart with the planned chart version. A nightly chart uses
    the latest release or RC Git tag core reachable from the selected source with
    `-nightly-<UTC timestamp>` appended, falling back to the `Chart.yaml`
@@ -113,7 +121,7 @@ America/Los_Angeles.
 | --- | --- | --- |
 | Wheels | Staged only | [PyPI](https://pypi.org) |
 | Containers | `ghcr.io/nvidia-nemo/nemo-platform/<id>:nightly-...` | `nvcr.io/nvidia/nemo-platform/<id>:<version>` and the public NGC catalog |
-| Helm chart | OCI chart at `oci://ghcr.io/nvidia-nemo/nemo-platform` | Initially staged at `0921617854601259/nemo-platform`, then promoted to the public [NGC Helm repository](https://helm.ngc.nvidia.com/nvidia/nemo-platform) |
+| Helm chart | OCI chart at `oci://ghcr.io/nvidia-nemo/nemo-platform` | Initially staged at `0921617854601259/nemo-platform-dev`, then promoted to the public [NGC Helm repository](https://helm.ngc.nvidia.com/nvidia/nemo-platform) |
 
 The stable Helm promotion is external to this workflow. The workflow polls the
 public NGC Helm repository, not the internal staging endpoint, before it marks
@@ -139,7 +147,7 @@ Dry-runs do not poll or send the delayed or final notification.
 | Secret | Used for |
 | --- | --- |
 | `CI_DISPATCH_REPO` | `owner/repo` of the internal release repository that receives release dispatches. |
-| `CI_DISPATCH_TOKEN` | Authenticating those cross-repository dispatches. |
+| `CI_DISPATCH_TOKEN` | Authenticating cross-repository dispatches and reading release qualification deployments. |
 | `AIRE_NVCR_GITHUB` | Staging stable Helm charts in NGC. |
 | `AIRE_NGC_GITHUB_PLATFORM_RW` | Optional NGC metadata synchronization. |
 | `SLACK_ALERTS_WEBHOOK` | Release starts, delay alerts, and failed final statuses. |


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
<!-- In 1-3 plain sentences, explain what changes and why. Describe before-and-after behavior when it applies. -->

Stable releases currently rebuild containers on release day even though the release branch has already built the exact SHA. This PR makes release day reuse that prepared SHA: the operator provides the release series, exact SHA, and artifact scope, and the workflow derives the next patch version. For container scopes, it requires a successful preparation record matching the exact SHA, release branch, and derived version.

`release branch prepares exact SHA → operator selects SHA and scope → verify preparation → publish without rebuilding`

Wheel-only and Helm-only releases remain independent and do not require a prepared container candidate.

## Changes
<!-- List the concrete changes included in this pull request. -->

- replace the manually entered stable version with a `MAJOR.MINOR` release series and derive the next patch from Git tags
- validate that the exact source SHA belongs to the matching release branch
- require prior successful preparation only when the selected scope contains containers
- reuse the exact-SHA development containers for stable releases instead of dispatching another build
- keep nightly container builds and the existing wheel, Helm, polling, tag, and GitHub Release behavior unchanged

The companion internal release-tooling change must land first.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [x] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `flox -q activate --dir . -- uv run pre-commit run -a`
- `make check-github-scripts` (18 tests plus lint and format checks)
- `/opt/homebrew/bin/actionlint`
- ACT dry-runs for the release-branch dispatch and stable container release workflow
