### PR TITLE
fix(eval-author): normalize MLflow inputs to ensure proper ATIF timestamps

### DIFF
--- a/plugins/nemo-eval-author/skills/mlflow-to-atif/SKILL.md
+++ b/plugins/nemo-eval-author/skills/mlflow-to-atif/SKILL.md
@@ -94,7 +94,10 @@ that version; do not relabel v1.7 output as v1.8.
   agent steps with paired tool calls and observations.
 - Flatten the span tree into timestamp order while retaining native IDs, parent
   IDs, attributes, events, status, and assessments under namespaced `mlflow`
-  metadata.
+  metadata. When an event's parent-span bounds prove that its nominal
+  `time_unix_nano` value is actually in microseconds, normalize that value to
+  nanoseconds and record the correction under
+  `extra.mlflow_to_atif.normalization_codes`.
 - Reject unresolved parents, cycles, and exported search pages with a non-empty
   `next_page_token`; collect the complete export before conversion.
 - Distinguish missing, explicit null, and populated tool outputs in each result's

--- a/plugins/nemo-eval-author/skills/mlflow-to-atif/scripts/convert_mlflow_to_atif.py
+++ b/plugins/nemo-eval-author/skills/mlflow-to-atif/scripts/convert_mlflow_to_atif.py
@@ -25,7 +25,8 @@ from urllib.parse import urlparse
 from uuid import UUID
 
 SCHEMA_VERSION = "ATIF-v1.7"
-CANONICALIZER = "mlflow-to-atif@1"
+CANONICALIZER = "mlflow-to-atif@2"
+EVENT_TIME_MICROSECONDS_NORMALIZED = "event_time_microseconds_normalized_to_nanoseconds"
 LLM_TYPES = frozenset({"CHAT_MODEL", "LLM", "MODEL", "PROMPT"})
 TOOL_TYPES = frozenset({"EMBEDDING", "FUNCTION", "GUARDRAIL", "RERANKER", "RETRIEVER", "SEARCH", "TOOL"})
 ORCHESTRATION_TYPES = frozenset({"AGENT", "CHAIN", "TASK", "WORKFLOW"})
