### PR TITLE
feat(agents): Endpoint for checking Agents' MCP Status

### DIFF
--- a/plugins/nemo-agents/openapi/openapi.yaml
+++ b/plugins/nemo-agents/openapi/openapi.yaml
@@ -154,6 +154,43 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /apis/agents/v2/workspaces/{workspace}/agents/{name}/status:
+    get:
+      tags:
+      - Agents
+      summary: Get Agent Status
+      description: "Report the runtime status of an agent, including its MCP servers.\n\
+        \nA stdio MCP server that never spawns degrades an agent silently \u2014 the\n\
+        harness just gets fewer tools \u2014 so every declared server is listed here\n\
+        whether or not it started, and each running deployment is asked to resolve\n\
+        its own servers against the PATH its runtime actually has."
+      operationId: get_agent_status_apis_agents_v2_workspaces__workspace__agents__name__status_get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentStatus'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /apis/agents/v2/workspaces/{workspace}/compute-specs:
     post:
       tags:
@@ -3970,6 +4007,60 @@ components:
         \ ``agent_deployment``\nLifecycle: pending \u2192 starting \u2192 running\
         \ | failed.\nThe :class:`~nemo_agents_plugin.runner.controller.AgentDeploymentController`\n\
         drives state transitions by reconciling this entity against the\n:class:`~nemo_agents_plugin.runner.backend.RunnerBackend`."
+    AgentDeploymentStatus:
+      properties:
+        deployment:
+          type: string
+          title: Deployment
+          description: Name of the AgentDeployment.
+        deployment_mode:
+          type: string
+          enum:
+          - subprocess
+          - docker
+          - k8s
+          title: Deployment Mode
+          description: subprocess | docker | k8s.
+        status:
+          type: string
+          enum:
+          - pending
+          - starting
+          - running
+          - failed
+          - deleting
+          title: Status
+          description: Deployment lifecycle status.
+        endpoint:
+          type: string
+          title: Endpoint
+          description: Routable endpoint of the runtime, when it has one.
+          default: ''
+        error:
+          type: string
+          title: Error
+          description: Deployment-level error, when the deployment itself failed.
+          default: ''
+        probe_error:
+          type: string
+          title: Probe Error
+          description: Why the MCP status could not be read from the runtime; empty
+            when the check ran.
+          default: ''
+        mcp_servers:
+          items:
+            $ref: '#/components/schemas/McpServerStatus'
+          type: array
+          title: Mcp Servers
+          description: Every MCP server this deployment's config declares, with its
+            runtime state.
+      type: object
+      required:
+      - deployment
+      - deployment_mode
+      - status
+      title: AgentDeploymentStatus
+      description: Runtime status of one deployment of an agent, with its MCP servers.
     AgentEnvironment:
       properties:
         description:
@@ -4376,6 +4467,46 @@ components:
         The session entity owns Platform-level conversation identity only. Live
 
         harness state remains process-local to the deployment''s serving runtime.'
+    AgentStatus:
+      properties:
+        agent:
+          type: string
+          title: Agent
+          description: Name of the agent.
+        workspace:
+          type: string
+          title: Workspace
+          description: Workspace the agent belongs to.
+        checked_at:
+          type: string
+          format: date-time
+          title: Checked At
+          description: When the status was assembled.
+        declared_mcp_servers:
+          items:
+            $ref: '#/components/schemas/McpServerStatus'
+          type: array
+          title: Declared Mcp Servers
+          description: MCP servers declared in the stored agent config, each reported
+            as 'not_started'.
+        deployments:
+          items:
+            $ref: '#/components/schemas/AgentDeploymentStatus'
+          type: array
+          title: Deployments
+          description: Runtime status per deployment of this agent.
+      type: object
+      required:
+      - agent
+      - workspace
+      - checked_at
+      title: AgentStatus
+      description: "Response body for ``GET /v2/workspaces/{workspace}/agents/{name}/status``.\n\
+        \n``declared_mcp_servers`` is the static view from the stored agent config\
+        \ \u2014\nwhat the agent expects to exist \u2014 and is populated whether\
+        \ or not anything\nis deployed. ``deployments`` adds the runtime view, one\
+        \ entry per\ndeployment, each reporting the same servers as the runtime actually\
+        \ finds\nthem."
     AgentWorkdir:
       properties:
         base_workdir:
@@ -5822,6 +5953,78 @@ components:
         the url + env + secrets for that same name. Matched by server-name key at
 
         compile time; ``secrets`` are merged into the server''s ``env``.'
