### PR TITLE
fix(files): block fileset delete when models or adapters still reference it

### DIFF
--- a/openapi/ga/individual/platform.openapi.yaml
+++ b/openapi/ga/individual/platform.openapi.yaml
@@ -1836,7 +1836,9 @@ paths:
       description: 'Delete Fileset.
 
 
-        Permanently deletes a fileset from the platform.
+        Permanently deletes an unreferenced fileset from the platform.
+
+        Referencing model or adapter entities must be relinked or deleted first.
 
         Returns metadata about the deleted fileset.
 
@@ -1862,6 +1864,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FilesetOutput'
+        '409':
+          description: Fileset is referenced by a model or adapter entity
+        '503':
+          description: Fileset references could not be verified
         '422':
           description: Validation Error
           content:

--- a/openapi/ga/individual/platform.openapi.yaml
+++ b/openapi/ga/individual/platform.openapi.yaml
@@ -1866,8 +1866,22 @@ paths:
                 $ref: '#/components/schemas/FilesetOutput'
         '409':
           description: Fileset is referenced by a model or adapter entity
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
         '503':
           description: Fileset references could not be verified
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
         '422':
           description: Validation Error
           content:

--- a/openapi/ga/openapi.yaml
+++ b/openapi/ga/openapi.yaml
@@ -1836,7 +1836,9 @@ paths:
       description: 'Delete Fileset.
 
 
-        Permanently deletes a fileset from the platform.
+        Permanently deletes an unreferenced fileset from the platform.
+
+        Referencing model or adapter entities must be relinked or deleted first.
 
         Returns metadata about the deleted fileset.
 
@@ -1862,6 +1864,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FilesetOutput'
+        '409':
+          description: Fileset is referenced by a model or adapter entity
+        '503':
+          description: Fileset references could not be verified
         '422':
           description: Validation Error
           content:

--- a/openapi/ga/openapi.yaml
+++ b/openapi/ga/openapi.yaml
@@ -1866,8 +1866,22 @@ paths:
                 $ref: '#/components/schemas/FilesetOutput'
         '409':
           description: Fileset is referenced by a model or adapter entity
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
         '503':
           description: Fileset references could not be verified
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
         '422':
           description: Validation Error
           content:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1836,7 +1836,9 @@ paths:
       description: 'Delete Fileset.
 
 
-        Permanently deletes a fileset from the platform.
+        Permanently deletes an unreferenced fileset from the platform.
+
+        Referencing model or adapter entities must be relinked or deleted first.
 
         Returns metadata about the deleted fileset.
 
@@ -1862,6 +1864,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FilesetOutput'
+        '409':
+          description: Fileset is referenced by a model or adapter entity
+        '503':
+          description: Fileset references could not be verified
         '422':
           description: Validation Error
           content:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1866,8 +1866,22 @@ paths:
                 $ref: '#/components/schemas/FilesetOutput'
         '409':
           description: Fileset is referenced by a model or adapter entity
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
         '503':
           description: Fileset references could not be verified
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
         '422':
           description: Validation Error
           content:

--- a/packages/nmp_customization_common/src/nmp/customization_common/service/platform_client.py
+++ b/packages/nmp_customization_common/src/nmp/customization_common/service/platform_client.py
@@ -104,7 +104,7 @@ async def fetch_model_entity(
     default_workspace: str,
     sdk: AsyncNeMoPlatform,
 ) -> ModelEntity:
-    """Retrieve a model entity by reference string."""
+    """Retrieve a model entity and verify its weights fileset is accessible."""
     resolved_ref = parse_entity_ref(model_ref, default_workspace)
     models = client_from_platform(sdk, AsyncModelsClient)
     try:
@@ -113,10 +113,19 @@ async def fetch_model_entity(
             workspace=resolved_ref.workspace,
             query_params={"verbose": True},
         )
-        return response.data()
+        model = response.data()
     except PermissionDeniedError:
         raise PermissionError(f"Access denied to model '{resolved_ref.workspace}/{resolved_ref.name}'") from None
     except NotFoundError:
         raise ValueError(
             f"Model entity not found: '{resolved_ref.workspace}/{resolved_ref.name}'. Verify the model entity exists."
         ) from None
+
+    if model.fileset:
+        await check_fileset_access(
+            sdk,
+            model.fileset,
+            resolved_ref.workspace,
+            label=f"weights for model '{resolved_ref.workspace}/{resolved_ref.name}'",
+        )
+    return model

