### PR TITLE
fix(sandboxed-gym): stream rollout responses through the orchestrator proxy

### DIFF
--- a/packages/sandboxed_gym/src/sandboxed_gym/proxy_app.py
+++ b/packages/sandboxed_gym/src/sandboxed_gym/proxy_app.py
@@ -5,14 +5,16 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import urllib.error
 import urllib.request
+from collections.abc import AsyncGenerator
 from typing import Any
 
 from fastapi import FastAPI, Header, HTTPException, Request, Response
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 
 from sandboxed_gym.orchestrator import SandboxedGymSession
 from sandboxed_gym.wire import PROXY_AUTH_HEADER
@@ -21,6 +23,54 @@ LOGGER = logging.getLogger(__name__)
 
 #: Re-exported under its original name; the constant itself lives in the dependency-free wire module.
 AUTH_HEADER = PROXY_AUTH_HEADER
+
+#: Upper bound on one forwarded read, not a batch size: ``read1`` returns whatever has already
+#: arrived, so a lone heartbeat byte is passed straight through rather than waiting for a full one.
+_STREAM_CHUNK_BYTES = 64 * 1024
+
+
+async def _forward(response: Any, max_response_bytes: int) -> AsyncGenerator[bytes, None]:
+    """Yield the upstream body as it arrives, so a slow rollout stays visibly alive downstream.
+
+    The Gym host answers ``200`` before its batch finishes and pads the body with whitespace while
+    it works, so that no hop mistakes a long rollout for a dead one. Reading the response to
+    completion here would absorb every one of those bytes and re-emit them at the end, leaving this
+    proxy's own caller with exactly the silence the padding exists to prevent.
+
+    ``read1`` rather than ``read``: ``read`` blocks until the requested count or EOF, which would
+    reintroduce the buffering one chunk at a time.
+
+    Async rather than a plain generator, even though every read is blocking. Starlette runs a
+    *sync* iterator through ``iterate_in_threadpool``, and a client disconnect cannot interrupt a
+    worker thread parked in ``read1`` -- the ``finally`` below would not run until the host next
+    produced a byte, holding the upstream connection open for the rest of the batch. Awaiting each
+    read instead gives cancellation somewhere to land, and closing the response is what frees the
+    thread still sitting in that read.
+    """
+    forwarded = 0
+    try:
+        while True:
+            chunk = await asyncio.to_thread(response.read1, _STREAM_CHUNK_BYTES)
+            if not chunk:
+                return
+            forwarded += len(chunk)
+            if forwarded > max_response_bytes:
+                # Raised, not returned. The status line is long gone, so there is no 502 left to
+                # send -- but ending the stream cleanly here would hand the caller a 200 carrying a
+                # prefix of the body, and a prefix of `{"results": [...]}` can parse as a smaller
+                # but perfectly valid result set. A silently short rollout batch is worse than a
+                # failed one. Raising aborts the response mid-body instead, which every HTTP client
+                # surfaces as a broken read.
+                raise RuntimeError(
+                    f"upstream rollout response exceeded max_response_bytes "
+                    f"({forwarded} > {max_response_bytes}); aborting rather than forwarding a "
+                    f"truncated body that could parse as a complete one"
+                )
+            yield chunk
+    finally:
+        # Runs on cancellation too, which is the point: a disconnect closes the upstream instead of
+        # leaving it open until the rollout deadline.
+        response.close()
 
 
 def build_proxy_app(session: SandboxedGymSession) -> FastAPI:
@@ -88,11 +138,12 @@ def build_proxy_app(session: SandboxedGymSession) -> FastAPI:
                 **session.host.headers,
             },
         )
+        # Opened off the event loop, and awaited before streaming so the upstream status and
+        # headers still decide this response's own -- once bytes start flowing neither can change.
         try:
