### PR TITLE
docs: raise reasoning model output budget

### DIFF
--- a/docs/evaluator/metrics/model-configuration.mdx
+++ b/docs/evaluator/metrics/model-configuration.mdx
@@ -93,7 +93,7 @@ job = evaluator.submit(
     dataset=dataset,
     config=RunConfigOnlineModel(
         parallelism=4,
-        inference=InferenceParams(temperature=0.1, max_tokens=64),
+        inference=InferenceParams(temperature=0.1, max_tokens=4096),
     ),
     target=model,
     prompt_template={


### PR DESCRIPTION
## Summary

- follow up on #1712 and NVBug 6710048
- raise the concise Model Configuration example's output budget from 64 to 4096 tokens
- keep the example compatible with the public `InferenceParams` constructor and the replacement Nemotron 3.5 Lightning reasoning model

## Why

Nemotron 3.5 Lightning can spend a 64-token completion budget entirely on reasoning and return no visible answer. In three repeated live requests, the published 64-token configuration returned HTTP 200 with `finish_reason=length` and empty content every time. A larger total budget lets the model finish its reasoning and produce the expected concise answer.

## Verification

Live target: OSS `release/0.5` source deployment `d4066e093`, no-auth, real Platform inference traffic and Docker Evaluator jobs; no mocks.

- concise direct request, 1024 tokens: 5/5 HTTP 200, `finish_reason=stop`, non-empty answer
- concise direct request, 4096 tokens: 5/5 HTTP 200, `finish_reason=stop`, non-empty answer
- final 4096-token Docker target path: 3/3 jobs completed; each produced one row, Exact Match mean 1.0, and `nan_count=0`
- Model Configuration judge path: passed with one row and judge score 5.0
- resolved inline Model path: passed with one row, Exact Match mean 1.0, and `nan_count=0`
- ModelRef path: passed with one row, Exact Match mean 1.0, and `nan_count=0`
- LLM-as-a-Judge page blocks 1-6: 6/6 passed, including the durable Docker job
- `make docs-check`: passed; 218 MDX files parsed cleanly
- `make docs-check-python-snippets DOCS_PATH=docs/evaluator/metrics/model-configuration.mdx`: passed; 8/8 snippets
- targeted pre-commit and `git diff --check`: passed

Focused evidence is preserved under `/tmp/nmp-test/docs-runs/20260903/verify-nvbug-6710048-followup` on the QA host.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Increased the `max_tokens` setting in the model-target evaluation example from 64 to 4096.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->