### PR TITLE
feat(studio): let the deployment wizard choose an inference engine (ASTD-553)

### DIFF
--- a/web/packages/studio/src/routes/DeploymentsListRoute/CreateDeploymentSidePanel/EngineFields.tsx
+++ b/web/packages/studio/src/routes/DeploymentsListRoute/CreateDeploymentSidePanel/EngineFields.tsx
@@ -1,0 +1,79 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ControlledSelect } from '@nemo/common/src/components/form/ControlledSelect';
+import { ControlledTextInput } from '@nemo/common/src/components/form/ControlledTextInput';
+import { Engine } from '@nemo/sdk/generated/platform/schema';
+import {
+  engineRequiresImage,
+  type WizardFormValues,
+} from '@studio/routes/DeploymentsListRoute/CreateDeploymentSidePanel/schema';
+import type { FC } from 'react';
+import { useWatch, type Control, type FieldErrors } from 'react-hook-form';
+
+const ENGINE_ITEMS = [
+  { value: Engine.vllm, children: 'vLLM' },
+  { value: Engine.nim, children: 'NIM' },
+  { value: Engine.generic, children: 'Generic container' },
+];
+
+const ENGINE_INFO: Record<Engine, string> = {
+  [Engine.vllm]:
+    'Serves any supported architecture from a model-agnostic vLLM image. Leave the image blank to use the platform default.',
+  [Engine.nim]:
+    'Runs a prebuilt NIM container. The image must match the model architecture, so it is required here.',
+  [Engine.generic]:
+    'Runs your image as-is, with no inference-engine compilation. The image is required.',
+};
+
+export type EngineFieldsProps = {
+  control: Control<WizardFormValues>;
+  errors: FieldErrors<WizardFormValues>;
+};
+
+/**
+ * Engine picker plus the image fields it governs.
+ *
+ * Shared by the HuggingFace and Workspace sources. The NGC source is a NIM
+ * container by definition and collects its image in `NgcSourceFields`.
+ */
+export const EngineFields: FC<EngineFieldsProps> = ({ control, errors }) => {
+  const engine = useWatch({ control, name: 'engine' });
+  const imageRequired = engineRequiresImage(engine);
+
+  return (
+    <>
+      <ControlledSelect
+        useControllerProps={{ control, name: 'engine' }}
+        items={ENGINE_ITEMS}
+        formFieldProps={{
+          slotLabel: 'Engine',
+          slotInfo: ENGINE_INFO[engine],
+          slotError: errors.engine?.message,
+        }}
+      />
+      <ControlledTextInput
+        useControllerProps={{ control, name: 'imageName' }}
+        name="imageName"
+        label={imageRequired ? 'Image name' : 'Image name (optional)'}
+        formFieldProps={{
+          slotInfo: imageRequired
+            ? 'Fully qualified image repository, e.g. nvcr.io/nim/meta/llama-3.1-8b-instruct.'
+            : 'Override the default vLLM image. Leave blank unless you need a specific build.',
+          slotError: errors.imageName?.message,
+        }}
+      />
+      <ControlledTextInput
+        useControllerProps={{ control, name: 'imageTag' }}
+        name="imageTag"
+        label={imageRequired ? 'Image tag' : 'Image tag (optional)'}
+        formFieldProps={{
+          slotInfo: 'Pin a specific tag rather than relying on a floating one.',
+          slotError: errors.imageTag?.message,
+        }}
+      />
+    </>
+  );
+};