@@ -101,6 +102,36 @@ def _iso_from_nanos(value: Any) -> str:
     seconds, remainder = divmod(nanoseconds, 1_000_000_000)
     timestamp = datetime.fromtimestamp(seconds, tz=timezone.utc).replace(microsecond=remainder // 1000)
     return timestamp.isoformat()
+
+
+def _normalize_event_times(span: dict[str, Any]) -> int:
+    """Correct microsecond event times when nanosecond parent bounds prove the unit mismatch."""
+    events = span.get("events")
+    start = span.get("start_time_unix_nano")
+    end = span.get("end_time_unix_nano")
+    if (
+        not isinstance(events, list)
+        or not isinstance(start, int)
+        or isinstance(start, bool)
+        or not isinstance(end, int)
+        or isinstance(end, bool)
+    ):
+        return 0
+    if start > end:
+        return 0
+
+    normalized = 0
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        value = event.get("time_unix_nano")
+        if not isinstance(value, int) or isinstance(value, bool):
+            continue
+        event_time_nanos = value * 1_000
+        if not start <= value <= end and start <= event_time_nanos <= end:
+            event["time_unix_nano"] = event_time_nanos
+            normalized += 1
+    return normalized
 
 
 def _parse_bound(value: str) -> datetime:
@@ -361,13 +392,26 @@ def _agent_step(span: dict[str, Any], attributes: dict[str, Any], span_type: str
 
 def _trace_input(info: dict[str, Any], root_attributes: dict[str, Any]) -> Any:
     value = _input(root_attributes)
-    if value is not None:
+    if _has_trace_input(value):
         return value
     metadata = _object(info.get("trace_metadata") or {}, "MLflow trace metadata")
     for key in ("mlflow.traceInputs", "inputs"):
         if key in metadata:
-            return _parse_json(metadata[key])
+            value = _parse_json(metadata[key])
+            if _has_trace_input(value):
+                return value
     return _parse_json(info.get("request_preview"))
+
+
+def _has_trace_input(value: Any) -> bool:
+    """Whether an input carries an instruction rather than an empty export placeholder."""
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, dict | list | tuple):
+        return bool(value)
+    return True
 
 
 def _trace_output(info: dict[str, Any], root_attributes: dict[str, Any]) -> Any:
@@ -456,6 +500,7 @@ def convert_trace(
         raise ValueError(f"trace[{trace_index}] does not contain spans")
     for span_index, span in enumerate(spans):
         _require_span_fields(span, trace_index=trace_index, span_index=span_index)
+    normalized_event_times = sum(_normalize_event_times(span) for span in spans)
     canonical_span_ids = [_span_id(span.get("span_id")) for span in spans]
     if len(canonical_span_ids) != len(set(canonical_span_ids)):
         raise ValueError(f"trace[{trace_index}] contains duplicate span IDs")
@@ -474,7 +519,7 @@ def convert_trace(
     root = roots[0]
     root_attributes = _attributes(root)
     trace_input = _trace_input(info, root_attributes)
-    if trace_input is None:
+    if not _has_trace_input(trace_input):
         raise ValueError(f"trace[{trace_index}] has no recoverable root input for an ATIF human instruction")
 
     external_trace_id = info_trace_id or _trace_id(root.get("trace_id"))
@@ -549,7 +594,11 @@ def convert_trace(
                 "info": info,
                 "spans": [_jsonable(span) for span in spans],
             },
-            "mlflow_to_atif": {"canonicalizer": CANONICALIZER, "loss_codes": sorted(loss_codes)},
+            "mlflow_to_atif": {
+                "canonicalizer": CANONICALIZER,
+                "loss_codes": sorted(loss_codes),
+                "normalization_codes": ([EVENT_TIME_MICROSECONDS_NORMALIZED] if normalized_event_times else []),
+            },
         },
     }
 

--- a/plugins/nemo-eval-author/tests/test_skill_contract.py
+++ b/plugins/nemo-eval-author/tests/test_skill_contract.py
@@ -696,9 +696,53 @@ def test_mlflow_to_atif_converts_export_to_private_v17_trajectory(tmp_path: Path
         "mlflow_span_tree_linearized",
         "orchestration_parent_not_emitted_as_step",
     ]
+    assert trajectory["extra"]["mlflow_to_atif"]["normalization_codes"] == []
     if os.name == "posix":
         assert output.stat().st_mode & 0o777 == 0o700
         assert target.stat().st_mode & 0o777 == 0o600
+
+
+def test_mlflow_to_atif_normalizes_parent_bounded_microsecond_event_times() -> None:
+    converter = _load_mlflow_to_atif()
+    payload = _mlflow_export()
+    event_time_micros = 1_788_000_000_000_006
+    event_time_nanos = event_time_micros * 1_000
+    root, tool = payload["traces"][0]["data"]["spans"]
+    root["start_time_unix_nano"] = event_time_nanos - 2_000
+    root["end_time_unix_nano"] = event_time_nanos + 2_000
+    tool["start_time_unix_nano"] = event_time_nanos - 1_000
+    tool["end_time_unix_nano"] = event_time_nanos + 1_000
+    tool["events"] = [{"name": "completed", "time_unix_nano": event_time_micros}]
+
+    (trajectory,) = converter.convert_export(
+        payload,
+        agent_name="fixture-agent",
+        agent_version="1.0.0",
+    )
+
+    preserved_tool = trajectory["extra"]["mlflow"]["spans"][1]
+    assert preserved_tool["events"][0]["time_unix_nano"] == event_time_nanos
+    assert trajectory["steps"][1]["extra"]["mlflow"]["events"][0]["time_unix_nano"] == event_time_nanos
+    assert trajectory["extra"]["mlflow_to_atif"]["normalization_codes"] == [
+        "event_time_microseconds_normalized_to_nanoseconds"
+    ]
+
+
+def test_mlflow_to_atif_does_not_normalize_event_time_outside_parent_bounds() -> None:
+    converter = _load_mlflow_to_atif()
+    payload = _mlflow_export()
+    event_time = 1_788_000_000_000_006
+    payload["traces"][0]["data"]["spans"][1]["events"] = [{"name": "unbounded", "time_unix_nano": event_time}]
+
+    (trajectory,) = converter.convert_export(
+        payload,
+        agent_name="fixture-agent",
+        agent_version="1.0.0",
+    )
+
+    preserved_tool = trajectory["extra"]["mlflow"]["spans"][1]
+    assert preserved_tool["events"][0]["time_unix_nano"] == event_time
+    assert trajectory["extra"]["mlflow_to_atif"]["normalization_codes"] == []
 
 
 def test_mlflow_to_atif_accepts_one_bare_trace_to_dict_value(tmp_path: Path) -> None:
@@ -717,6 +761,23 @@ def test_mlflow_to_atif_accepts_one_bare_trace_to_dict_value(tmp_path: Path) -> 
 
     assert result.returncode == 0, result.stderr
     assert json.loads(result.stdout)["converted"] == 1
+
+
+def test_mlflow_to_atif_uses_request_preview_after_empty_input_placeholders() -> None:
+    converter = _load_mlflow_to_atif()
+    payload = _mlflow_export()
+    info = payload["traces"][0]["info"]
+    info["request_preview"] = "Where is Paris?"
+    info["trace_metadata"]["mlflow.traceInputs"] = "{}"
+    payload["traces"][0]["data"]["spans"][0]["attributes"]["mlflow.spanInputs"] = "[]"
+
+    (trajectory,) = converter.convert_export(
+        payload,
+        agent_name="fixture-agent",
+        agent_version="1.0.0",
+    )
+
+    assert trajectory["steps"][0]["message"] == "Where is Paris?"
 
 
 def test_mlflow_to_atif_matches_current_mlflow_external_and_native_trace_ids(tmp_path: Path) -> None:


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
<!-- In 1-3 plain sentences, explain what changes and why. Describe before-and-after behavior when it applies. -->

## Related Issue
<!-- Use Fixes #NNN or Closes #NNN for a related issue. Remove this section if there is none. -->

## Changes
<!-- List the concrete changes included in this pull request. -->

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [ ] Pull request title follows the repository's Conventional Commit format
- [ ] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [ ] Targeted tests pass, or tests are marked not applicable above
- [ ] No secrets, API keys, or credentials are included

Targeted validation:

<!-- List each command and result. Explain skipped, blocked, or non-successful checks without marking them as passed. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved MLflow-to-ATIF conversion by correcting event timestamps when parent-span data confirms a unit mismatch.
  - Records timestamp normalization details in the converted output metadata.
  - Recovers input from available request previews when other input fields are empty.

- **Bug Fixes**
  - Empty or whitespace-only input values are now skipped during input recovery.
  - Invalid or unrecoverable chat-shaped inputs continue to be rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->