--- a/packages/nmp_customization_common/tests/test_platform_client.py
+++ b/packages/nmp_customization_common/tests/test_platform_client.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Callable
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from nemo_platform_plugin.client.errors import NotFoundError
+from nemo_platform_plugin.files.client import AsyncFilesClient
+from nemo_platform_plugin.models.client import AsyncModelsClient
+from nmp.customization_common.service.platform_client import fetch_model_entity
+
+
+def _not_found() -> NotFoundError:
+    return NotFoundError(httpx.Response(404, request=httpx.Request("GET", "http://platform/resource")))
+
+
+def _clients(
+    model: SimpleNamespace,
+    *,
+    fileset_error: Exception | None = None,
+) -> tuple[MagicMock, MagicMock, Callable[[object, type], MagicMock]]:
+    models = MagicMock()
+    models.get_model = AsyncMock(return_value=SimpleNamespace(data=lambda: model))
+    files = MagicMock()
+    files.get_fileset = AsyncMock()
+    if fileset_error is not None:
+        files.get_fileset.side_effect = fileset_error
+
+    def dispatch(_sdk: object, client_type: type):
+        if client_type is AsyncModelsClient:
+            return models
+        if client_type is AsyncFilesClient:
+            return files
+        raise AssertionError(f"Unexpected client type: {client_type}")
+
+    return models, files, dispatch
+
+
+async def test_fetch_model_entity_verifies_weights_fileset() -> None:
+    model = SimpleNamespace(name="base", workspace="default", fileset="weights/default-base")
+    models, files, dispatch = _clients(model)
+
+    with patch(
+        "nmp.customization_common.service.platform_client.client_from_platform",
+        side_effect=dispatch,
+    ):
+        result = await fetch_model_entity("default/base", "default", MagicMock())
+
+    assert result is model
+    models.get_model.assert_awaited_once_with(
+        name="base",
+        workspace="default",
+        query_params={"verbose": True},
+    )
+    files.get_fileset.assert_awaited_once_with(workspace="weights", name="default-base")
+
+
+async def test_fetch_model_entity_rejects_missing_weights_fileset() -> None:
+    model = SimpleNamespace(name="base", workspace="default", fileset="default/missing")
+    _, _, dispatch = _clients(model, fileset_error=_not_found())
+
+    with (
+        patch(
+            "nmp.customization_common.service.platform_client.client_from_platform",
+            side_effect=dispatch,
+        ),
+        pytest.raises(ValueError, match="Weights for model 'default/base' fileset 'missing' not found"),
+    ):
+        await fetch_model_entity("default/base", "default", MagicMock())
+
+
+async def test_fetch_model_entity_without_weights_fileset_skips_files_service() -> None:
+    model = SimpleNamespace(name="api-model", workspace="default", fileset=None)
+    _, files, dispatch = _clients(model)
+
+    with patch(
+        "nmp.customization_common.service.platform_client.client_from_platform",
+        side_effect=dispatch,
+    ):
+        result = await fetch_model_entity("api-model", "default", MagicMock())
+
+    assert result is model
+    files.get_fileset.assert_not_awaited()

--- a/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
+++ b/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
@@ -1839,7 +1839,9 @@ paths:
       description: 'Delete Fileset.
 
 
-        Permanently deletes a fileset from the platform.
+        Permanently deletes an unreferenced fileset from the platform.
+
+        Referencing model or adapter entities must be relinked or deleted first.
 
         Returns metadata about the deleted fileset.
 
@@ -1865,6 +1867,24 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FilesetOutput'
+        '409':
+          description: Fileset is referenced by a model or adapter entity
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+        '503':
+          description: Fileset references could not be verified
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
         '422':
           description: Validation Error
           content:

--- a/sdk/python/nemo-platform/src/nemo_platform/resources/files/filesets.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/resources/files/filesets.py
@@ -345,11 +345,12 @@ class FilesetsResource(SyncAPIResource):
     ) -> Fileset:
         """Delete Fileset.
 
-        Permanently deletes a fileset from the platform.
+        Permanently deletes an unreferenced fileset from the platform.
 
-        Returns metadata about the
-        deleted fileset. For local storage backends, this also deletes the underlying
-        files.
+        Referencing model
+        or adapter entities must be relinked or deleted first. Returns metadata about
+        the deleted fileset. For local storage backends, this also deletes the
+        underlying files.
 
         Args:
           extra_headers: Send extra headers
@@ -671,11 +672,12 @@ class AsyncFilesetsResource(AsyncAPIResource):
     ) -> Fileset:
         """Delete Fileset.
 
-        Permanently deletes a fileset from the platform.
+        Permanently deletes an unreferenced fileset from the platform.
 
-        Returns metadata about the
-        deleted fileset. For local storage backends, this also deletes the underlying
-        files.
+        Referencing model
+        or adapter entities must be relinked or deleted first. Returns metadata about
+        the deleted fileset. For local storage backends, this also deletes the
+        underlying files.
 
         Args:
           extra_headers: Send extra headers

--- a/sdk/python/nemo-platform/src/nemo_platform/resources/workspaces/workspaces.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/resources/workspaces/workspaces.py
@@ -248,6 +248,9 @@ class WorkspacesResource(SyncAPIResource):
         """
         List all workspaces with pagination.
 
+        Workspaces marked for deletion (non-null deletion_stage) are omitted so the list
+        matches GET/DELETE, which treat those workspaces as not found.
+
         When authentication is enabled, only workspaces the principal has access to are
         returned. Service principals and platform admins have access to all workspaces.
 
@@ -557,6 +560,9 @@ class AsyncWorkspacesResource(AsyncAPIResource):
     ) -> AsyncPaginator[Workspace, AsyncDefaultPagination[Workspace]]:
         """
         List all workspaces with pagination.
