### PR TITLE
fix(anonymizer): model replace kind as a discriminated field

### DIFF
--- a/plugins/nemo-anonymizer/openapi/openapi.yaml
+++ b/plugins/nemo-anonymizer/openapi/openapi.yaml
@@ -465,17 +465,22 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
 components:
   schemas:
-    Annotate:
+    AnnotateRequest:
       properties:
         format_template:
           type: string
           title: Format Template
           description: Template with {text} and {label} placeholders.
           default: <{text}, {label}>
+        kind:
+          type: string
+          const: annotate
+          title: Kind
+          default: annotate
       type: object
-      title: Annotate
+      title: AnnotateRequest
       description: Tag each entity with a readable label token.
-    AnonymizerConfig:
+    AnonymizerConfigRequest:
       properties:
         detect:
           allOf:
@@ -486,10 +491,17 @@ components:
           description: Replacement method (Substitute(), Redact(), Annotate(), or
             Hash()).
           oneOf:
-          - $ref: '#/components/schemas/Annotate'
-          - $ref: '#/components/schemas/Redact'
-          - $ref: '#/components/schemas/Hash'
-          - $ref: '#/components/schemas/Substitute'
+          - $ref: '#/components/schemas/SubstituteRequest'
+          - $ref: '#/components/schemas/RedactRequest'
+          - $ref: '#/components/schemas/AnnotateRequest'
+          - $ref: '#/components/schemas/HashRequest'
+          discriminator:
+            propertyName: kind
+            mapping:
+              annotate: '#/components/schemas/AnnotateRequest'
+              hash: '#/components/schemas/HashRequest'
+              redact: '#/components/schemas/RedactRequest'
+              substitute: '#/components/schemas/SubstituteRequest'
         rewrite:
           allOf:
           - $ref: '#/components/schemas/Rewrite'
@@ -502,8 +514,21 @@ components:
             out at the environment or CLI level.
           default: true
       type: object
-      title: AnonymizerConfig
-      description: Primary user-facing config for anonymization behavior.
+      title: AnonymizerConfigRequest
+      description: 'Wire-level mirror of ``AnonymizerConfig``.
+
+
+        Restates ``replace`` as a proper ``kind``-discriminated union so the
+
+        OpenAPI schema and generated SDK types are self-describing (ASTD-329),
+
+        and so a missing/invalid ``kind`` fails pydantic validation (422)
+
+        instead of the upstream callable discriminator''s bare ``TypeError``
+
+        (ASTD-328). Convert to the upstream type with ``to_anonymizer_config()``
+
+        before handing it to the ``anonymizer`` library.'
     AnonymizerInputSpec:
       properties:
         source:
@@ -541,7 +566,7 @@ components:
     AnonymizerRequest:
       properties:
         config:
-          $ref: '#/components/schemas/AnonymizerConfig'
+          $ref: '#/components/schemas/AnonymizerConfigRequest'
         data:
           $ref: '#/components/schemas/AnonymizerInputSpec'
         model_configs:
@@ -557,11 +582,11 @@ components:
       - data
       title: AnonymizerRequest
       description: "User-facing anonymizer execution request.\n\nFields:\n  config:\
-        \           AnonymizerConfig \u2014 replace/rewrite mode + detection params.\n\
-        \  data:             AnonymizerInputSpec \u2014 HTTP(S) URL or fileset source\
-        \ + text/id columns.\n  model_configs:    DD ``ModelConfig`` list. ``provider``\
-        \ on each entry must\n                    reference a NeMo Platform inference\
-        \ provider name (optionally\n                    ``workspace/provider``).\
+        \           AnonymizerConfigRequest \u2014 replace/rewrite mode + detection\
+        \ params.\n  data:             AnonymizerInputSpec \u2014 HTTP(S) URL or fileset\
+        \ source + text/id columns.\n  model_configs:    DD ``ModelConfig`` list.\
+        \ ``provider`` on each entry must\n                    reference a NeMo Platform\
+        \ inference provider name (optionally\n                    ``workspace/provider``).\
         \ Optional on the request model for\n                    compatibility, but\
         \ required by plugin preview/run execution\n                    so requests\
         \ route through NeMo Platform Inference Gateway.\n  selected_models:  Optional\
@@ -812,7 +837,7 @@ components:
           title: Detail
       type: object
       title: HTTPValidationError
-    Hash:
+    HashRequest:
       properties:
         algorithm:
           type: string
@@ -835,8 +860,13 @@ components:
           title: Format Template
           description: Template with {digest} required and optional {label}.
           default: <HASH_{label}_{digest}>
+        kind:
+          type: string
+          const: hash
+          title: Kind
+          default: hash
       type: object
-      title: Hash
+      title: HashRequest
       description: Replace each entity with a deterministic hash token.
     Heartbeat:
       properties:
@@ -1288,7 +1318,7 @@ components:
     PreviewRequest:
       properties:
         config:
-          $ref: '#/components/schemas/AnonymizerConfig'
+          $ref: '#/components/schemas/AnonymizerConfigRequest'
         data:
           $ref: '#/components/schemas/AnonymizerInputSpec'
         model_configs:
@@ -1329,7 +1359,7 @@ components:
       - preserve
       title: PrivacyGoal
       description: Structured privacy and utility goal for rewrite mode.
-    Redact:
+    RedactRequest:
       properties:
         format_template:
           type: string
@@ -1341,8 +1371,13 @@ components:
           title: Normalize Label
           description: Uppercase and clean label before substitution.
           default: true
+        kind:
+          type: string
+          const: redact
+          title: Kind
+          default: redact
       type: object
-      title: Redact
+      title: RedactRequest
       description: Replace each entity with a configurable redaction template.
     Rewrite:
       properties:
@@ -1597,14 +1632,19 @@ components:
           type: array
       title: StringFilter
       type: object
-    Substitute:
+    SubstituteRequest:
       properties:
         instructions:
           title: Instructions
           description: Additional instructions for the LLM replacement generator.
           type: string
+        kind:
+          type: string
+          const: substitute
+          title: Kind
+          default: substitute
       type: object
-      title: Substitute
+      title: SubstituteRequest
       description: Replace entities with LLM-generated synthetic values.
     TraceDatasetFrame:
       properties:

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/app/task_config.py
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/app/task_config.py
@@ -5,15 +5,49 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any, Literal, Union, cast
 
 import data_designer.config as dd
-from anonymizer.config.anonymizer_config import AnonymizerConfig
-from anonymizer.config.replace_strategies import Annotate, Hash, Redact, ReplaceMethodBase, Substitute
+from anonymizer.config.anonymizer_config import AnonymizerConfig, Detect, Rewrite
+from anonymizer.config.replace_strategies import Annotate, Hash, Redact, ReplaceMethod, ReplaceMethodBase, Substitute
 from nemo_anonymizer_plugin.app.input import AnonymizerInputSpec
 from nemo_anonymizer_plugin.app.model_configs import SelectedModelsOverrides
 from nemo_anonymizer_plugin.config import DEFAULT_MAX_PREVIEW_NUM_RECORDS