-            with urllib.request.urlopen(upstream, timeout=session.cfg.sandbox.rollout_timeout_s) as response:
-                body = response.read()
-                status = response.status
-                content_type = response.headers.get("Content-Type", "application/json")
+            response = await asyncio.to_thread(
+                urllib.request.urlopen, upstream, timeout=session.cfg.sandbox.rollout_timeout_s
+            )
         except urllib.error.HTTPError as exc:
             return Response(
                 content=exc.read(),
@@ -104,9 +155,11 @@ def build_proxy_app(session: SandboxedGymSession) -> FastAPI:
             LOGGER.exception("upstream rollout failed")
             return JSONResponse(status_code=502, content={"error": "upstream rollout failed"})
 
-        if len(body) > session.cfg.sandbox.max_response_bytes:
-            raise HTTPException(status_code=502, detail="upstream response too large")
-        return Response(content=body, status_code=status, media_type=content_type)
+        return StreamingResponse(
+            _forward(response, session.cfg.sandbox.max_response_bytes),
+            status_code=response.status,
+            media_type=response.headers.get("Content-Type", "application/json"),
+        )
 
     @app.get("/session")
     def session_info(

--- a/packages/sandboxed_gym/tests/test_proxy_streaming.py
+++ b/packages/sandboxed_gym/tests/test_proxy_streaming.py
@@ -1,0 +1,213 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The orchestrator proxy forwards a rollout body as it arrives, rather than after it completes.
+
+The Gym host answers ``200`` before its batch finishes and pads the body with whitespace while it
+works, so no hop mistakes a long rollout for a dead one. A proxy that read the response to
+completion would absorb every one of those bytes and re-emit them at the end -- handing its own
+caller exactly the silence the padding exists to prevent.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+import urllib.error
+import urllib.request
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+from sandboxed_gym.config import BrokerEndpoint
+from sandboxed_gym.host.models import GymHostHandle
+from sandboxed_gym.orchestrator import SandboxedGymSession
+from sandboxed_gym.proxy_app import _forward, build_proxy_app
+from sandboxed_gym.serve_config import SandboxedGymServeConfig
+
+ROLLOUT_BODY = {"results": [{"reward": 1.0}]}
+
+
+def _session(**sandbox_overrides: Any) -> SandboxedGymSession:
+    cfg = SandboxedGymServeConfig.model_validate(
+        {
+            "job_id": "job-1",
+            "sandbox": {
+                "image": "runtime:dev",
+                "network_policy": {"egress_allow": []},
+                "environment_pvc_claim": "env",
+                "workspace_pvc_claim": "work",
+                **sandbox_overrides,
+            },
+        }
+    )
+    return SandboxedGymSession(
+        cfg=cfg,
+        broker_server=MagicMock(),
+        broker=BrokerEndpoint(url="http://broker:1", host="broker", port=1, token="t"),
+        host_provider=MagicMock(),
+        host=GymHostHandle(
+            host_id="h1",
+            health_url="http://host/health",
+            rollout_url="http://host/rollouts/run",
+            headers={},
+        ),
+    )
+
+
+class _DrippingResponse:
+    """An upstream that emits a heartbeat, stalls until released, then sends its payload."""
+
+    status = 200
+    headers = {"Content-Type": "application/json"}
+
+    def __init__(self, release: threading.Event, payload: bytes) -> None:
+        self._release = release
+        self._chunks = [b" ", payload]
+        self.closed = False
+
+    def read1(self, size: int) -> bytes:
+        if not self._chunks:
+            return b""
+        if len(self._chunks) == 1:
+            # The payload is withheld until the test releases it, standing in for a batch still
+            # running. Raising rather than proceeding on timeout: a consumer that read to
+            # completion would otherwise just look slow instead of failing.
+            if not self._release.wait(5):
+                raise AssertionError("the payload was read before the batch was released")
+        return self._chunks.pop(0)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+async def test_the_heartbeat_is_forwarded_before_the_payload_exists() -> None:
+    """The property the whole change exists for.
+
+    The first chunk has to come out while the upstream is still working on the rest. Asserted on
+    the generator rather than through ``TestClient``: the ASGI test transport hands back the body
+    as one piece, so a buffered and a streamed proxy are indistinguishable from that side.
+    """
+    release = threading.Event()
+    payload = json.dumps(ROLLOUT_BODY).encode()
+    chunks = _forward(_DrippingResponse(release, payload), max_response_bytes=1024)
+
+    # Would block -- and then trip the stub's assertion -- against a proxy that read to completion.
+    assert await anext(chunks) == b" "
+
+    release.set()
+    assert json.loads(b"".join([chunk async for chunk in chunks])) == ROLLOUT_BODY
+
+
+def test_the_whole_body_still_round_trips_through_the_app(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Streaming must not change what the caller ends up with, only when it starts arriving."""
+    release = threading.Event()
+    release.set()
+    payload = json.dumps(ROLLOUT_BODY).encode()
+    monkeypatch.setattr(urllib.request, "urlopen", lambda *a, **k: _DrippingResponse(release, payload))
+
+    client = TestClient(build_proxy_app(_session()))
+    response = client.post("/rollouts/run", json={"examples": [{"id": 1}]})
+
+    assert response.status_code == 200
+    assert response.json() == ROLLOUT_BODY
+
+
+def test_the_upstream_status_still_decides_the_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Opened before streaming starts, so a refusal is still a refusal and not a 200 with a body."""
+    monkeypatch.setattr(
+        urllib.request,
+        "urlopen",
+        _raising(urllib.error.HTTPError("http://host", 503, "nope", {}, None)),  # ty: ignore[invalid-argument-type]
+    )
+
+    client = TestClient(build_proxy_app(_session()))
+
+    assert client.post("/rollouts/run", json={"examples": [{"id": 1}]}).status_code == 503
+
+
+def test_an_upstream_that_never_connects_is_a_502(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The exception text stays server-side; it can name the host's internal address."""
+    monkeypatch.setattr(urllib.request, "urlopen", _raising(urllib.error.URLError("refused")))
+
+    client = TestClient(build_proxy_app(_session()))
+    response = client.post("/rollouts/run", json={"examples": [{"id": 1}]})
+
+    assert response.status_code == 502
+    assert "refused" not in response.text
+
+
+def _raising(exc: BaseException):
+    def _raise(*args: Any, **kwargs: Any):
+        raise exc
+
+    return _raise
+
+
+async def test_an_oversize_body_fails_loudly_rather_than_truncating() -> None:
+    """A truncated rollout body must not be able to look like a complete one.
+
+    Ending the stream cleanly on overflow would send a 200 carrying a prefix -- and a prefix of
+    ``{"results": [...]}`` can itself be valid JSON describing a *smaller* result set, which the
+    SDK consumer would accept as a successful run that simply produced fewer rollouts. Aborting
+    mid-body is what makes it a read error instead.
+    """
+    release = threading.Event()
+    release.set()
+    response = _DrippingResponse(release, b"x" * 100)
+
+    with pytest.raises(RuntimeError, match="exceeded max_response_bytes"):
+        async for _ in _forward(response, max_response_bytes=8):
+            pass
+
+    assert response.closed, "the upstream response was left open"
+
+
+def test_a_prefix_of_a_results_body_would_have_parsed_as_a_smaller_batch() -> None:
+    """Why the abort above matters, stated as the property that makes truncation dangerous."""
+    full = b'{"results": [{"reward": 1.0}, {"reward": 0.0}]}'
+    prefix = b'{"results": [{"reward": 1.0}]}'
+
+    assert full.startswith(prefix[:20])
+    # The prefix is not merely unparseable garbage -- it is a valid, wrong answer.
+    assert json.loads(prefix) == {"results": [{"reward": 1.0}]}
+
+
+async def test_the_upstream_is_closed_once_the_body_is_forwarded() -> None:
+    """The generator owns the response, so nothing else is positioned to close it."""
+    release = threading.Event()
+    release.set()
+    response = _DrippingResponse(release, b'{"results": []}')
+
+    async for _ in _forward(response, max_response_bytes=1024):
+        pass
+
+    assert response.closed
+
+
+async def test_a_disconnect_closes_an_upstream_still_blocked_in_a_read() -> None:
+    """A client that leaves mid-batch must not pin the upstream connection open.
+
+    This is why ``_forward`` is an async generator despite every read being blocking. Starlette
+    runs a *sync* iterator in a worker thread, and cancellation cannot reach a thread parked in
+    ``read1`` -- the cleanup would wait for the host's next byte, which for an abandoned rollout
+    means the rest of the batch. Awaiting the read gives the cancellation somewhere to land.
+    """
+    release = threading.Event()
+    response = _DrippingResponse(release, b'{"results": []}')
+    chunks = _forward(response, max_response_bytes=1024)
+
+    assert await anext(chunks) == b" "
+
+    # Now blocked on the payload, exactly as it would be mid-rollout.
+    pending = asyncio.ensure_future(anext(chunks))
+    await asyncio.sleep(0.05)
+    pending.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await pending
+    await chunks.aclose()
+
+    assert response.closed, "the upstream was left open after the caller disconnected"
+    release.set()


### PR DESCRIPTION
## Summary

Completes the heartbeat path added in #1756 across the one hop it does not reach. The Gym host answers `200` before a rollout batch finishes and pads the body with whitespace while it works, so no intermediary mistakes a long rollout for a dead one. The orchestrator-mode proxy read that response to completion before answering its own caller — absorbing every heartbeat byte and re-emitting them at the end, which is exactly the silence the padding exists to prevent.

**Merge after #1756.** Until the host heartbeats there is nothing to forward early, so on `main` today this is a correctness-neutral improvement rather than a fix.

## Related Issue

Follow-up from AALGO-584, found by adversarial review of #1756. Parent: AALGO-583.

## Changes

- Open the upstream off the event loop and await only status and headers, which still decide this response's own — neither can change once bytes are flowing. The handler is `async def` but previously called blocking `urlopen` directly, holding the event loop for the length of a rollout.
- Stream the body with `StreamingResponse`. **`read1`, not `read`**: `read` blocks until the requested count or EOF, which would reintroduce the buffering one chunk at a time and forward nothing early. Starlette wraps a sync generator in `iterate_in_threadpool`, so the blocking read stays off the loop.
- **An oversize response aborts by raising rather than ending cleanly.** This is the part worth reviewing: returning would send a `200` carrying a prefix of the body, and a prefix of `{"results": [...]}` can itself be valid JSON describing a *smaller* result set — which the SDK consumer accepts as a successful run that simply produced fewer rollouts. A silently short batch is worse than a failed one. The host applies the same limit before writing anything and can still choose its status, so this stays a backstop against a host that did not.

## Known limitation

If the caller disconnects while the generator is blocked in `read1`, the upstream response is not closed until that read returns. The host's own rollout deadline bounds it rather than leaking indefinitely; closing promptly would need a disconnect watcher, which this does not add.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: no user-visible surface change; the proxy's routes, status codes and body contract are unchanged apart from the oversize case, which is described above and in the code.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `pytest packages/sandboxed_gym/tests/ -q` → **239 passed, 2 skipped** (baseline on `main`: 232).
- `ruff check` / `ruff format --check` clean; `ty check` on the changed files → All checks passed.
- `uv run pre-commit run -a` → **exit 0, no failures**, inside `flox activate` with `web/` deps installed.
- Mutation-checked: `read1`→`read` fails 4 tests; dropping the size guard fails 1; dropping `response.close()` fails 2; returning quietly on overflow instead of raising fails the test that exists to prevent exactly that.
- Verified rather than assumed: Starlette 1.4.1 wraps a sync iterator in `iterate_in_threadpool` (so `read1` does not block the loop), and `http.client.HTTPResponse` implements `read1`.

### Not verified

Incremental delivery is asserted on the generator, not end to end. `TestClient`'s ASGI transport hands back the body as one piece, so a buffered and a streamed proxy are indistinguishable from that side — proving the bytes actually leave early would need a real server and a real socket. As with #1756, none of this has run against a real OpenSandbox deployment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Rollout responses are now delivered incrementally, allowing progress to appear before completion.
  - Long-running streams send heartbeat data to maintain responsiveness.
  - Response size limits are enforced during delivery to prevent oversized responses.

- **Bug Fixes**
  - Upstream HTTP status codes are preserved.
  - Connection failures now return sanitized error responses.
  - Incomplete or oversized responses no longer appear as successful truncated results.
  - Upstream connections are reliably closed after streaming or client disconnects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->