+
+        Workspaces marked for deletion (non-null deletion_stage) are omitted so the list
+        matches GET/DELETE, which treat those workspaces as not found.
 
         When authentication is enabled, only workspaces the principal has access to are
         returned. Service principals and platform admins have access to all workspaces.

--- a/services/core/entities/src/nmp/core/entities/controllers/workspace_cleanup.py
+++ b/services/core/entities/src/nmp/core/entities/controllers/workspace_cleanup.py
@@ -105,6 +105,11 @@ class WorkspaceCleanup(HeartbeatMixin, Controller):
                 self.emit_heartbeat()
                 await self._cleanup_deployments(workspace)
                 self.emit_heartbeat()
+                # Models and adapters can hold fileset refs in this workspace.
+                # Delete them before filesets so same-workspace teardown is not
+                # blocked by the fileset DELETE 409 referential guard.
+                await self._cleanup_models_and_adapters(workspace)
+                self.emit_heartbeat()
                 await self._cleanup_filesets(workspace)
                 self.emit_heartbeat()
 
@@ -180,6 +185,44 @@ class WorkspaceCleanup(HeartbeatMixin, Controller):
 
         except Exception as e:
             logger.error(f"Failed to list deployments for workspace {workspace.name}: {e}")
+            raise
+
+    @tracer.start_as_current_span("workspace_cleanup/cleanup_models_and_adapters")
+    async def _cleanup_models_and_adapters(self, workspace: Workspace) -> None:
+        logger.info(f"Cleaning up models and adapters for workspace: {workspace.name}")
+        try:
+            models_client = client_from_platform(self._nmp_sdk, AsyncModelsClient)
+            adapters_response = await models_client.list_adapters(workspace=workspace.name)
+            adapters = [adapter async for adapter in adapters_response.items()]
+            models_response = await models_client.list_models(workspace=workspace.name)
+            models = [model async for model in models_response.items()]
+
+            for adapter in adapters:
+                try:
+                    logger.info(f"Deleting adapter: {adapter.name}")
+                    await models_client.delete_adapter(
+                        name=adapter.name,
+                        workspace=workspace.name,
+                    )
+                except Exception as e:
+                    logger.warning(f"Failed to delete adapter {adapter.name}: {e}")
+                finally:
+                    self.emit_heartbeat()
+
+            for model in models:
+                try:
+                    logger.info(f"Deleting model: {model.name}")
+                    await models_client.delete_model(
+                        name=model.name,
+                        workspace=workspace.name,
+                    )
+                except Exception as e:
+                    logger.warning(f"Failed to delete model {model.name}: {e}")
+                finally:
+                    self.emit_heartbeat()
+
+        except Exception as e:
+            logger.error(f"Failed to list models or adapters for workspace {workspace.name}: {e}")
             raise
 
     @tracer.start_as_current_span("workspace_cleanup/cleanup_filesets")

--- a/services/core/entities/tests/controllers/test_workspace_cleanup.py
+++ b/services/core/entities/tests/controllers/test_workspace_cleanup.py
@@ -55,16 +55,23 @@ def _make_jobs_client(jobs: list | None = None) -> MagicMock:
     return jobs_client
 
 
-def _make_models_client(deployments: list | None = None) -> MagicMock:
+def _make_models_client(
+    deployments: list | None = None,
+    models: list | None = None,
+    adapters: list | None = None,
+) -> MagicMock:
     """Build a mock typed AsyncModelsClient.
 
-    Production routes deployment cleanup through ``client_from_platform(sdk,
-    AsyncModelsClient)`` and iterates ``(await models_client.list_deployments(...)).items()``,
-    then calls ``delete_deployment(name=..., workspace=...)`` per deployment.
+    Production routes deployment, model, and adapter cleanup through
+    ``client_from_platform(sdk, AsyncModelsClient)``.
     """
     models_client = MagicMock()
     models_client.list_deployments = AsyncMock(return_value=_MockAsyncPaginatedResponse(deployments or []))
     models_client.delete_deployment = AsyncMock()
+    models_client.list_models = AsyncMock(return_value=_MockAsyncPaginatedResponse(models or []))
+    models_client.delete_model = AsyncMock()
+    models_client.list_adapters = AsyncMock(return_value=_MockAsyncPaginatedResponse(adapters or []))
+    models_client.delete_adapter = AsyncMock()
     return models_client
 
 
@@ -86,10 +93,9 @@ def _patch_jobs_client(jobs_client: MagicMock):
 def _patch_clients(jobs_client: MagicMock, files_client: MagicMock, models_client: MagicMock | None = None):
     """Patch ``client_from_platform`` to dispatch by requested client class.
 
-    ``_async_step`` cleans up jobs, deployments, and filesets, so it calls
-    ``client_from_platform(sdk, AsyncJobsClient)``,
-    ``client_from_platform(sdk, AsyncModelsClient)``, and
-    ``client_from_platform(sdk, AsyncFilesClient)`` — return the matching mock.
+    ``_async_step`` cleans up jobs, deployments, models/adapters, and filesets,
+    so it calls ``client_from_platform`` for ``AsyncJobsClient``,
+    ``AsyncModelsClient``, and ``AsyncFilesClient`` — return the matching mock.
     """
     from nemo_platform_plugin.files.client import AsyncFilesClient
     from nemo_platform_plugin.jobs.client import AsyncJobsClient