+    McpServerStatus:
+      properties:
+        name:
+          type: string
+          title: Name
+          description: Server name as declared under mcp.servers in the agent config.
+        transport:
+          type: string
+          title: Transport
+          description: Transport as declared (e.g. 'stdio', 'streamable_http').
+        target:
+          type: string
+          title: Target
+          description: Command to spawn for stdio servers, or the endpoint URL for
+            remote ones.
+        args:
+          items:
+            type: string
+          type: array
+          title: Args
+          description: Arguments passed to a stdio command.
+        exposure:
+          type: string
+          title: Exposure
+          description: '''harness_native'' or ''fabric_managed''.'
+          default: ''
+        state:
+          type: string
+          enum:
+          - running
+          - unresolved
+          - spawn_failed
+          - unreachable
+          - not_started
+          - unknown
+          title: State
+          description: 'running: reachable and initialized. unresolved: stdio command
+            not found on the runtime PATH. spawn_failed: command resolved but the
+            server died or never initialized. unreachable: remote server did not answer.
+            not_started: nothing is running to check against. unknown: transport not
+            understood, so no check was made.'
+        command_resolved:
+          type: boolean
+          title: Command Resolved
+          description: Whether a stdio command was found on the runtime PATH. Always
+            false for remote transports, which have no command to resolve. The path
+            it resolved to is deliberately not reported.
+          default: false
+        detail:
+          type: string
+          title: Detail
+          description: Human-readable explanation of the state.
+          default: ''
+        error:
+          type: string
+          title: Error
+          description: Error message or stderr snippet when the server failed to start.
+          default: ''
+        tools:
+          items:
+            type: string
+          type: array
+          title: Tools
+          description: Tool names the server advertised, when it started.
+      type: object
+      required:
+      - name
+      - transport
+      - target
+      - state
+      title: McpServerStatus
+      description: Runtime state of one MCP server an agent declares.
     ModelProviderOverride:
       properties:
         base_url:

--- a/plugins/nemo-agents/openapi/openapi.yaml
+++ b/plugins/nemo-agents/openapi/openapi.yaml
@@ -159,11 +159,7 @@ paths:
       tags:
       - Agents
       summary: Get Agent Status
-      description: "Report the runtime status of an agent, including its MCP servers.\n\
-        \nA stdio MCP server that never spawns degrades an agent silently \u2014 the\n\
-        harness just gets fewer tools \u2014 so every declared server is listed here\n\
-        whether or not it started, and each running deployment is asked to resolve\n\
-        its own servers against the PATH its runtime actually has."
+      description: Report the runtime status of an agent, including its MCP servers.
       operationId: get_agent_status_apis_agents_v2_workspaces__workspace__agents__name__status_get
       parameters:
       - name: workspace
@@ -185,6 +181,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgentStatus'
+        '404':
+          description: Agent not found
         '422':
           description: Validation Error
           content:
@@ -4501,12 +4499,16 @@ components:
       - workspace
       - checked_at
       title: AgentStatus
-      description: "Response body for ``GET /v2/workspaces/{workspace}/agents/{name}/status``.\n\
-        \n``declared_mcp_servers`` is the static view from the stored agent config\
-        \ \u2014\nwhat the agent expects to exist \u2014 and is populated whether\
-        \ or not anything\nis deployed. ``deployments`` adds the runtime view, one\
-        \ entry per\ndeployment, each reporting the same servers as the runtime actually\
-        \ finds\nthem."
+      description: 'Response body for ``GET /v2/workspaces/{workspace}/agents/{name}/status``.
+
+
+        ``declared_mcp_servers`` is the static view from the stored agent config,
+
+        what the agent expects to exist, and is populated whether or not anything
+
+        is deployed. ``deployments`` adds the runtime view, one entry per deployment,
+
+        each reporting the same servers as the runtime actually finds them.'
     AgentWorkdir:
       properties:
         base_workdir:

--- a/plugins/nemo-agents/openapi/openapi.yaml
+++ b/plugins/nemo-agents/openapi/openapi.yaml
@@ -183,6 +183,15 @@ paths:
                 $ref: '#/components/schemas/AgentStatus'
         '404':
           description: Agent not found
+        '500':
+          description: Failed to list deployments for the agent
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
         '422':
           description: Validation Error
           content:
@@ -6011,7 +6020,7 @@ components:
         error:
           type: string
           title: Error
-          description: Error message or stderr snippet when the server failed to start.
+          description: Short, generic error message when the server failed to start.
           default: ''
         tools:
           items:

--- a/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/agents.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/agents.py
@@ -11,17 +11,28 @@ prefix from the RouterSpec).
 from __future__ import annotations
 
 import logging
+from datetime import UTC, datetime
 from typing import Any
 
+import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query
 from nemo_agents_plugin.agent_config_formats import AgentConfigFormatError, validate_agent_config
 from nemo_agents_plugin.api.v2._perms import AgentPerms
 from nemo_agents_plugin.api.v2.dependencies import get_entity_client
 from nemo_agents_plugin.authz import scope
+from nemo_agents_plugin.deployment_routing import get_deployment_endpoint, is_deployment_routable
 from nemo_agents_plugin.entities import Agent, AgentDeployment
+from nemo_agents_plugin.mcp_status import (
+    McpServerStatus,
+    McpStatusResponse,
+    config_from_dict,
+    declared_mcp_servers,
+)
 from nemo_agents_plugin.schema import (
+    AgentDeploymentStatus,
     AgentFilter,
     AgentPage,
+    AgentStatus,
     CreateAgentRequest,
 )
 from nemo_platform_plugin.api.filters import make_filter_obj_dep
@@ -33,6 +44,8 @@ from nemo_platform_plugin.schema import PaginationData
 # "failed" and "deleting" are excluded — they are terminal/in-cleanup and
 # do not represent an actively running process the user needs to clean up first.
 _BLOCKING_STATUSES = frozenset({"pending", "starting", "running"})
+
+_RUNTIME_PROBE_TIMEOUT_SECONDS = 30.0
 
 logger = logging.getLogger(__name__)
 
@@ -125,8 +138,12 @@ async def get_agent(
     entity_client: NemoEntitiesClient = Depends(get_entity_client),
 ) -> Agent:
     """Get a specific agent by name."""
+    return await _get_agent_or_404(workspace, name, entity_client)
+
+
+async def _get_agent_or_404(workspace: str, name: str, entity_client: NemoEntitiesClient) -> Agent:
     try:
-        agent = await entity_client.get(Agent, name=name, workspace=workspace)
+        return await entity_client.get(Agent, name=name, workspace=workspace)
     except NemoEntityNotFoundError as exc:
         raise HTTPException(
             status_code=404,
@@ -135,7 +152,90 @@ async def get_agent(
     except Exception as exc:
         logger.exception("Failed to get agent '%s'", name)
         raise HTTPException(status_code=500, detail="Failed to get agent.") from exc
-    return agent
+
+
+@router.get("/agents/{name}/status", response_model=AgentStatus, tags=["Agents"])
+@scope.read
+@path_rule(
+    callers=[CallerKind.PRINCIPAL],
+    permissions=[AgentPerms.READ],
+)
+async def get_agent_status(
+    workspace: str,
+    name: str,
+    entity_client: NemoEntitiesClient = Depends(get_entity_client),
+) -> AgentStatus:
+    """Report the runtime status of an agent, including its MCP servers."""
+    agent = await _get_agent_or_404(workspace, name, entity_client)
+
+    try:
+        result = await entity_client.list(AgentDeployment, workspace=workspace)
+    except Exception as exc:
+        logger.exception("Failed to list deployments for agent '%s'", name)
+        raise HTTPException(status_code=500, detail="Failed to list deployments.") from exc
+
+    agent_config = config_from_dict(agent.config)
+    deployments = sorted((d for d in result.data if d.agent == name), key=lambda d: d.name)
+    return AgentStatus(
+        agent=name,
+        workspace=workspace,
+        checked_at=datetime.now(UTC),
+        declared_mcp_servers=declared_mcp_servers(agent_config) if agent_config else [],
+        deployments=[await _deployment_status(deployment) for deployment in deployments],
+    )
+
+
+async def _deployment_status(deployment: AgentDeployment) -> AgentDeploymentStatus:
+    """Read one deployment's MCP status from its runtime, or say why we could not."""
+    config = config_from_dict(deployment.config)
+    declared = declared_mcp_servers(config) if config else []
+    endpoint = get_deployment_endpoint(deployment) or ""
+    status = AgentDeploymentStatus(
+        deployment=deployment.name,
+        deployment_mode=deployment.deployment_mode,
+        status=deployment.status,
+        endpoint=endpoint,
+        error=deployment.error,
+        mcp_servers=declared,
+    )
+    if not is_deployment_routable(deployment):
+        return status
+
+    probed, probe_error = await _probe_deployment(endpoint)
+    if probed is None:
+        status.probe_error = probe_error
+        status.mcp_servers = [_unknown(server, probe_error) for server in declared]
+        return status
+    status.mcp_servers = probed.servers
+    return status
+
+
+async def _probe_deployment(endpoint: str) -> tuple[McpStatusResponse | None, str]:
+    """Ask one runtime for its MCP status, or return a short reason it could not be read."""
+    url = f"{endpoint.rstrip('/')}/mcp/status"
+    try:
+        async with httpx.AsyncClient(timeout=_RUNTIME_PROBE_TIMEOUT_SECONDS) as client:
+            response = await client.get(url)
+    except httpx.TimeoutException:
+        logger.debug("MCP status check of %s timed out", url, exc_info=True)
+        return None, "Runtime did not respond in time."
+    except httpx.HTTPError:
+        logger.debug("MCP status check of %s failed", url, exc_info=True)
+        return None, "Could not reach the runtime."
+    if response.status_code == 404:
+        return None, "Runtime does not report MCP status."
+    if response.status_code >= 400:
+        return None, f"Runtime returned HTTP {response.status_code}."
+    try:
+        return McpStatusResponse.model_validate(response.json()), ""
+    except Exception:
+        logger.debug("Unreadable MCP status from %s", url, exc_info=True)
+        return None, "Runtime returned an unreadable status."
+
+
+def _unknown(server: McpServerStatus, probe_error: str) -> McpServerStatus:
+    """The declared server, marked as un-checked because the runtime did not answer."""
+    return server.model_copy(update={"state": "unknown", "detail": probe_error})
 
 
 @router.delete("/agents/{name}", status_code=204, tags=["Agents"])

--- a/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/agents.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/agents.py
@@ -159,7 +159,15 @@ async def _get_agent_or_404(workspace: str, name: str, entity_client: NemoEntiti
     "/agents/{name}/status",
     response_model=AgentStatus,
     tags=["Agents"],
-    responses={404: {"description": "Agent not found"}},
+    responses={
+        404: {"description": "Agent not found"},
+        500: {
+            "description": "Failed to list deployments for the agent",
+            "content": {
+                "application/json": {"schema": {"type": "object", "properties": {"detail": {"type": "string"}}}}
+            },
+        },
+    },
 )
 @scope.read
 @path_rule(

--- a/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/agents.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/agents.py
@@ -10,6 +10,7 @@ prefix from the RouterSpec).
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import UTC, datetime
 from typing import Any
@@ -154,7 +155,12 @@ async def _get_agent_or_404(workspace: str, name: str, entity_client: NemoEntiti
         raise HTTPException(status_code=500, detail="Failed to get agent.") from exc
 
 
-@router.get("/agents/{name}/status", response_model=AgentStatus, tags=["Agents"])
+@router.get(
+    "/agents/{name}/status",
+    response_model=AgentStatus,
+    tags=["Agents"],
+    responses={404: {"description": "Agent not found"}},
+)
 @scope.read
 @path_rule(
     callers=[CallerKind.PRINCIPAL],
@@ -176,12 +182,13 @@ async def get_agent_status(
 
     agent_config = config_from_dict(agent.config)
     deployments = sorted((d for d in result.data if d.agent == name), key=lambda d: d.name)
+    deployment_statuses = await asyncio.gather(*(_deployment_status(deployment) for deployment in deployments))
     return AgentStatus(
         agent=name,
         workspace=workspace,
         checked_at=datetime.now(UTC),
         declared_mcp_servers=declared_mcp_servers(agent_config) if agent_config else [],
-        deployments=[await _deployment_status(deployment) for deployment in deployments],
+        deployments=list(deployment_statuses),
     )
 
 

--- a/plugins/nemo-agents/src/nemo_agents_plugin/fabric/server.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/fabric/server.py
@@ -48,6 +48,11 @@ from nemo_agents_plugin.fabric.streaming import (
     iter_openai_chat_completion_sse,
     openai_chat_completion_error_sse,
 )
+from nemo_agents_plugin.mcp_status import (
+    DEFAULT_PROBE_TIMEOUT_SECONDS,
+    McpStatusResponse,
+    probe_mcp_servers,
+)
 from nemo_agents_plugin.session_protocol import SESSION_ID_HEADER
 
 logger = logging.getLogger(__name__)
@@ -298,6 +303,17 @@ def create_fabric_serving_app(
             "runtime_instance_id": runtime_instance_id,
             "runtime_started_at": runtime_started_at.isoformat(),
         }
+
+    @app.get("/mcp/status", response_model=McpStatusResponse)
+    async def mcp_status() -> McpStatusResponse:
+        """Report every declared MCP server as this runtime process sees it."""
+        agent_config: AgentConfig = app.state.agent_config
+        servers = await probe_mcp_servers(agent_config, timeout=DEFAULT_PROBE_TIMEOUT_SECONDS)
+        return McpStatusResponse(
+            runtime_instance_id=runtime_instance_id,
+            checked_at=datetime.now(UTC),
+            servers=servers,
+        )
 
     @app.post("/v1/chat/completions", response_model=None, response_model_exclude_none=True)
     async def chat_completions(

--- a/plugins/nemo-agents/src/nemo_agents_plugin/mcp_status.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/mcp_status.py
@@ -13,7 +13,11 @@ subprocess would really inherit.
 Nothing here reports host filesystem layout. Whether a stdio command resolved
 is a boolean, never a path; messages are one short sentence and never quote the
 ``PATH`` that was searched; and any absolute path that still reaches a message
-or a captured stderr snippet is reduced to its final component on the way out.
+is reduced to its final component on the way out. A spawned server's stderr is
+never included in the response — the declared env it runs with can hold
+secrets that a crashing process might echo back — so a launch failure is
+reported as a short generic sentence, with the captured stderr logged
+server-side only, for operators to read from logs rather than the API.
 """
 
 from __future__ import annotations
@@ -79,7 +83,7 @@ class McpServerStatus(BaseModel):
         ),
     )
     detail: str = Field(default="", description="Human-readable explanation of the state.")
-    error: str = Field(default="", description="Error message or stderr snippet when the server failed to start.")
+    error: str = Field(default="", description="Short, generic error message when the server failed to start.")
     tools: list[str] = Field(default_factory=list, description="Tool names the server advertised, when it started.")
 
 
@@ -190,10 +194,11 @@ async def _start_stdio_server(
                         listed = await session.list_tools()
                         return True, [tool.name for tool in listed.tools], ""
         except TimeoutError:
-            return False, [], _with_stderr(f"Server did not initialize within {timeout:g}s.", errlog)
-        except Exception as exc:  # noqa: BLE001 — any launch failure is reportable status, not a 500.
-            logger.debug("MCP stdio probe of '%s' failed", command, exc_info=True)
-            return False, [], _with_stderr(f"{type(exc).__name__}: {exc}", errlog)
+            logger.debug("MCP stdio probe of '%s' timed out: %s", command, _stderr_tail(errlog))
+            return False, [], f"Server did not initialize within {timeout:g}s."
+        except Exception:  # noqa: BLE001 — any launch failure is reportable status, not a 500.
+            logger.debug("MCP stdio probe of '%s' failed: %s", command, _stderr_tail(errlog), exc_info=True)
+            return False, [], "Server exited before initializing."
 
 
 async def _probe_remote_server(name: str, server: McpServerConfig, timeout: float) -> McpServerStatus:
@@ -219,6 +224,13 @@ async def _probe_remote_server(name: str, server: McpServerConfig, timeout: floa
             state="unreachable",
             detail="Server did not respond.",
             error=f"{type(exc).__name__}: {exc}",
+        )
+    if response.is_error or response.is_redirect:
+        return _base_status(
+            name,
+            server,
+            state="unreachable",
+            detail=f"Responded with HTTP {response.status_code}.",
         )
     return _base_status(
         name,
@@ -273,15 +285,14 @@ def _default_environment() -> dict[str, str]:
     return get_default_environment()
 
 
-def _with_stderr(message: str, errlog: IO[str]) -> str:
-    """Append the tail of the server's stderr to *message*, when it wrote any."""
+def _stderr_tail(errlog: IO[str]) -> str:
+    """Read the tail of the server's captured stderr, for server-side logs only."""
     try:
         errlog.flush()
         errlog.seek(0)
-        snippet = errlog.read()[-_STDERR_SNIPPET_BYTES:].strip()
+        return errlog.read()[-_STDERR_SNIPPET_BYTES:].strip()
     except (OSError, ValueError):
-        return message
-    return f"{message}\n{snippet}" if snippet else message
+        return ""
 
 
 def config_from_dict(config: dict) -> AgentConfig | None:

--- a/plugins/nemo-agents/src/nemo_agents_plugin/mcp_status.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/mcp_status.py
@@ -1,0 +1,292 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Runtime status of the MCP servers an agent declares.
+
+An agent that declares a stdio MCP server degrades silently when the server
+never spawns: the harness simply gets fewer tools. The models here describe,
+per declared server, whether the runtime can actually reach it, and
+:func:`probe_mcp_servers` produces that answer *from inside the runtime
+process* so the ``PATH`` a stdio command is resolved against is the one the
+subprocess would really inherit.
+
+Nothing here reports host filesystem layout. Whether a stdio command resolved
+is a boolean, never a path; messages are one short sentence and never quote the
+``PATH`` that was searched; and any absolute path that still reaches a message
+or a captured stderr snippet is reduced to its final component on the way out.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+import shutil
+import tempfile
+from datetime import datetime
+from typing import IO, Literal
+
+from nemo_agents_plugin.agent_config import AgentConfig, McpServerConfig
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+# Transport spellings the Fabric adapters normalize to a stdio subprocess.
+_STDIO_TRANSPORTS = frozenset({"stdio", "command", "process"})
+# Transport spellings that address a server over the network. An empty
+# transport means streamable HTTP, matching adapter normalization.
+_REMOTE_TRANSPORTS = frozenset({"", "http", "streamable_http", "streamablehttp", "sse", "websocket"})
+
+DEFAULT_PROBE_TIMEOUT_SECONDS = 10.0
+
+# Bytes of captured stderr kept for a failed launch. Enough for a traceback's
+# last frames without turning the status response into a log dump.
+_STDERR_SNIPPET_BYTES = 2000
+
+McpServerState = Literal[
+    "running",
+    "unresolved",
+    "spawn_failed",
+    "unreachable",
+    "not_started",
+    "unknown",
+]
+
+
+class McpServerStatus(BaseModel):
+    """Runtime state of one MCP server an agent declares."""
+
+    name: str = Field(description="Server name as declared under mcp.servers in the agent config.")
+    transport: str = Field(description="Transport as declared (e.g. 'stdio', 'streamable_http').")
+    target: str = Field(description="Command to spawn for stdio servers, or the endpoint URL for remote ones.")
+    args: list[str] = Field(default_factory=list, description="Arguments passed to a stdio command.")
+    exposure: str = Field(default="", description="'harness_native' or 'fabric_managed'.")
+    state: McpServerState = Field(
+        description=(
+            "running: reachable and initialized. unresolved: stdio command not found on the runtime PATH. "
+            "spawn_failed: command resolved but the server died or never initialized. "
+            "unreachable: remote server did not answer. not_started: nothing is running to check against. "
+            "unknown: transport not understood, so no check was made."
+        )
+    )
+    command_resolved: bool = Field(
+        default=False,
+        description=(
+            "Whether a stdio command was found on the runtime PATH. Always false for remote "
+            "transports, which have no command to resolve. The path it resolved to is "
+            "deliberately not reported."
+        ),
+    )
+    detail: str = Field(default="", description="Human-readable explanation of the state.")
+    error: str = Field(default="", description="Error message or stderr snippet when the server failed to start.")
+    tools: list[str] = Field(default_factory=list, description="Tool names the server advertised, when it started.")
+
+
+class McpStatusResponse(BaseModel):
+    """A runtime's answer to "are your MCP servers up?"."""
+
+    runtime_instance_id: str = Field(default="", description="Id of the runtime process that ran the check.")
+    checked_at: datetime = Field(description="When the check ran.")
+    servers: list[McpServerStatus] = Field(default_factory=list, description="One entry per declared MCP server.")
+
+
+def declared_mcp_servers(config: AgentConfig) -> list[McpServerStatus]:
+    """Return every declared server as a ``not_started`` status, in name order."""
+    servers = config.mcp.servers if config.mcp is not None else {}
+    return [
+        _base_status(
+            name,
+            server,
+            state="not_started",
+            detail="Agent is not deployed.",
+        )
+        for name, server in sorted(servers.items())
+    ]
+
+
+async def probe_mcp_servers(
+    config: AgentConfig,
+    *,
+    timeout: float = DEFAULT_PROBE_TIMEOUT_SECONDS,
+) -> list[McpServerStatus]:
+    """Check every declared MCP server against the current process environment."""
+    servers = config.mcp.servers if config.mcp is not None else {}
+    ordered = sorted(servers.items())
+    results = await asyncio.gather(*(_probe_server(name, server, timeout) for name, server in ordered))
+    return list(results)
+
+
+async def _probe_server(name: str, server: McpServerConfig, timeout: float) -> McpServerStatus:
+    transport = _normalize_transport(server.transport)
+    if transport in _STDIO_TRANSPORTS:
+        return await _probe_stdio_server(name, server, timeout)
+    if transport in _REMOTE_TRANSPORTS:
+        return await _probe_remote_server(name, server, timeout)
+    return _base_status(
+        name,
+        server,
+        state="unknown",
+        detail=f"Unsupported transport '{server.transport}'.",
+    )
+
+
+async def _probe_stdio_server(name: str, server: McpServerConfig, timeout: float) -> McpServerStatus:
+    command = os.path.expandvars(server.url).strip()
+    env = {**_default_environment(), **server.env}
+    if not command:
+        return _base_status(
+            name,
+            server,
+            state="unresolved",
+            detail="No command configured.",
+        )
+
+    if shutil.which(command, path=env.get("PATH")) is None:
+        return _base_status(
+            name,
+            server,
+            state="unresolved",
+            detail="Command not found.",
+        )
+
+    started, tools, error = await _start_stdio_server(command, server.args, env, timeout)
+    if not started:
+        return _base_status(
+            name,
+            server,
+            state="spawn_failed",
+            command_resolved=True,
+            detail="Server did not start.",
+            error=error,
+        )
+    return _base_status(
+        name,
+        server,
+        state="running",
+        command_resolved=True,
+        detail=f"Started with {len(tools)} tool(s).",
+        tools=tools,
+    )
+
+
+async def _start_stdio_server(
+    command: str,
+    args: list[str],
+    env: dict[str, str],
+    timeout: float,
+) -> tuple[bool, list[str], str]:
+    """Spawn the server, initialize a session, and list its tools."""
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+
+    params = StdioServerParameters(command=command, args=list(args), env=env)
+    with tempfile.TemporaryFile(mode="w+", encoding="utf-8", errors="replace") as errlog:
+        try:
+            async with asyncio.timeout(timeout):
+                async with stdio_client(params, errlog=errlog) as (read, write):
+                    async with ClientSession(read, write) as session:
+                        await session.initialize()
+                        listed = await session.list_tools()
+                        return True, [tool.name for tool in listed.tools], ""
+        except TimeoutError:
+            return False, [], _with_stderr(f"Server did not initialize within {timeout:g}s.", errlog)
+        except Exception as exc:  # noqa: BLE001 — any launch failure is reportable status, not a 500.
+            logger.debug("MCP stdio probe of '%s' failed", command, exc_info=True)
+            return False, [], _with_stderr(f"{type(exc).__name__}: {exc}", errlog)
+
+
+async def _probe_remote_server(name: str, server: McpServerConfig, timeout: float) -> McpServerStatus:
+    """Check that a remote server answers."""
+    import httpx
+
+    url = os.path.expandvars(server.url).strip()
+    if not url:
+        return _base_status(
+            name,
+            server,
+            state="unreachable",
+            detail="No URL configured.",
+        )
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            response = await client.get(url, headers=server.custom_headers or None)
+    except Exception as exc:  # noqa: BLE001 — connection failures are reportable status.
+        logger.debug("MCP remote probe of '%s' failed", url, exc_info=True)
+        return _base_status(
+            name,
+            server,
+            state="unreachable",
+            detail="Server did not respond.",
+            error=f"{type(exc).__name__}: {exc}",
+        )
+    return _base_status(
+        name,
+        server,
+        state="running",
+        detail=f"Responded with HTTP {response.status_code}.",
+    )
+
+
+def _base_status(
+    name: str,
+    server: McpServerConfig,
+    *,
+    state: McpServerState,
+    command_resolved: bool = False,
+    detail: str = "",
+    error: str = "",
+    tools: list[str] | None = None,
+) -> McpServerStatus:
+    return McpServerStatus(
+        name=name,
+        transport=server.transport,
+        target=_redact_paths(server.url),
+        args=list(server.args),
+        exposure=server.exposure,
+        state=state,
+        command_resolved=command_resolved,
+        detail=_redact_paths(detail),
+        error=_redact_paths(error),
+        tools=tools or [],
+    )
+
+
+# An absolute POSIX path, not preceded by a word character, ':' or '/' so that
+# URL paths ("http://host/mcp") and relative fragments are left alone.
+_ABSOLUTE_PATH_RE = re.compile(r"(?<![\w.:/])/(?:[^\s'\"()\\,;]+/)+([^\s'\"()\\,;]*)")
+
+
+def _redact_paths(text: str) -> str:
+    """Reduce absolute host paths in *text* to their final component."""
+    return _ABSOLUTE_PATH_RE.sub(lambda match: f".../{match.group(1)}" if match.group(1) else ".../", text)
+
+
+def _normalize_transport(transport: str) -> str:
+    return transport.strip().lower().replace("-", "_")
+
+
+def _default_environment() -> dict[str, str]:
+    """The env an MCP stdio subprocess inherits, per the mcp SDK's allowlist."""
+    from mcp.client.stdio import get_default_environment
+
+    return get_default_environment()
+
+
+def _with_stderr(message: str, errlog: IO[str]) -> str:
+    """Append the tail of the server's stderr to *message*, when it wrote any."""
+    try:
+        errlog.flush()
+        errlog.seek(0)
+        snippet = errlog.read()[-_STDERR_SNIPPET_BYTES:].strip()
+    except (OSError, ValueError):
+        return message
+    return f"{message}\n{snippet}" if snippet else message
+
+
+def config_from_dict(config: dict) -> AgentConfig | None:
+    """Load an agent config dict, returning None when it is not a v1 agent spec."""
+    try:
+        return AgentConfig.model_validate(config)
+    except Exception:  # noqa: BLE001 — a NAT-format or malformed config simply declares no MCP servers here.
+        return None

--- a/plugins/nemo-agents/src/nemo_agents_plugin/schema.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/schema.py
@@ -20,6 +20,7 @@ Naming conventions:
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any
 
 from nemo_agents_plugin.entities import (
@@ -36,6 +37,7 @@ from nemo_agents_plugin.entities import (
     DeploymentStatus,
     EnvironmentSpecInline,
 )
+from nemo_agents_plugin.mcp_status import McpServerStatus
 from nemo_platform_plugin.schema import NemoFilter, NemoListResponse
 from pydantic import BaseModel, Field
 
@@ -98,6 +100,46 @@ class CreateSessionRequest(BaseModel):
 # ---------------------------------------------------------------------------
 # Filters — extend NemoFilter so extra fields are rejected (extra="forbid")
 # ---------------------------------------------------------------------------
+
+
+class AgentDeploymentStatus(BaseModel):
+    """Runtime status of one deployment of an agent, with its MCP servers."""
+
+    deployment: str = Field(description="Name of the AgentDeployment.")
+    deployment_mode: DeploymentMode = Field(description="subprocess | docker | k8s.")
+    status: DeploymentStatus = Field(description="Deployment lifecycle status.")
+    endpoint: str = Field(default="", description="Routable endpoint of the runtime, when it has one.")
+    error: str = Field(default="", description="Deployment-level error, when the deployment itself failed.")
+    probe_error: str = Field(
+        default="",
+        description="Why the MCP status could not be read from the runtime; empty when the check ran.",
+    )
+    mcp_servers: list[McpServerStatus] = Field(
+        default_factory=list,
+        description="Every MCP server this deployment's config declares, with its runtime state.",
+    )
+
+
+class AgentStatus(BaseModel):
+    """Response body for ``GET /v2/workspaces/{workspace}/agents/{name}/status``.
+
+    ``declared_mcp_servers`` is the static view from the stored agent config,
+    what the agent expects to exist, and is populated whether or not anything
+    is deployed. ``deployments`` adds the runtime view, one entry per deployment,
+    each reporting the same servers as the runtime actually finds them.
+    """
+
+    agent: str = Field(description="Name of the agent.")
+    workspace: str = Field(description="Workspace the agent belongs to.")
+    checked_at: datetime = Field(description="When the status was assembled.")
+    declared_mcp_servers: list[McpServerStatus] = Field(
+        default_factory=list,
+        description="MCP servers declared in the stored agent config, each reported as 'not_started'.",
+    )
+    deployments: list[AgentDeploymentStatus] = Field(
+        default_factory=list,
+        description="Runtime status per deployment of this agent.",
+    )
 
 
 class AgentFilter(NemoFilter):

--- a/plugins/nemo-agents/tests/unit/test_agents_api.py
+++ b/plugins/nemo-agents/tests/unit/test_agents_api.py
@@ -16,7 +16,9 @@ from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
+import httpx
 import pytest
+import respx
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from nemo_agents_plugin.api.v2 import agents as agents_router_module
@@ -500,3 +502,157 @@ class TestDeleteAgent:
         resp = client.delete("/apis/agents/v2/workspaces/default/agents/calc")
 
         assert resp.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# GET /agents/{name}/status — runtime status incl. MCP servers
+# ---------------------------------------------------------------------------
+
+
+def _mcp_agent_config() -> dict[str, Any]:
+    config = _fabric_agent_config()
+    config["mcp"] = {
+        "servers": {
+            "iocs": {"transport": "stdio", "url": "email-security-triage-iocs"},
+        }
+    }
+    return config
+
+
+class TestGetAgentStatus:
+    def test_missing_agent_returns_404(self, client: TestClient, mock_entity_client: AsyncMock) -> None:
+        mock_entity_client.get = AsyncMock(side_effect=NemoEntityNotFoundError("nope"))
+
+        resp = client.get("/apis/agents/v2/workspaces/default/agents/calc/status")
+
+        assert resp.status_code == 404
+
+    def test_declares_mcp_servers_without_any_deployment(
+        self, client: TestClient, mock_entity_client: AsyncMock
+    ) -> None:
+        """The servers an agent expects are listed even when nothing is deployed."""
+        agent = _make_agent("triage", config=_mcp_agent_config(), config_format=NEMO_AGENTS_SPEC_CONFIG_FORMAT)
+        mock_entity_client.get = AsyncMock(return_value=agent)
+        mock_entity_client.list = AsyncMock(return_value=_list_response([]))
+
+        resp = client.get("/apis/agents/v2/workspaces/default/agents/triage/status")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["deployments"] == []
+        [declared] = body["declared_mcp_servers"]
+        assert declared["name"] == "iocs"
+        assert declared["transport"] == "stdio"
+        assert declared["target"] == "email-security-triage-iocs"
+        assert declared["state"] == "not_started"
+
+    def test_nat_format_agent_declares_no_mcp_servers(self, client: TestClient, mock_entity_client: AsyncMock) -> None:
+        mock_entity_client.get = AsyncMock(return_value=_make_agent("calc", config={"llms": {}}))
+        mock_entity_client.list = AsyncMock(return_value=_list_response([]))
+
+        resp = client.get("/apis/agents/v2/workspaces/default/agents/calc/status")
+
+        assert resp.status_code == 200
+        assert resp.json()["declared_mcp_servers"] == []
+
+    def test_pending_deployment_reports_not_started_without_probing(
+        self, client: TestClient, mock_entity_client: AsyncMock
+    ) -> None:
+        """A deployment that is not up yet must not look like a failed server."""
+        dep = _make_deployment(agent="triage", status="pending")
+        dep.config = _mcp_agent_config()
+        mock_entity_client.get = AsyncMock(
+            return_value=_make_agent("triage", config=_mcp_agent_config(), config_format=NEMO_AGENTS_SPEC_CONFIG_FORMAT)
+        )
+        mock_entity_client.list = AsyncMock(return_value=_list_response([dep]))
+
+        resp = client.get("/apis/agents/v2/workspaces/default/agents/triage/status")
+
+        [deployment] = resp.json()["deployments"]
+        assert deployment["status"] == "pending"
+        assert deployment["probe_error"] == ""
+        assert [s["state"] for s in deployment["mcp_servers"]] == ["not_started"]
+
+    def test_running_deployment_reports_the_runtime_probe(
+        self, client: TestClient, mock_entity_client: AsyncMock
+    ) -> None:
+        dep = _make_deployment(agent="triage", status="running")
+        dep.config = _mcp_agent_config()
+        dep.endpoint = "http://localhost:9001"
+        mock_entity_client.get = AsyncMock(
+            return_value=_make_agent("triage", config=_mcp_agent_config(), config_format=NEMO_AGENTS_SPEC_CONFIG_FORMAT)
+        )
+        mock_entity_client.list = AsyncMock(return_value=_list_response([dep]))
+
+        with respx.mock:
+            respx.get("http://localhost:9001/mcp/status").respond(
+                200,
+                json={
+                    "runtime_instance_id": "runtime-1",
+                    "checked_at": NOW.isoformat(),
+                    "servers": [
+                        {
+                            "name": "iocs",
+                            "transport": "stdio",
+                            "target": "email-security-triage-iocs",
+                            "state": "unresolved",
+                            "detail": "Command not found.",
+                        }
+                    ],
+                },
+            )
+            resp = client.get("/apis/agents/v2/workspaces/default/agents/triage/status")
+
+        [deployment] = resp.json()["deployments"]
+        assert deployment["endpoint"] == "http://localhost:9001"
+        assert deployment["probe_error"] == ""
+        [server] = deployment["mcp_servers"]
+        assert server["state"] == "unresolved"
+        assert server["detail"] == "Command not found."
+
+    def test_unreachable_runtime_marks_servers_unknown(self, client: TestClient, mock_entity_client: AsyncMock) -> None:
+        """A runtime we cannot ask is reported as such, not as a healthy or failed server."""
+        dep = _make_deployment(agent="triage", status="running")
+        dep.config = _mcp_agent_config()
+        dep.endpoint = "http://localhost:9001"
+        mock_entity_client.get = AsyncMock(
+            return_value=_make_agent("triage", config=_mcp_agent_config(), config_format=NEMO_AGENTS_SPEC_CONFIG_FORMAT)
+        )
+        mock_entity_client.list = AsyncMock(return_value=_list_response([dep]))
+
+        with respx.mock:
+            respx.get("http://localhost:9001/mcp/status").mock(side_effect=httpx.ConnectError("refused"))
+            resp = client.get("/apis/agents/v2/workspaces/default/agents/triage/status")
+
+        [deployment] = resp.json()["deployments"]
+        assert deployment["probe_error"] == "Could not reach the runtime."
+        assert [s["state"] for s in deployment["mcp_servers"]] == ["unknown"]
+
+    def test_runtime_without_mcp_status_route_is_reported(
+        self, client: TestClient, mock_entity_client: AsyncMock
+    ) -> None:
+        dep = _make_deployment(agent="triage", status="running")
+        dep.config = _mcp_agent_config()
+        dep.endpoint = "http://localhost:9001"
+        mock_entity_client.get = AsyncMock(
+            return_value=_make_agent("triage", config=_mcp_agent_config(), config_format=NEMO_AGENTS_SPEC_CONFIG_FORMAT)
+        )
+        mock_entity_client.list = AsyncMock(return_value=_list_response([dep]))
+
+        with respx.mock:
+            respx.get("http://localhost:9001/mcp/status").respond(404)
+            resp = client.get("/apis/agents/v2/workspaces/default/agents/triage/status")
+
+        [deployment] = resp.json()["deployments"]
+        assert deployment["probe_error"] == "Runtime does not report MCP status."
+
+    def test_only_deployments_for_this_agent_are_reported(
+        self, client: TestClient, mock_entity_client: AsyncMock
+    ) -> None:
+        other = _make_deployment(name="other-dep", agent="other-agent", status="running")
+        mock_entity_client.get = AsyncMock(return_value=_make_agent("triage"))
+        mock_entity_client.list = AsyncMock(return_value=_list_response([other]))
+
+        resp = client.get("/apis/agents/v2/workspaces/default/agents/triage/status")
+
+        assert resp.json()["deployments"] == []

--- a/plugins/nemo-agents/tests/unit/test_fabric_server.py
+++ b/plugins/nemo-agents/tests/unit/test_fabric_server.py
@@ -117,6 +117,42 @@ def _sse_line_payload(line: str) -> dict[str, object]:
     return json.loads(line.removeprefix("data: "))
 
 
+def test_mcp_status_reports_a_declared_stdio_server_that_is_not_on_path(
+    tmp_path: Path,
+    mock_validate_agent_config: list[tuple[AgentConfig, Path]],
+) -> None:
+    """The runtime answers for a server it cannot resolve, rather than staying silent."""
+    config = _example_config()
+    config["mcp"] = {"servers": {"iocs": {"transport": "stdio", "url": "nemo-mcp-server-that-is-not-installed"}}}
+    config_path = _write_agent_config(tmp_path, config)
+    app = create_fabric_serving_app(config_path)
+
+    with TestClient(app) as client:
+        response = client.get("/mcp/status")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert uuid.UUID(body["runtime_instance_id"])
+    [server_status] = body["servers"]
+    assert server_status["name"] == "iocs"
+    assert server_status["state"] == "unresolved"
+    assert server_status["detail"] == "Command not found."
+
+
+def test_mcp_status_is_empty_when_no_servers_are_declared(
+    tmp_path: Path,
+    mock_validate_agent_config: list[tuple[AgentConfig, Path]],
+) -> None:
+    config_path = _write_agent_config(tmp_path)
+    app = create_fabric_serving_app(config_path)
+
+    with TestClient(app) as client:
+        response = client.get("/mcp/status")
+
+    assert response.status_code == 200
+    assert response.json()["servers"] == []
+
+
 def test_shutdown_removes_a_staged_agent_root(
     tmp_path: Path,
     mock_validate_agent_config: list[tuple[AgentConfig, Path]],

--- a/plugins/nemo-agents/tests/unit/test_mcp_status.py
+++ b/plugins/nemo-agents/tests/unit/test_mcp_status.py
@@ -37,9 +37,6 @@ _WORKING_SERVER = textwrap.dedent(
 
 _CRASHING_SERVER = "import sys; sys.stderr.write('ModuleNotFoundError: no such package\\n'); sys.exit(1)"
 
-# A server whose stderr names host paths, the way a real traceback does.
-_PATHY_SERVER = "import sys; sys.stderr.write('FileNotFoundError: /private/var/host/secrets/keys.json\\n'); sys.exit(1)"
-
 
 def _config(servers: dict[str, dict[str, Any]]) -> AgentConfig:
     return AgentConfig.model_validate(
@@ -93,7 +90,7 @@ class TestProbeStdioServers:
         # The PATH the probe searched is host layout, not status.
         assert os.environ["PATH"] not in status.detail
 
-    async def test_resolved_command_that_dies_is_spawn_failed_with_stderr(self) -> None:
+    async def test_resolved_command_that_dies_is_spawn_failed_with_generic_error(self) -> None:
         config = _config(
             {
                 "iocs": {
@@ -108,7 +105,8 @@ class TestProbeStdioServers:
 
         assert status.state == "spawn_failed"
         assert status.command_resolved is True
-        assert "ModuleNotFoundError: no such package" in status.error
+        assert status.error == "Server exited before initializing."
+        assert "ModuleNotFoundError" not in status.error
 
     async def test_working_server_is_running_and_lists_its_tools(self, tmp_path: Path) -> None:
         script = tmp_path / "server.py"
@@ -137,16 +135,19 @@ class TestProbeStdioServers:
         assert status.state == "unresolved"
 
 
-class TestPathRedaction:
-    """Status is a report on the agent, not a map of the host filesystem."""
+class TestStderrNotExposed:
+    """A crashed server's stderr — which can hold whatever its declared env held — never reaches the API."""
 
-    async def test_stderr_paths_are_reduced_to_their_filename(self) -> None:
+    async def test_stderr_secret_env_value_is_not_in_the_response(self) -> None:
+        secret = "sk-super-secret-token-value"  # noqa: S105 — test fixture, not a real credential.
+        server = "import os, sys; sys.stderr.write(os.environ['API_KEY']); sys.exit(1)"
         config = _config(
             {
                 "iocs": {
                     "transport": "stdio",
                     "url": sys.executable,
-                    "args": ["-c", _PATHY_SERVER],
+                    "args": ["-c", server],
+                    "env": {"API_KEY": secret},
                 }
             }
         )
@@ -154,8 +155,8 @@ class TestPathRedaction:
         [status] = await probe_mcp_servers(config, timeout=15)
 
         assert status.state == "spawn_failed"
-        assert "/private/var/host/secrets" not in status.error
-        assert ".../keys.json" in status.error
+        assert secret not in status.error
+        assert status.error == "Server exited before initializing."
 
 
 class TestProbeRemoteServers:
@@ -174,6 +175,33 @@ class TestProbeRemoteServers:
 
         assert status.state == "running"
         assert status.detail == "Responded with HTTP 200."
+
+    async def test_client_error_response_is_not_running(self, httpx_status_url) -> None:
+        url = httpx_status_url(404)
+        config = _config({"docs": {"transport": "streamable_http", "url": url}})
+
+        [status] = await probe_mcp_servers(config, timeout=5)
+
+        assert status.state == "unreachable"
+        assert status.detail == "Responded with HTTP 404."
+
+    async def test_server_error_response_is_not_running(self, httpx_status_url) -> None:
+        url = httpx_status_url(500)
+        config = _config({"docs": {"transport": "streamable_http", "url": url}})
+
+        [status] = await probe_mcp_servers(config, timeout=5)
+
+        assert status.state == "unreachable"
+        assert status.detail == "Responded with HTTP 500."
+
+    async def test_redirect_response_is_not_running(self, httpx_status_url) -> None:
+        url = httpx_status_url(302)
+        config = _config({"docs": {"transport": "streamable_http", "url": url}})
+
+        [status] = await probe_mcp_servers(config, timeout=5)
+
+        assert status.state == "unreachable"
+        assert status.detail == "Responded with HTTP 302."
 
 
 class TestProbeUnknownTransport:
@@ -195,3 +223,18 @@ def httpx_mock_url() -> Any:
     with respx.mock:
         respx.get(url).respond(200)
         yield url
+
+
+@pytest.fixture
+def httpx_status_url() -> Any:
+    """A factory for a URL that answers with a given status code, via respx."""
+    import respx
+
+    url = "https://mcp.example.invalid/mcp"
+    with respx.mock:
+
+        def _make(status_code: int) -> str:
+            respx.get(url).respond(status_code)
+            return url
+
+        yield _make

--- a/plugins/nemo-agents/tests/unit/test_mcp_status.py
+++ b/plugins/nemo-agents/tests/unit/test_mcp_status.py
@@ -1,0 +1,197 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the MCP server status probe.
+
+The stdio cases spawn real subprocesses — a working MCP server, a command that
+exits immediately, and a command that is not on PATH — because the failure this
+probe exists to catch is exactly a subprocess that does not come up.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import textwrap
+from pathlib import Path
+from typing import Any
+
+import pytest
+from nemo_agents_plugin.agent_config import AgentConfig
+from nemo_agents_plugin.mcp_status import declared_mcp_servers, probe_mcp_servers
+
+# A minimal stdio MCP server that advertises one tool.
+_WORKING_SERVER = textwrap.dedent(
+    """
+    from mcp.server.fastmcp import FastMCP
+
+    server = FastMCP("probe-test")
+
+    @server.tool()
+    def extract_iocs(text: str) -> str:
+        return text
+
+    server.run()
+    """
+)
+
+_CRASHING_SERVER = "import sys; sys.stderr.write('ModuleNotFoundError: no such package\\n'); sys.exit(1)"
+
+# A server whose stderr names host paths, the way a real traceback does.
+_PATHY_SERVER = "import sys; sys.stderr.write('FileNotFoundError: /private/var/host/secrets/keys.json\\n'); sys.exit(1)"
+
+
+def _config(servers: dict[str, dict[str, Any]]) -> AgentConfig:
+    return AgentConfig.model_validate(
+        {
+            "config_format": "nemo-agents-spec-v1",
+            "name": "probe-agent",
+            "default_harness": "hermes",
+            "harnesses": {"hermes": {"kind": "hermes"}},
+            "mcp": {"servers": servers},
+        }
+    )
+
+
+class TestDeclaredMcpServers:
+    def test_lists_every_declared_server_as_not_started(self) -> None:
+        config = _config(
+            {
+                "iocs": {"transport": "stdio", "url": "email-security-triage-iocs"},
+                "docs": {"transport": "streamable_http", "url": "https://example.invalid/mcp"},
+            }
+        )
+
+        statuses = declared_mcp_servers(config)
+
+        assert [s.name for s in statuses] == ["docs", "iocs"]
+        assert {s.state for s in statuses} == {"not_started"}
+        assert statuses[1].target == "email-security-triage-iocs"
+
+    def test_no_mcp_section_declares_nothing(self) -> None:
+        config = AgentConfig.model_validate(
+            {
+                "config_format": "nemo-agents-spec-v1",
+                "name": "probe-agent",
+                "default_harness": "hermes",
+                "harnesses": {"hermes": {"kind": "hermes"}},
+            }
+        )
+
+        assert declared_mcp_servers(config) == []
+
+
+class TestProbeStdioServers:
+    async def test_command_not_on_path_is_unresolved(self) -> None:
+        config = _config({"iocs": {"transport": "stdio", "url": "nemo-mcp-server-that-is-not-installed"}})
+
+        [status] = await probe_mcp_servers(config, timeout=5)
+
+        assert status.state == "unresolved"
+        assert status.command_resolved is False
+        assert status.detail == "Command not found."
+        # The PATH the probe searched is host layout, not status.
+        assert os.environ["PATH"] not in status.detail
+
+    async def test_resolved_command_that_dies_is_spawn_failed_with_stderr(self) -> None:
+        config = _config(
+            {
+                "iocs": {
+                    "transport": "stdio",
+                    "url": sys.executable,
+                    "args": ["-c", _CRASHING_SERVER],
+                }
+            }
+        )
+
+        [status] = await probe_mcp_servers(config, timeout=15)
+
+        assert status.state == "spawn_failed"
+        assert status.command_resolved is True
+        assert "ModuleNotFoundError: no such package" in status.error
+
+    async def test_working_server_is_running_and_lists_its_tools(self, tmp_path: Path) -> None:
+        script = tmp_path / "server.py"
+        script.write_text(_WORKING_SERVER, encoding="utf-8")
+        config = _config(
+            {
+                "iocs": {
+                    "transport": "stdio",
+                    "url": sys.executable,
+                    "args": [str(script)],
+                }
+            }
+        )
+
+        [status] = await probe_mcp_servers(config, timeout=30)
+
+        assert status.state == "running", status.error
+        assert status.command_resolved is True
+        assert status.tools == ["extract_iocs"]
+
+    async def test_empty_command_is_unresolved(self) -> None:
+        config = _config({"iocs": {"transport": "stdio", "url": "   "}})
+
+        [status] = await probe_mcp_servers(config, timeout=5)
+
+        assert status.state == "unresolved"
+
+
+class TestPathRedaction:
+    """Status is a report on the agent, not a map of the host filesystem."""
+
+    async def test_stderr_paths_are_reduced_to_their_filename(self) -> None:
+        config = _config(
+            {
+                "iocs": {
+                    "transport": "stdio",
+                    "url": sys.executable,
+                    "args": ["-c", _PATHY_SERVER],
+                }
+            }
+        )
+
+        [status] = await probe_mcp_servers(config, timeout=15)
+
+        assert status.state == "spawn_failed"
+        assert "/private/var/host/secrets" not in status.error
+        assert ".../keys.json" in status.error
+
+
+class TestProbeRemoteServers:
+    async def test_unreachable_remote_server_is_reported(self) -> None:
+        config = _config({"docs": {"transport": "streamable_http", "url": "http://127.0.0.1:1/mcp"}})
+
+        [status] = await probe_mcp_servers(config, timeout=5)
+
+        assert status.state == "unreachable"
+        assert status.error
+
+    async def test_reachable_remote_server_is_running(self, httpx_mock_url: str) -> None:
+        config = _config({"docs": {"transport": "streamable_http", "url": httpx_mock_url}})
+
+        [status] = await probe_mcp_servers(config, timeout=5)
+
+        assert status.state == "running"
+        assert status.detail == "Responded with HTTP 200."
+
+
+class TestProbeUnknownTransport:
+    async def test_unknown_transport_is_not_checked(self) -> None:
+        config = _config({"weird": {"transport": "carrier-pigeon", "url": "somewhere"}})
+
+        [status] = await probe_mcp_servers(config, timeout=5)
+
+        assert status.state == "unknown"
+        assert status.detail == "Unsupported transport 'carrier-pigeon'."
+
+
+@pytest.fixture
+def httpx_mock_url() -> Any:
+    """A URL that answers 200, served by respx rather than a real socket."""
+    import respx
+
+    url = "https://mcp.example.invalid/mcp"
+    with respx.mock:
+        respx.get(url).respond(200)
+        yield url


### PR DESCRIPTION
This PR is related to ASTD-480. This supports the backend changes for exposing MCP status of an Agent through a new endpoint `/agents/{name}/status`. This new endpoint returns the agent's status as well as details about its declared MCP servers and server statuses. 

Signed-off-by: Sean Teramae <steramae@nvidia.com>

<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
<!-- In 1-3 plain sentences, explain what changes and why. Describe before-and-after behavior when it applies. -->

## Related Issue
<!-- Use Fixes #NNN or Closes #NNN for a related issue. Remove this section if there is none. -->

## Changes
<!-- List the concrete changes included in this pull request. -->

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [ ] Pull request title follows the repository's Conventional Commit format
- [ ] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [ ] Targeted tests pass, or tests are marked not applicable above
- [ ] No secrets, API keys, or credentials are included

Targeted validation:

<!-- List each command and result. Explain skipped, blocked, or non-successful checks without marking them as passed. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an agent status endpoint showing deployment lifecycle, runtime endpoints, errors, and MCP server details, including clear responses for missing agents.
  - Added MCP server status reporting for declared tools, transport availability, connectivity, launch errors, and runtime metadata.
  - Added runtime status checks for deployed agents and MCP servers, with safe handling of unavailable, unsupported, or unreachable configurations.
  - Documented deployment-listing failure responses and standardized MCP server errors as short, generic messages.

- **Tests**
  - Added coverage for agent deployments, runtime probing, MCP server states, connectivity failures, unsupported configurations, and protection of sensitive error details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->