### PR TITLE
fix(plugin): reject unqualified model refs in configured_model_refs

### DIFF
--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/nooa_model_client.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/nooa_model_client.py
@@ -76,7 +76,29 @@ def configured_model_refs() -> ConfiguredModelRefs:
         raise ValueError("No default model is configured. Run `nemo setup` and select agent models.")
     if not fast:
         raise ValueError("No fast model is configured. Run `nemo setup` and select agent models.")
+    _validate_configured_ref(default, "NEMO_DEFAULT_MODEL")
+    _validate_configured_ref(fast, "NEMO_FAST_MODEL")
     return ConfiguredModelRefs(default=default, fast=fast)
+
+
+def _validate_configured_ref(model_ref: str, env_var: str) -> None:
+    """Reject an unqualified model ref where the operator can still act on it.
+
+    Model Entity IDs discovered by ``nemo setup`` are always ``workspace/name``, but
+    the ``NEMO_DEFAULT_MODEL`` / ``NEMO_FAST_MODEL`` overrides are read verbatim. An
+    unqualified value used to survive every layer and only fail inside a running job,
+    long after the job was created, so the operator saw a stack trace instead of the
+    one-line fix.
+    """
+    try:
+        _parse_model_ref(model_ref)
+    except ValueError:
+        raise ValueError(
+            f"Model reference {model_ref!r} must use workspace/name format "
+            f"(for example 'default/{model_ref}'). "
+            f"Set {env_var} to a workspace-qualified Model Entity ID, or unset it and "
+            f"re-run `nemo setup` to select one."
+        ) from None
 
 
 def _parse_model_ref(model_ref: str) -> tuple[str, str]:

--- a/packages/nemo_platform_plugin/tests/test_nooa_model_client.py
+++ b/packages/nemo_platform_plugin/tests/test_nooa_model_client.py
@@ -82,6 +82,33 @@ def test_configured_model_refs_requires_default(monkeypatch):
         configured_model_refs()
 
 
+def test_configured_model_refs_rejects_unqualified_default(monkeypatch):
+    """An unqualified NEMO_DEFAULT_MODEL must fail here, not inside a running job."""
+    monkeypatch.setattr(
+        nooa_model_client,
+        "get_context",
+        lambda: SimpleNamespace(default_model="nvidia-nemotron-mini-4b-instruct", fast_model=None),
+    )
+
+    with pytest.raises(ValueError, match="must use workspace/name format") as excinfo:
+        configured_model_refs()
+
+    message = str(excinfo.value)
+    assert "default/nvidia-nemotron-mini-4b-instruct" in message
+    assert "NEMO_DEFAULT_MODEL" in message
+
+
+def test_configured_model_refs_rejects_unqualified_fast(monkeypatch):
+    monkeypatch.setattr(
+        nooa_model_client,
+        "get_context",
+        lambda: SimpleNamespace(default_model="default/quality", fast_model="bare-fast"),
+    )
+
+    with pytest.raises(ValueError, match="NEMO_FAST_MODEL"):
+        configured_model_refs()
+
+
 async def test_resolve_model_clients_deduplicates_same_model(monkeypatch):
     model_entity = _model_entity(
         workspace="default",


### PR DESCRIPTION
## Summary

`configured_model_refs()` accepted an unqualified model reference from `NEMO_DEFAULT_MODEL` / `NEMO_FAST_MODEL` and passed it through every layer untouched. The value only failed deep inside a running job, long after the job was created, so the operator saw a stack trace instead of the one-line fix. It is now rejected where it is read, with a message naming the offending value, the environment variable that set it, and the corrected form.

## Changes

- Add `_validate_configured_ref()` and call it for both the default and fast refs in `configured_model_refs()`.
- Raise `ValueError` with the env var name and a `default/<name>` suggestion when the ref is not `workspace/name`.
- Add two tests covering the unqualified default and unqualified fast cases.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: the new message is self-describing and no documented workflow changes.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `uv run --frozen pytest packages/nemo_platform_plugin/tests/test_nooa_model_client.py -q` — 14 passed.
- `uv run ruff check packages/nemo_platform_plugin/` — all checks passed.
- `uv run ruff format --check packages/nemo_platform_plugin/` — 223 files already formatted.
- `uv run --frozen ty check packages/nemo_platform_plugin/` — 64 diagnostics, identical to the count on `origin/main`; this PR adds none.
- `uv run pre-commit run -a` — passes. Four hooks could not run in this environment and were not counted as passing: `uv-version-consistency`, `python-version-consistency`, and `node-version-consistency` exit 127 because `yq` is not installed, and Helm Docs needs `helm-docs`. All four check version/config files that this PR does not touch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for default and fast model references to ensure they use the required `workspace/name` format.
  * Improved configuration errors with actionable guidance, including the affected environment variable and setup command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->