--- a/web/packages/studio/src/routes/DeploymentsListRoute/CreateDeploymentSidePanel/GPULoraFields.tsx
+++ b/web/packages/studio/src/routes/DeploymentsListRoute/CreateDeploymentSidePanel/GPULoraFields.tsx
@@ -23,7 +23,7 @@ export const GPULoraFields = ({
           label="GPUs"
           type="number"
           formFieldProps={{
-            slotInfo: 'GPU count for this NIM (TP×PP for multi-LLM NIM; see docs).',
+            slotInfo: 'GPU count for this deployment (TP×PP where the engine supports it).',
             slotError: errors.gpu?.message,
           }}
         />
@@ -34,7 +34,8 @@ export const GPULoraFields = ({
           attributes={{ Flex: { justify: 'start' } }}
           formFieldProps={{
             slotLabel: 'LoRA Enabled',
-            slotInfo: 'Enable when serving LoRA adapters on this base image.',
+            slotInfo:
+              'Serve LoRA adapters alongside this base model. Adapters trained against it are picked up automatically and addressed as “workspace--adapter-name”.',
           }}
         />
       </Flex>

--- a/web/packages/studio/src/routes/DeploymentsListRoute/CreateDeploymentSidePanel/HuggingFaceSourceFields.tsx
+++ b/web/packages/studio/src/routes/DeploymentsListRoute/CreateDeploymentSidePanel/HuggingFaceSourceFields.tsx
@@ -11,6 +11,8 @@
  */
 
 import { ControlledTextInput } from '@nemo/common/src/components/form/ControlledTextInput';
+import { EngineFields } from '@studio/routes/DeploymentsListRoute/CreateDeploymentSidePanel/EngineFields';
+import { GPULoraFields } from '@studio/routes/DeploymentsListRoute/CreateDeploymentSidePanel/GPULoraFields';
 import type { WizardFormValues } from '@studio/routes/DeploymentsListRoute/CreateDeploymentSidePanel/schema';
 import { CreateSecretModal } from '@studio/routes/SecretsListRoute/CreateSecretModal';
 import { SecretSearchableSelect } from '@studio/routes/SecretsListRoute/SecretSearchableSelect';
@@ -55,17 +57,8 @@ export const HuggingFaceSourceFields: FC<HuggingFaceSourceFieldsProps> = ({
           slotError: errors.hfTokenSecret?.message,
         }}
       />
-      <ControlledTextInput
-        useControllerProps={{ control, name: 'gpu' }}
-        name="gpu"
-        label="GPUs"
-        type="number"
-        formFieldProps={{
-          slotInfo:
-            'Typically uses multi-LLM NIM; see supported architectures in deploy-models docs.',
-          slotError: errors.gpu?.message,
-        }}
-      />
+      <EngineFields control={control} errors={errors} />
+      <GPULoraFields control={control} errors={errors} />
       <CreateSecretModal
         workspace={workspace}
         open={createSecretModalOpen}

--- a/web/packages/studio/src/routes/DeploymentsListRoute/CreateDeploymentSidePanel/WorkspaceSourceFields.tsx
+++ b/web/packages/studio/src/routes/DeploymentsListRoute/CreateDeploymentSidePanel/WorkspaceSourceFields.tsx
@@ -5,10 +5,11 @@
 
 import { useModelSearch } from '@nemo/common/src/api/models/useModelSearch';
 import { FilesetSearchableSelect } from '@nemo/common/src/components/FilesetSearchableSelect';
-import { ControlledTextInput } from '@nemo/common/src/components/form/ControlledTextInput';
 import { type ModelSelection, ModelSelectV2 } from '@nemo/common/src/components/ModelSelectV2';
 import { RadioCard } from '@nemo/common/src/components/RadioCard';
 import { Flex, FormField, RadioGroupRoot, Stack } from '@nvidia/foundations-react-core';
+import { EngineFields } from '@studio/routes/DeploymentsListRoute/CreateDeploymentSidePanel/EngineFields';
+import { GPULoraFields } from '@studio/routes/DeploymentsListRoute/CreateDeploymentSidePanel/GPULoraFields';
 import {
   WORKSPACE_PICKER_FILESET,
   WORKSPACE_PICKER_MODEL,
@@ -81,16 +82,9 @@ export const WorkspaceSourceFields: FC<WorkspaceSourceFieldsProps> = ({
         />
       )}
 
-      <ControlledTextInput
-        useControllerProps={{ control, name: 'gpu' }}
-        name="gpu"
-        label="GPUs"
-        type="number"
-        formFieldProps={{
-          slotInfo: 'Uses the multi-LLM NIM; verify model architecture is supported.',
-          slotError: errors.gpu?.message,
-        }}
-      />
+      <EngineFields control={control} errors={errors} />
+
+      <GPULoraFields control={control} errors={errors} />
     </Stack>
   );
 };

--- a/web/packages/studio/src/routes/DeploymentsListRoute/CreateDeploymentSidePanel/index.tsx
+++ b/web/packages/studio/src/routes/DeploymentsListRoute/CreateDeploymentSidePanel/index.tsx
@@ -200,9 +200,8 @@ export const CreateDeploymentSidePanel: FC<CreateDeploymentSidePanelProps> = ({
         />
         {(source === SOURCE_HF || source === SOURCE_WORKSPACE) && (
           <Text kind="body/regular/md">
-            {source === SOURCE_HF
-              ? 'HuggingFace deployments support specific model architectures—verify compatibility before deploying or use a model-specific NIM image if required.'
-              : 'Workspace deployments use the multi-LLM NIM by default—verify model architecture is supported.'}
+            Choose the engine that serves this model. vLLM runs any supported architecture from a
+            default image; NIM needs an image built for the specific architecture.
           </Text>
         )}
 

--- a/web/packages/studio/src/routes/DeploymentsListRoute/CreateDeploymentSidePanel/schema.test.ts
+++ b/web/packages/studio/src/routes/DeploymentsListRoute/CreateDeploymentSidePanel/schema.test.ts
@@ -1,12 +1,14 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { Engine } from '@nemo/sdk/generated/platform/schema';
 import {
   additionalEnvsFormToApi,
   configNameFromWizardBaseName,
   createDeploymentWizardSchema,
   defaultWizardValues,
   deploymentNameFromWizardBaseName,
+  engineRequiresImage,
   WORKSPACE_PICKER_FILESET,
   WORKSPACE_PICKER_MODEL,
   SOURCE_HF,
@@ -66,6 +68,69 @@ describe('defaultWizardValues', () => {
     expect(vals.loraEnabled).toBe(true);
     expect(typeof vals.name).toBe('string');
     expect(vals.name.length).toBeGreaterThan(0);
+  });
+
+  it('defaults the engine to vLLM, which needs no image', () => {
+    expect(defaultWizardValues().engine).toBe(Engine.vllm);
+    expect(engineRequiresImage(Engine.vllm)).toBe(false);
+  });
+});
+
+describe('engine image requirements', () => {
+  const workspaceValues = (overrides: Record<string, unknown>) => ({
+    ...defaultWizardValues(),
+    source: SOURCE_WORKSPACE,
+    name: 'my-deploy',
+    workspacePickerType: WORKSPACE_PICKER_MODEL,
+    modelRef: 'ws/model',
+    ...overrides,
+  });
+
+  it.each([Engine.nim, Engine.generic])('requires an image for the %s engine', (engine) => {
+    expect(engineRequiresImage(engine)).toBe(true);
+
+    const result = createDeploymentWizardSchema.safeParse(
+      workspaceValues({ engine, imageName: '', imageTag: '' })
+    );
+
+    expect(result.success).toBe(false);
+    const paths = result.success ? [] : result.error.issues.map((i) => i.path.join('.'));
+    expect(paths).toContain('imageName');
+    expect(paths).toContain('imageTag');
+  });
+
+  it('accepts a blank image for the vLLM engine', () => {
+    const result = createDeploymentWizardSchema.safeParse(
+      workspaceValues({ engine: Engine.vllm, imageName: '', imageTag: '' })
+    );
+
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts NIM once an image is supplied', () => {
+    const result = createDeploymentWizardSchema.safeParse(
+      workspaceValues({
+        engine: Engine.nim,
+        imageName: 'nvcr.io/nim/meta/llama-3.1-8b-instruct',
+        imageTag: '1.8.5',
+      })
+    );
+
+    expect(result.success).toBe(true);
+  });
+
+  it('applies the rule to the HuggingFace source too', () => {
+    const result = createDeploymentWizardSchema.safeParse({
+      ...defaultWizardValues(),
+      source: SOURCE_HF,
+      name: 'my-deploy',
+      repoId: 'Qwen/Qwen3-0.6B',
+      engine: Engine.nim,
+      imageName: '',
+      imageTag: '',
+    });
+
+    expect(result.success).toBe(false);
   });
 });
 

--- a/web/packages/studio/src/routes/DeploymentsListRoute/CreateDeploymentSidePanel/schema.ts
+++ b/web/packages/studio/src/routes/DeploymentsListRoute/CreateDeploymentSidePanel/schema.ts
@@ -12,6 +12,7 @@
 
 import { resourceRefSchema } from '@nemo/common/src/types';
 import { generateDefaultName } from '@nemo/common/src/utils/generateDefaultName';
+import { Engine } from '@nemo/sdk/generated/platform/schema';
 import {
   modelsCreateDeploymentBodyNameMax,
   modelsCreateDeploymentBodyNameRegExp,
@@ -52,16 +53,66 @@ export const SOURCE_WORKSPACE = 'workspace' as const;
 export const WORKSPACE_PICKER_MODEL = 'model' as const;
 export const WORKSPACE_PICKER_FILESET = 'fileset' as const;
 
+/**
+ * Engines that need an explicit image.
+ *
+ * `vllm` resolves to a model-agnostic default server image, so leaving the image
+ * blank is safe. `nim` falls back to a model-specific NIM (Llama-3.1-8B today),
+ * which silently mismatches any other architecture, and `generic` has no
+ * compiler at all — both need the user to say which image to run.
+ */
+export const ENGINES_REQUIRING_IMAGE: readonly Engine[] = [Engine.nim, Engine.generic];
+
+export function engineRequiresImage(engine: Engine): boolean {
+  return ENGINES_REQUIRING_IMAGE.includes(engine);
+}
+
+/** Sources where the user picks the engine; NGC is a NIM container by definition. */
+export function sourceSupportsEngineChoice(source: WizardFormValues['source']): boolean {
+  return source === SOURCE_HF || source === SOURCE_WORKSPACE;
+}
+
 const additionalEnvRowSchema = z.object({
   key: z.string(),
   value: z.string().optional(),
 });
+
+/**
+ * Require an explicit image for engines whose default would otherwise be wrong.
+ *
+ * Only applies to the sources that expose an engine picker — the NGC source
+ * already requires an image unconditionally.
+ */
+function requireImageForEngine(
+  data: { engine: Engine; imageName?: string; imageTag?: string },
+  ctx: z.RefinementCtx
+): void {
+  if (!engineRequiresImage(data.engine)) return;
+
+  const label = data.engine === Engine.nim ? 'NIM' : 'generic';
+  if (!data.imageName?.trim()) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `Image name is required for the ${label} engine`,
+      path: ['imageName'],
+    });
+  }
+  if (!data.imageTag?.trim()) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `Image tag is required for the ${label} engine`,
+      path: ['imageTag'],
+    });
+  }
+}
 
 export const createDeploymentWizardSchema = z
   .object({
     source: z.enum([SOURCE_NGC, SOURCE_HF, SOURCE_WORKSPACE]),
     /** Base name: NGC NIM `model_name`, and API deployment/config become `<name>-deployment` / `<name>-config`. */
     name: wizardBaseNameSchema,
+    /** Inference engine. Ignored for the NGC source, which is always a NIM container. */
+    engine: z.nativeEnum(Engine),
     imageName: z.string().optional(),
     imageTag: z.string().optional(),
     gpu: z.coerce.number().int().min(1, 'At least 1 GPU'),
@@ -102,7 +153,9 @@ export const createDeploymentWizardSchema = z
           path: ['repoId'],
         });
       }
