### PR TITLE
fix(models): chmod pulled weights before NIM server start

### DIFF
--- a/services/core/models/src/nmp/core/models/controllers/backends/deployments_plugin/compiler.py
+++ b/services/core/models/src/nmp/core/models/controllers/backends/deployments_plugin/compiler.py
@@ -107,6 +107,16 @@ def _busybox_image(config: DeploymentsPluginConfig) -> str:
     return _image(config.busybox_image, config.busybox_image_tag)
 
 
+def _weights_permissions_init_container(config: DeploymentsPluginConfig, volume_name: str) -> Container:
+    """chmod the model store so a non-root server can read the puller's 0600 HF cache."""
+    return Container(
+        name="weights-permissions-init",
+        image=_busybox_image(config),
+        command=["sh", "-c", f"chmod -R a+rX {_WEIGHTS_MOUNT}"],
+        volumeMounts=[VolumeMount(name=volume_name, mountPath=_WEIGHTS_MOUNT)],
+    )
+
+
 def _weighted(resolved: ResolvedPluginDeployment, engine: str) -> bool:
     is_files = resolved.weights_type == ModelWeightsType.FILES_SERVICE
     if engine == ENGINE_VLLM:
@@ -319,7 +329,12 @@ def compile_model_deployment(
     mounts: list[VolumeMount] = []
     if weighted:
         mounts.append(VolumeMount(name=names.volume, mountPath=_WEIGHTS_MOUNT, readOnly=True))
-    init_containers: list[Container] = list(tool_call_inits or [])
+    init_containers: list[Container] = []
+    # Skip when k8s pins a shared uid; otherwise the root puller's 0600 HF cache is unreadable.
+    security_context = backend_config.k8s.security_context if backend_config and backend_config.k8s else None
+    if weighted and (security_context is None or security_context.run_as_user is None):
+        init_containers.append(_weights_permissions_init_container(config, names.volume))
+    init_containers.extend(tool_call_inits or [])
     server_config_containers: list[Container]
     readiness_probe = Probe(httpGet=HTTPGetAction(path=resolve_health_path(engine, resolved.view), port=8000))
     vllm_command = ["vllm", "serve"] if engine == ENGINE_VLLM else None

--- a/services/core/models/tests/unit/controllers/backends/deployments_plugin/test_compiler.py
+++ b/services/core/models/tests/unit/controllers/backends/deployments_plugin/test_compiler.py
@@ -12,6 +12,7 @@ from nmp.core.models.app import ModelWeightsType
 from nmp.core.models.controllers.backends.common import DeploymentConfigView
 from nmp.core.models.controllers.backends.deployments_plugin.compiler import _busybox_image, compile_model_deployment
 from nmp.core.models.controllers.backends.deployments_plugin.config import DeploymentsPluginConfig
+from nmp.core.models.controllers.backends.deployments_plugin.nim_compiler import pod_security_context_for_engine
 from nmp.core.models.controllers.backends.deployments_plugin.resolve import ResolvedPluginDeployment
 from nmp.core.models.controllers.backends.vllm_compiler import MODEL_STORE_PATH
 
@@ -54,6 +55,51 @@ def test_docker_weights_volume_requests_init_chmod() -> None:
     assert docker_cfg.init_image == _busybox_image(config)
 
 
+def test_docker_weighted_server_fixes_pulled_weight_permissions() -> None:
+    # The volume init chmod runs on an empty volume, so it cannot reach the 0600
+    # HF tree manifest the puller writes later. A server init container fixes the
+    # pulled contents before the non-root serving image checksums them.
+    config = DeploymentsPluginConfig()
+    compiled = compile_model_deployment(_resolved("nim", runtime=Runtime.DOCKER), config)
+    init = compiled.server_config.init_containers[0]
+    assert init.name == "weights-permissions-init"
+    assert init.image == _busybox_image(config)
+    assert init.command == ["sh", "-c", "chmod -R a+rX /model-store"]
+    # The server mounts the weights read-only; the fixup needs write access.
+    assert [(mount.name, mount.read_only) for mount in init.volume_mounts] == [(compiled.names.volume, False)]
+
+
+@pytest.mark.parametrize("engine", ["nim", "vllm"])
+def test_k8s_weighted_server_has_no_weights_permissions_init(engine: str) -> None:
+    # A pod securityContext pins one uid for both the puller Job and the server, so
+    # the manifest is already owned by the serving uid. Chmod-ing there would also
+    # fail, since the mount root is owned by the fs_group rather than run_as_user.
+    compiled = compile_model_deployment(_resolved(engine, runtime=Runtime.KUBERNETES), DeploymentsPluginConfig())
+    assert "weights-permissions-init" not in [init.name for init in compiled.server_config.init_containers]
+
+
+def test_k8s_generic_engine_fixes_pulled_weight_permissions() -> None:
+    # The generic engine defaults to the image's own user, so no pod securityContext
+    # is emitted and the root puller's 0600 manifest is unreadable by a non-root
+    # serving image -- the same split docker has.
+    config = DeploymentsPluginConfig()
+    resolved = _resolved("generic", runtime=Runtime.KUBERNETES)
+    resolved.view.image_name = "custom/server"
+    assert pod_security_context_for_engine("generic", resolved.view, config) is None
+    compiled = compile_model_deployment(resolved, config)
+    assert compiled.server_config.init_containers[0].name == "weights-permissions-init"
+
+
+def test_k8s_generic_engine_with_run_as_user_skips_permissions_init() -> None:
+    # An explicit run_as_user restores the shared-uid guarantee.
+    config = DeploymentsPluginConfig()
+    resolved = _resolved("generic", runtime=Runtime.KUBERNETES)
+    resolved.view.image_name = "custom/server"
+    resolved.view.run_as_user = 1000
+    compiled = compile_model_deployment(resolved, config)
+    assert "weights-permissions-init" not in [init.name for init in compiled.server_config.init_containers]
+
+
 def test_k8s_weights_volume_has_no_docker_init_chmod() -> None:
     # On k8s, pod securityContext/fs_group handles volume ownership, so no docker
     # init-chmod is emitted.
@@ -89,6 +135,8 @@ def test_vllm_server_command_image_args_and_gpu() -> None:
     puller_env = {item.name: item.value for item in puller.env}
     assert puller_env["HF_ENDPOINT"] == resolved.files_hf_url
     assert puller_env["HF_TOKEN"] == "service:models"
+    assert puller.command == ["hf"]
+    assert puller.args == ["download", "org/model", "--local-dir", "/model-store"]
     assert "nvidia.com/gpu" not in puller.resources.limits
 
 


### PR DESCRIPTION
Fixes https://nvbugspro.nvidia.com/bug/6711340

Add a weights-permissions-init server init container that chmods the HF cache after the puller finishes. Docker and k8s generic engines without a shared run_as_user need this so a non-root NIM image can read the puller's 0600 manifest. Skip it when k8s already pins a shared uid for puller and server.

<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
<!-- In 1-3 plain sentences, explain what changes and why. Describe before-and-after behavior when it applies. -->

## Related Issue
<!-- Use Fixes #NNN or Closes #NNN for a related issue. Remove this section if there is none. -->

## Changes
<!-- List the concrete changes included in this pull request. -->

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [ ] Pull request title follows the repository's Conventional Commit format
- [ ] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [ ] Targeted tests pass, or tests are marked not applicable above
- [ ] No secrets, API keys, or credentials are included

Targeted validation:

<!-- List each command and result. Explain skipped, blocked, or non-successful checks without marking them as passed. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved weighted deployments so non-root inference servers can reliably access models downloaded to the shared model cache.
  - Deployment initialization now preserves existing tool-call setup while applying the appropriate access permissions across supported engines.
  - Kubernetes deployments with an explicitly shared user identity continue to use their configured security settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->