@@ -214,6 +220,33 @@ class TestWorkspaceCleanupAsyncStep:
             name="test-workspace",
             deletion_stage=WorkspaceDeletionStage.DELETING,
         )
+        repo.delete_workspace.assert_awaited_once_with(name="test-workspace")
+
+    @pytest.mark.asyncio
+    async def test_deletes_models_and_adapters_before_filesets(self):
+        workspace = _make_workspace()
+        repo = AsyncMock()
+        repo.list_workspaces.return_value = ([workspace], None)
+        repo.mark_workspace_for_deletion.return_value = True
+
+        adapter = MagicMock()
+        adapter.name = "adapter"
+        model = MagicMock()
+        model.name = "model"
+        fileset = MagicMock()
+        fileset.name = "weights"
+        call_order: list[str] = []
+        models_client = _make_models_client(models=[model], adapters=[adapter])
+        models_client.delete_adapter = AsyncMock(side_effect=lambda **_: call_order.append("adapter"))
+        models_client.delete_model = AsyncMock(side_effect=lambda **_: call_order.append("model"))
+        mock_files = _make_mock_files_client([fileset])
+        mock_files.delete_fileset = AsyncMock(side_effect=lambda **_: call_order.append("fileset"))
+        controller = _make_controller(workspace_repo=repo)
+
+        with _patch_clients(_make_jobs_client([]), mock_files, models_client):
+            await controller._async_step()
+
+        assert call_order == ["adapter", "model", "fileset"]
         repo.delete_workspace.assert_awaited_once_with(name="test-workspace")
 
     @pytest.mark.asyncio
@@ -371,6 +404,70 @@ class TestWorkspaceCleanupDeployments:
             await controller._cleanup_deployments(workspace)
 
         assert models_client.delete_deployment.await_count == 2
+
+
+class TestWorkspaceCleanupModelsAndAdapters:
+    @pytest.mark.asyncio
+    async def test_deletes_adapters_before_models(self):
+        workspace = _make_workspace()
+        adapter = MagicMock()
+        adapter.name = "test-adapter"
+        model = MagicMock()
+        model.name = "test-model"
+        models_client = _make_models_client(models=[model], adapters=[adapter])
+        call_order: list[str] = []
+        models_client.delete_adapter = AsyncMock(side_effect=lambda **_: call_order.append("adapter"))
+        models_client.delete_model = AsyncMock(side_effect=lambda **_: call_order.append("model"))
+        controller = _make_controller()
+
+        with patch(_CLIENT_FROM_PLATFORM_PATCH, return_value=models_client):
+            await controller._cleanup_models_and_adapters(workspace)
+
+        assert call_order == ["adapter", "model"]
+        models_client.delete_adapter.assert_awaited_once_with(
+            name="test-adapter",
+            workspace="test-workspace",
+        )
+        models_client.delete_model.assert_awaited_once_with(
+            name="test-model",
+            workspace="test-workspace",
+        )
+
+    @pytest.mark.asyncio
+    async def test_continues_on_individual_model_and_adapter_failure(self):
+        workspace = _make_workspace()
+        adapter1 = MagicMock()
+        adapter1.name = "adapter1"
+        adapter2 = MagicMock()
+        adapter2.name = "adapter2"
+        model1 = MagicMock()
+        model1.name = "model1"
+        model2 = MagicMock()
+        model2.name = "model2"
+        models_client = _make_models_client(
+            models=[model1, model2],
+            adapters=[adapter1, adapter2],
+        )
+        models_client.delete_adapter = AsyncMock(side_effect=[Exception("fail"), None])
+        models_client.delete_model = AsyncMock(side_effect=[Exception("fail"), None])
+        controller = _make_controller()
+
+        with patch(_CLIENT_FROM_PLATFORM_PATCH, return_value=models_client):
+            await controller._cleanup_models_and_adapters(workspace)
+
+        assert models_client.delete_adapter.await_count == 2
+        assert models_client.delete_model.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_raises_on_list_failure(self):
+        workspace = _make_workspace()
+        models_client = _make_models_client()
+        models_client.list_adapters = AsyncMock(side_effect=Exception("unavailable"))
+        controller = _make_controller()
+
+        with pytest.raises(Exception, match="unavailable"):
+            with patch(_CLIENT_FROM_PLATFORM_PATCH, return_value=models_client):
+                await controller._cleanup_models_and_adapters(workspace)
 
 
 class TestWorkspaceCleanupFilesets:

--- a/services/core/files/src/nmp/core/files/api/v2/filesets/endpoints.py
+++ b/services/core/files/src/nmp/core/files/api/v2/filesets/endpoints.py
@@ -101,6 +101,23 @@ router = APIRouter()
 _REFERENCE_COUNT_PAGE_SIZE = 1
 
 
