### PR TITLE
fix(experimentalist): keep trajectory scoring from ending a run

### DIFF
--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/trace_scorer.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/trace_scorer.py
@@ -286,7 +286,13 @@ class GoalTreeTrajectoryScorer(Agent, roles.TrajectoryScorer):
             config=goal_config,
             framework_skills_dirs=self._framework_skills_dirs,
         )
-        updated_tree = await generator.update(goal_tree, analysis, round_num, dataset, ethos=ethos)
+        try:
+            updated_tree = await generator.update(goal_tree, analysis, round_num, dataset, ethos=ethos)
+        except Exception as exc:  # noqa: BLE001 - refinement is optional; the previous tree still scores
+            logger.warning(
+                f"[TRAJ] Failed to refine goal tree for round {round_num + 1}; keeping the previous one: {exc}"
+            )
+            return
         next_goal_path.parent.mkdir(parents=True, exist_ok=True)
         next_goal_path.write_text(updated_tree.to_json())
 

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/strategies/evolutionary.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/strategies/evolutionary.py
@@ -464,7 +464,15 @@ class EvolutionaryStrategy(Agent, roles.Strategy):
                 scorer = self._trajectory_scorer(ctx, config)
                 # round_num - 1: the counter has already advanced past the round this
                 # analysis describes, and the scorer names its state after that round.
-                scored = await scorer.run(ctx, candidates=candidates, round_num=round_num - 1, analysis=analysis)
+                # Best-effort: trajectory scoring is optional enrichment on top of the
+                # validation channel, so a failure here (an unreadable trace, an LLM error
+                # the scorer could not absorb) must never end a run that has already spent
+                # hours producing validation rewards.
+                try:
+                    scored = await scorer.run(ctx, candidates=candidates, round_num=round_num - 1, analysis=analysis)
+                except Exception as exc:  # noqa: BLE001 - see above
+                    logger.warning("[TRAJ] trajectory scoring failed (run continues): %s", exc)
+                    scored = {}
                 for candidate in candidates:
                     if (record := scored.get(candidate.id)) is not None:
                         await ctx.record_reward(candidate, channel="validation-trajectory", result=record)


### PR DESCRIPTION
Trajectory scoring is optional enrichment on top of the validation channel: it measures how a candidate reached its result, while the validation rewards the optimizer actually selects on are already recorded by the time it runs. A failure there was ending runs that had spent hours earning those rewards.

Two paths in that channel were unguarded:

- `_update_goal_tree` refines the goal tree with an LLM call and let the error propagate, unlike its sibling `_ensure_goal_tree`, which already falls back. It now keeps the previous round's tree, which still scores.
- The `scorer.run` call site was bare, so anything the scorer could not absorb internally (trace loading, goal-tree I/O, aggregation) ended the round loop. It is now best-effort with an empty-result fallback, mirroring `_project_best_effort` in the backend.

The concurrent scoring fan-out in `_reward_trajectories` already passes `return_exceptions=True` and is unchanged.

<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
<!-- In 1-3 plain sentences, explain what changes and why. Describe before-and-after behavior when it applies. -->

## Related Issue
<!-- Use Fixes #NNN or Closes #NNN for a related issue. Remove this section if there is none. -->

## Changes
<!-- List the concrete changes included in this pull request. -->

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [ ] Pull request title follows the repository's Conventional Commit format
- [ ] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [ ] Targeted tests pass, or tests are marked not applicable above
- [ ] No secrets, API keys, or credentials are included

Targeted validation:

<!-- List each command and result. Explain skipped, blocked, or non-successful checks without marking them as passed. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Goal-tree refinement failures no longer interrupt processing; the previous tree is retained and a warning is logged.
  * Evolutionary runs now continue when trajectory scoring fails, rather than aborting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->