-from pydantic import BaseModel, Field, field_serializer
+from pydantic import BaseModel, Field, Tag, model_validator
+
+# The upstream `ReplaceMethod` union resolves `kind` through a callable
+# `Discriminator` that reads a dict key, so `kind` never became a modelled
+# field and is invisible to OpenAPI / generated SDKs (ASTD-329). A dict
+# missing it also makes that callable raise a bare `TypeError`, which
+# propagates as an unhandled 500 instead of a validation error (ASTD-328).
+# These wire-level subclasses restate `kind` as a real `Literal` field so
+# pydantic's own tagged-union discriminator — not a callable — resolves and
+# validates it, giving both problems the same fix.
+
+
+class SubstituteRequest(Substitute):
+    """Replace entities with LLM-generated synthetic values."""
+
+    kind: Literal["substitute"] = "substitute"
+
+
+class RedactRequest(Redact):
+    """Replace each entity with a configurable redaction template."""
+
+    kind: Literal["redact"] = "redact"
+
+
+class AnnotateRequest(Annotate):
+    """Tag each entity with a readable label token."""
+
+    kind: Literal["annotate"] = "annotate"
+
+
+class HashRequest(Hash):
+    """Replace each entity with a deterministic hash token."""
+
+    kind: Literal["hash"] = "hash"
+
 
 _REPLACE_METHOD_KINDS: dict[type[ReplaceMethodBase], str] = {
     Annotate: "annotate",
@@ -22,12 +56,87 @@ _REPLACE_METHOD_KINDS: dict[type[ReplaceMethodBase], str] = {
     Substitute: "substitute",
 }
 
+_REPLACE_UPSTREAM_TYPES: dict[type, type[ReplaceMethodBase]] = {
+    SubstituteRequest: Substitute,
+    RedactRequest: Redact,
+    AnnotateRequest: Annotate,
+    HashRequest: Hash,
+}
+
+ReplaceMethodRequest = Annotated[
+    Union[
+        Annotated[SubstituteRequest, Tag("substitute")],
+        Annotated[RedactRequest, Tag("redact")],
+        Annotated[AnnotateRequest, Tag("annotate")],
+        Annotated[HashRequest, Tag("hash")],
+    ],
+    Field(discriminator="kind"),
+]
+
+
+def _wire_replace_payload(replace: ReplaceMethodBase) -> dict:
+    """Convert an upstream ``ReplaceMethodBase`` instance into a `kind`-tagged dict."""
+    payload = replace.model_dump(mode="python", exclude_none=True)
+    for replace_type, kind in _REPLACE_METHOD_KINDS.items():
+        if isinstance(replace, replace_type):
+            return {"kind": kind, **payload}
+    return payload
+
+
+def _to_upstream_replace(replace: ReplaceMethodRequest) -> ReplaceMethod:
+    upstream_type = _REPLACE_UPSTREAM_TYPES[type(replace)]
+    return cast(ReplaceMethod, upstream_type(**replace.model_dump(exclude={"kind"})))
+
+
+class AnonymizerConfigRequest(BaseModel):
+    """Wire-level mirror of ``AnonymizerConfig``.
+
+    Restates ``replace`` as a proper ``kind``-discriminated union so the
+    OpenAPI schema and generated SDK types are self-describing (ASTD-329),
+    and so a missing/invalid ``kind`` fails pydantic validation (422)
+    instead of the upstream callable discriminator's bare ``TypeError``
+    (ASTD-328). Convert to the upstream type with ``to_anonymizer_config()``
+    before handing it to the ``anonymizer`` library.
+    """
+
+    detect: Detect = Field(default_factory=Detect, description="Entity detection configuration.")
+    replace: ReplaceMethodRequest | None = Field(
+        default=None,
+        description="Replacement method (Substitute(), Redact(), Annotate(), or Hash()).",
+    )
+    rewrite: Rewrite | None = Field(default=None, description="Optional rewrite-mode parameters. ")
+    emit_telemetry: bool = Field(
+        default=True,
+        description=(
+            "Whether to emit anonymous Anonymizer telemetry events. See the Telemetry section "
+            "in the README for what is collected and how to opt out at the environment or CLI level."
+        ),
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _coerce_upstream_config(cls, data: Any) -> Any:
+        if isinstance(data, AnonymizerConfig):
+            payload = data.model_dump(mode="python", exclude_none=True, exclude={"replace"})
+            if data.replace is not None:
+                payload["replace"] = _wire_replace_payload(data.replace)
+            return payload
+        return data
+
+    def to_anonymizer_config(self) -> AnonymizerConfig:
+        return AnonymizerConfig(
+            detect=self.detect,
+            replace=_to_upstream_replace(self.replace) if self.replace is not None else None,
+            rewrite=self.rewrite,
+            emit_telemetry=self.emit_telemetry,
+        )
+
 
 class AnonymizerRequest(BaseModel):
     """User-facing anonymizer execution request.
 
     Fields:
-      config:           AnonymizerConfig — replace/rewrite mode + detection params.
+      config:           AnonymizerConfigRequest — replace/rewrite mode + detection params.
       data:             AnonymizerInputSpec — HTTP(S) URL or fileset source + text/id columns.
       model_configs:    DD ``ModelConfig`` list. ``provider`` on each entry must
                         reference a NeMo Platform inference provider name (optionally
@@ -40,17 +149,10 @@ class AnonymizerRequest(BaseModel):
 
     model_config = {"json_schema_mode_override": "validation"}
 
-    config: AnonymizerConfig
+    config: AnonymizerConfigRequest
     data: AnonymizerInputSpec
     model_configs: list[dd.ModelConfig] | None = None
     selected_models: SelectedModelsOverrides | None = None
-
-    @field_serializer("config")
-    def serialize_config(self, config: AnonymizerConfig) -> dict:
-        payload = config.model_dump(mode="json", exclude_none=True)
-        if config.replace is not None:
-            payload["replace"] = _serialize_replace_method(config.replace)
-        return payload
 
 
 class PreviewRequest(AnonymizerRequest):
@@ -75,11 +177,3 @@ class AnonymizerStepConfig(BaseModel):
     # the Inference Gateway URL with the right auth headers. The task will pass
     # these to ``Anonymizer(model_providers=...)``.
     dd_model_providers: list[dict[str, Any]]
-
-
-def _serialize_replace_method(replace: ReplaceMethodBase) -> dict:
-    payload = replace.model_dump(mode="json", exclude_none=True)
-    for replace_type, kind in _REPLACE_METHOD_KINDS.items():
-        if isinstance(replace, replace_type):
-            return {"kind": kind, **payload}
-    return payload

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/functions/_preview_worker.py
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/functions/_preview_worker.py
@@ -38,7 +38,7 @@ def _make_preview(
 ) -> None:
     """Run ``Anonymizer.preview(...)`` and stream the result frames."""
     anonymizer = _make_anonymizer(model_configs_yaml=model_configs_yaml, dd_providers=dd_providers)
-    config: AnonymizerConfig = spec.config
+    config: AnonymizerConfig = spec.config.to_anonymizer_config()
 
     result = anonymizer.preview(config=config, data=data, num_records=num_records)
 

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/jobs/run.py
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/jobs/run.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 from typing import ClassVar, cast
 
-from anonymizer.config.anonymizer_config import AnonymizerConfig
 from anonymizer.interface.anonymizer import Anonymizer
 from anonymizer.interface.errors import InvalidConfigError
 from data_designer_nemo.errors import NDDInvalidConfigError
@@ -18,6 +17,7 @@ from nemo_anonymizer_plugin.app.model_configs import (
     validate_selected_models_have_model_configs,
 )
 from nemo_anonymizer_plugin.app.task_config import (
+    AnonymizerConfigRequest,
     AnonymizerRequest,
     AnonymizerStepConfig,
 )
@@ -35,7 +35,7 @@ from nemo_platform_plugin.jobs.api_factory import (
 from nemo_platform_plugin.jobs.constants import DEFAULT_JOB_STORAGE_PATH, PERSISTENT_JOB_STORAGE_PATH_ENVVAR
 from nemo_platform_plugin.jobs.exceptions import PlatformJobCompilationError
 from nemo_platform_plugin.jobs.image import get_qualified_image
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 
 class RunJob(NemoJob):
@@ -85,14 +85,15 @@ class RunJob(NemoJob):
         )
 
     @classmethod
-    def _validate_anonymizer_config(cls, config: AnonymizerConfig) -> None:
+    def _validate_anonymizer_config(cls, config: AnonymizerConfigRequest) -> None:
         # ``Anonymizer.validate_config`` cross-checks the user-supplied config
         # against the model selection (e.g. that a ``Substitute`` strategy has
         # a ``replacement_generator`` model defined). Doing it here gives the
         # caller a synchronous 422 instead of an async job failure.
         try:
-            Anonymizer().validate_config(config)
-        except InvalidConfigError as e:
+            anonymizer_config = config.to_anonymizer_config()
+            Anonymizer().validate_config(anonymizer_config)
+        except (InvalidConfigError, ValidationError) as e:
             raise AnonymizerInvalidConfigError(str(e)) from e
 
     @classmethod

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/service.py
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/service.py
@@ -76,6 +76,17 @@ class AnonymizerService(NemoService):
                 content={"detail": str(ex)},
             )
 
+        async def type_error_handler(_request: Request, ex: TypeError):
+            # The upstream `ReplaceMethod` union resolves `kind` through a callable
+            # `Discriminator` that raises a bare `TypeError` on a bad/missing `kind`
+            # instead of a pydantic `ValidationError` (ASTD-328). Any caller that
+            # still reaches the upstream discriminator directly — bypassing the
+            # `kind`-aware wire schema in `task_config.py` — gets a 422 here too.
+            return JSONResponse(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                content={"detail": str(ex)},
+            )
+
         async def anonymizer_invalid_config_handler(_request: Request, ex: InvalidConfigError):
             return JSONResponse(
                 status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
@@ -114,6 +125,7 @@ class AnonymizerService(NemoService):
 
         return {
             ValidationError: validation_error_handler,
+            TypeError: type_error_handler,
             InvalidConfigError: anonymizer_invalid_config_handler,
             AnonymizerError: anonymizer_error_handler,
             AnonymizerInternalError: plugin_internal_error_handler,

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/tasks/anonymizer/run.py
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/tasks/anonymizer/run.py
@@ -93,7 +93,7 @@ def _run_with_step_config(
                 artifact_path=storage_path / "anonymizer-artifacts",
             )
         logger.info("Running anonymizer pipeline")
-        result = anonymizer.run(config=request.config, data=prepared_input.input)
+        result = anonymizer.run(config=request.config.to_anonymizer_config(), data=prepared_input.input)
     finally:
         prepared_input.cleanup()
 

--- a/plugins/nemo-anonymizer/tests/unit/test_exception_handlers.py
+++ b/plugins/nemo-anonymizer/tests/unit/test_exception_handlers.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for ``AnonymizerService.get_exception_handlers``."""
+
+from __future__ import annotations
+
+import pytest
+from nemo_anonymizer_plugin.service import AnonymizerService
+from starlette import status
+
+
+def test_type_error_maps_to_422() -> None:
+    """ASTD-328: a bare TypeError (e.g. the upstream replace-kind Discriminator) must 422, not 500."""
+    handlers = AnonymizerService().get_exception_handlers()
+
+    assert TypeError in handlers
+
+
+@pytest.mark.asyncio
+async def test_type_error_handler_returns_422_response() -> None:
+    handlers = AnonymizerService().get_exception_handlers()
+    handler = handlers[TypeError]
+
+    response = await handler(None, TypeError("dict is missing a valid 'kind' key: {}"))
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT

--- a/plugins/nemo-anonymizer/tests/unit/test_preview_function.py
+++ b/plugins/nemo-anonymizer/tests/unit/test_preview_function.py
@@ -9,12 +9,12 @@ from unittest.mock import AsyncMock
 import data_designer.config as dd
 import pandas as pd
 import pytest
-from anonymizer.config.anonymizer_config import AnonymizerConfig, AnonymizerInput
-from anonymizer.config.replace_strategies import Redact
+from anonymizer.config.anonymizer_config import AnonymizerInput
 from nemo_anonymizer_plugin.app import context as context_module
 from nemo_anonymizer_plugin.app.errors import AnonymizerInvalidConfigError
 from nemo_anonymizer_plugin.app.input import AnonymizerInputSpec
 from nemo_anonymizer_plugin.app.model_configs import SelectedModelsOverrides
+from nemo_anonymizer_plugin.app.task_config import AnonymizerConfigRequest, RedactRequest
 from nemo_anonymizer_plugin.functions import _preview_worker as worker_module
 from nemo_anonymizer_plugin.functions._preview_logs import request_callback_cvar
 from nemo_anonymizer_plugin.functions.preview import LogFrame, PreviewFunction, PreviewSpec, TraceDatasetFrame
@@ -25,7 +25,7 @@ from pydantic import BaseModel
 
 def _preview_spec() -> PreviewSpec:
     return PreviewSpec(
-        config=AnonymizerConfig(replace=Redact()),
+        config=AnonymizerConfigRequest(replace=RedactRequest()),
         data=AnonymizerInputSpec(source="https://example.com/input.csv", text_column="biography"),
         model_configs=[dd.ModelConfig(alias="detector", model="test/model", provider="provider")],
         num_records=1,

--- a/plugins/nemo-anonymizer/tests/unit/test_routing.py
+++ b/plugins/nemo-anonymizer/tests/unit/test_routing.py
@@ -50,9 +50,11 @@ def test_sdk_run_uses_run_job_collection_path() -> None:
         default_headers={},
         _client=Client(),
     )
-    resource = AnonymizerResource(platform)  # type: ignore[arg-type]
+    resource = AnonymizerResource(platform)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+    # SDK ergonomics: real callers can hand `AnonymizerRequest` an upstream
+    # `AnonymizerConfig` directly; `AnonymizerConfigRequest` coerces it (ASTD-329).
     request = AnonymizerRequest(
-        config=AnonymizerConfig(replace=Redact()),
+        config=AnonymizerConfig(replace=Redact()),  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
         data=AnonymizerInputSpec(source="inputs#records.csv"),
     )
 

--- a/plugins/nemo-anonymizer/tests/unit/test_run_job.py
+++ b/plugins/nemo-anonymizer/tests/unit/test_run_job.py
@@ -13,14 +13,18 @@ import data_designer.config as dd
 import nemo_anonymizer_plugin.tasks.anonymizer.run as task_run_module
 import pytest
 from anonymizer.config.anonymizer_config import AnonymizerConfig
-from anonymizer.config.replace_strategies import Redact
 from data_designer.engine.model_provider import ModelProvider as NDDModelProvider
 from data_designer.engine.model_provider import ModelProviderRegistry
 from data_designer_nemo.errors import NDDInvalidConfigError
 from nemo_anonymizer_plugin.app import context as context_module
 from nemo_anonymizer_plugin.app.input import AnonymizerInputSpec
 from nemo_anonymizer_plugin.app.model_configs import SelectedModelsOverrides
-from nemo_anonymizer_plugin.app.task_config import AnonymizerRequest, AnonymizerStepConfig
+from nemo_anonymizer_plugin.app.task_config import (
+    AnonymizerConfigRequest,
+    AnonymizerRequest,
+    AnonymizerStepConfig,
+    RedactRequest,
+)
 from nemo_anonymizer_plugin.jobs import run as run_module
 from nemo_anonymizer_plugin.jobs.run import RunJob
 from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
@@ -79,7 +83,7 @@ async def test_run_job_rejects_selected_models_without_model_configs(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     request = AnonymizerRequest(
-        config=AnonymizerConfig(replace=Redact()),
+        config=AnonymizerConfigRequest(replace=RedactRequest()),
         data=AnonymizerInputSpec(source="https://example.com/input.csv", text_column="text"),
         selected_models=SelectedModelsOverrides(detection={"entity_detector": "detector"}),
     )
@@ -94,7 +98,7 @@ async def test_run_job_wraps_shared_provider_config_errors(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     request = AnonymizerRequest(
-        config=AnonymizerConfig(replace=Redact()),
+        config=AnonymizerConfigRequest(replace=RedactRequest()),
         data=AnonymizerInputSpec(source="https://example.com/input.csv", text_column="text"),
         model_configs=[dd.ModelConfig(alias="detector", model="test/model", provider="missing")],
     )
@@ -114,7 +118,7 @@ async def test_run_submit_requires_model_configs(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     request = AnonymizerRequest(
-        config=AnonymizerConfig(replace=Redact()),
+        config=AnonymizerConfigRequest(replace=RedactRequest()),
         data=AnonymizerInputSpec(source="https://example.com/input.csv", text_column="text"),
     )
     monkeypatch.setattr(RunJob, "_validate_anonymizer_config", classmethod(lambda cls, config: None))
@@ -132,7 +136,7 @@ async def test_run_job_uses_igw_provider_registry(
     )
     igw_lookup = AsyncMock(return_value=igw_registry)
     request = AnonymizerRequest(
-        config=AnonymizerConfig(replace=Redact()),
+        config=AnonymizerConfigRequest(replace=RedactRequest()),
         data=AnonymizerInputSpec(source="https://example.com/input.csv", text_column="text"),
         model_configs=[dd.ModelConfig(alias="detector", model="test/model", provider="provider")],
     )
@@ -156,7 +160,7 @@ async def test_run_serialized_step_config_can_be_revalidated(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     request = AnonymizerRequest(
-        config=AnonymizerConfig(replace=Redact()),
+        config=AnonymizerConfigRequest(replace=RedactRequest()),
         data=AnonymizerInputSpec(source="https://example.com/input.csv", text_column="text"),
         model_configs=[dd.ModelConfig(alias="detector", model="test/model", provider="provider")],
     )
@@ -216,7 +220,7 @@ def test_run_step_config_uses_ctx_results(
 
     step_config = AnonymizerStepConfig(
         request=AnonymizerRequest(
-            config=AnonymizerConfig(replace=Redact()),
+            config=AnonymizerConfigRequest(replace=RedactRequest()),
             data=AnonymizerInputSpec(source="https://example.com/input.csv", text_column="text"),
         ),
         model_configs_yaml="model_configs:\n- alias: detector\n  model: test/model\n  provider: provider\n",
@@ -253,7 +257,7 @@ def test_run_step_config_uses_ctx_results(
 def test_run_step_config_remote_requires_sdk(tmp_path: Path) -> None:
     step_config = AnonymizerStepConfig(
         request=AnonymizerRequest(
-            config=AnonymizerConfig(replace=Redact()),
+            config=AnonymizerConfigRequest(replace=RedactRequest()),
             data=AnonymizerInputSpec(source="https://example.com/input.csv", text_column="text"),
         ),
         model_configs_yaml="",
@@ -274,7 +278,7 @@ def test_run_step_config_requires_resolved_model_configs(
 ) -> None:
     step_config = AnonymizerStepConfig(
         request=AnonymizerRequest(
-            config=AnonymizerConfig(replace=Redact()),
+            config=AnonymizerConfigRequest(replace=RedactRequest()),
             data=AnonymizerInputSpec(source="https://example.com/input.csv", text_column="text"),
         ),
         model_configs_yaml="",
@@ -300,7 +304,7 @@ async def test_run_submit_rejects_local_file(
     csv = tmp_path / "input.csv"
     csv.write_text("text\nhello\n")
     request = AnonymizerRequest(
-        config=AnonymizerConfig(replace=Redact()),
+        config=AnonymizerConfigRequest(replace=RedactRequest()),
         data=AnonymizerInputSpec(source=str(csv), text_column="text"),
         model_configs=[dd.ModelConfig(alias="detector", model="test/model", provider="provider")],
     )

--- a/plugins/nemo-anonymizer/tests/unit/test_task_config.py
+++ b/plugins/nemo-anonymizer/tests/unit/test_task_config.py
@@ -7,15 +7,22 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from anonymizer.config.anonymizer_config import AnonymizerConfig
 from anonymizer.config.replace_strategies import Redact
 from nemo_anonymizer_plugin.app.input import AnonymizerInputSpec
-from nemo_anonymizer_plugin.app.task_config import AnonymizerRequest, PreviewRequest
+from nemo_anonymizer_plugin.app.task_config import (
+    AnonymizerConfigRequest,
+    AnonymizerRequest,
+    PreviewRequest,
+    RedactRequest,
+)
 from nemo_anonymizer_plugin.config import DEFAULT_MAX_PREVIEW_NUM_RECORDS
+from pydantic import ValidationError
 
 
-def _config() -> AnonymizerConfig:
-    return AnonymizerConfig(replace=Redact())
+def _config() -> AnonymizerConfigRequest:
+    return AnonymizerConfigRequest(replace=RedactRequest())
 
 
 def test_preview_request_accepts_http_source() -> None:
@@ -73,3 +80,53 @@ def test_request_dump_preserves_replace_discriminator() -> None:
     dumped = req.model_dump(mode="json")
 
     assert dumped["config"]["replace"]["kind"] == "redact"
+
+
+def test_replace_missing_kind_raises_validation_error_not_type_error() -> None:
+    """ASTD-328: a missing discriminator must 422, not crash the upstream callable Discriminator with a raw TypeError."""
+    with pytest.raises(ValidationError, match="kind"):
+        AnonymizerConfigRequest.model_validate({"replace": {}})
+
+
+def test_replace_invalid_kind_raises_validation_error() -> None:
+    with pytest.raises(ValidationError, match="kind"):
+        AnonymizerConfigRequest.model_validate({"replace": {"kind": "not-a-real-strategy"}})
+
+
+def test_replace_schema_models_kind_as_a_literal_field() -> None:
+    """ASTD-329: ``kind`` must be a real modelled field so OpenAPI/generated SDKs see it."""
+    schema = AnonymizerConfigRequest.model_json_schema()
+    replace_variants = schema["$defs"]
+
+    for variant_name in ("SubstituteRequest", "RedactRequest", "AnnotateRequest", "HashRequest"):
+        variant = replace_variants[variant_name]
+        assert (
+            variant["properties"]["kind"]["const"]
+            == {
+                "SubstituteRequest": "substitute",
+                "RedactRequest": "redact",
+                "AnnotateRequest": "annotate",
+                "HashRequest": "hash",
+            }[variant_name]
+        )
+
+
+def test_replace_accepts_a_valid_kind_and_round_trips_to_upstream_config() -> None:
+    req = AnonymizerConfigRequest.model_validate({"replace": {"kind": "redact"}})
+
+    upstream = req.to_anonymizer_config()
+
+    assert isinstance(upstream, AnonymizerConfig)
+    assert isinstance(upstream.replace, Redact)
+
+
+def test_config_still_accepts_an_upstream_anonymizer_config_instance() -> None:
+    """SDK callers that build an upstream ``AnonymizerConfig`` directly (as before ASTD-329) keep working."""
+    req = AnonymizerRequest(
+        config=AnonymizerConfig(replace=Redact()),  # ty: ignore[invalid-argument-type]
+        data=AnonymizerInputSpec(source="https://example.com/x.csv", text_column="text"),
+    )
+
+    assert req.config.replace is not None
+    assert req.config.replace.kind == "redact"
+    assert isinstance(req.config.to_anonymizer_config().replace, Redact)

--- a/sdk/python/nemo-platform/src/nemo_platform/resources/workspaces/workspaces.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/resources/workspaces/workspaces.py
@@ -248,6 +248,9 @@ class WorkspacesResource(SyncAPIResource):
         """
         List all workspaces with pagination.
 
+        Workspaces marked for deletion (non-null deletion_stage) are omitted so the list
+        matches GET/DELETE, which treat those workspaces as not found.
+
         When authentication is enabled, only workspaces the principal has access to are
         returned. Service principals and platform admins have access to all workspaces.
 
@@ -557,6 +560,9 @@ class AsyncWorkspacesResource(AsyncAPIResource):
     ) -> AsyncPaginator[Workspace, AsyncDefaultPagination[Workspace]]:
         """
         List all workspaces with pagination.
+
+        Workspaces marked for deletion (non-null deletion_stage) are omitted so the list
+        matches GET/DELETE, which treat those workspaces as not found.
 
         When authentication is enabled, only workspaces the principal has access to are
         returned. Service principals and platform admins have access to all workspaces.

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/schema.ts
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/schema.ts
@@ -7,12 +7,16 @@ import {
 } from '@nemo/common/src/components/ModelSelectV2/InferenceParameters';
 import { generateDefaultName } from '@nemo/common/src/utils/generateDefaultName';
 import type {
-  AnonymizerConfig,
+  AnnotateRequest,
+  AnonymizerConfigRequest,
+  HashRequest,
   ModelConfig,
   PreviewRequest,
+  RedactRequest,
   Rewrite,
   RunJobRequest,
   SelectedModelsOverrides,
+  SubstituteRequest,
 } from '@nemo/sdk/generated/anonymizer/schema';
 import {
   activeRolesForStrategy,
@@ -144,30 +148,27 @@ const withTemplate = <T extends object>(base: T, template: string): T => {
   return trimmed ? { ...base, format_template: trimmed } : base;
 };
 
-const buildReplaceConfig = (form: AnonymizerFormData): AnonymizerConfig['replace'] => {
-  const replace = ((): object => {
-    switch (form.strategy) {
-      case STRATEGY_REDACT:
-        return withTemplate(
-          { kind: STRATEGY_REDACT, normalize_label: form.redactNormalizeLabel },
-          form.redactTemplate
-        );
-      case STRATEGY_ANNOTATE:
-        return withTemplate({ kind: STRATEGY_ANNOTATE }, form.annotateTemplate);
-      case STRATEGY_HASH:
-        return withTemplate(
-          {
-            kind: STRATEGY_HASH,
-            algorithm: form.hashAlgorithm,
-            digest_length: form.hashDigestLength,
-          },
-          form.hashTemplate
-        );
-      default:
-        return { kind: STRATEGY_SUBSTITUTE };
-    }
-  })();
-  return replace as AnonymizerConfig['replace'];
+const buildReplaceConfig = (form: AnonymizerFormData): AnonymizerConfigRequest['replace'] => {
+  switch (form.strategy) {
+    case STRATEGY_REDACT:
+      return withTemplate<RedactRequest>(
+        { kind: STRATEGY_REDACT, normalize_label: form.redactNormalizeLabel },
+        form.redactTemplate
+      );
+    case STRATEGY_ANNOTATE:
+      return withTemplate<AnnotateRequest>({ kind: STRATEGY_ANNOTATE }, form.annotateTemplate);
+    case STRATEGY_HASH:
+      return withTemplate<HashRequest>(
+        {
+          kind: STRATEGY_HASH,
+          algorithm: form.hashAlgorithm,
+          digest_length: form.hashDigestLength,
+        },
+        form.hashTemplate
+      );
+    default:
+      return { kind: STRATEGY_SUBSTITUTE } satisfies SubstituteRequest;
+  }
 };
 
 const buildRewriteConfig = (form: AnonymizerFormData): Rewrite => {
@@ -199,7 +200,7 @@ const buildRewriteConfig = (form: AnonymizerFormData): Rewrite => {
 const buildDetectConfig = (
   form: AnonymizerFormData,
   defaultEntityLabels: string[]
-): AnonymizerConfig['detect'] => {
+): AnonymizerConfigRequest['detect'] => {
   if (form.entityMode !== ENTITY_MODE_CUSTOM) return undefined;
 
   const labels = form.includeDefaultEntities
@@ -242,7 +243,7 @@ export const buildAnonymizerJobRequest = (
   form: AnonymizerFormData,
   defaultEntityLabels: string[] = []
 ): RunJobRequest => {
-  const config: AnonymizerConfig =
+  const config: AnonymizerConfigRequest =
     form.strategy === REWRITE_STRATEGY
       ? { rewrite: buildRewriteConfig(form) }
       : { replace: buildReplaceConfig(form) };


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary

The anonymizer `replace` union resolves its `kind` discriminator through a callable `Discriminator` that reads a dict key instead of a modelled field, so a missing/invalid `kind` raises a bare `TypeError` that surfaces as an unhandled 500 instead of a 422 (ASTD-328), and `kind` is invisible to the OpenAPI schema and generated SDK (ASTD-329). This adds wire-level request types that model `kind` as a real discriminated field, fixing both.

## Changes

- `task_config.py`: add `SubstituteRequest`/`RedactRequest`/`AnnotateRequest`/`HashRequest` — thin subclasses of the upstream strategy classes restating `kind` as a `Literal` field — wired through pydantic's own `Field(discriminator="kind")` tagged union via a new `AnonymizerConfigRequest`. `AnonymizerRequest.config` now uses this type; a `mode="before"` validator still accepts an upstream `AnonymizerConfig` instance for SDK-ergonomics backward compatibility. `to_anonymizer_config()` converts back to the upstream type before calling into the `anonymizer` library.
- `jobs/run.py`, `tasks/anonymizer/run.py`, `functions/_preview_worker.py`: call `.to_anonymizer_config()` at the three points that hand the config to the upstream `anonymizer` library.
- `service.py`: add a defensive `TypeError` → 422 exception handler for any path that still reaches the upstream callable discriminator directly.
- Regenerated `plugins/nemo-anonymizer/openapi/openapi.yaml`, the Python SDK (`make stainless`), and the TS SDK (`pnpm gen`, gitignored/not committed) from the updated schema.
- `web/packages/studio/.../AnonymizerBuilderRoute/schema.ts`: dropped the `as AnonymizerConfig['replace']` cast now that the generated SDK types carry `kind` natively.
- Added/updated unit tests covering the missing/invalid-`kind` → `ValidationError` path, the `kind` literal in the generated JSON schema, the upstream-`AnonymizerConfig` backward-compat path, and the `TypeError` → 422 handler.

## Related Issue

Fixes ASTD-328, ASTD-329 (Linear; no linked GitHub issue).

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: no user-facing docs describe this error-handling/schema detail.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `pytest plugins/nemo-anonymizer/tests/unit -q` — 74 passed
- `ruff check` / `ruff format --check` on changed Python files — clean
- `ty check --python .venv plugins/nemo-anonymizer` — clean (0 errors from this change; 3 pre-existing, unrelated errors remain in `test_input.py`, confirmed present on `origin/main` before this branch)
- `tsc --noEmit --noErrorTruncation` (studio package) — clean
- `vitest --run src/routes/AnonymizerBuilderRoute` — 56 passed
- `eslint` on the changed frontend file — clean
- `python -m script.generate_openapi_spec -v` — regenerated `plugins/nemo-anonymizer/openapi/openapi.yaml` cleanly, no other plugin specs changed
- `make stainless` — regenerated the vendored Python SDK; ran `tools/lint/copyright_fixer.py` afterward to restore SPDX headers stainless drops on `.md` output, leaving only the intended `AnonymizerConfigRequest`/`kind` schema change plus one unrelated pre-existing doc-drift line in `workspaces.py`
- `pnpm --filter @nemo/sdk gen:all-force` — regenerated the TS SDK (gitignored, not committed)
- `uv run pre-commit run -a` — blocked: `helm-docs` (binary not installed in this sandbox) and `uv-lock` (sandbox uv `0.9.30` vs pinned `0.9.14`) fail for environment/tooling reasons unrelated to this change; all other hooks pass, including `ty`, `ruff`, and copyright checks
