### PR TITLE
fix(studio): send the backend's own model name when chatting with an adapter (ASTD-552)

### DIFF
--- a/web/packages/common/src/utils/models.test.ts
+++ b/web/packages/common/src/utils/models.test.ts
@@ -1,9 +1,18 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ModelDeploymentStatus, type ModelEntity } from '@nemo/sdk/generated/platform/schema';
+import {
+  type Adapter,
+  FinetuningType,
+  ModelDeploymentStatus,
+  type ModelEntity,
+} from '@nemo/sdk/generated/platform/schema';
 
-import { getModelEntityChatStatus, groupModelsByWorkspace } from './models';
+import {
+  getModelEntityChatStatus,
+  groupModelsByWorkspace,
+  toInferenceModelEntityId,
+} from './models';
 
 const createModel = (overrides: Partial<ModelEntity> = {}): ModelEntity => ({
   id: 'test-id',
@@ -12,6 +21,56 @@ const createModel = (overrides: Partial<ModelEntity> = {}): ModelEntity => ({
   created_at: '2025-01-07T12:00:00Z',
   updated_at: '2025-01-07T12:00:00Z',
   ...overrides,
+});
+
+const createAdapter = (overrides: Partial<Adapter> = {}): Adapter => ({
+  name: 'test-adapter',
+  workspace: 'test-namespace',
+  fileset: 'test-namespace/test-adapter',
+  finetuning_type: FinetuningType.lora,
+  ...overrides,
+});
+
+describe('toInferenceModelEntityId', () => {
+  it('returns the plain entity ref when there is no adapter', () => {
+    const model = createModel({ workspace: 'default', name: 'qwen3-0.6b' });
+    expect(toInferenceModelEntityId(model)).toBe('default/qwen3-0.6b');
+    expect(toInferenceModelEntityId(model, null)).toBe('default/qwen3-0.6b');
+  });
+
+  it('builds the composite id the provider reconciler writes for an adapter', () => {
+    const model = createModel({ workspace: 'default', name: 'qwen3-0.6b' });
+    const adapter = createAdapter({ workspace: 'default', name: 'pirate-voice' });
+    expect(toInferenceModelEntityId(model, adapter)).toBe(
+      'default/qwen3-0.6b&adapters/default/pirate-voice'
+    );
+  });
+
+  it('carries the adapter workspace, which may differ from the base model workspace', () => {
+    const model = createModel({ workspace: 'nvidia', name: 'qwen3-0.6b' });
+    const adapter = createAdapter({ workspace: 'default', name: 'pirate-voice' });
+    expect(toInferenceModelEntityId(model, adapter)).toBe(
+      'nvidia/qwen3-0.6b&adapters/default/pirate-voice'
+    );
+  });
+
+  it('matches a served_models entry by identity', () => {
+    // This id exists to look up `provider.served_models`; the value that goes on
+    // the wire is that entry's `served_model_name`, never this.
+    const model = createModel({ workspace: 'default', name: 'qwen3-0.6b' });
+    const adapter = createAdapter({ workspace: 'default', name: 'pirate-voice' });
+    const servedModels = [
+      { model_entity_id: 'default/qwen3-0.6b', served_model_name: 'default/qwen3-0.6b' },
+      {
+        model_entity_id: 'default/qwen3-0.6b&adapters/default/pirate-voice',
+        served_model_name: 'default--pirate-voice',
+      },
+    ];
+    const match = servedModels.find(
+      (sm) => sm.model_entity_id === toInferenceModelEntityId(model, adapter)
+    );
+    expect(match?.served_model_name).toBe('default--pirate-voice');
+  });
 });
 
 describe('getModelEntityChatStatus', () => {

--- a/web/packages/common/src/utils/models.ts
+++ b/web/packages/common/src/utils/models.ts
@@ -62,6 +62,32 @@ export const getBaseModelURN = (model: ModelEntity) => {
 };
 
 /**
+ * Platform-side model entity id, as it appears in a provider's `served_models`.
+ *
+ * This is an **identity, not a wire value**. Use it to find the provider entry
+ * for a model or adapter; the value that goes into a request body is that
+ * entry's `served_model_name`, which is the backend's own name and is discovered
+ * rather than derived (`{ws}--{name}`, sometimes namespace-qualified, plus two
+ * legacy shapes).
+ *
+ * A LoRA adapter has no standalone Model Entity, so the platform addresses it
+ * with a composite id built by the provider reconciler:
+ *
+ *     {base_workspace}/{base_name}&adapters/{adapter_workspace}/{adapter_name}
+ *
+ * The adapter segment carries its own workspace because an adapter may live in a
+ * different one from the base model.
+ *
+ * @param model - The base model entity being served
+ * @param adapter - The adapter to target, if any
+ * @returns The `model_entity_id` to match against `provider.served_models`
+ */
+export const toInferenceModelEntityId = (model: ModelEntity, adapter?: Adapter | null): string => {
+  const base = `${model.workspace}/${model.name}`;
+  return adapter ? `${base}&adapters/${adapter.workspace}/${adapter.name}` : base;
+};
+
+/**
  * Build a model config for evaluation related types like targets and metrics
  * @param model_id - The model URN to build the config for
  * @returns The model config

--- a/web/packages/studio/src/components/sidePanels/ModelPanels/ModelPanel/index.tsx
+++ b/web/packages/studio/src/components/sidePanels/ModelPanels/ModelPanel/index.tsx
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { DeleteConfirmationModal } from '@nemo/common/src/components/DeleteConfirmationModal';
+import { getPartsFromReference } from '@nemo/common/src/namedEntity';
+import { toInferenceModelEntityId } from '@nemo/common/src/utils/models';
 import { getProviderProxyGetQueryKey } from '@nemo/sdk/generated/platform/inference-gateway';
 import {
   getModelsListModelsQueryKey,
@@ -31,6 +33,7 @@ import {
 } from '@studio/components/sidePanels/ModelPanels/ModelPanel/components';
 import { PLATFORM_BASE_URL } from '@studio/constants/environment';
 import { useModelChatAvailability } from '@studio/hooks/useModelChatAvailability';
+import { useServedModel } from '@studio/hooks/useServedModel';
 import { useQueryClient } from '@tanstack/react-query';
 import {
   type ComponentProps,
@@ -111,6 +114,19 @@ export const ModelPanel: FC<ModelPanelProps> = ({
     adapter,
   });
 
+  // An adapter is reached through the provider proxy, so the request needs the
+  // backend's own name for it. That mapping is discovered by the platform, so
+  // look it up rather than constructing it.
+  const {
+    servedModel: adapterServedModel,
+    providerRef: adapterProviderRef,
+    isLoading: isAdapterTargetLoading,
+  } = useServedModel(
+    adapter ? model : undefined,
+    adapter && model ? toInferenceModelEntityId(model, adapter) : ''
+  );
+  const adapterServedModelName = adapterServedModel?.served_model_name;
+
   const [selectedTab, setSelectedTab] = useState<ModelPanelTab>(defaultTab ?? 'model-details');
   const tabItems = useMemo(
     () => [
@@ -190,34 +206,55 @@ export const ModelPanel: FC<ModelPanelProps> = ({
       </Stack>
     );
   } else {
-    const usedModelName = adapter?.name ?? model.name;
     const workspace = model.workspace;
 
-    // When chatting with an adapter, route through the provider proxy which
-    // forwards the request body as-is (preserving the adapter name in the
-    // `model` field). The model-entity proxy would overwrite it with the
-    // base model's served_model_name.
-    let adapterBaseURL: string | undefined;
-    if (adapter && model.model_providers?.length) {
-      const providerRef = model.model_providers[0];
-      const providerName = providerRef.includes('/') ? providerRef.split('/').pop()! : providerRef;
-      adapterBaseURL =
-        PLATFORM_BASE_URL + getProviderProxyGetQueryKey(workspace, providerName, 'v1/')[0];
+    // Adapters have no autoprovisioned VirtualModel (the provider reconciler
+    // skips any served model whose id contains "&adapters/"), and both the
+    // model-entity and OpenAI gateway routes 404 without one. So they go through
+    // the provider proxy, which forwards the body to the backend unrewritten —
+    // meaning `model` must be the backend's own name, not a platform id.
+    const adapterProviderParts = adapterProviderRef
+      ? getPartsFromReference(adapterProviderRef)
+      : undefined;
+    const adapterBaseURL = adapterProviderParts
+      ? PLATFORM_BASE_URL +
+        getProviderProxyGetQueryKey(
+          adapterProviderParts.workspace,
+          adapterProviderParts.name,
+          'v1/'
+        )[0]
+      : undefined;
+
+    const isLoadingChat = isChatStatusLoading || isAdapterTargetLoading;
+    // Without the backend's name for the adapter there is nothing safe to send:
+    // falling back to the base model would quietly chat with the wrong weights.
+    const adapterUnresolved = Boolean(adapter) && !(adapterServedModelName && adapterBaseURL);
+
+    let chatContent: ReactNode;
+    if (isLoadingChat) {
+      chatContent = <Loading />;
+    } else if (adapterUnresolved) {
+      chatContent = (
+        <Empty
+          title="Adapter is not currently served"
+          description="No provider lists this adapter among its served models, so it cannot be chatted with yet. It becomes available once the deployment serving its base model has loaded the adapter."
+        />
+      );
+    } else {
+      chatContent = (
+        <ModelChat
+          model={adapter ? adapterServedModelName! : model.name}
+          workspace={workspace}
+          baseURL={adapterBaseURL}
+          promptData={model.prompt}
+          modelChatStatus={modelChatStatus}
+        />
+      );
     }
 
     content = (
       <Block className="h-full min-h-0" padding="4">
-        {isChatStatusLoading ? (
-          <Loading />
-        ) : (
-          <ModelChat
-            model={usedModelName}
-            workspace={workspace}
-            baseURL={adapterBaseURL}
-            promptData={model.prompt}
-            modelChatStatus={modelChatStatus}
-          />
-        )}
+        {chatContent}
       </Block>
     );
   }

--- a/web/packages/studio/src/hooks/useModelIsServed/index.ts
+++ b/web/packages/studio/src/hooks/useModelIsServed/index.ts
@@ -1,14 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { getPartsFromReference } from '@nemo/common/src/namedEntity';
-import {
-  getModelsGetProviderQueryKey,
-  modelsGetProvider,
-} from '@nemo/sdk/generated/platform/model-providers';
-import type { ModelEntity, ModelProvider } from '@nemo/sdk/generated/platform/schema';
-import { useQueries } from '@tanstack/react-query';
-import { useMemo } from 'react';
+import type { ModelEntity } from '@nemo/sdk/generated/platform/schema';
+import { useServedModel } from '@studio/hooks/useServedModel';
 
 interface UseModelIsServedResult {
   /** Whether at least one provider lists this model in its served_models. */
@@ -16,36 +10,9 @@ interface UseModelIsServedResult {
   isLoading: boolean;
 }
 
-function providerServesModel(provider: ModelProvider, modelEntityId: string): boolean {
-  return (provider.served_models ?? []).some((sm) => sm.model_entity_id === modelEntityId);
-}
-
 export function useModelIsServed(model: ModelEntity | null | undefined): UseModelIsServedResult {
   const modelEntityId = model ? `${model.workspace}/${model.name}` : '';
-  const providerRefs = model?.model_providers ?? [];
-  const enabled = Boolean(model) && providerRefs.length > 0;
+  const { servedModel, isLoading } = useServedModel(model, modelEntityId);
 
-  const queries = useQueries({
-    queries: providerRefs.map((ref) => {
-      const parts = getPartsFromReference(ref);
-      return {
-        queryKey: getModelsGetProviderQueryKey(parts.workspace, parts.name),
-        queryFn: () => modelsGetProvider(parts.workspace, parts.name),
-        enabled,
-        retry: false,
-        staleTime: 5 * 60 * 1000,
-      };
-    }),
-  });
-
-  return useMemo(() => {
-    if (!enabled) {
-      return { isServed: false, isLoading: false };
-    }
-
-    const isLoading = queries.some((q) => q.isLoading);
-    const isServed = queries.some((q) => q.data && providerServesModel(q.data, modelEntityId));
-
-    return { isServed, isLoading };
-  }, [enabled, queries, modelEntityId]);
+  return { isServed: Boolean(servedModel), isLoading };
 }

--- a/web/packages/studio/src/hooks/useServedModel/index.ts
+++ b/web/packages/studio/src/hooks/useServedModel/index.ts
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { getPartsFromReference } from '@nemo/common/src/namedEntity';
+import {
+  getModelsGetProviderQueryKey,
+  modelsGetProvider,
+} from '@nemo/sdk/generated/platform/model-providers';
+import type {
+  ModelEntity,
+  ModelProvider,
+  ServedModelMapping,
+} from '@nemo/sdk/generated/platform/schema';
+import { useQueries } from '@tanstack/react-query';
+import { useMemo } from 'react';
+
+export interface UseServedModelResult {
+  /**
+   * The provider's `served_models` entry for this id, if any provider serves it.
+   * Its `served_model_name` is the backend's own name for the model — the value a
+   * request must carry when it reaches the backend unrewritten (provider proxy).
+   */
+  servedModel?: ServedModelMapping;
+  /** `<workspace>/<name>` ref of the provider that serves it. */
+  providerRef?: string;
+  isLoading: boolean;
+}
+
+/**
+ * Look up how a model entity id is served, by walking `model.model_providers`.
+ *
+ * The mapping is discovered by the platform's provider reconciler rather than
+ * derived, which matters for LoRA adapters: the backend's name for an adapter
+ * (`{adapter_workspace}--{adapter_name}`, sometimes namespace-qualified, plus two
+ * legacy shapes) is not reliably constructible on the client.
+ *
+ * @param model - Model entity whose providers to search
+ * @param modelEntityId - Id to match against each provider's `served_models`
+ */
+export function useServedModel(
+  model: ModelEntity | null | undefined,
+  modelEntityId: string
+): UseServedModelResult {
+  const providerRefs = useMemo(() => model?.model_providers ?? [], [model]);
+  const enabled = Boolean(model) && providerRefs.length > 0 && Boolean(modelEntityId);
+
+  const queries = useQueries({
+    queries: providerRefs.map((ref) => {
+      const parts = getPartsFromReference(ref);
+      return {
+        queryKey: getModelsGetProviderQueryKey(parts.workspace, parts.name),
+        queryFn: () => modelsGetProvider(parts.workspace, parts.name),
+        enabled,
+        retry: false,
+        staleTime: 5 * 60 * 1000,
+      };
+    }),
+  });
+
+  return useMemo(() => {
+    if (!enabled) {
+      return { isLoading: false };
+    }
+
+    const isLoading = queries.some((q) => q.isLoading);
+
+    for (const [index, query] of queries.entries()) {
+      const provider: ModelProvider | undefined = query.data;
+      const match = (provider?.served_models ?? []).find(
+        (sm) => sm.model_entity_id === modelEntityId
+      );
+      if (match) {
+        return { servedModel: match, providerRef: providerRefs[index], isLoading };
+      }
+    }
+
+    return { isLoading };
+  }, [enabled, queries, modelEntityId, providerRefs]);
+}


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary

Chatting with a LoRA adapter sent `model: <adapter-name>` through the provider proxy. The proxy forwards the body to the inference backend unrewritten, and the backend knows an adapter by the name the sidecar registered it under (`{adapter_workspace}--{adapter_name}`), so a bare adapter name never resolved. The adapter's backend name is now resolved from the provider that serves it, so adapter chat reaches the adapter instead of failing.

https://github.com/user-attachments/assets/566ae0a0-15ab-4bad-a909-a32bac353569

## Changes

- Add `useServedModel`, which walks `model.model_providers` and returns the `served_models` entry matching a given model entity id, along with the provider serving it.
- `useModelIsServed` delegates to it, so there is a single path for fetching providers.
- Add `toInferenceModelEntityId`, which builds the composite `{base}&adapters/{ws}/{name}` id the provider reconciler records for an adapter.
- `ModelPanel` sends the resolved `served_model_name` and keeps adapters on the provider proxy. The model-entity and OpenAI gateway routes both require a VirtualModel, and the reconciler skips any served model whose id contains `&adapters/`, so neither can address an adapter today.
- When no provider serves the adapter, render an empty state rather than falling back to the base model. A silent fallback answers from the base weights and makes a fine-tune look like it had no effect.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [x] Documentation not applicable — justification: no user-facing documentation covers the model chat panel's request construction.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `pnpm --filter @nemo/common test src/utils/models.test.ts` — 21 passed
- `pnpm --filter nemo-studio-ui test src/hooks src/components/sidePanels` — 110 passed across 14 files
- `pnpm --filter @nemo/common typecheck` — clean
- `pnpm --filter nemo-studio-ui typecheck` — clean
- `pnpm lint` — clean
- `uv run pre-commit run -a` was not run; the commit-time hooks (copyright headers, UI lint-staged, DCO, merge-conflict) passed.

Verified against a live platform: a vLLM deployment serving `qwen3-0.6b` with a LoRA adapter returns adapter-styled output for `default--pirate-speak` and base-model output for `default/qwen3-0.6b` on the same prompt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved adapter chat routing to use the correct served model and provider.
  - Adapter requests now wait for model availability and clearly indicate when an adapter is not served.
  - Improved detection of whether models and adapters are currently served across providers.
  - Added more accurate model identification using workspace, model, and adapter details, reducing routing errors for similarly named models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->