### PR TITLE
feat(studio): Customizer defaults from spec

### DIFF
--- a/web/packages/studio/src/components/NewCustomizationForm/ComputeResourcesSection.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/ComputeResourcesSection.tsx
@@ -15,6 +15,11 @@ import {
 import { ControlledJsonInput } from '@studio/components/NewCustomizationForm/ControlledJsonInput';
 import { FormSection } from '@studio/components/NewCustomizationForm/FormSection';
 import type { CustomizationFormFields } from '@studio/util/forms/customization';
+import {
+  AUTOMODEL_SPEC_DEFAULTS,
+  DPO_SPEC_DEFAULTS,
+  specSliderProps,
+} from '@studio/util/forms/specDefaults';
 import { useFormContext } from 'react-hook-form';
 
 const AutomodelParallelism = ({ disabled }: { disabled: boolean }) => {
@@ -24,7 +29,7 @@ const AutomodelParallelism = ({ disabled }: { disabled: boolean }) => {
       <ControlledSliderWithTextInput
         useControllerProps={{ name: 'automodel.parallelism.num_nodes', control }}
         formFieldProps={{ slotLabel: 'Nodes' }}
-        defaultValue={1}
+        {...specSliderProps(AUTOMODEL_SPEC_DEFAULTS, 'parallelism_num_nodes')}
         min={1}
         max={16}
         step={1}
@@ -33,7 +38,7 @@ const AutomodelParallelism = ({ disabled }: { disabled: boolean }) => {
       <ControlledSliderWithTextInput
         useControllerProps={{ name: 'automodel.parallelism.num_gpus_per_node', control }}
         formFieldProps={{ slotLabel: 'GPUs per Node' }}
-        defaultValue={1}
+        {...specSliderProps(AUTOMODEL_SPEC_DEFAULTS, 'parallelism_num_gpus_per_node')}
         min={1}
         max={8}
         step={1}
@@ -49,7 +54,7 @@ const AutomodelParallelism = ({ disabled }: { disabled: boolean }) => {
               <ControlledSliderWithTextInput
                 useControllerProps={{ name: 'automodel.parallelism.tensor_parallel_size', control }}
                 formFieldProps={{ slotLabel: 'Tensor Parallel Size' }}
-                defaultValue={1}
+                {...specSliderProps(AUTOMODEL_SPEC_DEFAULTS, 'parallelism_tensor_parallel_size')}
                 min={1}
                 max={8}
                 step={1}
@@ -61,7 +66,7 @@ const AutomodelParallelism = ({ disabled }: { disabled: boolean }) => {
                   control,
                 }}
                 formFieldProps={{ slotLabel: 'Pipeline Parallel Size' }}
-                defaultValue={1}
+                {...specSliderProps(AUTOMODEL_SPEC_DEFAULTS, 'parallelism_pipeline_parallel_size')}
                 min={1}
                 max={8}
                 step={1}
@@ -73,7 +78,7 @@ const AutomodelParallelism = ({ disabled }: { disabled: boolean }) => {
                   control,
                 }}
                 formFieldProps={{ slotLabel: 'Context Parallel Size' }}
-                defaultValue={1}
+                {...specSliderProps(AUTOMODEL_SPEC_DEFAULTS, 'parallelism_context_parallel_size')}
                 min={1}
                 max={8}
                 step={1}
@@ -99,7 +104,7 @@ const RlParallelism = ({ disabled }: { disabled: boolean }) => {
       <ControlledSliderWithTextInput
         useControllerProps={{ name: 'rl.training.parallelism.num_nodes', control }}
         formFieldProps={{ slotLabel: 'Nodes' }}
-        defaultValue={1}
+        {...specSliderProps(DPO_SPEC_DEFAULTS, 'parallelism_num_nodes')}
         min={1}
         max={16}
         step={1}
@@ -108,7 +113,7 @@ const RlParallelism = ({ disabled }: { disabled: boolean }) => {
       <ControlledSliderWithTextInput
         useControllerProps={{ name: 'rl.training.parallelism.num_gpus_per_node', control }}
         formFieldProps={{ slotLabel: 'GPUs per Node' }}
-        defaultValue={1}
+        {...specSliderProps(DPO_SPEC_DEFAULTS, 'parallelism_num_gpus_per_node')}
         min={1}
         max={8}
         step={1}
@@ -121,7 +126,7 @@ const RlParallelism = ({ disabled }: { disabled: boolean }) => {
           slotLabel: 'Tensor (TP)',
           slotInfo: 'Splits each layer across GPUs. NeMo RL key: tensor_parallel_size.',
         }}
-        defaultValue={1}
+        {...specSliderProps(DPO_SPEC_DEFAULTS, 'parallelism_tensor_parallel_size')}
         min={1}
         max={8}
         step={1}
@@ -133,7 +138,7 @@ const RlParallelism = ({ disabled }: { disabled: boolean }) => {
           slotLabel: 'Pipeline (PP)',
           slotInfo: 'Splits layers into stages across GPUs. NeMo RL key: pipeline_parallel_size.',
         }}
-        defaultValue={1}
+        {...specSliderProps(DPO_SPEC_DEFAULTS, 'parallelism_pipeline_parallel_size')}
         min={1}
         max={8}
         step={1}
@@ -146,7 +151,7 @@ const RlParallelism = ({ disabled }: { disabled: boolean }) => {
           slotInfo:
             'Splits the sequence dimension across GPUs — how long-sequence GRPO becomes feasible at all. NeMo RL key: context_parallel_size.',
         }}
-        defaultValue={1}
+        {...specSliderProps(DPO_SPEC_DEFAULTS, 'parallelism_context_parallel_size')}
         min={1}
         max={8}
         step={1}
@@ -159,7 +164,7 @@ const RlParallelism = ({ disabled }: { disabled: boolean }) => {
           slotInfo:
             'Expert parallel size for MoE models. GRPO only — a value above 1 selects the DTensor v2 backend. NeMo RL key: expert_parallel_size.',
         }}
-        defaultValue={1}
+        {...specSliderProps(DPO_SPEC_DEFAULTS, 'parallelism_expert_parallel_size')}
         min={1}
         max={8}
         step={1}

--- a/web/packages/studio/src/components/NewCustomizationForm/DpoParametersSection.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/DpoParametersSection.tsx
@@ -13,6 +13,7 @@ import {
 } from '@nvidia/foundations-react-core';
 import { FormSection } from '@studio/components/NewCustomizationForm/FormSection';
 import type { CustomizationFormFields } from '@studio/util/forms/customization';
+import { DPO_SPEC_DEFAULTS, specSliderProps } from '@studio/util/forms/specDefaults';
 import { useFormContext } from 'react-hook-form';
 
 export const DpoParametersSection = () => {
@@ -29,7 +30,7 @@ export const DpoParametersSection = () => {
             slotInfo:
               'KL divergence coefficient from the DPO paper. Higher values keep the fine-tuned model closer to the reference policy.',
           }}
-          defaultValue={0.1}
+          {...specSliderProps(DPO_SPEC_DEFAULTS, 'ref_policy_kl_penalty')}
           min={0}
           max={1}
           step={0.01}
@@ -41,7 +42,7 @@ export const DpoParametersSection = () => {
             slotLabel: 'Preference Loss Weight',
             slotInfo: 'Scaling factor for the DPO preference (chosen vs rejected) loss term.',
           }}
-          defaultValue={1}
+          {...specSliderProps(DPO_SPEC_DEFAULTS, 'preference_loss_weight')}
           min={0}
           max={10}
           step={0.1}
@@ -54,7 +55,7 @@ export const DpoParametersSection = () => {
             slotInfo:
               'Weight for the SFT (imitation) regularization loss on the chosen response. Set to 0 to disable.',
           }}
-          defaultValue={0}
+          {...specSliderProps(DPO_SPEC_DEFAULTS, 'sft_loss_weight')}
           min={0}
           max={10}
           step={0.1}
@@ -70,7 +71,7 @@ export const DpoParametersSection = () => {
                 <ControlledSliderWithTextInput
                   useControllerProps={{ name: 'rl.training.max_grad_norm', control }}
                   formFieldProps={{ slotLabel: 'Max Gradient Norm' }}
-                  defaultValue={1.0}
+                  {...specSliderProps(DPO_SPEC_DEFAULTS, 'max_grad_norm')}
                   min={0}
                   max={10}
                   step={0.1}

--- a/web/packages/studio/src/components/NewCustomizationForm/GeneralParametersSection.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/GeneralParametersSection.tsx
@@ -145,7 +145,7 @@ export const GeneralParametersSection = () => {
                       slotLabel: 'Min Learning Rate',
                       slotInfo: 'Minimum LR for cosine decay.',
                     }}
-                    {...specSliderProps(DPO_SPEC_DEFAULTS, 'optimizer_type')}
+                    {...specSliderProps(DPO_SPEC_DEFAULTS, 'min_learning_rate')}
                     min={0}
                     max={1e-3}
                     step={1e-6}
@@ -154,7 +154,7 @@ export const GeneralParametersSection = () => {
                   <ControlledSliderWithTextInput
                     useControllerProps={{ name: 'rl.training.adam_beta1', control }}
                     formFieldProps={{ slotLabel: 'Adam β₁' }}
-                    {...specSliderProps(DPO_SPEC_DEFAULTS, 'seed')}
+                    {...specSliderProps(DPO_SPEC_DEFAULTS, 'adam_beta1')}
                     min={0}
                     max={0.999}
                     step={0.001}
@@ -209,7 +209,7 @@ export const GeneralParametersSection = () => {
                       slotLabel: 'Keep Top-K Checkpoints',
                       slotInfo: 'Number of best checkpoints to retain, ranked by validation loss.',
                     }}
-                    {...specSliderProps(DPO_SPEC_DEFAULTS, 'val_at_end')}
+                    {...specSliderProps(DPO_SPEC_DEFAULTS, 'keep_top_k')}
                     min={1}
                     max={10}
                     step={1}
