### PR TITLE
fix(sandboxed-gym): keep a long rollout batch alive through the sandbox proxy

### DIFF
--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/sandboxed.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/sandboxed.py
@@ -128,6 +128,44 @@ class SandboxedGymAgentTaskRunner:
             headers[PROXY_AUTH_HEADER] = self._config.auth_token
         return headers
 
+    def _decode_body(self, response: httpx.Response) -> Any:
+        """Decode a 2xx rollout body, naming the host when there is nothing decodable in it.
+
+        The host commits its 200 before the batch finishes and pads the open connection with
+        whitespace heartbeats until it has an envelope to write. A host that dies mid-batch --
+        OOMKilled, evicted -- therefore leaves a well-formed 200 whose body is heartbeats and
+        nothing else. Left to ``response.json()`` that surfaces as a bare ``JSONDecodeError``,
+        which is a ``ValueError`` and so escapes callers guarding this runner for ``RuntimeError``:
+        a dead sandbox reads as a bug in the evaluator. ``RolloutOrchestrator._decode_results``
+        classifies the same three bodies for the other client of this endpoint.
+        """
+        try:
+            # Strict, and caught rather than avoided: errors="replace" would let a body with one
+            # corrupt byte still parse, handing the caller U+FFFD where the host wrote data.
+            text = response.content.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise RuntimeError(
+                f"sandboxed Gym host returned a body that is not UTF-8 from {self._config.rollout_url}: {exc}"
+            ) from exc
+        if not text.strip():
+            raise RuntimeError(
+                f"sandboxed Gym host at {self._config.rollout_url} answered and then stopped "
+                f"without sending a `results` envelope ({len(response.content)} byte(s) of heartbeat "
+                f"only); it most likely died mid-batch -- check whether the sandbox was OOMKilled "
+                f"or evicted"
+            )
+        try:
+            # The host heartbeats leading whitespace while a batch runs; json tolerates it.
+            return json.loads(text)
+        except (ValueError, RecursionError) as exc:
+            # Wider than JSONDecodeError because json also refuses input outright -- the
+            # integer-digit limit, deep nesting -- and narrowing this back lets those escape as
+            # something other than a named host failure.
+            raise RuntimeError(
+                f"sandboxed Gym host returned a body that is not JSON from "
+                f"{self._config.rollout_url} ({exc}); first 200 bytes: {text[:200]!r}"
+            ) from exc
+
     async def _collect(self, examples: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """POST the examples and return the host's rollout records."""
         async with httpx.AsyncClient(timeout=self._config.timeout_s) as client:
@@ -143,7 +181,17 @@ class SandboxedGymAgentTaskRunner:
                 f"sandboxed Gym host returned {response.status_code} from {self._config.rollout_url}: "
                 f"{response.text[:2000]}"
             )