+      requireImageForEngine(data, ctx);
     } else {
+      requireImageForEngine(data, ctx);
       if (data.workspacePickerType === WORKSPACE_PICKER_MODEL) {
         if (!data.modelRef?.trim()) {
           ctx.addIssue({
@@ -140,6 +193,10 @@ export type WizardFormValues = z.infer<typeof createDeploymentWizardSchema>;
 export const defaultWizardValues = (): WizardFormValues => ({
   source: SOURCE_NGC,
   name: generateDefaultName(),
+  // vLLM serves any architecture from a model-agnostic default image, so it is
+  // the safe default for the sources that expose the picker. The NGC source
+  // overrides this to `nim` when building its request.
+  engine: Engine.vllm,
   imageName: '',
   imageTag: '',
   gpu: 1,

--- a/web/packages/studio/src/routes/DeploymentsListRoute/CreateDeploymentSidePanel/useCreateDeploymentBySource.test.tsx
+++ b/web/packages/studio/src/routes/DeploymentsListRoute/CreateDeploymentSidePanel/useCreateDeploymentBySource.test.tsx
@@ -6,6 +6,7 @@ import { filesCreateFileset } from '@nemo/sdk/generated/platform/files';
 import { modelsCreateDeploymentConfig } from '@nemo/sdk/generated/platform/model-deployment-configs';
 import { modelsCreateDeployment } from '@nemo/sdk/generated/platform/model-deployments';
 import { modelsCreateModel } from '@nemo/sdk/generated/platform/models';
+import { Engine } from '@nemo/sdk/generated/platform/schema';
 import {
   defaultWizardValues,
   WORKSPACE_PICKER_FILESET,
@@ -84,10 +85,11 @@ describe('useCreateDeploymentBySource — workspace source', () => {
 
     expect(mockModelsCreateDeploymentConfig).toHaveBeenCalledWith(workspace, {
       name: 'my-deploy-config',
-      engine: 'nim',
+      engine: 'vllm',
       model_spec: {
         model_namespace: 'other-ws',
         model_name: 'existing-model',
+        lora_enabled: true,
       },
       executor_config: {
         gpu: 2,
@@ -126,10 +128,11 @@ describe('useCreateDeploymentBySource — workspace source', () => {
 
     expect(mockModelsCreateDeploymentConfig).toHaveBeenCalledWith(workspace, {
       name: 'my-deploy-config',
-      engine: 'nim',
+      engine: 'vllm',
       model_spec: {
         model_namespace: workspace,
         model_name: 'my-deploy',
+        lora_enabled: true,
       },
       executor_config: {
         gpu: 2,
@@ -143,6 +146,56 @@ describe('useCreateDeploymentBySource — workspace source', () => {
     });
 
     expect(onSuccess).toHaveBeenCalled();
+  });
+
+  it('sends the selected engine and image overrides', async () => {
+    const { result } = renderHook(() => useCreateDeploymentBySource(workspace), { wrapper });
+
+    await act(async () => {
+      await result.current.createDeploymentFromWizard(
+        baseWorkspaceValues({
+          workspacePickerType: WORKSPACE_PICKER_MODEL,
+          modelRef: 'ws/m',
+          engine: Engine.nim,
+          imageName: '  nvcr.io/nim/meta/llama-3.1-8b-instruct  ',
+          imageTag: ' 1.8.5 ',
+        }),
+        vi.fn()
+      );
+    });
+
+    expect(mockModelsCreateDeploymentConfig).toHaveBeenCalledWith(
+      workspace,
+      expect.objectContaining({
+        engine: 'nim',
+        executor_config: {
+          gpu: 2,
+          image_name: 'nvcr.io/nim/meta/llama-3.1-8b-instruct',
+          image_tag: '1.8.5',
+        },
+      })
+    );
+  });
+
+  it('omits blank image fields so the engine default is used', async () => {
+    const { result } = renderHook(() => useCreateDeploymentBySource(workspace), { wrapper });
+
+    await act(async () => {
+      await result.current.createDeploymentFromWizard(
+        baseWorkspaceValues({
+          workspacePickerType: WORKSPACE_PICKER_MODEL,
+          modelRef: 'ws/m',
+          engine: Engine.vllm,
+          imageName: '   ',
+          imageTag: '',
+        }),
+        vi.fn()
+      );
+    });
+
+    const [, request] = mockModelsCreateDeploymentConfig.mock.calls.at(-1)!;
+    expect(request.executor_config).toEqual({ gpu: 2 });
+    expect(request.executor_config).not.toHaveProperty('image_name');
   });
 
   it('surfaces submit errors and does not call onSuccess', async () => {

--- a/web/packages/studio/src/routes/DeploymentsListRoute/CreateDeploymentSidePanel/useCreateDeploymentBySource.ts
+++ b/web/packages/studio/src/routes/DeploymentsListRoute/CreateDeploymentSidePanel/useCreateDeploymentBySource.ts
@@ -31,8 +31,8 @@ import {
 } from '@nemo/sdk/generated/platform/models';
 import {
   Engine,
+  type ContainerExecutorConfig,
   type CreateFilesetRequest,
-  type CreateModelDeploymentConfigRequest,
 } from '@nemo/sdk/generated/platform/schema';
 import {
   additionalEnvsFormToApi,
@@ -55,12 +55,21 @@ import { useCallback, useState } from 'react';
 
 type ReportStage = (message: string) => void;
 
-function createNimDeploymentConfigRequest(
-  request: Omit<CreateModelDeploymentConfigRequest, 'engine'>
-): CreateModelDeploymentConfigRequest {
+/**
+ * Image overrides for the engines that accept one.
+ *
+ * Blank is meaningful: the platform resolves the engine's own default image
+ * (model-agnostic for vLLM), so an empty field must be omitted rather than sent
+ * as an empty string.
+ */
+function imageOverrides(
+  values: WizardFormValues
+): Partial<Pick<ContainerExecutorConfig, 'image_name' | 'image_tag'>> {
+  const imageName = values.imageName?.trim();
+  const imageTag = values.imageTag?.trim();
   return {
-    ...request,
-    engine: Engine.nim,
+    ...(imageName ? { image_name: imageName } : {}),
+    ...(imageTag ? { image_tag: imageTag } : {}),
   };
 }
 
@@ -75,23 +84,22 @@ async function createNgcDeployment(
   const modelName = values.name.trim();
 
   reportStage('Creating deployment configuration…');
-  await modelsCreateDeploymentConfig(
-    workspace,
-    createNimDeploymentConfigRequest({
-      name: configName,
-      model_spec: {
-        model_name: modelName,
-        lora_enabled: values.loraEnabled,
-      },
-      executor_config: {
-        gpu: values.gpu,
-        image_name: values.imageName!.trim(),
-        image_tag: values.imageTag!.trim(),
-        disk_size: values.diskSize?.trim() || '50Gi',
-        ...(additionalEnvs ? { additional_envs: additionalEnvs } : {}),
-      },
-    })
-  );
+  await modelsCreateDeploymentConfig(workspace, {
+    name: configName,
+    // The NGC source deploys a NIM container by definition; it has no engine picker.
+    engine: Engine.nim,
+    model_spec: {
+      model_name: modelName,
+      lora_enabled: values.loraEnabled,
+    },
+    executor_config: {
+      gpu: values.gpu,
+      image_name: values.imageName!.trim(),
+      image_tag: values.imageTag!.trim(),
+      disk_size: values.diskSize?.trim() || '50Gi',
+      ...(additionalEnvs ? { additional_envs: additionalEnvs } : {}),
+    },
+  });
 
   reportStage('Creating deployment…');
   await modelsCreateDeployment(workspace, {
@@ -138,20 +146,20 @@ async function createHuggingFaceDeployment(
   });
 
   reportStage('Creating deployment configuration…');
-  await modelsCreateDeploymentConfig(
-    workspace,
-    createNimDeploymentConfigRequest({
-      name: configName,
-      model_spec: {
-        model_namespace: workspace,
-        model_name: modelEntityName,
-      },
-      executor_config: {
-        gpu: values.gpu,
-      },
-      model_entity_id: `${workspace}/${modelEntityName}`,
-    })
-  );
+  await modelsCreateDeploymentConfig(workspace, {
+    name: configName,
+    engine: values.engine,
+    model_spec: {
+      model_namespace: workspace,
+      model_name: modelEntityName,
+      lora_enabled: values.loraEnabled,
+    },
+    executor_config: {
+      gpu: values.gpu,
+      ...imageOverrides(values),
+    },
+    model_entity_id: `${workspace}/${modelEntityName}`,
+  });
 
   reportStage('Creating deployment…');
   await modelsCreateDeployment(workspace, {
@@ -194,20 +202,20 @@ async function createWorkspaceDeployment(
   }
 
   reportStage('Creating deployment configuration…');
-  await modelsCreateDeploymentConfig(
-    workspace,
-    createNimDeploymentConfigRequest({
-      name: configName,
-      model_spec: {
-        model_namespace: modelNamespace,
-        model_name: modelName,
-      },
-      executor_config: {
-        gpu: values.gpu,
-      },
-      model_entity_id: `${modelNamespace}/${modelName}`,
-    })
-  );
+  await modelsCreateDeploymentConfig(workspace, {
+    name: configName,
+    engine: values.engine,
+    model_spec: {
+      model_namespace: modelNamespace,
+      model_name: modelName,
+      lora_enabled: values.loraEnabled,
+    },
+    executor_config: {
+      gpu: values.gpu,
+      ...imageOverrides(values),
+    },
+    model_entity_id: `${modelNamespace}/${modelName}`,
+  });
 
   reportStage('Creating deployment…');
   await modelsCreateDeployment(workspace, {


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary

The create-deployment wizard hardcoded `engine: nim` for every source, so a deployment could not be created with vLLM even though that is what the LoRA customization docs use. `lora_enabled` was collected by the form but sent only on the NGC path, so the Workspace and HuggingFace paths — the two a user reaches a fine-tuned checkpoint through — silently dropped it. The wizard can now pick an engine and always sends `lora_enabled`.

| HuggingFace | Workspace |
| --- | --- |
| <img width="597" height="867" alt="image" src="https://github.com/user-attachments/assets/0f6c363a-92cc-4226-8329-9df5bcf64756" /> | <img width="601" height="866" alt="image" src="https://github.com/user-attachments/assets/9908de8c-0c48-477d-aaeb-975dc049bd1f" /> |

## Changes

- Add an engine picker (`EngineFields`) to the HuggingFace and Workspace sources, defaulting to vLLM. NGC keeps `nim` and its required image fields, since that source is a NIM container by definition.
- Send `lora_enabled` on all three sources.
- Require an image when the engine is `nim` or `generic`. A blank image with `nim` silently resolves to `nvcr.io/nim/meta/llama-3.1-8b-instruct`, so an arbitrary checkpoint would be served by a Llama-specific NIM; `generic` has no compiler and cannot run without one.
- Omit blank image fields entirely so vLLM resolves its own model-agnostic default.
- Correct the side panel copy, which told the user that Workspace and HuggingFace deployments use the multi-LLM NIM. They did not: no image was sent, and the platform default is Llama-specific.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [x] Documentation not applicable — justification: the deployments route is still behind `VITE_FF_DEPLOYMENTS_ENABLED` and has no published user documentation yet.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `pnpm --filter nemo-studio-ui test src/routes/DeploymentsListRoute` — 38 passed across 3 files
- `pnpm --filter nemo-studio-ui typecheck` — clean
- `pnpm lint` — clean
- `uv run pre-commit run -a` was not run; the commit-time hooks (copyright headers, UI lint-staged, DCO, merge-conflict) passed.

Verified against a live platform: a vLLM deployment with `lora_enabled` created through this wizard reaches `READY` and serves both its base model and a LoRA adapter.