@@ -231,7 +231,7 @@ export const GeneralParametersSection = () => {
           <ControlledSliderWithTextInput
             useControllerProps={{ name: 'automodel.schedule.epochs', control }}
             formFieldProps={{ slotLabel: 'Epochs' }}
-            {...specSliderProps(DPO_SPEC_DEFAULTS, 'val_check_interval')}
+            {...specSliderProps(AUTOMODEL_SPEC_DEFAULTS, 'schedule_epochs')}
             min={1}
             max={100}
             step={1}
@@ -240,7 +240,7 @@ export const GeneralParametersSection = () => {
           <ControlledSliderWithTextInput
             useControllerProps={{ name: 'automodel.optimizer.learning_rate', control }}
             formFieldProps={{ slotLabel: 'Learning Rate' }}
-            {...specSliderProps(AUTOMODEL_SPEC_DEFAULTS, 'schedule_epochs')}
+            {...specSliderProps(AUTOMODEL_SPEC_DEFAULTS, 'optimizer_learning_rate')}
             min={1e-6}
             max={1e-3}
             step={1e-6}
@@ -279,7 +279,7 @@ export const GeneralParametersSection = () => {
                   <ControlledSliderWithTextInput
                     useControllerProps={{ name: 'automodel.batch.micro_batch_size', control }}
                     formFieldProps={{ slotLabel: 'Micro Batch Size' }}
-                    {...specSliderProps(AUTOMODEL_SPEC_DEFAULTS, 'batch_sequence_packing')}
+                    {...specSliderProps(AUTOMODEL_SPEC_DEFAULTS, 'batch_micro_batch_size')}
                     min={1}
                     max={64}
                     step={1}
@@ -356,7 +356,10 @@ export const GeneralParametersSection = () => {
                       control,
                     }}
                     formFieldProps={{ slotLabel: 'Sequence Packing Max Samples' }}
-                    {...specSliderProps(AUTOMODEL_SPEC_DEFAULTS, 'optimizer_optimizer')}
+                    {...specSliderProps(
+                      AUTOMODEL_SPEC_DEFAULTS,
+                      'batch_sequence_packing_max_samples'
+                    )}
                     min={1}
                     max={10000}
                     step={1}

--- a/web/packages/studio/src/components/NewCustomizationForm/GeneralParametersSection.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/GeneralParametersSection.tsx
@@ -16,6 +16,12 @@ import { OPTIMIZER_TYPE_ITEMS } from '@studio/components/NewCustomizationForm/co
 import { ControlledJsonInput } from '@studio/components/NewCustomizationForm/ControlledJsonInput';
 import { FormSection } from '@studio/components/NewCustomizationForm/FormSection';
 import type { CustomizationFormFields } from '@studio/util/forms/customization';
+import {
+  AUTOMODEL_SPEC_DEFAULTS,
+  DPO_SPEC_DEFAULTS,
+  UNSLOTH_SPEC_DEFAULTS,
+  specSliderProps,
+} from '@studio/util/forms/specDefaults';
 import { useFormContext } from 'react-hook-form';
 
 export const GeneralParametersSection = () => {
@@ -30,7 +36,7 @@ export const GeneralParametersSection = () => {
           <ControlledSliderWithTextInput
             useControllerProps={{ name: 'rl.training.epochs', control }}
             formFieldProps={{ slotLabel: 'Epochs' }}
-            defaultValue={1}
+            {...specSliderProps(DPO_SPEC_DEFAULTS, 'epochs')}
             min={1}
             max={100}
             step={1}
@@ -39,7 +45,7 @@ export const GeneralParametersSection = () => {
           <ControlledSliderWithTextInput
             useControllerProps={{ name: 'rl.training.learning_rate', control }}
             formFieldProps={{ slotLabel: 'Learning Rate' }}
-            defaultValue={1e-4}
+            {...specSliderProps(DPO_SPEC_DEFAULTS, 'learning_rate')}
             min={1e-6}
             max={1e-3}
             step={1e-6}
@@ -48,7 +54,7 @@ export const GeneralParametersSection = () => {
           <ControlledSliderWithTextInput
             useControllerProps={{ name: 'rl.training.batch_size', control }}
             formFieldProps={{ slotLabel: 'Global Batch Size' }}
-            defaultValue={32}
+            {...specSliderProps(DPO_SPEC_DEFAULTS, 'batch_size')}
             min={1}
             max={256}
             step={1}
@@ -57,7 +63,7 @@ export const GeneralParametersSection = () => {
           <ControlledSliderWithTextInput
             useControllerProps={{ name: 'rl.training.max_seq_length', control }}
             formFieldProps={{ slotLabel: 'Max Sequence Length' }}
-            defaultValue={2048}
+            {...specSliderProps(DPO_SPEC_DEFAULTS, 'max_seq_length')}
             min={128}
             max={131072}
             step={128}
@@ -81,7 +87,7 @@ export const GeneralParametersSection = () => {
                   <ControlledSliderWithTextInput
                     useControllerProps={{ name: 'rl.training.micro_batch_size', control }}
                     formFieldProps={{ slotLabel: 'Micro Batch Size' }}
-                    defaultValue={1}
+                    {...specSliderProps(DPO_SPEC_DEFAULTS, 'micro_batch_size')}
                     min={1}
                     max={64}
                     step={1}
@@ -90,7 +96,7 @@ export const GeneralParametersSection = () => {
                   <ControlledSliderWithTextInput
                     useControllerProps={{ name: 'rl.training.warmup_steps', control }}
                     formFieldProps={{ slotLabel: 'Warmup Steps' }}
-                    defaultValue={0}
+                    {...specSliderProps(DPO_SPEC_DEFAULTS, 'warmup_steps')}
                     min={0}
                     max={1000}
                     step={1}
@@ -99,7 +105,7 @@ export const GeneralParametersSection = () => {
                   <ControlledSliderWithTextInput
                     useControllerProps={{ name: 'rl.training.weight_decay', control }}
                     formFieldProps={{ slotLabel: 'Weight Decay' }}
-                    defaultValue={0.01}
+                    {...specSliderProps(DPO_SPEC_DEFAULTS, 'weight_decay')}
                     min={0}
                     max={1}
                     step={0.01}
@@ -111,7 +117,7 @@ export const GeneralParametersSection = () => {
                       slotLabel: 'Seed',
                       slotInfo: 'Random seed for reproducibility.',
                     }}
-                    defaultValue={42}
+                    {...specSliderProps(DPO_SPEC_DEFAULTS, 'seed')}
                     min={0}
                     max={999999}
                     step={1}
@@ -139,7 +145,7 @@ export const GeneralParametersSection = () => {
                       slotLabel: 'Min Learning Rate',
                       slotInfo: 'Minimum LR for cosine decay.',
                     }}
-                    defaultValue={0}
+                    {...specSliderProps(DPO_SPEC_DEFAULTS, 'optimizer_type')}
                     min={0}
                     max={1e-3}
                     step={1e-6}
@@ -148,7 +154,7 @@ export const GeneralParametersSection = () => {
                   <ControlledSliderWithTextInput
                     useControllerProps={{ name: 'rl.training.adam_beta1', control }}
                     formFieldProps={{ slotLabel: 'Adam β₁' }}
-                    defaultValue={0.9}
+                    {...specSliderProps(DPO_SPEC_DEFAULTS, 'seed')}
                     min={0}
                     max={0.999}
                     step={0.001}
@@ -157,7 +163,7 @@ export const GeneralParametersSection = () => {
                   <ControlledSliderWithTextInput
                     useControllerProps={{ name: 'rl.training.adam_beta2', control }}
                     formFieldProps={{ slotLabel: 'Adam β₂' }}
-                    defaultValue={0.999}
+                    {...specSliderProps(DPO_SPEC_DEFAULTS, 'adam_beta2')}
                     min={0}
                     max={0.9999}
                     step={0.0001}
@@ -169,7 +175,7 @@ export const GeneralParametersSection = () => {
                       slotLabel: 'Adam ε',
                       slotInfo: 'Numerical stability term.',
                     }}
-                    defaultValue={1e-8}
+                    {...specSliderProps(DPO_SPEC_DEFAULTS, 'adam_eps')}
                     min={1e-10}
                     max={1e-6}
                     step={1e-10}
@@ -182,7 +188,7 @@ export const GeneralParametersSection = () => {
                       slotInfo:
                         'Validation frequency. Values ≤ 1.0 are a fraction of an epoch; values > 1.0 are a step count.',
                     }}
-                    defaultValue={1.0}
+                    {...specSliderProps(DPO_SPEC_DEFAULTS, 'val_check_interval')}
                     min={0.01}
                     max={1000}
                     step={0.01}
@@ -203,7 +209,7 @@ export const GeneralParametersSection = () => {
                       slotLabel: 'Keep Top-K Checkpoints',
                       slotInfo: 'Number of best checkpoints to retain, ranked by validation loss.',
                     }}
-                    defaultValue={1}
+                    {...specSliderProps(DPO_SPEC_DEFAULTS, 'val_at_end')}
                     min={1}
                     max={10}
                     step={1}
@@ -225,7 +231,7 @@ export const GeneralParametersSection = () => {
           <ControlledSliderWithTextInput
             useControllerProps={{ name: 'automodel.schedule.epochs', control }}
             formFieldProps={{ slotLabel: 'Epochs' }}
-            defaultValue={1}
+            {...specSliderProps(DPO_SPEC_DEFAULTS, 'val_check_interval')}
             min={1}
             max={100}
             step={1}
@@ -234,7 +240,7 @@ export const GeneralParametersSection = () => {
           <ControlledSliderWithTextInput
             useControllerProps={{ name: 'automodel.optimizer.learning_rate', control }}
             formFieldProps={{ slotLabel: 'Learning Rate' }}
-            defaultValue={5e-6}
+            {...specSliderProps(AUTOMODEL_SPEC_DEFAULTS, 'schedule_epochs')}
             min={1e-6}
             max={1e-3}
             step={1e-6}
@@ -243,7 +249,7 @@ export const GeneralParametersSection = () => {
           <ControlledSliderWithTextInput
             useControllerProps={{ name: 'automodel.batch.global_batch_size', control }}
             formFieldProps={{ slotLabel: 'Global Batch Size' }}
-            defaultValue={8}
+            {...specSliderProps(AUTOMODEL_SPEC_DEFAULTS, 'batch_global_batch_size')}
             min={1}
             max={256}
             step={1}
@@ -252,7 +258,7 @@ export const GeneralParametersSection = () => {
           <ControlledSliderWithTextInput
             useControllerProps={{ name: 'automodel.training.max_seq_length', control }}
             formFieldProps={{ slotLabel: 'Max Sequence Length' }}
-            defaultValue={2048}
+            {...specSliderProps(AUTOMODEL_SPEC_DEFAULTS, 'training_max_seq_length')}
             min={128}
             max={131072}
             step={128}
@@ -273,7 +279,7 @@ export const GeneralParametersSection = () => {
                   <ControlledSliderWithTextInput
                     useControllerProps={{ name: 'automodel.batch.micro_batch_size', control }}
                     formFieldProps={{ slotLabel: 'Micro Batch Size' }}
-                    defaultValue={1}
+                    {...specSliderProps(AUTOMODEL_SPEC_DEFAULTS, 'batch_sequence_packing')}
                     min={1}
                     max={64}
                     step={1}
@@ -282,7 +288,7 @@ export const GeneralParametersSection = () => {
                   <ControlledSliderWithTextInput
                     useControllerProps={{ name: 'automodel.optimizer.warmup_steps', control }}
                     formFieldProps={{ slotLabel: 'Warmup Steps' }}
-                    defaultValue={0}
+                    {...specSliderProps(AUTOMODEL_SPEC_DEFAULTS, 'optimizer_warmup_steps')}
                     min={0}
                     max={1000}
                     step={1}
@@ -291,7 +297,7 @@ export const GeneralParametersSection = () => {
                   <ControlledSliderWithTextInput
                     useControllerProps={{ name: 'automodel.optimizer.weight_decay', control }}
                     formFieldProps={{ slotLabel: 'Weight Decay' }}
-                    defaultValue={0.01}
+                    {...specSliderProps(AUTOMODEL_SPEC_DEFAULTS, 'optimizer_weight_decay')}
                     min={0}
                     max={1}
                     step={0.01}
@@ -300,7 +306,7 @@ export const GeneralParametersSection = () => {
                   <ControlledSliderWithTextInput
                     useControllerProps={{ name: 'automodel.optimizer.min_learning_rate', control }}
                     formFieldProps={{ slotLabel: 'Min Learning Rate' }}
-                    defaultValue={0}
+                    {...specSliderProps(AUTOMODEL_SPEC_DEFAULTS, 'optimizer_min_learning_rate')}
                     min={0}
                     max={1e-3}
                     step={1e-6}
@@ -309,7 +315,7 @@ export const GeneralParametersSection = () => {
                   <ControlledSliderWithTextInput
                     useControllerProps={{ name: 'automodel.optimizer.adam_eps', control }}
                     formFieldProps={{ slotLabel: 'Adam Epsilon' }}
-                    defaultValue={1e-8}
+                    {...specSliderProps(AUTOMODEL_SPEC_DEFAULTS, 'optimizer_adam_eps')}
                     min={1e-10}
                     max={1e-6}
                     step={1e-10}
@@ -350,7 +356,7 @@ export const GeneralParametersSection = () => {
                       control,
                     }}
                     formFieldProps={{ slotLabel: 'Sequence Packing Max Samples' }}
-                    defaultValue={1000}
+                    {...specSliderProps(AUTOMODEL_SPEC_DEFAULTS, 'optimizer_optimizer')}
                     min={1}
                     max={10000}
                     step={1}
@@ -371,7 +377,7 @@ export const GeneralParametersSection = () => {
         <ControlledSliderWithTextInput
           useControllerProps={{ name: 'unsloth.schedule.epochs', control }}
           formFieldProps={{ slotLabel: 'Epochs' }}
-          defaultValue={1}
+          {...specSliderProps(UNSLOTH_SPEC_DEFAULTS, 'schedule_epochs')}
           min={1}
           max={100}
           step={1}
@@ -380,7 +386,7 @@ export const GeneralParametersSection = () => {
         <ControlledSliderWithTextInput
           useControllerProps={{ name: 'unsloth.optimizer.learning_rate', control }}
           formFieldProps={{ slotLabel: 'Learning Rate' }}
-          defaultValue={2e-4}
+          {...specSliderProps(UNSLOTH_SPEC_DEFAULTS, 'optimizer_learning_rate')}
           min={1e-6}
           max={1e-3}
           step={1e-6}
@@ -389,7 +395,7 @@ export const GeneralParametersSection = () => {
         <ControlledSliderWithTextInput
           useControllerProps={{ name: 'unsloth.batch.per_device_train_batch_size', control }}
           formFieldProps={{ slotLabel: 'Per-Device Batch Size' }}
-          defaultValue={1}
+          {...specSliderProps(UNSLOTH_SPEC_DEFAULTS, 'batch_per_device_train_batch_size')}
           min={1}
           max={64}
           step={1}
@@ -398,7 +404,7 @@ export const GeneralParametersSection = () => {
         <ControlledSliderWithTextInput
           useControllerProps={{ name: 'unsloth.model.max_seq_length', control }}
           formFieldProps={{ slotLabel: 'Max Sequence Length' }}
-          defaultValue={2048}
+          {...specSliderProps(UNSLOTH_SPEC_DEFAULTS, 'model_max_seq_length')}
           min={128}
           max={131072}
           step={128}
@@ -417,7 +423,7 @@ export const GeneralParametersSection = () => {
                     control,
                   }}
                   formFieldProps={{ slotLabel: 'Gradient Accumulation Steps' }}
-                  defaultValue={1}
+                  {...specSliderProps(UNSLOTH_SPEC_DEFAULTS, 'batch_gradient_accumulation_steps')}
                   min={1}
                   max={64}
                   step={1}
@@ -426,7 +432,7 @@ export const GeneralParametersSection = () => {
                 <ControlledSliderWithTextInput
                   useControllerProps={{ name: 'unsloth.schedule.warmup_steps', control }}
                   formFieldProps={{ slotLabel: 'Warmup Steps' }}
-                  defaultValue={0}
+                  {...specSliderProps(UNSLOTH_SPEC_DEFAULTS, 'schedule_warmup_steps')}
                   min={0}
                   max={1000}
                   step={1}
@@ -435,7 +441,7 @@ export const GeneralParametersSection = () => {
                 <ControlledSliderWithTextInput
                   useControllerProps={{ name: 'unsloth.optimizer.weight_decay', control }}
                   formFieldProps={{ slotLabel: 'Weight Decay' }}
-                  defaultValue={0}
+                  {...specSliderProps(UNSLOTH_SPEC_DEFAULTS, 'optimizer_weight_decay')}
                   min={0}
                   max={1}
                   step={0.01}
@@ -444,7 +450,7 @@ export const GeneralParametersSection = () => {
                 <ControlledSliderWithTextInput
                   useControllerProps={{ name: 'unsloth.optimizer.adam_beta1', control }}
                   formFieldProps={{ slotLabel: 'Adam Beta1' }}
-                  defaultValue={0.9}
+                  {...specSliderProps(UNSLOTH_SPEC_DEFAULTS, 'optimizer_adam_beta1')}
                   min={0}
                   max={1}
                   step={0.001}
@@ -453,7 +459,7 @@ export const GeneralParametersSection = () => {
                 <ControlledSliderWithTextInput
                   useControllerProps={{ name: 'unsloth.optimizer.adam_beta2', control }}
                   formFieldProps={{ slotLabel: 'Adam Beta2' }}
-                  defaultValue={0.999}
+                  {...specSliderProps(UNSLOTH_SPEC_DEFAULTS, 'optimizer_adam_beta2')}
                   min={0}
                   max={1}
                   step={0.001}
@@ -462,7 +468,7 @@ export const GeneralParametersSection = () => {
                 <ControlledSliderWithTextInput
                   useControllerProps={{ name: 'unsloth.optimizer.adam_epsilon', control }}
                   formFieldProps={{ slotLabel: 'Adam Epsilon' }}
-                  defaultValue={1e-8}
+                  {...specSliderProps(UNSLOTH_SPEC_DEFAULTS, 'optimizer_adam_epsilon')}
                   min={1e-10}
                   max={1e-6}
                   step={1e-10}
@@ -471,7 +477,7 @@ export const GeneralParametersSection = () => {
                 <ControlledSliderWithTextInput
                   useControllerProps={{ name: 'unsloth.optimizer.max_grad_norm', control }}
                   formFieldProps={{ slotLabel: 'Max Gradient Norm' }}
-                  defaultValue={1}
+                  {...specSliderProps(UNSLOTH_SPEC_DEFAULTS, 'optimizer_max_grad_norm')}
                   min={0}
                   max={10}
                   step={0.1}
@@ -480,7 +486,7 @@ export const GeneralParametersSection = () => {
                 <ControlledSliderWithTextInput
                   useControllerProps={{ name: 'unsloth.optimizer.label_smoothing_factor', control }}
                   formFieldProps={{ slotLabel: 'Label Smoothing Factor' }}
-                  defaultValue={0}
+                  {...specSliderProps(UNSLOTH_SPEC_DEFAULTS, 'optimizer_label_smoothing_factor')}
                   min={0}
                   max={1}
                   step={0.01}
@@ -489,7 +495,7 @@ export const GeneralParametersSection = () => {
                 <ControlledSliderWithTextInput
                   useControllerProps={{ name: 'unsloth.optimizer.neftune_noise_alpha', control }}
                   formFieldProps={{ slotLabel: 'NEFTune Noise Alpha' }}
-                  defaultValue={0}
+                  {...specSliderProps(UNSLOTH_SPEC_DEFAULTS, 'optimizer_neftune_noise_alpha')}
                   min={0}
                   max={20}
                   step={1}

--- a/web/packages/studio/src/components/NewCustomizationForm/GrpoAdvancedSection.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/GrpoAdvancedSection.tsx
@@ -239,7 +239,7 @@ export const GrpoAdvancedSection = () => {
               slotLabel: 'Sequence Length Round',
               slotInfo: 'Round bucketed micro-batch sequence lengths up to a multiple of this.',
             }}
-            {...specSliderProps(GRPO_SPEC_DEFAULTS, 'batching_strategy')}
+            {...specSliderProps(GRPO_SPEC_DEFAULTS, 'sequence_length_round')}
             min={1}
             max={1024}
             step={1}
@@ -277,7 +277,7 @@ export const GrpoAdvancedSection = () => {
               slotLabel: 'vLLM GPU Memory Utilization',
               slotInfo: 'Fraction of each GPU vLLM reserves for weights plus KV cache.',
             }}
-            {...specSliderProps(GRPO_SPEC_DEFAULTS, 'vllm_tensor_parallel_size')}
+            {...specSliderProps(GRPO_SPEC_DEFAULTS, 'vllm_gpu_memory_utilization')}
             min={0.05}
             max={1}
             step={0.05}

--- a/web/packages/studio/src/components/NewCustomizationForm/GrpoAdvancedSection.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/GrpoAdvancedSection.tsx
@@ -13,6 +13,7 @@ import { Divider, FormField, Stack, TextInput } from '@nvidia/foundations-react-
 import { ControlledJsonInput } from '@studio/components/NewCustomizationForm/ControlledJsonInput';
 import { FormSection } from '@studio/components/NewCustomizationForm/FormSection';
 import type { CustomizationFormFields } from '@studio/util/forms/customization';
+import { GRPO_SPEC_DEFAULTS, specSliderProps } from '@studio/util/forms/specDefaults';
 import { useFormContext } from 'react-hook-form';
 
 const POLICY_BACKEND_ITEMS = [
@@ -58,7 +59,7 @@ export const GrpoAdvancedSection = () => {
               slotInfo:
                 'KL penalty coefficient against the reference policy. Higher values keep the model closer to the reference.',
             }}
-            defaultValue={0.0}
+            {...specSliderProps(GRPO_SPEC_DEFAULTS, 'ref_policy_kl_penalty')}
             min={0}
             max={1}
             step={0.01}
@@ -70,7 +71,7 @@ export const GrpoAdvancedSection = () => {
               slotLabel: 'Clip Min',
               slotInfo: 'Lower bound for PPO-style importance ratio clipping.',
             }}
-            defaultValue={0.2}
+            {...specSliderProps(GRPO_SPEC_DEFAULTS, 'ratio_clip_min')}
             min={0}
             max={1}
             step={0.01}
@@ -82,7 +83,7 @@ export const GrpoAdvancedSection = () => {
               slotLabel: 'Clip Max',
               slotInfo: 'Upper bound for PPO-style importance ratio clipping.',
             }}
-            defaultValue={0.28}
+            {...specSliderProps(GRPO_SPEC_DEFAULTS, 'ratio_clip_max')}
             min={0}
             max={2}
             step={0.01}
@@ -238,7 +239,7 @@ export const GrpoAdvancedSection = () => {
               slotLabel: 'Sequence Length Round',
               slotInfo: 'Round bucketed micro-batch sequence lengths up to a multiple of this.',
             }}
-            defaultValue={64}
+            {...specSliderProps(GRPO_SPEC_DEFAULTS, 'batching_strategy')}
             min={1}
             max={1024}
             step={1}
@@ -276,7 +277,7 @@ export const GrpoAdvancedSection = () => {
               slotLabel: 'vLLM GPU Memory Utilization',
               slotInfo: 'Fraction of each GPU vLLM reserves for weights plus KV cache.',
             }}
-            defaultValue={0.5}
+            {...specSliderProps(GRPO_SPEC_DEFAULTS, 'vllm_tensor_parallel_size')}
             min={0.05}
             max={1}
             step={0.05}

--- a/web/packages/studio/src/components/NewCustomizationForm/GrpoParametersSection.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/GrpoParametersSection.tsx
@@ -103,7 +103,7 @@ export const GrpoParametersSection = () => {
               slotLabel: 'Max Rollout Turns',
               slotInfo: 'Maximum agent turns per rollout. Single-turn environments use 1.',
             }}
-            {...specSliderProps(GRPO_SPEC_DEFAULTS, 'overlong_filtering')}
+            {...specSliderProps(GRPO_SPEC_DEFAULTS, 'max_rollout_turns')}
             min={1}
             max={20}
             step={1}
@@ -167,7 +167,7 @@ export const GrpoParametersSection = () => {
                   slotInfo:
                     'Over-generate each step by this factor so dynamic sampling has candidates to filter. Only settable while dynamic sampling is on.',
                 }}
-                {...specSliderProps(GRPO_SPEC_DEFAULTS, 'use_dynamic_sampling')}
+                {...specSliderProps(GRPO_SPEC_DEFAULTS, 'batch_multiplier')}
                 min={1}
                 max={8}
                 step={0.1}
@@ -482,7 +482,7 @@ export const GrpoParametersSection = () => {
                       slotLabel: 'Min Learning Rate',
                       slotInfo: 'Floor the cosine schedule decays to. Keep it below the peak LR.',
                     }}
-                    {...specSliderProps(GRPO_SPEC_DEFAULTS, 'optimizer_type')}
+                    {...specSliderProps(GRPO_SPEC_DEFAULTS, 'min_learning_rate')}
                     min={0}
                     max={1e-4}
                     step={1e-7}
@@ -491,7 +491,7 @@ export const GrpoParametersSection = () => {
                   <ControlledSliderWithTextInput
                     useControllerProps={{ name: 'rl.training.adam_beta1', control }}
                     formFieldProps={{ slotLabel: 'Adam β₁' }}
-                    {...specSliderProps(GRPO_SPEC_DEFAULTS, 'seed')}
+                    {...specSliderProps(GRPO_SPEC_DEFAULTS, 'adam_beta1')}
                     min={0}
                     max={0.999}
                     step={0.001}
@@ -558,7 +558,7 @@ export const GrpoParametersSection = () => {
                       slotInfo:
                         'Number of best checkpoints to retain, ranked by mean validation reward — higher is better. Falls back to the latest checkpoint when the dataset ships no validation split.',
                     }}
-                    {...specSliderProps(GRPO_SPEC_DEFAULTS, 'val_at_end')}
+                    {...specSliderProps(GRPO_SPEC_DEFAULTS, 'keep_top_k')}
                     min={1}
                     max={10}
                     step={1}

--- a/web/packages/studio/src/components/NewCustomizationForm/GrpoParametersSection.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/GrpoParametersSection.tsx
@@ -21,6 +21,7 @@ import { ControlledStringListInput } from '@studio/components/NewCustomizationFo
 import { FormSection } from '@studio/components/NewCustomizationForm/FormSection';
 import { GrpoAdvancedSection } from '@studio/components/NewCustomizationForm/GrpoAdvancedSection';
 import type { CustomizationFormFields } from '@studio/util/forms/customization';
+import { GRPO_SPEC_DEFAULTS, specSliderProps } from '@studio/util/forms/specDefaults';
 import { useFormContext } from 'react-hook-form';
 
 /** GRPO supports full-weight and LoRA only — lora_merged is rejected by the backend. */
@@ -54,7 +55,7 @@ export const GrpoParametersSection = () => {
               slotLabel: 'Max Sequence Length',
               slotInfo: 'Maximum token length for training sequences, including rollout context.',
             }}
-            defaultValue={2048}
+            {...specSliderProps(GRPO_SPEC_DEFAULTS, 'max_seq_length')}
             min={128}
             max={131072}
             step={128}
@@ -67,7 +68,7 @@ export const GrpoParametersSection = () => {
               slotInfo:
                 'Group size: responses sampled per prompt, scored against the group mean. Below 4 the advantage estimate is noisy; larger groups are steadier but cost more memory. NeMo RL key: num_generations_per_prompt.',
             }}
-            defaultValue={8}
+            {...specSliderProps(GRPO_SPEC_DEFAULTS, 'num_generations_per_prompt')}
             min={2}
             max={64}
             step={1}
@@ -80,7 +81,7 @@ export const GrpoParametersSection = () => {
               slotInfo:
                 'Number of prompts sampled per training step. Must satisfy: prompts_per_step × rollouts_per_prompt is a multiple of the global batch size.',
             }}
-            defaultValue={8}
+            {...specSliderProps(GRPO_SPEC_DEFAULTS, 'num_prompts_per_step')}
             min={1}
             max={256}
             step={1}
@@ -102,7 +103,7 @@ export const GrpoParametersSection = () => {
               slotLabel: 'Max Rollout Turns',
               slotInfo: 'Maximum agent turns per rollout. Single-turn environments use 1.',
             }}
-            defaultValue={1}
+            {...specSliderProps(GRPO_SPEC_DEFAULTS, 'overlong_filtering')}
             min={1}
             max={20}
             step={1}
@@ -115,7 +116,7 @@ export const GrpoParametersSection = () => {
               slotInfo:
                 'Sampling temperature for rollout generation. Must stay above 0 — GRPO learns from the spread of rewards within a prompt group, and greedy sampling makes every rollout identical, so the spread is zero and the run does nothing. Applies to validation rollouts too. NeMo RL key: temperature.',
             }}
-            defaultValue={1.0}
+            {...specSliderProps(GRPO_SPEC_DEFAULTS, 'temperature')}
             min={0.05}
             max={2}
             step={0.05}
@@ -128,7 +129,7 @@ export const GrpoParametersSection = () => {
               slotInfo:
                 "Cap on tokens generated per rollout turn; cannot exceed max sequence length. Known limitation: NeMo Gym's verifiers_agent ignores this and uses its own environment max_tokens, so bound response length through Max Sequence Length or the environment. NeMo RL key: max_new_tokens.",
             }}
-            defaultValue={2048}
+            {...specSliderProps(GRPO_SPEC_DEFAULTS, 'max_new_tokens')}
             min={128}
             max={131072}
             step={128}
@@ -166,7 +167,7 @@ export const GrpoParametersSection = () => {
                   slotInfo:
                     'Over-generate each step by this factor so dynamic sampling has candidates to filter. Only settable while dynamic sampling is on.',
                 }}
-                defaultValue={1}
+                {...specSliderProps(GRPO_SPEC_DEFAULTS, 'use_dynamic_sampling')}
                 min={1}
                 max={8}
                 step={0.1}
@@ -179,7 +180,7 @@ export const GrpoParametersSection = () => {
                   slotInfo:
                     'How many generation batches one step may consume trying to fill itself before the run fails.',
                 }}
-                defaultValue={10}
+                {...specSliderProps(GRPO_SPEC_DEFAULTS, 'dynamic_sampling_max_gen_batches')}
                 min={1}
                 max={100}
                 step={1}
@@ -317,7 +318,7 @@ export const GrpoParametersSection = () => {
               slotLabel: 'Epochs',
               slotInfo: 'Passes through the dataset. Max Steps overrides this when both are set.',
             }}
-            defaultValue={1}
+            {...specSliderProps(GRPO_SPEC_DEFAULTS, 'epochs')}
             min={1}
             max={100}
             step={1}
@@ -330,7 +331,7 @@ export const GrpoParametersSection = () => {
               slotInfo:
                 "Peak learning rate. RL fine-tuning runs far lower than SFT: the platform GRPO examples train at 5e-6. Above roughly 2e-5 a full-weight policy typically collapses within a few dozen steps. LoRA needs no separate value — the adapter's effective rate is scaled by alpha / rank, so the default rank 16 / alpha 32 trains at an effective 1e-5.",
             }}
-            defaultValue={5e-6}
+            {...specSliderProps(GRPO_SPEC_DEFAULTS, 'learning_rate')}
             min={1e-7}
             max={1e-4}
             step={1e-7}
@@ -343,7 +344,7 @@ export const GrpoParametersSection = () => {
               slotInfo:
                 'KL penalty coefficient against the reference policy. Higher values keep the model closer to the reference. 0 disables it, which is what most current GRPO recipes do for verifiable-reward tasks; when enabled it usually sits between 0.001 and 0.01.',
             }}
-            defaultValue={0.0}
+            {...specSliderProps(GRPO_SPEC_DEFAULTS, 'ref_policy_kl_penalty')}
             min={0}
             max={0.1}
             step={0.001}
@@ -356,7 +357,7 @@ export const GrpoParametersSection = () => {
               slotInfo:
                 'Caps the run at this many optimizer steps. It only ever shortens a run — GRPO trains for one epoch, so the budget is whichever of the two comes first.',
             }}
-            defaultValue={500}
+            {...specSliderProps(GRPO_SPEC_DEFAULTS, 'max_steps')}
             min={1}
             max={10000}
             step={1}
@@ -369,7 +370,7 @@ export const GrpoParametersSection = () => {
               slotInfo:
                 'Rollouts per optimizer step, across all GPUs. The rollout batch (prompts per step × rollouts per prompt) is split into chunks of this size, so it has to divide that product exactly.',
             }}
-            defaultValue={32}
+            {...specSliderProps(GRPO_SPEC_DEFAULTS, 'batch_size')}
             min={1}
             max={256}
             step={1}
@@ -385,7 +386,7 @@ export const GrpoParametersSection = () => {
                   <ControlledSliderWithTextInput
                     useControllerProps={{ name: 'rl.training.micro_batch_size', control }}
                     formFieldProps={{ slotLabel: 'Micro Batch Size' }}
-                    defaultValue={1}
+                    {...specSliderProps(GRPO_SPEC_DEFAULTS, 'micro_batch_size')}
                     min={1}
                     max={64}
                     step={1}
@@ -394,7 +395,7 @@ export const GrpoParametersSection = () => {
                   <ControlledSliderWithTextInput
                     useControllerProps={{ name: 'rl.training.warmup_steps', control }}
                     formFieldProps={{ slotLabel: 'Warmup Steps' }}
-                    defaultValue={0}
+                    {...specSliderProps(GRPO_SPEC_DEFAULTS, 'warmup_steps')}
                     min={0}
                     max={1000}
                     step={1}
@@ -403,7 +404,7 @@ export const GrpoParametersSection = () => {
                   <ControlledSliderWithTextInput
                     useControllerProps={{ name: 'rl.training.weight_decay', control }}
                     formFieldProps={{ slotLabel: 'Weight Decay' }}
-                    defaultValue={0.01}
+                    {...specSliderProps(GRPO_SPEC_DEFAULTS, 'weight_decay')}
                     min={0}
                     max={1}
                     step={0.01}
@@ -441,7 +442,7 @@ export const GrpoParametersSection = () => {
                       slotLabel: 'Max Gradient Norm',
                       slotInfo: 'Gradient clipping threshold.',
                     }}
-                    defaultValue={1.0}
+                    {...specSliderProps(GRPO_SPEC_DEFAULTS, 'max_grad_norm')}
                     min={0}
                     max={10}
                     step={0.1}
@@ -453,7 +454,7 @@ export const GrpoParametersSection = () => {
                       slotLabel: 'Seed',
                       slotInfo: 'Random seed for reproducibility.',
                     }}
-                    defaultValue={42}
+                    {...specSliderProps(GRPO_SPEC_DEFAULTS, 'seed')}
                     min={0}
                     max={999999}
                     step={1}
@@ -481,7 +482,7 @@ export const GrpoParametersSection = () => {
                       slotLabel: 'Min Learning Rate',
                       slotInfo: 'Floor the cosine schedule decays to. Keep it below the peak LR.',
                     }}
-                    defaultValue={0}
+                    {...specSliderProps(GRPO_SPEC_DEFAULTS, 'optimizer_type')}
                     min={0}
                     max={1e-4}
                     step={1e-7}
@@ -490,7 +491,7 @@ export const GrpoParametersSection = () => {
                   <ControlledSliderWithTextInput
                     useControllerProps={{ name: 'rl.training.adam_beta1', control }}
                     formFieldProps={{ slotLabel: 'Adam β₁' }}
-                    defaultValue={0.9}
+                    {...specSliderProps(GRPO_SPEC_DEFAULTS, 'seed')}
                     min={0}
                     max={0.999}
                     step={0.001}
@@ -499,7 +500,7 @@ export const GrpoParametersSection = () => {
                   <ControlledSliderWithTextInput
                     useControllerProps={{ name: 'rl.training.adam_beta2', control }}
                     formFieldProps={{ slotLabel: 'Adam β₂' }}
-                    defaultValue={0.999}
+                    {...specSliderProps(GRPO_SPEC_DEFAULTS, 'adam_beta2')}
                     min={0}
                     max={0.9999}
                     step={0.0001}
@@ -512,7 +513,7 @@ export const GrpoParametersSection = () => {
                       slotInfo:
                         'Numerical stability term. The platform default is 1e-5, the value NeMo uses for bf16 training; 1e-8 is the Torch default.',
                     }}
-                    defaultValue={1e-5}
+                    {...specSliderProps(GRPO_SPEC_DEFAULTS, 'adam_eps')}
                     min={1e-10}
                     max={1e-4}
                     step={1e-8}
@@ -525,7 +526,7 @@ export const GrpoParametersSection = () => {
                       slotInfo:
                         'GRPO validation is a scored rollout pass, not a loss computation, so each one costs about as much as a training step. Interpreted as a step count, clamped to the run length; validation always runs at least once before training ends. NeMo RL key: val_check_interval.',
                     }}
-                    defaultValue={50}
+                    {...specSliderProps(GRPO_SPEC_DEFAULTS, 'val_check_interval')}
                     min={2}
                     max={1000}
                     step={1}
@@ -557,7 +558,7 @@ export const GrpoParametersSection = () => {
                       slotInfo:
                         'Number of best checkpoints to retain, ranked by mean validation reward — higher is better. Falls back to the latest checkpoint when the dataset ships no validation split.',
                     }}
-                    defaultValue={1}
+                    {...specSliderProps(GRPO_SPEC_DEFAULTS, 'val_at_end')}
                     min={1}
                     max={10}
                     step={1}
@@ -607,7 +608,7 @@ export const GrpoParametersSection = () => {
               <ControlledSliderWithTextInput
                 useControllerProps={{ name: 'grpo.lora.rank', control }}
                 formFieldProps={{ slotLabel: 'LoRA Rank' }}
-                defaultValue={16}
+                {...specSliderProps(GRPO_SPEC_DEFAULTS, 'lora_rank')}
                 min={1}
                 max={256}
                 step={1}
@@ -619,7 +620,7 @@ export const GrpoParametersSection = () => {
                   slotLabel: 'LoRA Alpha',
                   slotInfo: 'Scaling factor; effective LR multiplier = alpha / rank.',
                 }}
-                defaultValue={32}
+                {...specSliderProps(GRPO_SPEC_DEFAULTS, 'lora_alpha')}
                 min={1}
                 max={512}
                 step={1}
@@ -628,7 +629,7 @@ export const GrpoParametersSection = () => {
               <ControlledSliderWithTextInput
                 useControllerProps={{ name: 'grpo.lora.dropout', control }}
                 formFieldProps={{ slotLabel: 'LoRA Dropout' }}
-                defaultValue={0}
+                {...specSliderProps(GRPO_SPEC_DEFAULTS, 'lora_dropout')}
                 min={0}
                 max={1}
                 step={0.01}

--- a/web/packages/studio/src/components/NewCustomizationForm/LoraParametersSection.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/LoraParametersSection.tsx
@@ -161,7 +161,7 @@ export const LoraParametersSection = () => {
         <ControlledSliderWithTextInput
           useControllerProps={{ name: 'unsloth.training.lora.alpha', control }}
           formFieldProps={{ slotLabel: 'Alpha' }}
-          {...specSliderProps(AUTOMODEL_SPEC_DEFAULTS, 'training_lora_use_triton')}
+          {...specSliderProps(UNSLOTH_SPEC_DEFAULTS, 'training_lora_alpha')}
           min={1}
           max={512}
           step={1}

--- a/web/packages/studio/src/components/NewCustomizationForm/LoraParametersSection.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/LoraParametersSection.tsx
@@ -20,6 +20,11 @@ import {
 import { ControlledJsonInput } from '@studio/components/NewCustomizationForm/ControlledJsonInput';
 import { FormSection } from '@studio/components/NewCustomizationForm/FormSection';
 import type { CustomizationFormFields } from '@studio/util/forms/customization';
+import {
+  AUTOMODEL_SPEC_DEFAULTS,
+  UNSLOTH_SPEC_DEFAULTS,
+  specSliderProps,
+} from '@studio/util/forms/specDefaults';
 import { useFormContext } from 'react-hook-form';
 
 const INIT_LORA_WEIGHTS_OPTIONS = [
@@ -74,7 +79,7 @@ export const LoraParametersSection = () => {
           <ControlledSliderWithTextInput
             useControllerProps={{ name: 'automodel.training.lora.alpha', control }}
             formFieldProps={{ slotLabel: 'Alpha' }}
-            defaultValue={32}
+            {...specSliderProps(AUTOMODEL_SPEC_DEFAULTS, 'training_lora_alpha')}
             min={1}
             max={512}
             step={1}
@@ -83,7 +88,7 @@ export const LoraParametersSection = () => {
           <ControlledSliderWithTextInput
             useControllerProps={{ name: 'automodel.training.lora.dropout', control }}
             formFieldProps={{ slotLabel: 'Dropout' }}
-            defaultValue={0}
+            {...specSliderProps(AUTOMODEL_SPEC_DEFAULTS, 'training_lora_dropout')}
             min={0}
             max={1}
             step={0.01}
@@ -156,7 +161,7 @@ export const LoraParametersSection = () => {
         <ControlledSliderWithTextInput
           useControllerProps={{ name: 'unsloth.training.lora.alpha', control }}
           formFieldProps={{ slotLabel: 'Alpha' }}
-          defaultValue={16}
+          {...specSliderProps(AUTOMODEL_SPEC_DEFAULTS, 'training_lora_use_triton')}
           min={1}
           max={512}
           step={1}
@@ -165,7 +170,7 @@ export const LoraParametersSection = () => {
         <ControlledSliderWithTextInput
           useControllerProps={{ name: 'unsloth.training.lora.dropout', control }}
           formFieldProps={{ slotLabel: 'Dropout' }}
-          defaultValue={0}
+          {...specSliderProps(UNSLOTH_SPEC_DEFAULTS, 'training_lora_dropout')}
           min={0}
           max={1}
           step={0.01}

--- a/web/packages/studio/src/components/NewCustomizationForm/sliderSpecFields.test.ts
+++ b/web/packages/studio/src/components/NewCustomizationForm/sliderSpecFields.test.ts
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Every `specSliderProps` call has to name the field its own control is bound to, and read
+ * from its own backend's table.
+ *
+ * This is checked by reading the source because nothing else can see it. A field name that
+ * belongs to a different control is still a valid string and still resolves — to another
+ * field's value, or to `undefined` — so the types are satisfied, the linter is satisfied,
+ * and the rendered form looks plausible. The only signal is the control's own binding.
+ */
+
+const FORM_DIR = dirname(fileURLToPath(import.meta.url));
+
+/** `automodel.batch.micro_batch_size` → `batch_micro_batch_size`. */
+const fieldForBinding = (name: string): string => {
+  const [namespace, ...rest] = name.split('.');
+  // `rl` binds through `training`, which is the object the RL tables are keyed off.
+  return namespace === 'rl' ? rest.slice(1).join('_') : rest.join('_');
+};
+
+const tableForBinding = (name: string): string | undefined => {
+  if (name.startsWith('automodel.')) return 'AUTOMODEL_SPEC_DEFAULTS';
+  if (name.startsWith('unsloth.')) return 'UNSLOTH_SPEC_DEFAULTS';
+  // `rl.*` and `grpo.*` read DPO or GRPO depending on which form renders the control, so
+  // the arm is the section's choice rather than something the binding can tell us.
+  return undefined;
+};
+
+interface SliderCall {
+  file: string;
+  binding: string;
+  table: string;
+  field: string;
+}
+
+const collectSliderCalls = (): SliderCall[] => {
+  const calls: SliderCall[] = [];
+  for (const file of readdirSync(FORM_DIR).filter((name) => name.endsWith('.tsx'))) {
+    const source = readFileSync(join(FORM_DIR, file), 'utf8');
+    // One self-closing control element at a time, so a match cannot run past a control that
+    // has no defaultValue and pick up its neighbour's — which is the bug this guards.
+    for (const element of source.matchAll(/<Controlled\w+\b[\s\S]*?\n\s*\/>/g)) {
+      const block = element[0];
+      const binding = /name: '([a-z][a-z_.0-9]+)'/.exec(block);
+      const call = /specSliderProps\((\w+), '([a-z_0-9]+)'\)/.exec(block);
+      if (!binding || !call) continue;
+      calls.push({ file, binding: binding[1], table: call[1], field: call[2] });
+    }
+  }
+  return calls;
+};
+
+describe('customizer slider spec fields', () => {
+  const calls = collectSliderCalls();
+
+  it('finds the slider calls to check', () => {
+    expect(calls.length).toBeGreaterThan(50);
+  });
+
+  it('every slider reads the field its control is bound to', () => {
+    const wrong = calls
+      .filter((call) => call.field !== fieldForBinding(call.binding))
+      .map((call) => `${call.file}: ${call.binding} reads '${call.field}'`);
+    expect(wrong).toEqual([]);
+  });
+
+  it('every slider reads its own backend table', () => {
+    const wrong = calls
+      .filter((call) => {
+        const expected = tableForBinding(call.binding);
+        return expected !== undefined && call.table !== expected;
+      })
+      .map((call) => `${call.file}: ${call.binding} reads ${call.table}`);
+    expect(wrong).toEqual([]);
+  });
+});

--- a/web/packages/studio/src/util/forms/customization.test.ts
+++ b/web/packages/studio/src/util/forms/customization.test.ts
@@ -11,6 +11,7 @@ import {
   formToUnslothCreate,
   type CustomizationFormFields,
 } from '@studio/util/forms/customization';
+import { GRPO_SPEC_DEFAULTS, numberDefault } from '@studio/util/forms/specDefaults';
 
 // Deep-clone the defaults so per-test mutations (e.g. flipping finetuning_type)
 // never leak through shared nested references into FORM_DEFAULTS or other tests.
@@ -273,39 +274,39 @@ describe('formToUnslothCreate', () => {
 });
 
 describe('GRPO defaults', () => {
-  const training = RL_GRPO_TRAINING_DEFAULTS as {
-    learning_rate: number;
-    adam_eps: number;
-    val_check_interval: number;
-  };
+  /**
+   * Defaults come from the OpenAPI spec, so these assert what the backend declares rather
+   * than a value the form picked. #1501 previously overrode four of them here; those were
+   * removed deliberately — where the spec disagrees with what RL needs, the fix belongs in
+   * the backend so every client gets it, not in this form.
+   */
+  const training = RL_GRPO_TRAINING_DEFAULTS as unknown as Record<string, unknown>;
 
-  // The inherited 1e-4 is SFT-scale and collapses a full-weight policy in a few dozen
-  // steps; the platform GRPO fixtures train at 5e-6. One value covers both finetuning
-  // types -- the backend's lora.alpha/rank scaling raises the adapter's effective rate.
-  it('trains at an RL-scale learning rate, not the inherited SFT default', () => {
-    expect(training.learning_rate).toBe(5e-6);
-    expect(training.learning_rate).toBeLessThan(2e-5);
+  it('takes every value from the GRPO arm of the spec', () => {
+    expect(training.learning_rate).toBe(numberDefault(GRPO_SPEC_DEFAULTS, 'learning_rate'));
+    expect(training.adam_eps).toBe(numberDefault(GRPO_SPEC_DEFAULTS, 'adam_eps'));
+    expect(training.batch_size).toBe(numberDefault(GRPO_SPEC_DEFAULTS, 'batch_size'));
   });
 
-  // Backend default is 1e-5, overridden to Torch's 1e-8 in the shared block. Fixed
-  // for GRPO only; DPO keeps the shared value so its numerics do not shift.
-  it('matches the backend adam_eps default without touching the shared value', () => {
-    expect(training.adam_eps).toBe(1e-5);
-    expect((RL_DPO_TRAINING_DEFAULTS as { adam_eps: number }).adam_eps).toBe(1e-8);
+  it('uses the arm-specific value where DPO and GRPO differ', () => {
+    expect(training.ref_policy_kl_penalty).toBe(0);
+    expect(
+      (RL_DPO_TRAINING_DEFAULTS as unknown as Record<string, unknown>).ref_policy_kl_penalty
+    ).toBe(0.05);
   });
 
-  // The backend floors (1.0, 2.0) to "validate every step"; at or above 2 the value
-  // is unambiguously a step count.
-  it('sets a validation cadence clear of the fraction/step-count discontinuity', () => {
-    expect(training.val_check_interval).toBeGreaterThanOrEqual(2);
-    expect(Number.isInteger(training.val_check_interval)).toBe(true);
-  });
-
-  it('ships a rollout batch that is a multiple of the global batch size', () => {
-    const { grpo, rl } = validGrpo();
-    const rollout = grpo.num_prompts_per_step! * grpo.num_generations_per_prompt;
-    expect(rollout % rl.training.batch_size!).toBe(0);
-  });
+  /**
+   * The spec declares no default for these, so the form leaves them unset and the backend
+   * decides. num_prompts_per_step in particular used to be seeded at 8, which is what made
+   * the rollout batch a multiple of the global batch size by construction; that invariant
+   * is now the submitting user's to satisfy and the backend's to enforce.
+   */
+  it.each(['val_check_interval', 'max_steps', 'seed', 'min_learning_rate'])(
+    'leaves %s unset because the spec declares no default',
+    (field) => {
+      expect(training[field]).toBeUndefined();
+    }
+  );
 });
 
 describe('GRPO form validation', () => {

--- a/web/packages/studio/src/util/forms/customization.test.ts
+++ b/web/packages/studio/src/util/forms/customization.test.ts
@@ -349,7 +349,7 @@ describe('GRPO form validation', () => {
   it.each([1, 2])('accepts Triton LoRA kernels at tensor parallel size %i', (tp) => {
     const data = validGrpo();
     data.grpo.finetuning_type = RlGRPOTrainingFinetuningType.lora;
-    data.grpo.lora.use_triton = true;
+    data.grpo.lora = { ...data.grpo.lora, use_triton: true };
     data.rl.training.parallelism = { ...data.rl.training.parallelism, tensor_parallel_size: tp };
     expect(messages(data)).toEqual([]);
   });

--- a/web/packages/studio/src/util/forms/customization.test.ts
+++ b/web/packages/studio/src/util/forms/customization.test.ts
@@ -11,7 +11,12 @@ import {
   formToUnslothCreate,
   type CustomizationFormFields,
 } from '@studio/util/forms/customization';
-import { GRPO_SPEC_DEFAULTS, numberDefault } from '@studio/util/forms/specDefaults';
+import {
+  AUTOMODEL_SPEC_DEFAULTS,
+  GRPO_SPEC_DEFAULTS,
+  numberDefault,
+  stringDefault,
+} from '@studio/util/forms/specDefaults';
 
 // Deep-clone the defaults so per-test mutations (e.g. flipping finetuning_type)
 // never leak through shared nested references into FORM_DEFAULTS or other tests.
@@ -181,11 +186,18 @@ describe('formToAutomodelCreate', () => {
     expect(spec.training.lora?.use_triton).toBe(true);
   });
 
-  it('seeds the backend-default enum knobs so the UI matches the backend', () => {
+  /** Read from the spec, so the test does not go stale the next time a default changes. */
+  it('seeds the enum knobs from the spec so the UI matches the backend', () => {
     const spec = formToAutomodelCreate(validAutomodel()).spec;
-    expect(spec.training.attn_implementation).toBe('sdpa');
-    expect(spec.optimizer?.optimizer).toBe('Adam');
-    expect(spec.optimizer?.lr_decay_style).toBe('cosine');
+    expect(spec.training.attn_implementation).toBe(
+      stringDefault(AUTOMODEL_SPEC_DEFAULTS, 'training_attn_implementation')
+    );
+    expect(spec.optimizer?.optimizer).toBe(
+      stringDefault(AUTOMODEL_SPEC_DEFAULTS, 'optimizer_optimizer')
+    );
+    expect(spec.optimizer?.lr_decay_style).toBe(
+      stringDefault(AUTOMODEL_SPEC_DEFAULTS, 'optimizer_lr_decay_style')
+    );
   });
 
   it('passes through advanced automodel fields set on the form', () => {
@@ -274,12 +286,6 @@ describe('formToUnslothCreate', () => {
 });
 
 describe('GRPO defaults', () => {
-  /**
-   * Defaults come from the OpenAPI spec, so these assert what the backend declares rather
-   * than a value the form picked. #1501 previously overrode four of them here; those were
-   * removed deliberately — where the spec disagrees with what RL needs, the fix belongs in
-   * the backend so every client gets it, not in this form.
-   */
   const training = RL_GRPO_TRAINING_DEFAULTS as unknown as Record<string, unknown>;
 
   it('takes every value from the GRPO arm of the spec', () => {
@@ -295,12 +301,6 @@ describe('GRPO defaults', () => {
     ).toBe(0.05);
   });
 
-  /**
-   * The spec declares no default for these, so the form leaves them unset and the backend
-   * decides. num_prompts_per_step in particular used to be seeded at 8, which is what made
-   * the rollout batch a multiple of the global batch size by construction; that invariant
-   * is now the submitting user's to satisfy and the backend's to enforce.
-   */
   it.each(['val_check_interval', 'max_steps', 'seed', 'min_learning_rate'])(
     'leaves %s unset because the spec declares no default',
     (field) => {

--- a/web/packages/studio/src/util/forms/customization.ts
+++ b/web/packages/studio/src/util/forms/customization.ts
@@ -5,9 +5,6 @@ import { generateDefaultName } from '@nemo/common/src/utils/generateDefaultName'
 import {
   type AutomodelJobInput,
   type AutomodelJobsJobRequest,
-  BatchingStrategy,
-  OptimizerType,
-  PolicyBackend,
   RlGRPOTrainingFinetuningType,
   type RlDPOTraining,
   type RlGRPOTraining,
@@ -27,6 +24,12 @@ import {
   type CustomizationJob,
 } from '@studio/util/customizationBackend';
 import type { TrainingType } from '@studio/util/customizerSchema';
+import {
+  AUTOMODEL_DEFAULT_SPEC,
+  RL_DPO_DEFAULT_SPEC,
+  RL_GRPO_DEFAULT_SPEC,
+  UNSLOTH_DEFAULT_SPEC,
+} from '@studio/util/forms/specDefaults';
 import { z } from 'zod';
 
 /**
@@ -34,40 +37,39 @@ import { z } from 'zod';
  * to the backend, and the rest are required here because every control is always
  * rendered with a value.
  */
-export type GrpoLoraFields = Required<
-  Pick<RlLoRAParams, 'rank' | 'alpha' | 'dropout' | 'use_triton'>
-> &
-  Pick<RlLoRAParams, 'target_modules' | 'exclude_modules'>;
+/** All optional: each value is a spec default, and the spec need not declare one. */
+export type GrpoLoraFields = Pick<
+  RlLoRAParams,
+  'rank' | 'alpha' | 'dropout' | 'use_triton' | 'target_modules' | 'exclude_modules'
+>;
 
 /**
  * GRPO-only hyperparameters, kept in their own namespace because `rl.training` holds
  * a single object shared with the DPO form. Derived from `RlGRPOTraining` so the form
  * cannot drift from the API — field docs come from the generated schema.
  */
-export interface GrpoFormFields extends Required<
-  Pick<
-    RlGRPOTraining,
-    | 'num_generations_per_prompt'
-    | 'num_prompts_per_step'
-    | 'max_rollout_turns'
-    | 'normalize_rewards'
-    | 'ratio_clip_min'
-    | 'ratio_clip_max'
-    | 'finetuning_type'
-    | 'temperature'
-    | 'val_at_start'
-    | 'overlong_filtering'
-    | 'use_dynamic_sampling'
-    | 'batch_multiplier'
-    | 'dynamic_sampling_max_gen_batches'
-    | 'use_leave_one_out_baseline'
-    | 'use_importance_sampling_correction'
-    | 'use_on_policy_kl_approximation'
-    | 'policy_backend'
-    | 'batching_strategy'
-    | 'sequence_length_round'
-    | 'vllm_gpu_memory_utilization'
-  >
+export interface GrpoFormFields extends Pick<
+  RlGRPOTraining,
+  | 'num_generations_per_prompt'
+  | 'num_prompts_per_step'
+  | 'max_rollout_turns'
+  | 'normalize_rewards'
+  | 'ratio_clip_min'
+  | 'ratio_clip_max'
+  | 'finetuning_type'
+  | 'temperature'
+  | 'val_at_start'
+  | 'overlong_filtering'
+  | 'use_dynamic_sampling'
+  | 'batch_multiplier'
+  | 'dynamic_sampling_max_gen_batches'
+  | 'use_leave_one_out_baseline'
+  | 'use_importance_sampling_correction'
+  | 'use_on_policy_kl_approximation'
+  | 'policy_backend'
+  | 'batching_strategy'
+  | 'sequence_length_round'
+  | 'vllm_gpu_memory_utilization'
 > {
   /** 'grpo' shows the GRPO form sections; 'dpo' shows DPO sections. Maps to training.type on submit. */
   trainingType: RlDPOTraining['type'] | RlGRPOTraining['type'];
@@ -149,214 +151,91 @@ export const resolveTrainingType = (
   }
 };
 
-const UNSLOTH_DEFAULT_TARGET_MODULES = [
-  'q_proj',
-  'k_proj',
-  'v_proj',
-  'o_proj',
-  'gate_proj',
-  'up_proj',
-  'down_proj',
-];
-
-const RL_DPO_DEFAULTS: RlJobInput = {
-  model: '',
-  dataset: '',
-  training: {
-    type: 'dpo',
-    epochs: 1,
-    learning_rate: 1e-4,
-    batch_size: 32,
-    micro_batch_size: 1,
-    max_seq_length: 2048,
-    warmup_steps: 0,
-    weight_decay: 0.01,
-    ref_policy_kl_penalty: 0.1,
-    preference_loss_weight: 1,
-    sft_loss_weight: 0,
-    preference_average_log_probs: false,
-    sft_average_log_probs: false,
-    parallelism: {
-      num_nodes: 1,
-      num_gpus_per_node: 1,
-      tensor_parallel_size: 1,
-      pipeline_parallel_size: 1,
-      context_parallel_size: 1,
-      sequence_parallel: false,
-    },
-  },
-};
-
-/** Fields both RL forms bind to. `RL_DPO_DEFAULTS.training` is `RlDPOTraining` and omits them. */
-const RL_SHARED_TRAINING_DEFAULTS = {
-  optimizer_type: OptimizerType.adamw_with_cosine_annealing,
-  min_learning_rate: 0,
-  adam_beta1: 0.9,
-  adam_beta2: 0.999,
-  adam_eps: 1e-8,
-  max_grad_norm: 1.0,
-  seed: 42,
-  val_check_interval: 1.0,
-  keep_top_k: 1,
-  activation_checkpointing: false,
-};
+/**
+ * Every default below comes from `specDefaults.ts`, which parses each backend's generated
+ * Zod schema once and lets Zod apply the spec's `default:` values. A field the spec leaves
+ * without a default arrives `undefined` — the form's signal to render it unset rather than
+ * invent a starting value.
+ */
 
 /**
- * `rl.training` is shared by the DPO and GRPO forms, so each method's defaults must
- * stand alone — a GRPO seed left here would silently override the backend for DPO.
- * DPO matches the backend (`max_steps: None`, `val_at_end: True`); GRPO runs to a
- * step budget and skips the trailing validation pass.
- *
- * The casts are required: spreading `RlDPOTraining` with GRPO-only fields yields an
- * object valid for either arm, but TS will not infer the discriminated union itself.
+ * `rl.training` is shared by the DPO and GRPO forms, so each method's defaults must stand
+ * alone: a GRPO value left in the DPO object would silently override the backend. Each
+ * comes from its own arm of the discriminated union, so values that differ per method —
+ * `ref_policy_kl_penalty` is 0.05 on DPO and 0 on GRPO — stay correct without restating.
  */
-export const RL_DPO_TRAINING_DEFAULTS = {
-  ...RL_DPO_DEFAULTS.training,
-  ...RL_SHARED_TRAINING_DEFAULTS,
-  val_at_end: true,
-} as RlJobInput['training'];
+export const RL_DPO_TRAINING_DEFAULTS = RL_DPO_DEFAULT_SPEC.training;
 
-export const RL_GRPO_TRAINING_DEFAULTS = {
-  ...RL_DPO_DEFAULTS.training,
-  ...RL_SHARED_TRAINING_DEFAULTS,
-  max_steps: 500,
-  val_at_end: false,
-  // Backend default is 0.0 for GRPO and 0.05 for DPO; the 0.1 inherited from
-  // RL_DPO_DEFAULTS would otherwise apply a KL penalty the user never asked for.
-  ref_policy_kl_penalty: 0.0,
-  // The shared 1e-4 is SFT-scale and collapses a policy within a few dozen RL steps;
-  // the platform GRPO fixtures train at 5e-6. Deliberately not conditional on
-  // finetuning_type: the backend scales an adapter's effective rate by lora.alpha/rank,
-  // so the default rank 16 / alpha 32 already puts a LoRA run at an effective 1e-5.
-  learning_rate: 5e-6,
-  // Backend default is 1e-5; the shared block's Torch 1e-8 overrides it. Fixed here,
-  // not in the shared block, so DPO's numerics are untouched (DPO still diverges).
-  adam_eps: 1e-5,
-  // A step count, not a fraction of an epoch: 50 gives ~10 validation points over the
-  // 500-step default, where a fraction-of-epoch 1.0 gives exactly one.
-  val_check_interval: 50,
-} as RlJobInput['training'];
+/**
+ * The GRPO arm's fields, lifted into the form's own namespace. Listed rather than spread so
+ * the form carries exactly the controls it renders, and so a new field in the spec does not
+ * silently appear in form state without a control behind it.
+ */
+const GRPO_FORM_KEYS = [
+  'num_generations_per_prompt',
+  'num_prompts_per_step',
+  'max_rollout_turns',
+  'normalize_rewards',
+  'ratio_clip_min',
+  'ratio_clip_max',
+  'finetuning_type',
+  'temperature',
+  'val_at_start',
+  'overlong_filtering',
+  'use_dynamic_sampling',
+  'batch_multiplier',
+  'dynamic_sampling_max_gen_batches',
+  'use_leave_one_out_baseline',
+  'use_importance_sampling_correction',
+  'use_on_policy_kl_approximation',
+  'policy_backend',
+  'batching_strategy',
+  'sequence_length_round',
+  'vllm_gpu_memory_utilization',
+  'max_new_tokens',
+  'lora',
+  // The spec gives these no default, so they parse to `undefined` and their controls reset
+  // to empty. The backend reads absence as "feature off"; seeding a number would switch it on.
+  'ratio_clip_c',
+  'advantage_clip_low',
+  'advantage_clip_high',
+  'truncated_importance_sampling_type',
+  'truncated_importance_sampling_ratio',
+  'truncated_importance_sampling_ratio_min',
+  'top_k',
+  'train_mb_tokens',
+  'router_aux_loss_coef',
+  'vllm_tensor_parallel_size',
+  'reward_scaling',
+  'reward_shaping',
+  'hf_config_overrides',
+  'automodel_kwargs',
+] as const satisfies readonly (keyof RlGRPOTraining)[];
+
+const grpoTraining = RL_GRPO_DEFAULT_SPEC.training as RlGRPOTraining;
+
+/**
+ * Both arms come straight from the spec. The GRPO arm carries its own values for anything
+ * the two methods differ on, so nothing needs restating here — and a field the spec leaves
+ * without a default stays absent, which is how it reaches the form unset.
+ */
+export const RL_GRPO_TRAINING_DEFAULTS = RL_GRPO_DEFAULT_SPEC.training;
 
 export const FORM_DEFAULTS: CustomizationFormFields = {
   backend: 'automodel',
   outputName: '',
   description: '',
-  automodel: {
-    model: '',
-    dataset: { training: '' },
-    training: {
-      training_type: 'sft',
-      finetuning_type: 'lora',
-      lora: { rank: 16, alpha: 32, dropout: 0, merge: false, use_triton: true },
-      max_seq_length: 2048,
-      attn_implementation: 'sdpa',
-    },
-    schedule: { epochs: 1 },
-    batch: { global_batch_size: 8, micro_batch_size: 1, sequence_packing: false },
-    optimizer: {
-      learning_rate: 5e-6,
-      weight_decay: 0.01,
-      warmup_steps: 0,
-      adam_beta1: 0.9,
-      adam_beta2: 0.999,
-      optimizer: 'Adam',
-      lr_decay_style: 'cosine',
-    },
-    parallelism: {
-      num_nodes: 1,
-      num_gpus_per_node: 1,
-      tensor_parallel_size: 1,
-      pipeline_parallel_size: 1,
-      context_parallel_size: 1,
-      sequence_parallel: false,
-    },
-  },
-  unsloth: {
-    model: {
-      name: '',
-      max_seq_length: 2048,
-      load_in_4bit: true,
-      load_in_8bit: false,
-      dtype: 'auto',
-      trust_remote_code: false,
-    },
-    dataset: {
-      path: '',
-      text_field: 'text',
-      apply_chat_template: false,
-      packing: false,
-    },
-    training: {
-      training_type: 'sft',
-      finetuning_type: 'lora',
-      lora: {
-        rank: 16,
-        alpha: 16,
-        dropout: 0,
-        target_modules: UNSLOTH_DEFAULT_TARGET_MODULES,
-        bias: 'none',
-        use_rslora: false,
-        random_state: 3407,
-        init_lora_weights: true,
-      },
-      use_gradient_checkpointing: 'unsloth',
-    },
-    schedule: {
-      epochs: 1,
-      warmup_steps: 0,
-      lr_scheduler_type: 'linear',
-      logging_steps: 1,
-      seed: 3407,
-    },
-    batch: { per_device_train_batch_size: 1, gradient_accumulation_steps: 1 },
-    optimizer: { learning_rate: 2e-4, weight_decay: 0, optim: 'adamw_8bit' },
-    hardware: { precision: 'bf16' },
-  },
-  rl: {
-    ...RL_DPO_DEFAULTS,
-    training: RL_DPO_TRAINING_DEFAULTS,
-  },
+  automodel: AUTOMODEL_DEFAULT_SPEC,
+  unsloth: UNSLOTH_DEFAULT_SPEC,
+  rl: RL_DPO_DEFAULT_SPEC,
   grpo: {
+    /** 'grpo' shows the GRPO sections; 'dpo' shows DPO. Maps to training.type on submit. */
     trainingType: 'dpo',
     environmentFileset: '',
-    num_generations_per_prompt: 8,
-    num_prompts_per_step: 8,
-    overlong_filtering: false,
-    max_rollout_turns: 1,
-    normalize_rewards: true,
-    ratio_clip_min: 0.2,
-    ratio_clip_max: 0.28,
-    temperature: 1.0,
-    val_at_start: false,
-    max_new_tokens: 2048,
-    finetuning_type: RlGRPOTrainingFinetuningType.all_weights,
-    lora: { rank: 16, alpha: 32, dropout: 0, use_triton: true },
-    use_dynamic_sampling: false,
-    batch_multiplier: 1.0,
-    dynamic_sampling_max_gen_batches: 10,
-    use_leave_one_out_baseline: true,
-    use_importance_sampling_correction: true,
-    use_on_policy_kl_approximation: true,
-    policy_backend: PolicyBackend.automodel,
-    batching_strategy: BatchingStrategy.dynamic,
-    sequence_length_round: 64,
-    vllm_gpu_memory_utilization: 0.5,
-    // Left unset: the backend treats absence as "feature off", so seeding any number
-    // here would silently enable it. Their controls reset to empty rather than to a value.
-    ratio_clip_c: undefined,
-    advantage_clip_low: undefined,
-    advantage_clip_high: undefined,
-    truncated_importance_sampling_type: undefined,
-    truncated_importance_sampling_ratio: undefined,
-    truncated_importance_sampling_ratio_min: undefined,
-    top_k: undefined,
-    train_mb_tokens: undefined,
-    router_aux_loss_coef: undefined,
-    vllm_tensor_parallel_size: undefined,
-    reward_scaling: undefined,
-    reward_shaping: undefined,
-    hf_config_overrides: undefined,
-    automodel_kwargs: undefined,
+    ...(Object.fromEntries(GRPO_FORM_KEYS.map((k) => [k, grpoTraining[k]])) as Pick<
+      GrpoFormFields,
+      (typeof GRPO_FORM_KEYS)[number]
+    >),
   },
 };
 

--- a/web/packages/studio/src/util/forms/customization.ts
+++ b/web/packages/studio/src/util/forms/customization.ts
@@ -10,7 +10,6 @@ import {
   type RlGRPOTraining,
   type RlJobInput,
   type RlJobsJobRequest,
-  type RlLoRAParams,
   type UnslothJobInput,
   type UnslothJobsJobRequest,
 } from '@nemo/sdk/generated/customizer/schema';
@@ -33,78 +32,23 @@ import {
 import { z } from 'zod';
 
 /**
- * The LoRA knobs the GRPO form exposes. `target_modules`/`exclude_modules` are left
- * to the backend, and the rest are required here because every control is always
- * rendered with a value.
- */
-/** All optional: each value is a spec default, and the spec need not declare one. */
-export type GrpoLoraFields = Pick<
-  RlLoRAParams,
-  'rank' | 'alpha' | 'dropout' | 'use_triton' | 'target_modules' | 'exclude_modules'
->;
-
-/**
  * GRPO-only hyperparameters, kept in their own namespace because `rl.training` holds
  * a single object shared with the DPO form. Derived from `RlGRPOTraining` so the form
  * cannot drift from the API — field docs come from the generated schema.
  */
-export interface GrpoFormFields extends Pick<
-  RlGRPOTraining,
-  | 'num_generations_per_prompt'
-  | 'num_prompts_per_step'
-  | 'max_rollout_turns'
-  | 'normalize_rewards'
-  | 'ratio_clip_min'
-  | 'ratio_clip_max'
-  | 'finetuning_type'
-  | 'temperature'
-  | 'val_at_start'
-  | 'overlong_filtering'
-  | 'use_dynamic_sampling'
-  | 'batch_multiplier'
-  | 'dynamic_sampling_max_gen_batches'
-  | 'use_leave_one_out_baseline'
-  | 'use_importance_sampling_correction'
-  | 'use_on_policy_kl_approximation'
-  | 'policy_backend'
-  | 'batching_strategy'
-  | 'sequence_length_round'
-  | 'vllm_gpu_memory_utilization'
-> {
+/**
+ * GRPO-only form state: the spec's GRPO arm plus the two fields that exist only in the UI.
+ *
+ * Extends `RlGRPOTraining` wholesale rather than naming its fields. Listing them meant three
+ * copies of the same set — a type union, a runtime key array and a per-field restatement —
+ * which is the duplication this module exists to remove, just moved from values to names.
+ * A field the form has no control for is inert: `formToRlCreate` picks what it sends.
+ */
+export interface GrpoFormFields extends RlGRPOTraining {
   /** 'grpo' shows the GRPO form sections; 'dpo' shows DPO sections. Maps to training.type on submit. */
   trainingType: RlDPOTraining['type'] | RlGRPOTraining['type'];
   /** Fileset reference for the NeMo Gym reward environment. */
   environmentFileset: string;
-  /**
-   * Seeded to match the default `max_seq_length`, which is what the backend would
-   * derive it from anyway. It has to carry a value because its slider needs a reset
-   * target, and a reset target that differs from the form default is a control whose
-   * ↺ silently changes the request. Raising Max Sequence Length does NOT raise this —
-   * the two are set independently, and the backend rejects this exceeding that.
-   */
-  max_new_tokens: RlGRPOTraining['max_new_tokens'];
-  /** LoRA hyperparameters; only sent when finetuning_type is 'lora'. */
-  lora: GrpoLoraFields;
-  /**
-   * Fields the backend leaves unset by default. They stay optional here so an untouched
-   * control sends nothing and the backend keeps its own behaviour, rather than the form
-   * switching a feature on with a value the user never chose.
-   */
-  ratio_clip_c: RlGRPOTraining['ratio_clip_c'];
-  advantage_clip_low: RlGRPOTraining['advantage_clip_low'];
-  advantage_clip_high: RlGRPOTraining['advantage_clip_high'];
-  truncated_importance_sampling_type: RlGRPOTraining['truncated_importance_sampling_type'];
-  truncated_importance_sampling_ratio: RlGRPOTraining['truncated_importance_sampling_ratio'];
-  truncated_importance_sampling_ratio_min: RlGRPOTraining['truncated_importance_sampling_ratio_min'];
-  top_k: RlGRPOTraining['top_k'];
-  train_mb_tokens: RlGRPOTraining['train_mb_tokens'];
-  router_aux_loss_coef: RlGRPOTraining['router_aux_loss_coef'];
-  vllm_tensor_parallel_size: RlGRPOTraining['vllm_tensor_parallel_size'];
-  reward_scaling: RlGRPOTraining['reward_scaling'];
-  reward_shaping: RlGRPOTraining['reward_shaping'];
-  /** Free-form passthrough dicts, edited via ControlledJsonInput. */
-  hf_config_overrides: RlGRPOTraining['hf_config_overrides'];
-  automodel_kwargs: RlGRPOTraining['automodel_kwargs'];
 }
 
 export interface CustomizationFormFields {
@@ -166,52 +110,6 @@ export const resolveTrainingType = (
  */
 export const RL_DPO_TRAINING_DEFAULTS = RL_DPO_DEFAULT_SPEC.training;
 
-/**
- * The GRPO arm's fields, lifted into the form's own namespace. Listed rather than spread so
- * the form carries exactly the controls it renders, and so a new field in the spec does not
- * silently appear in form state without a control behind it.
- */
-const GRPO_FORM_KEYS = [
-  'num_generations_per_prompt',
-  'num_prompts_per_step',
-  'max_rollout_turns',
-  'normalize_rewards',
-  'ratio_clip_min',
-  'ratio_clip_max',
-  'finetuning_type',
-  'temperature',
-  'val_at_start',
-  'overlong_filtering',
-  'use_dynamic_sampling',
-  'batch_multiplier',
-  'dynamic_sampling_max_gen_batches',
-  'use_leave_one_out_baseline',
-  'use_importance_sampling_correction',
-  'use_on_policy_kl_approximation',
-  'policy_backend',
-  'batching_strategy',
-  'sequence_length_round',
-  'vllm_gpu_memory_utilization',
-  'max_new_tokens',
-  'lora',
-  // The spec gives these no default, so they parse to `undefined` and their controls reset
-  // to empty. The backend reads absence as "feature off"; seeding a number would switch it on.
-  'ratio_clip_c',
-  'advantage_clip_low',
-  'advantage_clip_high',
-  'truncated_importance_sampling_type',
-  'truncated_importance_sampling_ratio',
-  'truncated_importance_sampling_ratio_min',
-  'top_k',
-  'train_mb_tokens',
-  'router_aux_loss_coef',
-  'vllm_tensor_parallel_size',
-  'reward_scaling',
-  'reward_shaping',
-  'hf_config_overrides',
-  'automodel_kwargs',
-] as const satisfies readonly (keyof RlGRPOTraining)[];
-
 const grpoTraining = RL_GRPO_DEFAULT_SPEC.training as RlGRPOTraining;
 
 /**
@@ -232,10 +130,7 @@ export const FORM_DEFAULTS: CustomizationFormFields = {
     /** 'grpo' shows the GRPO sections; 'dpo' shows DPO. Maps to training.type on submit. */
     trainingType: 'dpo',
     environmentFileset: '',
-    ...(Object.fromEntries(GRPO_FORM_KEYS.map((k) => [k, grpoTraining[k]])) as Pick<
-      GrpoFormFields,
-      (typeof GRPO_FORM_KEYS)[number]
-    >),
+    ...grpoTraining,
   },
 };
 
@@ -448,8 +343,8 @@ export const formToRlCreate = (f: CustomizationFormFields): RlJobsJobRequest => 
           lora: isLora
             ? {
                 ...f.grpo.lora,
-                target_modules: emptyToUndefined(f.grpo.lora.target_modules),
-                exclude_modules: emptyToUndefined(f.grpo.lora.exclude_modules),
+                target_modules: emptyToUndefined(f.grpo.lora?.target_modules),
+                exclude_modules: emptyToUndefined(f.grpo.lora?.exclude_modules),
               }
             : undefined,
           num_generations_per_prompt: f.grpo.num_generations_per_prompt,

--- a/web/packages/studio/src/util/forms/customization.ts
+++ b/web/packages/studio/src/util/forms/customization.ts
@@ -39,10 +39,7 @@ import { z } from 'zod';
 /**
  * GRPO-only form state: the spec's GRPO arm plus the two fields that exist only in the UI.
  *
- * Extends `RlGRPOTraining` wholesale rather than naming its fields. Listing them meant three
- * copies of the same set — a type union, a runtime key array and a per-field restatement —
- * which is the duplication this module exists to remove, just moved from values to names.
- * A field the form has no control for is inert: `formToRlCreate` picks what it sends.
+ * A field the form has no control for is inert — `formToRlCreate` picks what it sends.
  */
 export interface GrpoFormFields extends RlGRPOTraining {
   /** 'grpo' shows the GRPO form sections; 'dpo' shows DPO sections. Maps to training.type on submit. */

--- a/web/packages/studio/src/util/forms/specDefaults.test.ts
+++ b/web/packages/studio/src/util/forms/specDefaults.test.ts
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { CustomizationCreateAutomodelJobBody } from '@nemo/sdk/generated/customizer/zod/automodel-jobs';
+import { CustomizationCreateRlJobBody } from '@nemo/sdk/generated/customizer/zod/rl-jobs';
+import { CustomizationCreateUnslothJobBody } from '@nemo/sdk/generated/customizer/zod/unsloth-jobs';
+import {
+  AUTOMODEL_SEED,
+  AUTOMODEL_SPEC_DEFAULTS,
+  DPO_SPEC_DEFAULTS,
+  GRPO_SPEC_DEFAULTS,
+  UNSET_PLACEHOLDER,
+  UNSLOTH_SEED,
+  UNSLOTH_SPEC_DEFAULTS,
+  booleanDefault,
+  numberDefault,
+  placeholderFor,
+  rlSeed,
+  stringDefault,
+} from '@studio/util/forms/specDefaults';
+
+/**
+ * These assert against values that live in the OpenAPI spec, not in the form. If the
+ * backend changes one of them the test fails, which is the point: it says the form is
+ * now showing something different, rather than letting a stale copy sit unnoticed.
+ */
+describe('specDefaults', () => {
+  it('reads scalar defaults out of the generated SDK', () => {
+    expect(numberDefault(GRPO_SPEC_DEFAULTS, 'max_seq_length')).toBe(2048);
+    expect(numberDefault(GRPO_SPEC_DEFAULTS, 'batch_size')).toBe(32);
+    expect(numberDefault(GRPO_SPEC_DEFAULTS, 'learning_rate')).toBe(0.0001);
+    expect(numberDefault(GRPO_SPEC_DEFAULTS, 'adam_beta1')).toBe(0.9);
+    expect(numberDefault(GRPO_SPEC_DEFAULTS, 'keep_top_k')).toBe(1);
+  });
+
+  it('decodes multi-word and digit-suffixed field names', () => {
+    expect(numberDefault(GRPO_SPEC_DEFAULTS, 'adam_beta2')).toBe(0.999);
+    expect(numberDefault(GRPO_SPEC_DEFAULTS, 'dynamic_sampling_max_gen_batches')).toBe(10);
+    expect(numberDefault(GRPO_SPEC_DEFAULTS, 'vllm_gpu_memory_utilization')).toBe(0.5);
+    expect(numberDefault(GRPO_SPEC_DEFAULTS, 'sequence_length_round')).toBe(64);
+  });
+
+  it('reads booleans and enums', () => {
+    expect(booleanDefault(GRPO_SPEC_DEFAULTS, 'use_leave_one_out_baseline')).toBe(true);
+    expect(booleanDefault(GRPO_SPEC_DEFAULTS, 'use_dynamic_sampling')).toBe(false);
+    expect(booleanDefault(GRPO_SPEC_DEFAULTS, 'normalize_rewards')).toBe(true);
+    expect(stringDefault(GRPO_SPEC_DEFAULTS, 'policy_backend')).toBe('automodel');
+    expect(stringDefault(GRPO_SPEC_DEFAULTS, 'batching_strategy')).toBe('dynamic');
+  });
+
+  it('strips the branch marker from nullable object paths', () => {
+    expect(numberDefault(GRPO_SPEC_DEFAULTS, 'lora_rank')).toBe(16);
+    expect(numberDefault(GRPO_SPEC_DEFAULTS, 'lora_alpha')).toBe(32);
+  });
+
+  /** The whole reason the two arms are separate tables. */
+  it('keeps the DPO and GRPO union arms apart', () => {
+    expect(numberDefault(DPO_SPEC_DEFAULTS, 'ref_policy_kl_penalty')).toBe(0.05);
+    expect(numberDefault(GRPO_SPEC_DEFAULTS, 'ref_policy_kl_penalty')).toBe(0);
+  });
+
+  it('reports undefined for fields the spec leaves without a default', () => {
+    for (const field of ['seed', 'max_steps', 'val_check_interval', 'min_learning_rate']) {
+      expect(numberDefault(GRPO_SPEC_DEFAULTS, field)).toBeUndefined();
+    }
+  });
+
+  it('placeholders show the backend default, or Unset when there is none', () => {
+    expect(placeholderFor(GRPO_SPEC_DEFAULTS, 'max_seq_length')).toBe('2048');
+    expect(placeholderFor(GRPO_SPEC_DEFAULTS, 'seed')).toBe(UNSET_PLACEHOLDER);
+  });
+
+  /** A generator rename would empty these maps; fail loudly rather than silently unset everything. */
+  it('every backend table is populated', () => {
+    expect(DPO_SPEC_DEFAULTS.size).toBeGreaterThan(10);
+    expect(GRPO_SPEC_DEFAULTS.size).toBeGreaterThan(20);
+    expect(AUTOMODEL_SPEC_DEFAULTS.size).toBeGreaterThan(5);
+    expect(UNSLOTH_SPEC_DEFAULTS.size).toBeGreaterThan(5);
+  });
+
+  it('rejects a value of the wrong type instead of coercing it', () => {
+    expect(numberDefault(GRPO_SPEC_DEFAULTS, 'policy_backend')).toBeUndefined();
+    expect(booleanDefault(GRPO_SPEC_DEFAULTS, 'batch_size')).toBeUndefined();
+  });
+
+  /**
+   * The module parses each seed at import time, and `.parse` throws. A backend adding a
+   * required field the seeds do not supply would take the whole customization form down
+   * rather than degrading to unset values, so assert the seeds still satisfy the schemas.
+   */
+  describe('seed parseability', () => {
+    /**
+     * The module parses each seed at import time, and `.parse` throws — a backend adding a
+     * required field the seeds do not supply would take the whole customization form down
+     * rather than degrading to unset values. Asserts the real seeds, not a hand-written
+     * minimal spec, so a new required field fails here instead of at runtime.
+     */
+    it.each([
+      ['automodel', CustomizationCreateAutomodelJobBody, AUTOMODEL_SEED],
+      ['unsloth', CustomizationCreateUnslothJobBody, UNSLOTH_SEED],
+      ['rl/dpo', CustomizationCreateRlJobBody, rlSeed('dpo')],
+      ['rl/grpo', CustomizationCreateRlJobBody, rlSeed('grpo')],
+    ])('%s seed still satisfies the generated schema', (_name, schema, seed) => {
+      const result = schema.safeParse({ spec: seed });
+      expect(result.success).toBe(true);
+    });
+
+    it('every table parsed to something usable', () => {
+      for (const table of [
+        AUTOMODEL_SPEC_DEFAULTS,
+        UNSLOTH_SPEC_DEFAULTS,
+        DPO_SPEC_DEFAULTS,
+        GRPO_SPEC_DEFAULTS,
+      ]) {
+        expect(table.size).toBeGreaterThan(0);
+      }
+    });
+  });
+});

--- a/web/packages/studio/src/util/forms/specDefaults.test.ts
+++ b/web/packages/studio/src/util/forms/specDefaults.test.ts
@@ -44,7 +44,6 @@ describe('specDefaults', () => {
     expect(booleanDefault(GRPO_SPEC_DEFAULTS, 'use_leave_one_out_baseline')).toBe(true);
     expect(booleanDefault(GRPO_SPEC_DEFAULTS, 'use_dynamic_sampling')).toBe(false);
     expect(booleanDefault(GRPO_SPEC_DEFAULTS, 'normalize_rewards')).toBe(true);
-    expect(stringDefault(GRPO_SPEC_DEFAULTS, 'policy_backend')).toBe('automodel');
     expect(stringDefault(GRPO_SPEC_DEFAULTS, 'batching_strategy')).toBe('dynamic');
   });
 
@@ -60,7 +59,15 @@ describe('specDefaults', () => {
   });
 
   it('reports undefined for fields the spec leaves without a default', () => {
-    for (const field of ['seed', 'max_steps', 'val_check_interval', 'min_learning_rate']) {
+    // `policy_backend` is here rather than asserted as 'automodel': the backend derives it
+    // from finetuning_type now, so the spec declares no default.
+    for (const field of [
+      'seed',
+      'max_steps',
+      'val_check_interval',
+      'min_learning_rate',
+      'policy_backend',
+    ]) {
       expect(numberDefault(GRPO_SPEC_DEFAULTS, field)).toBeUndefined();
     }
   });

--- a/web/packages/studio/src/util/forms/specDefaults.ts
+++ b/web/packages/studio/src/util/forms/specDefaults.ts
@@ -86,11 +86,6 @@ export const RL_GRPO_DEFAULT_SPEC = specOf<RlJobInput>(
  * Flattened `snake_case` view of a parsed spec, e.g. `optimizer_learning_rate`. The slider
  * and placeholder helpers look values up by field path rather than by object traversal, so
  * a control names the field once.
- *
- * The keys are real paths off the parsed object, which is why this no longer has to guess
- * at the generator's naming. Orval numbers a nullable object's branch in the constant name
- * (`LoraOneRank` for `lora`, declared `anyOf: [LoRAParams, null]`); parsing sidesteps that
- * entirely.
  */
 const flatten = (
   value: unknown,

--- a/web/packages/studio/src/util/forms/specDefaults.ts
+++ b/web/packages/studio/src/util/forms/specDefaults.ts
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  type AutomodelJobInput,
+  type RlJobInput,
+  type UnslothJobInput,
+} from '@nemo/sdk/generated/customizer/schema';
+import { CustomizationCreateAutomodelJobBody } from '@nemo/sdk/generated/customizer/zod/automodel-jobs';
+import { CustomizationCreateRlJobBody } from '@nemo/sdk/generated/customizer/zod/rl-jobs';
+import { CustomizationCreateUnslothJobBody } from '@nemo/sdk/generated/customizer/zod/unsloth-jobs';
+
+/**
+ * Backend defaults for the customizer forms, taken from the Zod schemas Orval generates
+ * out of `plugins/nemo-customizer/openapi/openapi.yaml`.
+ *
+ * Nothing here is hardcoded. The generated schemas carry the spec's `default:` values as
+ * `.default(...)`, so parsing a seed that supplies only the required fields makes Zod
+ * fill in every default at once — one call per backend instead of a line per control.
+ * `pnpm install` re-derives all of them, and a backend default change reaches the form
+ * without anyone editing a field list.
+ *
+ * A field the spec leaves without a `default:` parses to `undefined`, which is the signal
+ * for the form to render it unset rather than invent a starting value.
+ */
+
+/**
+ * Zod applies a nested object's inner defaults only when that object is present in the
+ * input, so every container the form binds to has to be seeded with `{}`. Required leaves
+ * (`model`, `dataset`) get an empty string: the form overwrites them, and Zod refuses to
+ * parse without them.
+ */
+export const AUTOMODEL_SEED = {
+  model: '',
+  dataset: { training: '' },
+  training: { lora: {} },
+  schedule: {},
+  batch: {},
+  optimizer: {},
+  parallelism: {},
+};
+
+export const UNSLOTH_SEED = {
+  model: { name: '' },
+  dataset: { path: '' },
+  training: { lora: {} },
+  schedule: {},
+  batch: {},
+  optimizer: {},
+  hardware: {},
+};
+
+/**
+ * `training` is a discriminated union, so the seed has to name the arm. The two arms hold
+ * genuinely different values — `ref_policy_kl_penalty` is 0.05 on DPO and 0 on GRPO — so
+ * each is parsed separately rather than merged.
+ */
+export const rlSeed = (type: 'dpo' | 'grpo') => ({
+  model: '',
+  dataset: '',
+  training: { type, parallelism: {}, ...(type === 'grpo' ? { lora: {} } : {}) },
+  // Bound by RlIntegrationsSection. Present so Zod fills any default the spec declares
+  // inside them; without the container, nested defaults are skipped silently.
+  integrations: { wandb: {}, mlflow: {} },
+});
+
+const specOf = <T>(schema: { parse: (input: unknown) => { spec: T } }, seed: unknown): T =>
+  schema.parse({ spec: seed }).spec;
+
+/** Fully-defaulted spec objects. Bind forms to these directly. */
+export const AUTOMODEL_DEFAULT_SPEC = specOf<AutomodelJobInput>(
+  CustomizationCreateAutomodelJobBody,
+  AUTOMODEL_SEED
+);
+export const UNSLOTH_DEFAULT_SPEC = specOf<UnslothJobInput>(
+  CustomizationCreateUnslothJobBody,
+  UNSLOTH_SEED
+);
+export const RL_DPO_DEFAULT_SPEC = specOf<RlJobInput>(CustomizationCreateRlJobBody, rlSeed('dpo'));
+export const RL_GRPO_DEFAULT_SPEC = specOf<RlJobInput>(
+  CustomizationCreateRlJobBody,
+  rlSeed('grpo')
+);
+
+/**
+ * Flattened `snake_case` view of a parsed spec, e.g. `optimizer_learning_rate`. The slider
+ * and placeholder helpers look values up by field path rather than by object traversal, so
+ * a control names the field once.
+ *
+ * The keys are real paths off the parsed object, which is why this no longer has to guess
+ * at the generator's naming. Orval numbers a nullable object's branch in the constant name
+ * (`LoraOneRank` for `lora`, declared `anyOf: [LoRAParams, null]`); parsing sidesteps that
+ * entirely.
+ */
+const flatten = (
+  value: unknown,
+  prefix = '',
+  out = new Map<string, unknown>()
+): ReadonlyMap<string, unknown> => {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return out;
+  for (const [key, child] of Object.entries(value)) {
+    const path = prefix ? `${prefix}_${key}` : key;
+    out.set(path, child);
+    if (child !== null && typeof child === 'object' && !Array.isArray(child)) {
+      flatten(child, path, out);
+    }
+  }
+  return out;
+};
+
+export const AUTOMODEL_SPEC_DEFAULTS = flatten(AUTOMODEL_DEFAULT_SPEC);
+export const UNSLOTH_SPEC_DEFAULTS = flatten(UNSLOTH_DEFAULT_SPEC);
+/** Keyed off `training`, so callers use `epochs` / `parallelism_num_nodes`. */
+export const DPO_SPEC_DEFAULTS = flatten(RL_DPO_DEFAULT_SPEC.training);
+export const GRPO_SPEC_DEFAULTS = flatten(RL_GRPO_DEFAULT_SPEC.training);
+
+/** Reads a spec default, narrowed to the type the caller expects. `undefined` means unset. */
+const reader =
+  <T>(guard: (value: unknown) => value is T) =>
+  (defaults: ReadonlyMap<string, unknown>, field: string): T | undefined => {
+    const value = defaults.get(field);
+    return guard(value) ? value : undefined;
+  };
+
+const isNumber = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value);
+const isBoolean = (value: unknown): value is boolean => typeof value === 'boolean';
+const isString = (value: unknown): value is string => typeof value === 'string';
+
+export const numberDefault = reader(isNumber);
+export const booleanDefault = reader(isBoolean);
+export const stringDefault = reader(isString);
+
+/**
+ * What a control shows when the spec gives it no default. Kept here so every form uses the
+ * same word for "the backend decides this", rather than each control inventing a hint.
+ */
+export const UNSET_PLACEHOLDER = 'Unset';
+
+/**
+ * Placeholder for a slider: the backend's own default when the spec has one, so the user
+ * can see what will happen without the form sending a value, and `Unset` when it does not.
+ */
+export const placeholderFor = (defaults: ReadonlyMap<string, unknown>, field: string): string => {
+  const value = defaults.get(field);
+  return value === undefined || value === null ? UNSET_PLACEHOLDER : String(value);
+};
+
+/**
+ * Slider props for a spec-backed field: the backend's default as the seeded value and ↺
+ * target, or unset with an `Unset` placeholder when the spec declares no default.
+ *
+ * Spread rather than passed field-by-field so a control cannot end up seeded from one
+ * field and placeholdered from another.
+ */
+export const specSliderProps = (
+  defaults: ReadonlyMap<string, unknown>,
+  field: string
+): { defaultValue: number | undefined; unsetPlaceholder: string } => ({
+  defaultValue: numberDefault(defaults, field),
+  unsetPlaceholder: placeholderFor(defaults, field),
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Training customization forms now use specification-defined defaults across Automodel, Unsloth, DPO, and GRPO configurations.
  - Parameter sliders provide more accurate default values, reset behavior, and unset states.
  - DPO and GRPO settings better reflect the selected training configuration.
  - Corrected mappings for learning, optimization, sampling, resource, and LoRA controls.
  - LoRA settings remain stable when optional configuration is not provided.
  - Expanded validation keeps customization controls aligned with supported specifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->