+def _sanitize_for_log(value: object) -> str:
+    """Strip line breaks from a value before logging."""
+    return str(value).replace("\r", "").replace("\n", "")
+
+
+_HTTP_EXCEPTION_DETAIL = {
+    "content": {
+        "application/json": {
+            "schema": {
+                "type": "object",
+                "properties": {"detail": {"type": "string"}},
+            }
+        }
+    }
+}
+
+
 class _ModelFilesetReference(EntityBase):
     """Minimal model projection used for fileset reference checks."""
 
@@ -424,8 +441,14 @@ async def retrieve_fileset(
     summary="Delete Fileset",
     status_code=HTTP_200_OK,
     responses={
-        HTTP_409_CONFLICT: {"description": "Fileset is referenced by a model or adapter entity"},
-        HTTP_503_SERVICE_UNAVAILABLE: {"description": "Fileset references could not be verified"},
+        HTTP_409_CONFLICT: {
+            "description": "Fileset is referenced by a model or adapter entity",
+            **_HTTP_EXCEPTION_DETAIL,
+        },
+        HTTP_503_SERVICE_UNAVAILABLE: {
+            "description": "Fileset references could not be verified",
+            **_HTTP_EXCEPTION_DETAIL,
+        },
     },
 )
 async def delete_fileset(
@@ -464,7 +487,12 @@ async def delete_fileset(
             name,
         )
     except EntityStoreError as exc:
-        logger.error("Cannot verify dependents for fileset '%s/%s': %s", workspace, name, exc)
+        logger.error(
+            "Cannot verify dependents for fileset '%s/%s': %s",
+            _sanitize_for_log(workspace),
+            _sanitize_for_log(name),
+            exc,
+        )
         raise HTTPException(
             HTTP_503_SERVICE_UNAVAILABLE,
             f"Cannot delete fileset '{workspace}/{name}' because its model and adapter references "

--- a/services/core/files/src/nmp/core/files/api/v2/filesets/endpoints.py
+++ b/services/core/files/src/nmp/core/files/api/v2/filesets/endpoints.py
@@ -5,6 +5,7 @@
 
 import logging
 from dataclasses import dataclass
+from typing import ClassVar
 
 from fastapi import (
     APIRouter,
@@ -22,9 +23,11 @@ from nmp.common.api.parsed_filter import ParsedFilter, make_filter_dep
 from nmp.common.api.utils import generate_openapi_extra_params
 from nmp.common.auth import AuthClient, get_auth_client
 from nmp.common.entities.client import (
+    EntityBase,
     EntityClient,
     EntityConflictError,
     EntityNotFoundError,
+    EntityStoreError,
 )
 from nmp.common.files.storage_config import LocalStorageConfig, S3StorageConfig
 from nmp.common.observability import BaseContext, scoped_app_ctx
@@ -88,11 +91,79 @@ from starlette.status import (
     HTTP_409_CONFLICT,
     HTTP_500_INTERNAL_SERVER_ERROR,
     HTTP_502_BAD_GATEWAY,
+    HTTP_503_SERVICE_UNAVAILABLE,
     HTTP_507_INSUFFICIENT_STORAGE,
 )
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
+
+_REFERENCE_COUNT_PAGE_SIZE = 1
+
+
+class _ModelFilesetReference(EntityBase):
+    """Minimal model projection used for fileset reference checks."""
+
+    __entity_type__: ClassVar[str] = "model"
+    fileset: str | None = None
+
+
+class _AdapterFilesetReference(EntityBase):
+    """Minimal adapter projection used for fileset reference checks."""
+
+    __entity_type__: ClassVar[str] = "adapter"
+    fileset: str
+
+
+async def _count_fileset_references(
+    entity_store: EntityClient,
+    entity_type: type[_ModelFilesetReference] | type[_AdapterFilesetReference],
+    fileset_ref: str,
+    *,
+    workspace: str = "-",
+) -> int:
+    """Count references using pagination metadata without fetching every entity."""
+    result = await entity_store.list(
+        entity_type,
+        workspace=workspace,
+        filter_obj={"fileset": fileset_ref},
+        page_size=_REFERENCE_COUNT_PAGE_SIZE,
+    )
+    return result.pagination.total_results
+
+
+async def _count_entity_fileset_references(
+    entity_store: EntityClient,
+    entity_type: type[_ModelFilesetReference] | type[_AdapterFilesetReference],
+    workspace: str,
+    name: str,
+) -> int:
+    """Count qualified, legacy URI, and same-workspace bare references."""
+    qualified_ref = f"{workspace}/{name}"
+    qualified_count = await _count_fileset_references(entity_store, entity_type, qualified_ref)
+    legacy_uri_count = await _count_fileset_references(entity_store, entity_type, f"fileset://{qualified_ref}")
+    bare_count = await _count_fileset_references(
+        entity_store,
+        entity_type,
+        name,
+        workspace=workspace,
+    )
+    legacy_bare_count = await _count_fileset_references(
+        entity_store,
+        entity_type,
+        f"fileset://{name}",
+        workspace=workspace,
+    )
+    return qualified_count + legacy_uri_count + bare_count + legacy_bare_count
+
+
+def _format_fileset_dependents(workspace: str, name: str, model_count: int, adapter_count: int) -> str:
+    """Format a referential-integrity error without leaking entity names."""
+    return (
+        f"Cannot delete fileset '{workspace}/{name}' because {model_count} model entity reference(s) "
+        f"and {adapter_count} adapter entity reference(s) still use it. "
+        "Relink or delete the dependent entities first."
+    )
 
 
 def _get_cache_lock_manager(
@@ -352,6 +423,10 @@ async def retrieve_fileset(
     "/v2/workspaces/{workspace}/filesets/{name}",
     summary="Delete Fileset",
     status_code=HTTP_200_OK,
+    responses={
+        HTTP_409_CONFLICT: {"description": "Fileset is referenced by a model or adapter entity"},
+        HTTP_503_SERVICE_UNAVAILABLE: {"description": "Fileset references could not be verified"},
+    },
 )
 async def delete_fileset(
     workspace: str,
@@ -363,12 +438,44 @@ async def delete_fileset(
     """
     Delete Fileset.
 
-    Permanently deletes a fileset from the platform.
+    Permanently deletes an unreferenced fileset from the platform.
+    Referencing model or adapter entities must be relinked or deleted first.
     Returns metadata about the deleted fileset.
     For local storage backends, this also deletes the underlying files.
     """
     logger.info(f"DELETE /filesets/{name} - workspace={workspace}")
     fileset = await get_fileset(workspace, name, entity_store)
+
+    try:
+        # Referential checks and deletion are separate Entity Store requests. Model
+        # consumers revalidate the fileset before use so a concurrent write cannot
+        # turn into a late job-runtime failure.
+        reference_store = entity_store.as_service("files", internal=True)
+        model_count = await _count_entity_fileset_references(
+            reference_store,
+            _ModelFilesetReference,
+            workspace,
+            name,
+        )
+        adapter_count = await _count_entity_fileset_references(
+            reference_store,
+            _AdapterFilesetReference,
+            workspace,
+            name,
+        )
+    except EntityStoreError as exc:
+        logger.error("Cannot verify dependents for fileset '%s/%s': %s", workspace, name, exc)
+        raise HTTPException(
+            HTTP_503_SERVICE_UNAVAILABLE,
+            f"Cannot delete fileset '{workspace}/{name}' because its model and adapter references "
+            "could not be verified. Retry when the Entities service is available.",
+        ) from exc
+
+    if model_count or adapter_count:
+        raise HTTPException(
+            HTTP_409_CONFLICT,
+            _format_fileset_dependents(workspace, name, model_count, adapter_count),
+        )
 
     # Delete underlying source storage data. This is a no-op for external backends
     # like NGC/HuggingFace, and removes files for backends we own (local/S3).

--- a/services/core/files/src/nmp/core/files/api/v2/filesets/endpoints.py
+++ b/services/core/files/src/nmp/core/files/api/v2/filesets/endpoints.py
@@ -18,6 +18,7 @@ from fastapi import (
 )
 from fastapi.responses import FileResponse
 from nemo_platform import AsyncNeMoPlatform
+from nemo_platform_plugin.client.errors import NemoClientError
 from nmp.common.api.common import GenericSortField, PaginationData
 from nmp.common.api.parsed_filter import ParsedFilter, make_filter_dep
 from nmp.common.api.utils import generate_openapi_extra_params
@@ -486,7 +487,9 @@ async def delete_fileset(
             workspace,
             name,
         )
-    except EntityStoreError as exc:
+    except (EntityStoreError, NemoClientError) as exc:
+        # EntityClient.list() raises NemoHTTPError / NemoTransportError (both
+        # NemoClientError). EntityStoreError is reserved for grouped-count parsing.
         logger.error(
             "Cannot verify dependents for fileset '%s/%s': %s",
             _sanitize_for_log(workspace),

--- a/services/core/files/tests/test_fileset_delete_references.py
+++ b/services/core/files/tests/test_fileset_delete_references.py
@@ -1,0 +1,179 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from nmp.common.entities import EntityStoreError
+from nmp.core.files.api.v2.filesets.endpoints import (
+    _count_entity_fileset_references,
+    _count_fileset_references,
+    _ModelFilesetReference,
+    delete_fileset,
+)
+from nmp.core.files.entities import Fileset
+
+
+async def test_count_fileset_references_uses_total_results() -> None:
+    entity_store = MagicMock()
+    entity_store.list = AsyncMock(
+        return_value=SimpleNamespace(
+            data=[object()],
+            pagination=SimpleNamespace(total_results=203),
+        )
+    )
+
+    count = await _count_fileset_references(entity_store, _ModelFilesetReference, "default/weights")
+
+    assert count == 203
+    await_args = entity_store.list.await_args
+    assert await_args is not None
+    assert await_args.kwargs == {
+        "workspace": "-",
+        "filter_obj": {"fileset": "default/weights"},
+        "page_size": 1,
+    }
+
+
+async def test_count_entity_fileset_references_includes_supported_ref_formats() -> None:
+    with patch(
+        "nmp.core.files.api.v2.filesets.endpoints._count_fileset_references",
+        new=AsyncMock(side_effect=[2, 1, 3, 4]),
+    ) as count_references:
+        count = await _count_entity_fileset_references(
+            MagicMock(),
+            _ModelFilesetReference,
+            "default",
+            "weights",
+        )
+
+    assert count == 10
+    assert [call.args[2] for call in count_references.await_args_list] == [
+        "default/weights",
+        "fileset://default/weights",
+        "weights",
+        "fileset://weights",
+    ]
+    assert count_references.await_args_list[2].kwargs == {"workspace": "default"}
+    assert count_references.await_args_list[3].kwargs == {"workspace": "default"}
+
+
+async def test_delete_fileset_rejects_references_before_deleting_storage() -> None:
+    fileset = MagicMock(name="weights")
+    fileset.name = "weights"
+    entity_store = MagicMock()
+    entity_store.delete = AsyncMock()
+    entity_store.as_service.return_value = MagicMock()
+
+    with (
+        patch(
+            "nmp.core.files.api.v2.filesets.endpoints.get_fileset",
+            new=AsyncMock(return_value=fileset),
+        ),
+        patch(
+            "nmp.core.files.api.v2.filesets.endpoints._count_entity_fileset_references",
+            new=AsyncMock(side_effect=[1, 1]),
+        ),
+        patch("nmp.core.files.api.v2.filesets.endpoints.storage_impl_factory") as storage_factory,
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await delete_fileset(
+                workspace="default",
+                name="weights",
+                entity_store=entity_store,
+                sdk=MagicMock(),
+                auth_client=MagicMock(),
+            )
+
+    assert exc_info.value.status_code == 409
+    assert "1 model entity reference(s)" in exc_info.value.detail
+    assert "1 adapter entity reference(s)" in exc_info.value.detail
+    entity_store.as_service.assert_called_once_with("files", internal=True)
+    storage_factory.assert_not_called()
+    entity_store.delete.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "reference_results",
+    [
+        [EntityStoreError("model reference lookup failed")],
+        [0, EntityStoreError("adapter reference lookup failed")],
+    ],
+)
+async def test_delete_fileset_fails_closed_when_references_cannot_be_checked(
+    reference_results: list[int | EntityStoreError],
+) -> None:
+    entity_store = MagicMock()
+    entity_store.delete = AsyncMock()
+    entity_store.as_service.return_value = MagicMock()
+
+    with (
+        patch(
+            "nmp.core.files.api.v2.filesets.endpoints.get_fileset",
+            new=AsyncMock(return_value=MagicMock(name="weights")),
+        ),
+        patch(
+            "nmp.core.files.api.v2.filesets.endpoints._count_entity_fileset_references",
+            new=AsyncMock(side_effect=reference_results),
+        ),
+        patch("nmp.core.files.api.v2.filesets.endpoints.storage_impl_factory") as storage_factory,
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await delete_fileset(
+                workspace="default",
+                name="weights",
+                entity_store=entity_store,
+                sdk=MagicMock(),
+                auth_client=MagicMock(),
+            )
+
+    assert exc_info.value.status_code == 503
+    storage_factory.assert_not_called()
+    entity_store.delete.assert_not_awaited()
+
+
+async def test_delete_unreferenced_fileset_deletes_storage_and_entity() -> None:
+    fileset = MagicMock()
+    fileset.name = "weights"
+    fileset.storage = MagicMock()
+    storage = SimpleNamespace(delete_all=AsyncMock())
+    entity_store = MagicMock()
+    entity_store.delete = AsyncMock()
+    entity_store.as_service.return_value = MagicMock()
+    deleted_output = object()
+
+    with (
+        patch(
+            "nmp.core.files.api.v2.filesets.endpoints.get_fileset",
+            new=AsyncMock(return_value=fileset),
+        ),
+        patch(
+            "nmp.core.files.api.v2.filesets.endpoints._count_entity_fileset_references",
+            new=AsyncMock(side_effect=[0, 0]),
+        ),
+        patch(
+            "nmp.core.files.api.v2.filesets.endpoints.resolve_storage_secrets_for_user",
+            new=AsyncMock(return_value={}),
+        ),
+        patch(
+            "nmp.core.files.api.v2.filesets.endpoints.storage_impl_factory",
+            return_value=storage,
+        ),
+        patch(
+            "nmp.core.files.api.v2.filesets.endpoints.fileset_output_from_entity",
+            return_value=deleted_output,
+        ),
+    ):
+        result = await delete_fileset(
+            workspace="default",
+            name="weights",
+            entity_store=entity_store,
+            sdk=MagicMock(),
+            auth_client=MagicMock(),
+        )
+
+    assert result is deleted_output
+    storage.delete_all.assert_awaited_once_with()
+    entity_store.delete.assert_awaited_once_with(Fileset, "weights", workspace="default")

--- a/services/core/files/tests/test_fileset_delete_references.py
+++ b/services/core/files/tests/test_fileset_delete_references.py
@@ -4,8 +4,10 @@
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 from fastapi import HTTPException
+from nemo_platform_plugin.client.errors import InternalServerError, NemoTransportError
 from nmp.common.entities import EntityStoreError
 from nmp.core.files.api.v2.filesets.endpoints import (
     _count_entity_fileset_references,
@@ -14,6 +16,15 @@ from nmp.core.files.api.v2.filesets.endpoints import (
     delete_fileset,
 )
 from nmp.core.files.entities import Fileset
+
+
+def _internal_server_error() -> InternalServerError:
+    request = httpx.Request("GET", "http://entities.test/list")
+    return InternalServerError(httpx.Response(500, request=request))
+
+
+def _transport_error() -> NemoTransportError:
+    return NemoTransportError(httpx.ConnectError("connection refused"))
 
 
 async def test_count_fileset_references_uses_total_results() -> None:
@@ -99,11 +110,15 @@ async def test_delete_fileset_rejects_references_before_deleting_storage() -> No
     "reference_results",
     [
         [EntityStoreError("model reference lookup failed")],
+        [_internal_server_error()],
+        [_transport_error()],
         [0, EntityStoreError("adapter reference lookup failed")],
+        [0, _internal_server_error()],
+        [0, _transport_error()],
     ],
 )
 async def test_delete_fileset_fails_closed_when_references_cannot_be_checked(
-    reference_results: list[int | EntityStoreError],
+    reference_results: list[int | Exception],
 ) -> None:
     entity_store = MagicMock()
     entity_store.delete = AsyncMock()


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
A fileset used as a model or adapter weights source could be deleted with no referential check, leaving a dangling entity that only failed later during job download. Fileset DELETE now fails closed when dependents exist (HTTP 409) or when Entity Store cannot be queried (HTTP 503), and customization submit/compile verifies that a model's weights fileset is still accessible.

## Related Issue
[NVBug 6715026](https://nvbugspro.nvidia.com/bug/6715026)

Follow-ups (out of scope here): [ASTD-541](https://linear.app/nvidia/issue/ASTD-541/studio-surface-the-fileset-delete-409-in-the-delete-confirmation-flow), [ASTD-542](https://linear.app/nvidia/issue/ASTD-542/studio-customize-eligibility-and-fine-tune-model-picker-should-verify), [AIRCORE-1113](https://linear.app/nvidia/issue/AIRCORE-1113/workspace-cleanup-deletes-filesets-without-modeladapter-referential), [AIRCORE-1114](https://linear.app/nvidia/issue/AIRCORE-1114/provider-reconciler-can-write-modelfileset-without-a-files-api), [AIRCORE-1115](https://linear.app/nvidia/issue/AIRCORE-1115/customization-download-treats-an-empty-fileset-as-success), [AIRCORE-1116](https://linear.app/nvidia/issue/AIRCORE-1116/decide-whether-secrets-should-block-hard-delete-when-jobs-still), [AIRCORE-1117](https://linear.app/nvidia/issue/AIRCORE-1117/modelfileset-conflates-huggingface-artifact-paths-with-fileset)

## Changes
- Count model and adapter `fileset` references in Entity Store (qualified, `fileset://workspace/name`, same-workspace bare name, and `fileset://name`) before deleting a fileset.
- Return HTTP 409 with dependent counts when references exist; return HTTP 503 and skip storage deletion when the count cannot be verified.
- Extend `fetch_model_entity` to call `check_fileset_access` so missing weights filesets fail at customization submit/compile instead of download.
- Document 409/503 on the fileset DELETE OpenAPI operation with the standard `{detail: string}` envelope.
- Sanitize workspace/name on the new 503 error log (CodeQL log-injection).
- Add unit tests for the delete guard and the submit-time fileset check.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `uv run ruff check` / `uv run ruff format --check` on the four changed Python files: passed
- `uv run --frozen pytest services/core/files/tests/test_fileset_delete_references.py -q`: 6 passed
- `uv run --frozen pytest packages/nmp_customization_common/tests/test_platform_client.py -q`: 3 passed (full package was 201 on the original commit)
- `make lint-fix` (Flox): `refresh-openapi` succeeded; web SDK regen succeeded after `make bootstrap-studio` (no generated TS diff); remaining lint-fix steps succeeded except **stainless**
- Stainless did not run: `STAINLESS_API_KEY` is not set in this environment. `lint-python-sdk` (`nemo-platform-sdk-tools is-up-to-date`) will keep failing until someone with that key runs `make stainless` / `sdk/stainless.sh sync` and pushes the generated Python SDK
- DCO audit of `origin/main..HEAD`: DCO OK `b95efa6e34` and `bbd1b0a694`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fileset deletion now checks for model and adapter references before proceeding.
  * Added clear `409 Conflict` responses when references exist and `503 Service Unavailable` responses when verification cannot be completed.
  * Workspace cleanup now removes adapters and models before deleting filesets.

* **Bug Fixes**
  * Model retrieval now validates associated weight filesets and reports missing filesets appropriately.
  * Fileset reference checks support multiple reference formats and paginated results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->