-        body = response.json()
+        body = self._decode_body(response)
+        error = body.get("error") if isinstance(body, Mapping) else None
+        if error is not None:
+            # The host commits its 200 before the batch finishes, so that it can hold the
+            # connection open past the sandbox proxy's first-byte cap. A failure after that point
+            # has only the body left to travel in, and carries the code and traceback that say
+            # which of Gym's layers raised.
+            raise RuntimeError(
+                f"sandboxed Gym host reported an error from {self._config.rollout_url}: "
+                f"{error if isinstance(error, str) else json.dumps(error)[:2000]}"
+            )
         results = body.get("results") if isinstance(body, Mapping) else None
         if not isinstance(results, list):
             raise RuntimeError(

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_gym_sandboxed_runtime.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_gym_sandboxed_runtime.py
@@ -45,17 +45,26 @@ def tasks(tmp_path: Path) -> list:
 class _FakeHost:
     """Records what was posted and answers with rollout records keyed by the caller's own index."""
 
-    def __init__(self, *, status: int = 200, body: Any = None, rewards: dict[int, float] | None = None) -> None:
+    def __init__(
+        self,
+        status: int = 200,
+        body: Any = None,
+        content: bytes | None = None,
+        rewards: dict[int, float] | None = None,
+    ) -> None:
         self.requests: list[httpx.Request] = []
         self.posted: list[dict[str, Any]] = []
         self._status = status
         self._body = body
+        self._content = content
         self._rewards = rewards
 
     def transport(self) -> httpx.MockTransport:
         def handle(request: httpx.Request) -> httpx.Response:
             self.requests.append(request)
             self.posted = json.loads(request.content.decode())["examples"]
+            if self._content is not None:
+                return httpx.Response(self._status, content=self._content)
             if self._body is not None or self._status >= 400:
                 return httpx.Response(self._status, json=self._body if self._body is not None else {"error": "boom"})
             rewards = self._rewards if self._rewards is not None else {}
@@ -73,9 +82,8 @@ class _FakeHost:
         return httpx.MockTransport(handle)
 
 
-def runner_against(host: _FakeHost, monkeypatch: pytest.MonkeyPatch, **overrides: Any) -> SandboxedGymAgentTaskRunner:
-    """A runner whose HTTP client is bound to ``host``."""
-    transport = host.transport()
+def bind_http_transport(monkeypatch: pytest.MonkeyPatch, transport: httpx.MockTransport) -> None:
+    """Point ``httpx.AsyncClient`` at ``transport``. Typed kwargs so ty can check the call."""
     original = httpx.AsyncClient
 
     def bound(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
@@ -83,6 +91,11 @@ def runner_against(host: _FakeHost, monkeypatch: pytest.MonkeyPatch, **overrides
         return original(*args, **kwargs)
 
     monkeypatch.setattr(httpx, "AsyncClient", bound)
+
+
+def runner_against(host: _FakeHost, monkeypatch: pytest.MonkeyPatch, **overrides: Any) -> SandboxedGymAgentTaskRunner:
+    """A runner whose HTTP client is bound to ``host``."""
+    bind_http_transport(monkeypatch, host.transport())
     return SandboxedGymAgentTaskRunner(config=SandboxedGymRuntimeConfig(rollout_url=ROLLOUT_URL, **overrides))
 
 
@@ -147,6 +160,72 @@ async def test_an_http_error_names_the_host_and_carries_its_body(tasks, tmp_path
     assert "resources_server crashed" in message
 
 
+async def test_an_error_carried_on_a_200_is_still_a_failure(tasks, tmp_path, monkeypatch) -> None:
+    """The host commits its 200 before the batch finishes, so late failures ride the body.
+
+    It answers early on purpose: the sandbox proxy gives up on a request whose first byte has not
+    arrived, and a batch outlasts that. Reading only the status would call a deadline or a crashed
+    environment a success and then blame the run for having no results.
+    """
+    host = _FakeHost(body={"error": {"code": "deadline_exceeded", "message": "abandoned after 1800s"}})
+    runner = runner_against(host, monkeypatch)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await runner.run_tasks(tasks, AgentEvalRunConfig(work_dir=tmp_path))
+
+    message = str(excinfo.value)
+    assert "deadline_exceeded" in message
+    assert "abandoned after 1800s" in message
+    assert ROLLOUT_URL in message
+
+
+async def test_a_heartbeat_only_200_names_the_host_as_the_failure(tasks, tmp_path, monkeypatch) -> None:
+    """OOMKill after the host committed 200 leaves heartbeats and no envelope.
+
+    The orchestrator classifies that as the sandbox dying. This runner is a second client of the
+    same host; it must not surface a JSON decode error that looks like a bug in the evaluator.
+    """
+    host = _FakeHost(content=b"     ")
+    runner = runner_against(host, monkeypatch)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await runner.run_tasks(tasks, AgentEvalRunConfig(work_dir=tmp_path))
+
+    message = str(excinfo.value)
+    assert ROLLOUT_URL in message
+    assert "JSON" not in message
+    assert "error" in message.lower() or "results" in message.lower()
+
+
+async def test_a_non_json_200_names_the_host_rather_than_the_decoder(tasks, tmp_path, monkeypatch) -> None:
+    """A non-empty body that is not JSON is a broken response contract, not an evaluator bug.
+
+    `json.JSONDecodeError` is a `ValueError`, so leaving it unwrapped escapes every caller that
+    guards this runner for `RuntimeError`.
+    """
+    host = _FakeHost(content=b"   <html>502 Bad Gateway</html>")
+    runner = runner_against(host, monkeypatch)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await runner.run_tasks(tasks, AgentEvalRunConfig(work_dir=tmp_path))
+
+    message = str(excinfo.value)
+    assert ROLLOUT_URL in message
+    assert "502 Bad Gateway" in message  # the undecodable body itself, so the reader can place it
+
+
+async def test_a_non_utf8_200_names_the_host_rather_than_the_decoder(tasks, tmp_path, monkeypatch) -> None:
+    # Decoded strictly: errors="replace" would hand the parser U+FFFD where the host wrote data,
+    # and a corrupt batch would score rather than fail.
+    host = _FakeHost(content=b'{"results": [\xff\xfe]}')
+    runner = runner_against(host, monkeypatch)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await runner.run_tasks(tasks, AgentEvalRunConfig(work_dir=tmp_path))
+
+    assert ROLLOUT_URL in str(excinfo.value)
+
+
 async def test_a_response_without_a_results_list_is_refused(tasks, tmp_path, monkeypatch) -> None:
     # Reaching the parser with nothing collected would surface as "no rollouts", blaming the run
     # for what is a malformed reply.
@@ -167,9 +246,7 @@ async def test_a_task_the_host_never_answered_fails_the_run(tasks, tmp_path, mon
             json={"results": [{NG_TASK_INDEX: example[NG_TASK_INDEX], NG_ROLLOUT_INDEX: 0, "reward": 1.0}]},
         )
 
-    transport = httpx.MockTransport(handle)
-    original = httpx.AsyncClient
-    monkeypatch.setattr(httpx, "AsyncClient", lambda *a, **k: original(*a, **{**k, "transport": transport}))
+    bind_http_transport(monkeypatch, httpx.MockTransport(handle))
     runner = SandboxedGymAgentTaskRunner(config=SandboxedGymRuntimeConfig(rollout_url=ROLLOUT_URL))
 
     with pytest.raises(RuntimeError, match=r"no rollout for 1 of 2 requested task") as excinfo:

--- a/packages/sandboxed_gym/README.md
+++ b/packages/sandboxed_gym/README.md
@@ -10,6 +10,18 @@ This package has **no NeMo-RL / GRPO dependency**. Callers get raw Gym host
 `/health` and `/rollouts/run` results. RL-specific postprocessing belongs in the
 training client (e.g. NeMo-RL's thin `SandboxedGymActor` adapter).
 
+## Provenance
+
+Vendored from [`soluwalana/RL`](https://github.com/soluwalana/RL) branch `nmp/customizer` at
+**`67821a9`** (2026-08-03), the fork this code still shares an ancestor with. Upstream changes have
+been applied selectively since; the divergences are deliberate and documented where they occur.
+
+Recorded because the original vendoring landed as one squashed commit with no provenance, and
+recovering this took a per-file comparison against every revision of the upstream tree. Diffing
+from any earlier commit shows `host/entrypoint.py` and `host/gym_host.sh` as drift when they are
+already here. Update this line whenever upstream is merged again; it becomes moot once the shared
+wheel exists.
+
 ## Architecture
 
 ![Architecture](docs/architecture.png)

--- a/packages/sandboxed_gym/src/sandboxed_gym/host/models.py
+++ b/packages/sandboxed_gym/src/sandboxed_gym/host/models.py
@@ -24,6 +24,14 @@ DEFAULT_MAX_ROLLOUT_BYTES = 268_435_456  # 256 MiB
 DEFAULT_HOST_TTL_S = 14_400  # 4 hours
 DEFAULT_HOST_READY_TIMEOUT_S = 15 * 60
 DEFAULT_ROLLOUT_TIMEOUT_S = 30 * 60
+# A batch is split into bounded POSTs so request duration and response size track the chunk rather
+# than the batch. Tune the two together: concurrency offsets the split.
+DEFAULT_ROLLOUT_CHUNK_SIZE = 8
+DEFAULT_ROLLOUT_MAX_IN_FLIGHT = 8
+# Applied to transport failures only. An error the host itself reported is deterministic, so
+# retrying it just spends generation time to fail the same way.
+DEFAULT_ROLLOUT_MAX_ATTEMPTS = 3
+DEFAULT_ROLLOUT_RETRY_BACKOFF_S = 5.0
 
 FORBIDDEN_BOOTSTRAP_ENV_PREFIXES = ("OPENSANDBOX_",)
 FORBIDDEN_BOOTSTRAP_ENV_KEYS = frozenset(
@@ -197,6 +205,10 @@ class SandboxConfig(BaseModel):
     runtime_http_port: int = Field(default=DEFAULT_RUNTIME_HTTP_PORT, ge=1, le=65535)
     ready_timeout_s: float = Field(default=float(DEFAULT_HOST_READY_TIMEOUT_S), gt=0)
     rollout_timeout_s: float = Field(default=float(DEFAULT_ROLLOUT_TIMEOUT_S), gt=0)
+    rollout_chunk_size: int = Field(default=DEFAULT_ROLLOUT_CHUNK_SIZE, gt=0)
+    rollout_max_in_flight: int = Field(default=DEFAULT_ROLLOUT_MAX_IN_FLIGHT, gt=0)
+    rollout_max_attempts: int = Field(default=DEFAULT_ROLLOUT_MAX_ATTEMPTS, ge=1)
+    rollout_retry_backoff_s: float = Field(default=DEFAULT_ROLLOUT_RETRY_BACKOFF_S, ge=0)
     host_provider_options: dict[str, Any] = Field(default_factory=dict)
     entrypoint: list[str] | None = None
 
@@ -263,6 +275,7 @@ def build_bootstrap_env(
     max_request_bytes: int,
     max_response_bytes: int,
     dataset_path: str | None = None,
+    rollout_deadline_s: float | None = None,
     extra: Mapping[str, str] | None = None,
 ) -> dict[str, str]:
     """Build the bootstrap environment injected into the job sandbox.
@@ -281,6 +294,10 @@ def build_bootstrap_env(
         "NMP_MAX_REQUEST_BYTES": str(max_request_bytes),
         "NMP_MAX_RESPONSE_BYTES": str(max_response_bytes),
     }
+    if rollout_deadline_s is not None:
+        # The host gives up just before the client would, so a stuck batch comes back as a
+        # readable error instead of the client's own socket timeout.
+        env["NMP_ROLLOUT_DEADLINE_S"] = str(rollout_deadline_s)
     if dataset_path is not None:
         env["NMP_DATASET_PATH"] = dataset_path
     if extra:

--- a/packages/sandboxed_gym/src/sandboxed_gym/orchestrator.py
+++ b/packages/sandboxed_gym/src/sandboxed_gym/orchestrator.py
@@ -7,9 +7,11 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+import http.client
 import json
 import logging
 import threading
+import time
 import urllib.error
 import urllib.request
 from collections.abc import Coroutine, Mapping
@@ -38,6 +40,75 @@ from sandboxed_gym.serve_config import (
 LOGGER = logging.getLogger(__name__)
 
 T = TypeVar("T")
+
+#: Below this a request cannot have been cut for staying open too long, so the host went away
+#: instead. Only used to choose which hint an error carries.
+MIN_PROXY_CUTOFF_S = 30.0
+
+
+class RolloutTransportError(RuntimeError):
+    """A failed rollout POST, tagged with where it failed and whether a retry can help."""
+
+    def __init__(self, message: str, *, retryable: bool, origin: str) -> None:
+        super().__init__(message)
+        self.retryable = retryable
+        #: "proxy" (in transit), "sandbox" (the host reported it), or "client" (our own limits).
+        self.origin = origin
+
+
+def _decode_json_object(body: str) -> Mapping[str, Any] | None:
+    try:
+        decoded = json.loads(body)
+    except (ValueError, TypeError):
+        return None
+    return decoded if isinstance(decoded, Mapping) else None
+
+
+def _sandbox_reported_error(body: str) -> str | None:
+    """The Gym host's own error message from a response body, or None.
+
+    The host wraps its failures as ``{"error": {"code", "message"}}``. The sandbox proxy uses a
+    *flat* ``{"code", "message"}``, so looking only for this nested envelope is what keeps a proxy
+    timeout from being reported as an environment failure.
+    """
+    decoded = _decode_json_object(body)
+    if decoded is None or decoded.get("error") is None:
+        return None
+    error = decoded["error"]
+    if isinstance(error, Mapping):
+        return f"{error.get('code', 'unknown')}: {error.get('message', '')}".strip()
+    return str(error)
+
+
+def _proxy_reported_error(body: str) -> str | None:
+    """The sandbox proxy's own error from a response body, or None.
+
+    The proxy emits a flat ``{"code", "message"}`` with no nested ``error`` key, including when its
+    read timeout fires -- where the underlying ``ReadTimeout`` stringifies to an empty message.
+    That is a decision the proxy already made, not a dropped connection: retrying re-runs
+    generation for the same wall time and fails the same way.
+    """
+    decoded = _decode_json_object(body)
+    if decoded is None or "error" in decoded:
+        return None
+    code = decoded.get("code")
+    message = decoded.get("message", "")
+    if not isinstance(code, str) or not isinstance(message, str):
+        return None
+    return f"{code}: {message}".strip()
+
+
+def _transit_failure_hint(elapsed: float) -> str:
+    """Name the likely cause of a POST that failed in transit, from how long it ran."""
+    if elapsed < MIN_PROXY_CUTOFF_S:
+        return (
+            "too fast to be the proxy's request-duration cap, so the host stopped answering -- "
+            "check whether the sandbox is still running (OOMKilled, evicted, or crashed)"
+        )
+    return (
+        "the sandbox proxy caps how long one request may stay open, so lower "
+        "sandbox.rollout_chunk_size if this persists"
+    )
 
 
 def _run_coro_sync(coro: Coroutine[Any, Any, T]) -> T:
@@ -168,6 +239,7 @@ def build_gym_host_spec(
         sandbox.max_request_bytes,
         sandbox.max_response_bytes,
         dataset_path=dataset_path,
+        rollout_deadline_s=sandbox.rollout_timeout_s,
         extra=bootstrap_extra,
     )
 
@@ -238,6 +310,10 @@ class SandboxedGymSession:
         self._rollout_timeout_s = float(cfg.sandbox.rollout_timeout_s)
         self._max_request_bytes = cfg.sandbox.max_request_bytes
         self._max_response_bytes = cfg.sandbox.max_response_bytes
+        self._chunk_size = cfg.sandbox.rollout_chunk_size
+        self._max_in_flight = cfg.sandbox.rollout_max_in_flight
+        self._max_attempts = cfg.sandbox.rollout_max_attempts
+        self._retry_backoff_s = float(cfg.sandbox.rollout_retry_backoff_s)
 
     def descriptor(
         self, *, mode: str | None = None, orchestrator_url: str | None = None
@@ -257,38 +333,239 @@ class SandboxedGymSession:
         )
 
     def run_rollouts(self, examples: list[dict[str, Any]]) -> list[Any]:
+        """Run ``examples`` on the host as bounded concurrent chunks.
+
+        Results are not in input order and never have been -- Gym yields through
+        ``as_completed``. Attribution travels on each result as ``_ng_task_index`` /
+        ``_ng_rollout_index``; see ``_with_row_identity`` in the host runtime.
+        """
         if not examples:
             raise ValueError("rollout batch must not be empty")
-        body = json.dumps({"examples": examples}).encode("utf-8")
+        return _run_coro_sync(self._post_all_chunks(examples))
+
+    async def _post_all_chunks(self, examples: list[dict[str, Any]]) -> list[Any]:
+        chunks = [examples[start : start + self._chunk_size] for start in range(0, len(examples), self._chunk_size)]
+        semaphore = asyncio.Semaphore(self._max_in_flight)
+        # return_exceptions so one chunk failing does not leave the others running detached.
+        parts = await asyncio.gather(
+            *(
+                self._post_chunk_with_retries(index, chunk, len(chunks), semaphore)
+                for index, chunk in enumerate(chunks)
+            ),
+            return_exceptions=True,
+        )
+        failures = [part for part in parts if isinstance(part, BaseException)]
+        # A failure that is not a transport error is a bug in this process, not a report about
+        # the sandbox. Re-raised as itself: wrapping it would give it a plausible retryable/origin
+        # and hide the stack that explains it.
+        for failure in failures:
+            if not isinstance(failure, RolloutTransportError):
+                raise failure
+        if failures:
+            whole_batch = (
+                " Every chunk failed, so the sandbox itself is the likelier cause than any one request."
+                if len(failures) == len(chunks) > 1
+                else ""
+            )
+            raise RolloutTransportError(
+                f"{len(failures)} of {len(chunks)} rollout chunk(s) failed for this batch of "
+                f"{len(examples)} example(s).{whole_batch} First failure: {failures[0]}",
+                retryable=False,
+                origin=getattr(failures[0], "origin", "proxy"),
+            ) from failures[0]
+        return [result for part in parts for result in part]  # ty: ignore[not-iterable]
+
+    async def _post_chunk_with_retries(
+        self, index: int, chunk: list[dict[str, Any]], total: int, semaphore: asyncio.Semaphore
+    ) -> list[Any]:
+        label = f"chunk {index + 1}/{total}"
+        for attempt in range(1, self._max_attempts + 1):
+            try:
+                async with semaphore:
+                    # Logged before the POST and inside the semaphore, so the line appears when the
+                    # chunk actually goes out. The completion log below is reached only by a chunk
+                    # that came back, which leaves a stalled batch -- the failure this transport
+                    # exists to survive -- with nothing in the log at all.
+                    LOGGER.info(
+                        "rollout %s: POST %d example(s)%s",
+                        label,
+                        len(chunk),
+                        "" if attempt == 1 else f" (attempt {attempt}/{self._max_attempts})",
+                    )
+                    started = time.monotonic()
+                    results = await asyncio.to_thread(self._post_chunk, chunk)
+            except RolloutTransportError as exc:
+                if not exc.retryable or attempt == self._max_attempts:
+                    raise RolloutTransportError(
+                        f"rollout {label} ({len(chunk)} example(s)) failed after {attempt} attempt(s): {exc}",
+                        retryable=exc.retryable,
+                        origin=exc.origin,
+                    ) from exc
+                backoff = self._retry_backoff_s * attempt
+                LOGGER.warning(
+                    "rollout %s attempt %d/%d failed (%s); retrying in %.1fs: %s",
+                    label,
+                    attempt,
+                    self._max_attempts,
+                    exc.origin,
+                    backoff,
+                    exc,
+                )
+                # Slept outside the semaphore so a backing-off chunk frees its slot.
+                await asyncio.sleep(backoff)
+                continue
+            LOGGER.info("rollout %s: %d result(s) in %.1fs", label, len(results), time.monotonic() - started)
+            return results
+        raise AssertionError("unreachable: the loop either returns or raises")
+
+    def _post_chunk(self, chunk: list[dict[str, Any]]) -> list[Any]:
+        body = json.dumps({"examples": chunk}).encode("utf-8")
         if len(body) > self._max_request_bytes:
-            raise ValueError(f"rollout request exceeds max_request_bytes ({len(body)} > {self._max_request_bytes})")
+            raise RolloutTransportError(
+                f"rollout request exceeds max_request_bytes ({len(body)} > {self._max_request_bytes}); "
+                f"lower sandbox.rollout_chunk_size",
+                retryable=False,
+                origin="client",
+            )
         request = urllib.request.Request(
             self.host.rollout_url,
             data=body,
             method="POST",
-            headers={
-                "Content-Type": "application/json",
-                **self.host.headers,
-            },
+            headers={"Content-Type": "application/json", **self.host.headers},
         )
+        started = time.monotonic()
         try:
             with urllib.request.urlopen(request, timeout=self._rollout_timeout_s) as response:
                 payload = response.read()
         except urllib.error.HTTPError as exc:
-            error_body = exc.read().decode("utf-8", errors="replace")
-            raise RuntimeError(f"rollout POST failed with HTTP {exc.code}: {error_body}") from exc
+            raise self._transport_error(exc.read().decode("utf-8", errors="replace"), exc.code, chunk, started) from exc
+        except urllib.error.URLError as exc:
+            # Raised before any response headers arrived, so the host almost certainly never began
+            # this chunk. Safe to retry.
+            raise self._in_transit_error(str(exc.reason), chunk, started, retryable=True) from exc
+        except (OSError, http.client.HTTPException) as exc:
+            # The body died mid-read: a reset, a truncated response, a socket timeout. The heartbeat
+            # holds this connection open for the length of a batch, so there is far more of it to
+            # interrupt than there used to be, and none of it arrives as a URLError.
+            #
+            # Deliberately NOT retryable. Reaching a body means the host answered, which it only
+            # does after `submit_rollouts` has started the work -- and it has no request id to
+            # deduplicate against, so a retry runs the same examples a second time while the first
+            # is still going. Duplicated generation and duplicated environment side effects are a
+            # worse outcome than a failed chunk, and only the host can make this safe.
+            raise self._in_transit_error(f"{type(exc).__name__}: {exc}", chunk, started, retryable=False) from exc
         if len(payload) > self._max_response_bytes:
-            raise ValueError(
-                f"rollout response exceeds max_response_bytes ({len(payload)} > {self._max_response_bytes})"
+            raise RolloutTransportError(
+                f"rollout response exceeds max_response_bytes ({len(payload)} > {self._max_response_bytes})",
+                retryable=False,
+                origin="client",
             )
-        decoded = json.loads(payload.decode("utf-8"))
+        return self._decode_results(payload)
+
+    def _in_transit_error(
+        self, detail: str, chunk: list[dict[str, Any]], started: float, *, retryable: bool
+    ) -> RolloutTransportError:
+        elapsed = time.monotonic() - started
+        return RolloutTransportError(
+            f"rollout POST to {self.host.rollout_url} failed after {elapsed:.1f}s for "
+            f"{len(chunk)} example(s): {detail}; {_transit_failure_hint(elapsed)}",
+            retryable=retryable,
+            origin="proxy",
+        )
+
+    def _transport_error(
+        self, body: str, status: int, chunk: list[dict[str, Any]], started: float
+    ) -> RolloutTransportError:
+        """Classify a non-2xx response by who produced it."""
+        elapsed = time.monotonic() - started
+        reported = _sandbox_reported_error(body)
+        if reported is not None:
+            # The host answered, so the environment failed: deterministic, and a retry only
+            # spends generation time to reach the same place.
+            return RolloutTransportError(
+                f"the sandboxed environment failed this rollout after {elapsed:.1f}s for "
+                f"{len(chunk)} example(s) (HTTP {status} from {self.host.rollout_url}): {reported}",
+                retryable=False,
+                origin="sandbox",
+            )
+        proxy_reported = _proxy_reported_error(body)
+        if proxy_reported is not None:
+            # The proxy answered with its own envelope, so it has already given up.
+            return RolloutTransportError(
+                f"rollout POST was rejected by the sandbox proxy with HTTP {status} after "
+                f"{elapsed:.1f}s for {len(chunk)} example(s) to {self.host.rollout_url}: "
+                f"{proxy_reported}; {_transit_failure_hint(elapsed)}",
+                retryable=False,
+                origin="proxy",
+            )
+        return RolloutTransportError(
+            f"rollout POST was rejected in transit with HTTP {status} after {elapsed:.1f}s for "
+            f"{len(chunk)} example(s) to {self.host.rollout_url}; {_transit_failure_hint(elapsed)}. "
+            f"Body: {body[:512]}",
+            retryable=True,
+            origin="proxy",
+        )
+
+    def _decode_results(self, payload: bytes) -> list[Any]:
+        try:
+            # Strict, and caught rather than avoided: errors="replace" would let a body with one
+            # corrupt byte still parse, handing the caller U+FFFD where the host wrote data.
+            body = payload.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise RolloutTransportError(
+                f"the sandboxed Gym host returned a body that is not UTF-8 ({exc})",
+                retryable=False,
+                origin="sandbox",
+            ) from exc
+        if not body.strip():
+            # Heartbeats and nothing else: the host committed its 200, padded the connection while
+            # it worked, and then went away without ever writing the envelope -- an OOMKill or an
+            # evicted pod mid-batch. Reported as the sandbox failing rather than as malformed JSON,
+            # which is what `json.loads` alone would have called it.
+            raise RolloutTransportError(
+                f"the sandboxed Gym host answered and then stopped without sending a result "
+                f"envelope ({len(payload)} byte(s) of heartbeat only); it most likely died "
+                f"mid-batch -- check whether the sandbox was OOMKilled or evicted",
+                retryable=False,
+                origin="sandbox",
+            )
+        try:
+            # The host heartbeats leading whitespace while a batch runs; json tolerates it.
+            decoded = json.loads(body)
+        except (ValueError, RecursionError) as exc:
+            # A *non-empty* malformed body is a broken response contract, not a transport blip, so
+            # it must not be retried into looking like one. Wider than JSONDecodeError because json
+            # also refuses input outright -- the integer-digit limit, deep nesting -- and narrowing
+            # this back lets those leave unclassified.
+            raise RolloutTransportError(
+                f"the sandboxed Gym host returned a body that is not JSON ({exc}); first 200 bytes: {body[:200]!r}",
+                retryable=False,
+                origin="sandbox",
+            ) from exc
         if isinstance(decoded, dict) and "error" in decoded:
-            raise RuntimeError(f"rollout runtime error: {decoded['error']}")
+            # A 200 carrying an error: the host had already committed its status line when it
+            # failed, so this is the only channel it had left.
+            raise RolloutTransportError(
+                f"the sandboxed Gym host reported {decoded['error']}",
+                retryable=False,
+                origin="sandbox",
+            )
         if isinstance(decoded, dict) and "results" in decoded:
-            return list(decoded["results"])
+            results = decoded["results"]
+            if not isinstance(results, list):
+                raise RolloutTransportError(
+                    f"unexpected rollout response shape: 'results' is {type(results).__name__}, not a list",
+                    retryable=False,
+                    origin="sandbox",
+                )
+            return results
         if isinstance(decoded, list):
             return decoded
-        raise RuntimeError(f"unexpected rollout response shape: {type(decoded)}")
+        raise RolloutTransportError(
+            f"unexpected rollout response shape: {type(decoded).__name__}",
+            retryable=False,
+            origin="sandbox",
+        )
 
     def shutdown(self) -> None:
         try:

--- a/packages/sandboxed_gym/src/sandboxed_gym/runtime/gym_host_runtime.py
+++ b/packages/sandboxed_gym/src/sandboxed_gym/runtime/gym_host_runtime.py
@@ -11,12 +11,16 @@ is injected verbatim into the sandbox image, where ``nemo_rl`` may not be import
 """
 
 import asyncio
+import concurrent.futures
 import json
 import os
 import socket
 import subprocess
 import sys
-from http.server import BaseHTTPRequestHandler, HTTPServer
+import threading
+import time
+import traceback
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
 
 from sandboxed_gym.environment_package import (
@@ -55,6 +59,20 @@ _READY: bool = False
 _RUN_HELPER: Any = None
 _HEAD_SERVER_CONFIG: Any = None
 _ROLLOUT_HELPER: Any = None
+_EVENT_LOOP: asyncio.AbstractEventLoop | None = None
+_EVENT_LOOP_LOCK = threading.Lock()
+
+#: The sandbox proxy gives up on a request whose first byte has not arrived within 180s, a cap its
+#: config does not expose, and a batch routinely outlasts that. Whitespace is a valid JSON prefix,
+#: so writing it while the work runs costs the reader nothing and keeps every hop's timer alive.
+_HEARTBEAT_INTERVAL_S = 15.0
+#: With no hop left to time a rollout out, the host has to be what gives up: a wedged batch would
+#: otherwise heartbeat until the sandbox's ttl_s.
+ROLLOUT_DEADLINE_ENV_KEY = "NMP_ROLLOUT_DEADLINE_S"
+_DEFAULT_ROLLOUT_DEADLINE_S = 30 * 60.0
+# Bounded so a deeply recursive failure cannot produce an oversized error response.
+_TRACEBACK_FRAMES = 20
+_MAX_TRACEBACK_CHARS = 8_000
 
 
 def _env_int(name: str, default: int) -> int:
@@ -62,6 +80,13 @@ def _env_int(name: str, default: int) -> int:
     if not raw:
         return default
     return int(raw)
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    return float(raw)
 
 
 def _runtime_error(code: str, message: str) -> dict[str, Any]:
@@ -423,17 +448,51 @@ async def _collect_rollout_results(
     return results
 
 
+def _ensure_event_loop() -> asyncio.AbstractEventLoop:
+    """Return the process-wide event loop every rollout request runs on.
+
+    One loop per process, not one per request: Gym's shared HTTP client binds to the loop that
+    created it, so a per-request loop would leave the next request pointing at a closed one.
+    """
+    global _EVENT_LOOP
+    with _EVENT_LOOP_LOCK:
+        if _EVENT_LOOP is None:
+            _EVENT_LOOP = asyncio.new_event_loop()
+            threading.Thread(target=_EVENT_LOOP.run_forever, name="gym-host-event-loop", daemon=True).start()
+        return _EVENT_LOOP
+
+
+def submit_rollouts(
+    examples: list[dict],
+    head_server_config: Any,
+    rollout_helper: Any,
+) -> concurrent.futures.Future[list[dict]]:
+    """Start ``examples`` on the shared loop and return without waiting.
+
+    Handing back a future rather than the results is what lets the handler answer before the work
+    finishes, so a long batch does not look to the proxy like an unresponsive server.
+    """
+    # Handler threads hand work to the one loop, so concurrent /rollouts/run calls interleave on
+    # it rather than each running a loop of its own.
+    return asyncio.run_coroutine_threadsafe(
+        _collect_rollout_results(examples, head_server_config, rollout_helper),
+        _ensure_event_loop(),
+    )
+
+
 def run_rollouts_sync(
     examples: list[dict],
     head_server_config: Any,
     rollout_helper: Any,
 ) -> list[dict]:
-    return asyncio.run(_collect_rollout_results(examples, head_server_config, rollout_helper))
+    return submit_rollouts(examples, head_server_config, rollout_helper).result()
 
 
 class Handler(BaseHTTPRequestHandler):
     max_request_bytes: int = 268_435_456
     max_response_bytes: int = 268_435_456
+    heartbeat_interval_s: float = _HEARTBEAT_INTERVAL_S
+    rollout_deadline_s: float = _DEFAULT_ROLLOUT_DEADLINE_S
 
     def do_GET(self) -> None:
         if not self.path.startswith("/health"):
@@ -493,15 +552,72 @@ class Handler(BaseHTTPRequestHandler):
             )
             return
 
-        try:
-            results = run_rollouts_sync(examples, _HEAD_SERVER_CONFIG, _ROLLOUT_HELPER)
-        except Exception as exc:
-            self._send_json(
-                500,
-                _runtime_error("internal", str(exc)),
-            )
-            return
+        # The only progress signal this process emits: log_message is silenced below, and both Gym
+        # servers filter their own 200s.
+        print(f"gym-host: rollouts/run <- {len(examples)} example(s)", flush=True)
+        started = time.monotonic()
+        future = submit_rollouts(examples, _HEAD_SERVER_CONFIG, _ROLLOUT_HELPER)
 
+        # Committed to 200 before the work is done, so the first byte leaves immediately and no hop
+        # can mistake a long batch for a dead one. Everything judgeable from the request alone was
+        # rejected with a real status above; failures from here travel in the body as
+        # {"error": ...}, which the caller already treats as fatal. No Content-Length: the body is
+        # delimited by the close that `Connection: close` promises, which is what allows the
+        # heartbeats below to precede a payload of unknown length.
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Connection", "close")
+        self.end_headers()
+        self.wfile.write(self._await_results(future, started))
+
+    def _await_results(self, future: concurrent.futures.Future[list[dict]], started: float) -> bytes:
+        """Wait for ``future``, heartbeating while it runs, and return the body to send.
+
+        Returns an error envelope rather than raising: the status line is already on the wire by
+        the time this is called, so a failure can only be reported in the body.
+        """
+        deadline = started + self.rollout_deadline_s
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                future.cancel()
+                detail = f"rollout exceeded the host deadline of {self.rollout_deadline_s:g}s and was abandoned"
+                print(f"gym-host: rollouts/run failed: {detail}", flush=True)
+                return self._error_body("deadline_exceeded", detail)
+
+            # wait() rather than result(timeout=...): a rollout is free to raise TimeoutError of
+            # its own, which is not this loop's tick.
+            done, _ = concurrent.futures.wait([future], timeout=min(self.heartbeat_interval_s, remaining))
+            if not done:
+                try:
+                    self.wfile.write(b" ")
+                    self.wfile.flush()
+                except OSError as exc:
+                    # The caller is gone. Nothing will read this batch, so stop paying for it:
+                    # cancelling the future propagates to the collector task on the shared loop.
+                    # Rollouts Gym has already started keep running until they finish -- they are
+                    # its tasks, not ours, and the deadline above is what bounds them.
+                    future.cancel()
+                    print(
+                        f"gym-host: rollouts/run abandoned, the caller disconnected: {exc}",
+                        flush=True,
+                    )
+                    raise
+                continue
+
+            try:
+                results = future.result()
+            except Exception as exc:
+                # Returned to the caller: this process's stdout never reaches the job.
+                detail = traceback.format_exc(limit=_TRACEBACK_FRAMES)
+                print(f"gym-host: rollouts/run failed: {detail}", flush=True)
+                return self._error_body("internal", f"{type(exc).__name__}: {exc}\n{detail[-_MAX_TRACEBACK_CHARS:]}")
+            break
+
+        print(
+            f"gym-host: rollouts/run -> {len(results)} result(s) in {time.monotonic() - started:.1f}s",
+            flush=True,
+        )
         envelope = {
             "results": results,
             "job_id": os.environ.get("NMP_JOB_ID", ""),
@@ -510,20 +626,15 @@ class Handler(BaseHTTPRequestHandler):
         }
         body = json.dumps(envelope).encode("utf-8")
         if len(body) > self.max_response_bytes:
-            self._send_json(
-                413,
-                _runtime_error(
-                    "payload_too_large",
-                    f"response body {len(body)} exceeds max {self.max_response_bytes}",
-                ),
+            return self._error_body(
+                "payload_too_large",
+                f"response body {len(body)} exceeds max {self.max_response_bytes}; "
+                f"lower sandbox.rollout_chunk_size or raise sandbox.max_response_bytes",
             )
-            return
+        return body
 
-        self.send_response(200)
-        self.send_header("Content-Type", "application/json")
-        self.send_header("Content-Length", str(len(body)))
-        self.end_headers()
-        self.wfile.write(body)
+    def _error_body(self, code: str, message: str) -> bytes:
+        return json.dumps(_runtime_error(code, message)).encode("utf-8")
 
     def _send_json(self, status: int, payload: dict[str, Any]) -> None:
         body = json.dumps(payload).encode("utf-8")
@@ -542,12 +653,17 @@ def main() -> None:
 
     Handler.max_request_bytes = _env_int("NMP_MAX_REQUEST_BYTES", Handler.max_request_bytes)
     Handler.max_response_bytes = _env_int("NMP_MAX_RESPONSE_BYTES", Handler.max_response_bytes)
+    # Set from the caller's rollout_timeout_s. This, not that timeout, is what actually bounds a
+    # batch: the client's is a per-read socket timeout, and the heartbeat keeps resetting it.
+    Handler.rollout_deadline_s = _env_float(ROLLOUT_DEADLINE_ENV_KEY, Handler.rollout_deadline_s)
 
+    _ensure_event_loop()
     _RUN_HELPER, _HEAD_SERVER_CONFIG, _ROLLOUT_HELPER = bootstrap_gym_host()
     _READY = True
 
     port = _env_int("NMP_RUNTIME_HTTP_PORT", _DEFAULT_HTTP_PORT)
-    HTTPServer(("0.0.0.0", port), Handler).serve_forever()
+    # Threaded so chunked rollouts overlap and /health stays answerable mid-batch.
+    ThreadingHTTPServer(("0.0.0.0", port), Handler).serve_forever()
 
 
 if __name__ == "__main__":

--- a/packages/sandboxed_gym/tests/test_gym_host_runtime.py
+++ b/packages/sandboxed_gym/tests/test_gym_host_runtime.py
@@ -1,10 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 import json
 import socket
 import threading
-from http.server import HTTPServer
+import time
+from http.server import HTTPServer, ThreadingHTTPServer
 from types import ModuleType
 from typing import Any, cast
 from unittest.mock import MagicMock
@@ -673,3 +675,214 @@ def test_bootstrap_installs_wheels_before_starting_gym(monkeypatch):
     assert head_server_config.host == "127.0.0.1"
     assert head_server_config.port == 5000
     assert rollout_helper == "rollout-helper"
+
+
+# --------------------------------------------------------------------------------------------
+# Long-running rollouts
+#
+# The sandbox proxy caps how long it waits for a response's first byte, so a batch that takes
+# longer than the cap fails in transit no matter how healthy the host is. These cover the host
+# answering early and heartbeating, and the deadline that replaces the timeout no hop is left to
+# apply. Docker has no proxy in the path, which is why none of this was caught by running it.
+# --------------------------------------------------------------------------------------------
+
+
+class _SlowRolloutHelper:
+    """Blocks each rollout until released, so a batch's duration is controlled by the test.
+
+    ``cancelled`` records that the collector was actually cancelled, which is the only way to tell
+    an abandoned batch from one that merely finished while nobody was reading.
+    """
+
+    def __init__(self, release: threading.Event, *, fail: bool = False) -> None:
+        self._release = release
+        self._fail = fail
+        self.cancelled = threading.Event()
+
+    def run_examples(self, examples, head_server_config=None):
+        async def _one(row):
+            try:
+                await asyncio.get_running_loop().run_in_executor(None, self._release.wait, 30)
+            except asyncio.CancelledError:
+                self.cancelled.set()
+                raise
+            if self._fail:
+                raise RuntimeError("environment exploded")
+            return row, {"response": {"output": []}, "reward": 1.0}
+
+        return [_one(row) for row in examples]
+
+
+@pytest.fixture
+def slow_server():
+    """A threaded host whose rollouts block until the test releases them."""
+    release = threading.Event()
+    original = (
+        runtime.Handler.heartbeat_interval_s,
+        runtime.Handler.rollout_deadline_s,
+        runtime.Handler.max_request_bytes,
+        runtime.Handler.max_response_bytes,
+    )
+    started: list[ThreadingHTTPServer] = []
+
+    def _start(*, fail: bool = False, heartbeat_s: float = 0.05, deadline_s: float = 30.0):
+        runtime._READY = True
+        runtime._RUN_HELPER = MagicMock()
+        runtime._HEAD_SERVER_CONFIG = MagicMock()
+        runtime._ROLLOUT_HELPER = _SlowRolloutHelper(release, fail=fail)
+        runtime.Handler.max_request_bytes = 4096
+        runtime.Handler.max_response_bytes = 4096
+        runtime.Handler.heartbeat_interval_s = heartbeat_s
+        runtime.Handler.rollout_deadline_s = deadline_s
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), runtime.Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        started.append(server)
+        return f"http://127.0.0.1:{server.server_address[1]}", release
+
+    try:
+        yield _start
+    finally:
+        release.set()
+        for server in started:
+            server.shutdown()
+            server.server_close()
+        runtime._READY = False
+        runtime._HEAD_SERVER_CONFIG = None
+        runtime._ROLLOUT_HELPER = None
+        (
+            runtime.Handler.heartbeat_interval_s,
+            runtime.Handler.rollout_deadline_s,
+            runtime.Handler.max_request_bytes,
+            runtime.Handler.max_response_bytes,
+        ) = original
+
+
+def _post_rollouts(base_url: str, examples: list[dict], timeout: float = 30.0):
+    import urllib.request
+
+    payload = json.dumps({"examples": examples}).encode()
+    request = urllib.request.Request(
+        f"{base_url}/rollouts/run", data=payload, headers={"Content-Type": "application/json"}
+    )
+    return urllib.request.urlopen(request, timeout=timeout)
+
+
+def test_rollouts_run_answers_before_the_batch_finishes(slow_server):
+    """The status line must leave immediately, and the connection stay visibly alive after it.
+
+    A proxy that has seen no byte for its cap gives up on the request, so a batch slower than the
+    cap fails in transit however healthy the host is. Heartbeat whitespace is a valid JSON prefix,
+    so it holds the connection open without the reader having to know about it.
+    """
+    base_url, release = slow_server(heartbeat_s=0.05)
+
+    response = _post_rollouts(base_url, [{"id": 1}])
+    # Headers are readable while the rollout is still blocked: proof the host answered first.
+    assert response.status == 200
+    assert response.headers.get("Content-Length") is None
+
+    time.sleep(0.3)
+    release.set()
+    raw = response.read().decode()
+
+    assert raw.startswith(" "), "no heartbeat preceded the payload"
+    assert json.loads(raw)["results"][0]["reward"] == 1.0
+
+
+def test_rollouts_run_gives_up_at_the_host_deadline(slow_server):
+    """Nothing else can time a wedged batch out, so the host has to.
+
+    Every other hop has been taught to wait, so without this a stuck rollout heartbeats until the
+    sandbox's ttl_s and the caller learns nothing about why.
+    """
+    base_url, _ = slow_server(heartbeat_s=0.05, deadline_s=0.2)
+
+    body = json.loads(_post_rollouts(base_url, [{"id": 1}]).read().decode())
+
+    assert body["error"]["code"] == "deadline_exceeded"
+    assert "0.2s" in body["error"]["message"]
+
+
+def test_rollouts_run_reports_a_failed_batch_in_the_body(slow_server):
+    """After the status line is committed, a failure can only be reported in the body.
+
+    It carries a traceback because the host's stdout never reaches the job: without one the caller
+    sees the exception's ``str`` and has no idea which of Gym's layers raised it.
+    """
+    base_url, release = slow_server(fail=True)
+    release.set()
+
+    body = json.loads(_post_rollouts(base_url, [{"id": 1}]).read().decode())
+
+    assert body["error"]["code"] == "internal"
+    assert "environment exploded" in body["error"]["message"]
+    assert "Traceback" in body["error"]["message"]
+
+
+def test_health_stays_answerable_during_a_rollout(slow_server):
+    """A single-threaded server would queue /health behind the batch and read as unhealthy."""
+    import urllib.request
+
+    base_url, release = slow_server()
+    rollout = threading.Thread(target=lambda: _post_rollouts(base_url, [{"id": 1}]).read())
+    rollout.start()
+    try:
+        time.sleep(0.2)
+        with urllib.request.urlopen(f"{base_url}/health", timeout=5) as health:
+            assert json.loads(health.read().decode()) == {"status": "ready"}
+    finally:
+        release.set()
+        rollout.join(timeout=10)
+
+
+def test_a_disconnected_caller_cancels_the_batch(slow_server):
+    """Nothing will read the results, so the host should stop paying for them.
+
+    Without this the batch runs to completion against a socket that is gone, and with chunking
+    several abandoned batches can pile up on the shared loop at once.
+    """
+    import urllib.request
+
+    base_url, release = slow_server(heartbeat_s=0.05)
+    helper = runtime._ROLLOUT_HELPER
+    payload = json.dumps({"examples": [{"id": 1}]}).encode()
+    request = urllib.request.Request(
+        f"{base_url}/rollouts/run", data=payload, headers={"Content-Type": "application/json"}
+    )
+    response = urllib.request.urlopen(request, timeout=10)
+
+    # Drop the connection while the host is still heartbeating into it.
+    response.close()
+
+    assert helper.cancelled.wait(10), "the abandoned batch kept running after the caller left"
+
+    release.set()
+    # And the server stays healthy for the next caller rather than wedging on the broken one.
+    with urllib.request.urlopen(f"{base_url}/health", timeout=5) as health:
+        assert json.loads(health.read().decode()) == {"status": "ready"}
+
+
+def test_rollouts_reuse_one_live_event_loop():
+    """Gym's shared HTTP client binds to the loop that created it.
+
+    A loop per request would leave the client pointing at a closed one, so the second batch fails
+    inside Gym rather than here.
+    """
+    first = runtime._ensure_event_loop()
+    second = runtime._ensure_event_loop()
+
+    assert first is second
+    assert first.is_running()
+
+
+def test_concurrent_rollout_batches_interleave_on_that_loop():
+    """Chunked callers post several batches at once; they must not serialize or deadlock."""
+    helper = _FakeRolloutHelper()
+    config = MagicMock()
+
+    futures = [runtime.submit_rollouts([{"id": index}], config, helper) for index in range(4)]
+    results = [future.result(timeout=10) for future in futures]
+
+    assert [len(batch) for batch in results] == [1, 1, 1, 1]

--- a/packages/sandboxed_gym/tests/test_rollout_transport.py
+++ b/packages/sandboxed_gym/tests/test_rollout_transport.py
@@ -1,0 +1,482 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""How a rollout batch reaches the Gym host and how its failures are classified.
+
+Two hops can refuse a rollout and they say so differently: the Gym host wraps its own failures as
+a nested ``{"error": {...}}``, while the sandbox proxy answers with a flat ``{"code", "message"}``
+-- and does so when its read timeout fires, where the message is empty. Confusing the two turns a
+proxy giving up into "the environment failed", which sends the reader to the wrong system.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+import threading
+import time
+import urllib.error
+import urllib.request
+from email.message import Message
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from sandboxed_gym.config import BrokerEndpoint
+from sandboxed_gym.host.models import GymHostHandle
+from sandboxed_gym.orchestrator import RolloutTransportError, SandboxedGymSession
+from sandboxed_gym.serve_config import SandboxedGymServeConfig
+
+ROLLOUT_URL = "http://host/rollouts/run"
+
+
+def _session(**sandbox_overrides: Any) -> SandboxedGymSession:
+    cfg = SandboxedGymServeConfig.model_validate(
+        {
+            "job_id": "job-1",
+            "sandbox": {
+                "image": "runtime:dev",
+                "network_policy": {"egress_allow": []},
+                "environment_pvc_claim": "env",
+                "workspace_pvc_claim": "work",
+                "rollout_retry_backoff_s": 0,
+                **sandbox_overrides,
+            },
+        }
+    )
+    return SandboxedGymSession(
+        cfg=cfg,
+        broker_server=MagicMock(),
+        broker=BrokerEndpoint(url="http://broker:1", host="broker", port=1, token="t"),
+        host_provider=MagicMock(),
+        host=GymHostHandle(host_id="h1", health_url="http://host/health", rollout_url=ROLLOUT_URL, headers={}),
+    )
+
+
+def _http_error(status: int, body: dict[str, Any]) -> urllib.error.HTTPError:
+    payload = io.BytesIO(json.dumps(body).encode())
+    return urllib.error.HTTPError(ROLLOUT_URL, status, "err", Message(), payload)
+
+
+def _responds(monkeypatch: pytest.MonkeyPatch, results: list[Any]) -> list[list[dict]]:
+    """Record each chunk posted and answer it with ``results``."""
+    posted: list[list[dict]] = []
+
+    def _post(self: SandboxedGymSession, chunk: list[dict]) -> list[Any]:
+        posted.append(chunk)
+        return results
+
+    monkeypatch.setattr(SandboxedGymSession, "_post_chunk", _post)
+    return posted
+
+
+# --------------------------------------------------------------------------------------------
+# Chunking
+# --------------------------------------------------------------------------------------------
+
+
+def test_a_batch_is_split_into_bounded_chunks(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Request duration and response size have to track the chunk, not the batch.
+
+    A whole batch in one POST is what puts the request over the proxy's cap and the response over
+    max_response_bytes at the same time, with nothing to lower but the batch itself.
+    """
+    posted = _responds(monkeypatch, [{"reward": 1.0}])
+    session = _session(rollout_chunk_size=2)
+
+    results = session.run_rollouts([{"id": index} for index in range(5)])
+
+    # Sizes sorted, not in dispatch order: chunks go out concurrently, so which one records itself
+    # first is thread scheduling. What is guaranteed is the partition -- every example sent once.
+    assert sorted(len(chunk) for chunk in posted) == [1, 2, 2]
+    assert sorted(row["id"] for chunk in posted for row in chunk) == list(range(5))
+    assert len(results) == 3  # one stub result per chunk
+
+
+def test_an_empty_batch_is_refused() -> None:
+    with pytest.raises(ValueError, match="must not be empty"):
+        _session().run_rollouts([])
+
+
+def test_concurrency_is_bounded_by_max_in_flight(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Chunks must run concurrently, but only so many at once.
+
+    Asserts the peak is exactly the limit, not merely under it: a stub that returned instantly
+    would never overlap, and the test would pass just as well against unbounded fan-out.
+    """
+    lock = threading.Lock()
+    in_flight = 0
+    peak = 0
+
+    def _post(self: SandboxedGymSession, chunk: list[dict]) -> list[Any]:
+        nonlocal in_flight, peak
+        with lock:
+            in_flight += 1
+            peak = max(peak, in_flight)
+        time.sleep(0.05)
+        with lock:
+            in_flight -= 1
+        return [{"reward": 1.0}]
+
+    monkeypatch.setattr(SandboxedGymSession, "_post_chunk", _post)
+    _session(rollout_chunk_size=1, rollout_max_in_flight=2).run_rollouts([{"id": i} for i in range(8)])
+
+    assert peak == 2
+
+
+# --------------------------------------------------------------------------------------------
+# What a running batch says about itself
+# --------------------------------------------------------------------------------------------
+
+
+def test_a_chunk_announces_itself_before_it_goes_out(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A chunk that never comes back is the case worth logging, and only a line written
+    before the POST can cover it.
+
+    Asserted through a chunk that fails rather than one that hangs, because both reach the
+    completion log the same way -- they don't. A test that let the POST succeed would pass
+    against a log line written afterwards.
+    """
+
+    def _post(self: SandboxedGymSession, chunk: list[dict]) -> list[Any]:
+        raise RolloutTransportError("host is gone", retryable=False, origin="sandbox")
+
+    monkeypatch.setattr(SandboxedGymSession, "_post_chunk", _post)
+    caplog.set_level(logging.INFO, logger="sandboxed_gym.orchestrator")
+
+    with pytest.raises(RolloutTransportError):
+        _session(rollout_chunk_size=2).run_rollouts([{"id": i} for i in range(2)])
+
+    assert "rollout chunk 1/1: POST 2 example(s)" in caplog.text
+    # The chunk never returned, so nothing should claim it did.
+    assert "result(s) in" not in caplog.text
+
+
+def test_a_retried_chunk_names_the_attempt(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    """Two identical POST lines for one chunk would read as two chunks."""
+    attempts = 0
+
+    def _post(self: SandboxedGymSession, chunk: list[dict]) -> list[Any]:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RolloutTransportError("dropped", retryable=True, origin="proxy")
+        return [{"reward": 1.0}]
+
+    monkeypatch.setattr(SandboxedGymSession, "_post_chunk", _post)
+    caplog.set_level(logging.INFO, logger="sandboxed_gym.orchestrator")
+
+    _session(rollout_chunk_size=1, rollout_max_attempts=2).run_rollouts([{"id": 0}])
+
+    assert "rollout chunk 1/1: POST 1 example(s)\n" in caplog.text + "\n"
+    assert "(attempt 2/2)" in caplog.text
+
+
+# --------------------------------------------------------------------------------------------
+# Who refused the rollout
+# --------------------------------------------------------------------------------------------
+
+
+def test_a_host_error_is_attributed_to_the_sandbox_and_not_retried(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The host answered, so the environment failed: deterministic, and a retry only costs time.
+
+    Drives the real ``_post_chunk`` by failing the HTTP call, so the classification under test is
+    the one production runs rather than a re-implementation of it.
+    """
+    attempts = 0
+
+    def _urlopen(request, timeout=None):
+        nonlocal attempts
+        attempts += 1
+        raise _http_error(500, {"error": {"code": "internal", "message": "env exploded"}})
+
+    monkeypatch.setattr(urllib.request, "urlopen", _urlopen)
+
+    with pytest.raises(RolloutTransportError) as excinfo:
+        _session().run_rollouts([{"id": 1}])
+
+    assert excinfo.value.origin == "sandbox"
+    assert "env exploded" in str(excinfo.value)
+    assert attempts == 1, "a sandbox-reported error must not be retried"
+
+
+def test_a_transport_failure_reaching_no_host_is_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A connection that never landed is the case a retry genuinely fixes."""
+    attempts = 0
+
+    def _urlopen(request, timeout=None):
+        nonlocal attempts
+        attempts += 1
+        raise urllib.error.URLError("connection refused")
+
+    monkeypatch.setattr(urllib.request, "urlopen", _urlopen)
+
+    with pytest.raises(RolloutTransportError) as excinfo:
+        _session(rollout_max_attempts=2).run_rollouts([{"id": 1}])
+
+    assert attempts == 2
+    assert excinfo.value.origin == "proxy"
+
+
+def test_a_proxy_error_is_attributed_to_the_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The proxy's envelope is flat, and empty when its read timeout fires.
+
+    Matching only the host's nested envelope would let this fall through every branch and surface
+    as an unexpected response shape -- a parser bug with no message, for the failure most likely
+    to happen in production.
+    """
+    session = _session()
+    error = session._transport_error(json.dumps({"code": "timeout", "message": ""}), 504, [{}], 0.0)
+
+    assert error.origin == "proxy"
+    assert not error.retryable
+    assert "rejected by the sandbox proxy" in str(error)
+
+
+def test_an_unrecognised_body_stays_retryable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Neither envelope means the request died in transit, which a retry can genuinely fix."""
+    session = _session()
+    error = session._transport_error("<html>502 Bad Gateway</html>", 502, [{}], 0.0)
+
+    assert error.origin == "proxy"
+    assert error.retryable
+    assert "502 Bad Gateway" in str(error)
+
+
+def test_a_200_carrying_an_error_is_a_sandbox_failure() -> None:
+    """The host commits its status line before the work finishes, so a late failure rides the body.
+
+    Reading only the status would treat this as a successful batch and hand the caller an
+    ``error`` dict where results were expected.
+    """
+    session = _session()
+
+    with pytest.raises(RolloutTransportError) as excinfo:
+        session._decode_results(json.dumps({"error": {"code": "deadline_exceeded"}}).encode())
+
+    assert excinfo.value.origin == "sandbox"
+    assert not excinfo.value.retryable
+
+
+def test_heartbeat_whitespace_does_not_break_decoding() -> None:
+    """The host pads the body while it works; that padding reaches this decoder verbatim."""
+    session = _session()
+
+    assert session._decode_results(b'    {"results": [{"reward": 1.0}]}') == [{"reward": 1.0}]
+
+
+# --------------------------------------------------------------------------------------------
+# Retry
+# --------------------------------------------------------------------------------------------
+
+
+def test_a_transport_failure_is_retried_to_the_attempt_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempts = 0
+
+    def _post(self: SandboxedGymSession, chunk: list[dict]) -> list[Any]:
+        nonlocal attempts
+        attempts += 1
+        raise RolloutTransportError("in transit", retryable=True, origin="proxy")
+
+    monkeypatch.setattr(SandboxedGymSession, "_post_chunk", _post)
+
+    with pytest.raises(RolloutTransportError) as excinfo:
+        _session(rollout_max_attempts=3).run_rollouts([{"id": 1}])
+
+    assert attempts == 3
+    assert "failed after 3 attempt(s)" in str(excinfo.value)
+
+
+def test_a_retry_that_succeeds_returns_the_batch(monkeypatch: pytest.MonkeyPatch) -> None:
+    attempts = 0
+
+    def _post(self: SandboxedGymSession, chunk: list[dict]) -> list[Any]:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RolloutTransportError("in transit", retryable=True, origin="proxy")
+        return [{"reward": 1.0}]
+
+    monkeypatch.setattr(SandboxedGymSession, "_post_chunk", _post)
+
+    assert _session().run_rollouts([{"id": 1}]) == [{"reward": 1.0}]
+
+
+def test_every_chunk_failing_points_at_the_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    """One bad chunk is a request problem; all of them is the sandbox, and reads very differently."""
+
+    def _post(self: SandboxedGymSession, chunk: list[dict]) -> list[Any]:
+        raise RolloutTransportError("gone", retryable=False, origin="proxy")
+
+    monkeypatch.setattr(SandboxedGymSession, "_post_chunk", _post)
+
+    with pytest.raises(RolloutTransportError) as excinfo:
+        _session(rollout_chunk_size=1).run_rollouts([{"id": 1}, {"id": 2}])
+
+    assert "Every chunk failed" in str(excinfo.value)
+    assert "2 of 2" in str(excinfo.value)
+
+
+def test_a_body_that_dies_mid_read_is_not_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reaching a body means the host accepted the chunk and started running it.
+
+    The host answers ``200`` only after ``submit_rollouts`` is under way, and it has no request id
+    to deduplicate against, so retrying here runs the same examples a second time while the first
+    is still going. Duplicated generation and duplicated environment side effects are worse than a
+    failed chunk. The failure is still *classified* -- it carries the chunk, the URL and the
+    elapsed time -- it just does not go round again.
+    """
+    attempts = 0
+
+    class _DyingResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc_info):
+            return False
+
+        def read(self):
+            raise ConnectionResetError("connection reset by peer")
+
+    def _urlopen(request, timeout=None):
+        nonlocal attempts
+        attempts += 1
+        return _DyingResponse()
+
+    monkeypatch.setattr(urllib.request, "urlopen", _urlopen)
+
+    with pytest.raises(RolloutTransportError) as excinfo:
+        _session(rollout_max_attempts=3).run_rollouts([{"id": 1}])
+
+    assert attempts == 1, "a chunk the host had already accepted was sent again"
+    assert excinfo.value.origin == "proxy"
+    assert not excinfo.value.retryable
+    assert "ConnectionResetError" in str(excinfo.value)
+
+
+def test_a_connection_that_never_landed_is_still_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The counterpart: no response headers means the host never began the chunk.
+
+    This is the case a retry genuinely fixes, and the one that must survive the restriction above.
+    """
+    attempts = 0
+
+    def _urlopen(request, timeout=None):
+        nonlocal attempts
+        attempts += 1
+        raise urllib.error.URLError("connection refused")
+
+    monkeypatch.setattr(urllib.request, "urlopen", _urlopen)
+
+    with pytest.raises(RolloutTransportError):
+        _session(rollout_max_attempts=2).run_rollouts([{"id": 1}])
+
+    assert attempts == 2
+
+
+def test_a_heartbeat_only_body_names_the_host_as_the_failure() -> None:
+    """A host that dies mid-batch leaves exactly this: a 200, some padding, then nothing.
+
+    ``json.loads`` alone would call it malformed JSON, which reads as a response-contract bug and
+    sends the reader to the wrong system. It is the sandbox having gone away.
+    """
+    session = _session()
+
+    with pytest.raises(RolloutTransportError) as excinfo:
+        session._decode_results(b"    ")
+
+    assert excinfo.value.origin == "sandbox"
+    assert not excinfo.value.retryable
+    assert "OOMKilled" in str(excinfo.value)
+
+
+def test_a_malformed_non_empty_body_is_a_contract_failure() -> None:
+    """Distinct from the above, and deliberately not retried: the host said something wrong."""
+    session = _session()
+
+    with pytest.raises(RolloutTransportError) as excinfo:
+        session._decode_results(b"<html>gateway</html>")
+
+    assert not excinfo.value.retryable
+    assert "not JSON" in str(excinfo.value)
+
+
+def test_a_non_utf8_body_is_a_contract_failure_not_a_decode_crash() -> None:
+    """An uncaught decode raises UnicodeDecodeError, which is not a RolloutTransportError.
+
+    ``_post_chunk_with_retries`` only catches RolloutTransportError, so anything else reaches
+    ``_post_all_chunks`` and is re-raised as a bug in this process -- losing the chunk label and
+    the sandbox attribution for a failure the host produced.
+    """
+    session = _session()
+
+    with pytest.raises(RolloutTransportError) as excinfo:
+        session._decode_results(b'{"results": ["\xff"]}')
+
+    assert excinfo.value.origin == "sandbox"
+    assert not excinfo.value.retryable
+    assert "not UTF-8" in str(excinfo.value)
+
+
+def test_a_json_refusal_that_is_not_a_decode_error_is_a_contract_failure() -> None:
+    """``json`` has refusals that are not ``JSONDecodeError``, and they escape a narrow catch.
+
+    Both bodies below are well within ``max_response_bytes``, so nothing upstream stops them.
+    """
+    session = _session()
+
+    for payload in (b"1" * 5000, b"[" * 100_000 + b"]" * 100_000):
+        with pytest.raises(RolloutTransportError) as excinfo:
+            session._decode_results(payload)
+
+        assert excinfo.value.origin == "sandbox"
+        assert not excinfo.value.retryable
+
+
+def test_a_non_list_results_field_is_a_contract_failure() -> None:
+    """``{"results": null}`` would raise TypeError from ``list(None)`` and escape the same way."""
+    session = _session()
+
+    with pytest.raises(RolloutTransportError) as excinfo:
+        session._decode_results(b'{"results": null}')
+
+    assert excinfo.value.origin == "sandbox"
+    assert not excinfo.value.retryable
+    assert "not a list" in str(excinfo.value)
+
+
+def test_a_top_level_scalar_response_is_a_contract_failure() -> None:
+    """The host produced it, so it is attributed to the sandbox like every other bad envelope."""
+    session = _session()
+
+    with pytest.raises(RolloutTransportError) as excinfo:
+        session._decode_results(b"42")
+
+    assert excinfo.value.origin == "sandbox"
+    assert not excinfo.value.retryable
+    assert "unexpected rollout response shape" in str(excinfo.value)
+
+
+def test_a_bug_in_this_process_is_not_disguised_as_a_transport_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Wrapping every failure would give a programming error a plausible origin and retryable flag.
+
+    It also swallows the stack that explains it, which is how a missing method once read as a
+    sandbox that had stopped answering.
+    """
+
+    def _post(self: SandboxedGymSession, chunk: list[dict]) -> list[Any]:
+        raise AttributeError("no such method")
+
+    monkeypatch.setattr(SandboxedGymSession, "_post_chunk", _post)
+
+    with pytest.raises(AttributeError, match="no such method"):
+        _session().run_rollouts([{"id": 1}])

--- a/packages/sandboxed_gym/tests/test_sandboxed_gym_host.py
+++ b/packages/sandboxed_gym/tests/test_sandboxed_gym_host.py
@@ -331,6 +331,36 @@ def test_gym_host_spec_carries_a_configured_entrypoint_through():
     assert spec.entrypoint == ("/bin/sh", "/opt/nemo-rl/gym_host.sh")
 
 
+def test_gym_host_spec_forwards_the_rollout_deadline():
+    """The host has to know when to give up, and only the caller's config knows when that is.
+
+    Without this the host falls back to its own 30-minute default while the client gives up at
+    ``rollout_timeout_s``, so a stuck batch never produces the clean ``deadline_exceeded`` body
+    the client timeout was supposed to replace.
+    """
+    from sandboxed_gym.config import BrokerEndpoint
+    from sandboxed_gym.orchestrator import build_gym_host_spec
+    from sandboxed_gym.serve_config import SandboxedGymServeConfig
+
+    cfg = SandboxedGymServeConfig.model_validate(
+        {
+            "job_id": "job-1",
+            "sandbox": {
+                "image": "runtime:dev",
+                "network_policy": {"egress_allow": []},
+                "environment_pvc_claim": "env",
+                "workspace_pvc_claim": "work",
+                "rollout_timeout_s": 120,
+            },
+        }
+    )
+    broker = BrokerEndpoint(url="http://broker:1", host="broker", port=1, token="t")
+
+    spec = build_gym_host_spec(cfg, broker)
+
+    assert spec.bootstrap_env["NMP_ROLLOUT_DEADLINE_S"] == "120.0"
+
+
 def test_gym_host_spec_carries_global_config_in_bootstrap():
     import json
 


### PR DESCRIPTION
## Summary

The sandbox proxy gives up on a request whose first byte has not arrived within 180s, and its config does not expose that cap. A rollout batch routinely takes longer, so **any real batch currently fails in transit however healthy the host is** — and reports itself as `unexpected rollout response shape: <class 'dict'>`, with no message. This makes the host answer early and heartbeat, splits the batch into bounded chunks, and teaches the client which hop actually refused it.

Docker has no proxy in the path, which is why running this end-to-end on Docker for #1400 never showed it.

## Related Issue

Part of AALGO-584 (items A1, A2, A3, A8, A9, A10 of the drift analysis attached there). Follows #1734, which took the four independent fixes. Parent: AALGO-583.

## Changes

Ports `soluwalana/RL@893ec0b` (heartbeat) and `@5719a3e` (chunking, retry, error classification), kept as one commit because they are one change: each addresses a different consequence of the same cap.

**Host** — answer `200` before the work finishes and write a space every 15s while it runs. Whitespace is a valid JSON prefix, so it costs the reader nothing and keeps every hop's timer alive. Consequences: no `Content-Length` (the body is delimited by the close `Connection: close` promises), and a failure after the status line can only be reported in the body, so error envelopes now carry a bounded traceback. Adds a host-side deadline, `ThreadingHTTPServer` so `/health` stays answerable mid-batch, and one process-wide event loop — Gym's shared HTTP client binds to the loop that created it.

**Client** — bounded chunks at bounded concurrency, so request duration and response size track the chunk rather than the batch; transport failures retried with backoff. Four new `SandboxConfig` fields.

**Classification** — the Gym host reports nested `{"error": {...}}`; the proxy reports flat `{"code", "message"}`, with an *empty* message when its read timeout fires. The old code matched only the nested form, so the single most likely production failure fell through every branch. Sandbox-reported errors are deterministic and are not retried.

### Beyond the port

Three of these came out of adversarial review rather than the upstream diff:

- **The host deadline is fed from `rollout_timeout_s`** through the bootstrap env. Upstream reads `NMP_ROLLOUT_DEADLINE_S` but never sets it, so its host silently keeps the 30-minute default however the job was configured.
- **`packages/nemo_evaluator_sdk/.../gym/sandboxed.py` is a second, independent client** of `/rollouts/run` that judged failure purely by status code. Against the new host, a deadline or crashed environment arrives as `200` with an error body, so it raised "returned no `results` list" and discarded the code and traceback. Fixed in its own commit; every existing test there asserts on a status code, which is why the suite did not catch it.
- **A non-transport exception is re-raised as itself**, not wrapped. Wrapping everything gives a programming error a plausible `origin`/`retryable` and hides the stack — which is exactly how a missing method read as "the sandbox stopped answering" while this was being written.

### Design calls

- **Results are still not in input order, and never were** — Gym yields through `as_completed`. Attribution rides on each result as `_ng_task_index` / `_ng_rollout_index`. Upstream instead tags results `[_rowidx, result]`; the two wire formats are incompatible, and reconciling them is a decision for the shared wheel, not this PR.
- **Progress is logged at INFO on this package's own logger.** Upstream forces the level with `LOGGER.setLevel`; a library has no business overriding its host's logging config, and the serve CLI already exposes `--log-level`.

### Known limitation, not fixed here

The **orchestrator-mode proxy** (`proxy_app.py`) buffers the entire upstream response before answering its own caller, so the heartbeat does not cross that hop. It does not affect the direct OpenSandbox host route this PR is about, and streaming it hits the same can't-change-status-mid-body problem — so it is left as follow-up rather than widening this change.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: no user-visible surface changes. The four new `SandboxConfig` fields are deployment tuning with working defaults, documented at their definition.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `pytest packages/sandboxed_gym/tests/ -q` → **253 passed, 2 skipped** (baseline on `main`: 232). Run **6 times** to shake out `pytest-randomly` orderings.
- `pytest packages/nemo_evaluator_sdk/tests/ -q` → **1793 passed, 10 skipped**.
- `pytest plugins/nemo-evaluator/tests/ -q` → **960 passed, 26 skipped**.
- Both commits independently green, verified in a scratch worktree across 3 random seeds each.
- `ruff check` / `ruff format --check` clean. `ty check` — no new diagnostics on changed files.
- `uv run pre-commit run -a` → **exit 0, no failures**, run inside `flox activate` with `web/` dependencies installed so `studio-lint-staged` actually executes rather than skipping.
- Every new test mutation-checked: the production change reverted, the test confirmed red, then restored. Two mutations initially reported false negatives because the replacement text no longer matched after formatting; both were re-run against the real source.

### Not verified

**Nothing here has been exercised against a real OpenSandbox deployment.** That matters more for this PR than the last one: the entire change exists to satisfy a proxy whose behaviour is asserted from its source, not observed. The tests prove the host emits heartbeats and that urllib reads a close-delimited body with leading whitespace; they cannot prove the OpenSandbox proxy forwards or accepts it. Until this runs against a real sandbox, treat the 180s cap and its interaction with the heartbeat as the design's central assumption.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Rollouts can run in bounded concurrent batches with configurable retries and backoff.
  - Configurable rollout deadlines help prevent indefinitely running requests.
  - Long-running requests provide heartbeat signals while processing continues.

- **Bug Fixes**
  - Improved handling of connection, proxy, sandbox, timeout, decoding, and response-size failures.
  - Error details now identify failure origins and include diagnostic information.
  - Error payloads returned with successful HTTP statuses are surfaced instead of treated as valid results.
  - Disconnected clients can cancel pending rollouts.

- **Documentation**
  - Added provenance and maintenance guidance for the sandboxed Gym package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->