### PR TITLE
docs: update agent build guidance for Fabric

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ If a user asks you to set up, try, build, evaluate, harden, or optimize an agent
 
 - DO NOT invoke any plugin-based skill, `/skill-name` slash command, or globally-installed assistant for these requests. The repo skills are authoritative. A globally-installed skill (brainstorming, planning, code-review, etc.) will give the wrong answer because it does not know NeMo.
 - DO NOT brainstorm a solution from scratch when a NeMo skill claims the task. The skill already has the answer.
-- DO NOT write Python, Pydantic AI, LangChain, or any agent framework code from scratch. NeMo Platform uses the NVIDIA NeMo Agent Toolkit (NAT) under the hood. Skills will tell you the right way to wire your agent.
+- DO NOT write Python, Pydantic AI, LangChain, or other agent framework code from scratch when a shipped skill covers the request. Skills will tell you the supported way to connect the agent to NeMo Platform. For a new agent build, `nemo-build-agent` uses LangChain Deep Agents through Fabric. Work on a NAT workflow only when the user explicitly asks to maintain or migrate an existing one.
 - DO NOT improvise CLI flags. Only use flags documented in the skill or shown in `nemo <subcommand> --help`.
 - DO NOT report a task complete if you cannot verify it. If a verification step fails or times out, surface what you saw and ask the user to confirm before continuing.
 
@@ -32,7 +32,7 @@ User-facing skills in `packages/nemo_platform_ext/src/nemo_platform_ext/skills/`
 - `setup`: verifies that NeMo Platform is installed and running. If install is missing, tells the user how to run the CLI install (`make bootstrap` + `nemo setup`). **Install itself is CLI-only.** Do not attempt to install NeMo via skill-driven pip; the workspace dependency graph and credential handling are not reliably automatable inside a sandbox.
 - `nemo-explore`: design conversation that feeds into an Ethos. Always confirms purpose, principles, and vision.
 - `nemo-ethos`: writes `agents/<name>-ethos/ETHOS.md` from explore output, then shows a gut-check of the agent.
-- `nemo-build-agent`: scaffolds NAT workflow YAML from the Ethos and deploys.
+- `nemo-build-agent`: builds a tested LangChain Deep Agent from an approved Ethos, then packages and registers it through Fabric.
 - `nemo-try-agent`: test a deployed agent or chat with a model.
 - `nemo-intake`: instrument agents, choose an ingest format, upload/query telemetry, and attach evaluator results.
 - `nemo-experiments-upload`: publish named evaluation runs and scores to the Experiments leaderboard.
@@ -56,9 +56,9 @@ NeMo Platform brings together NVIDIA NeMo libraries under one CLI, Python SDK, a
 - **Harden agents**: guardrails (content safety, jailbreak detection, PII redaction), auditor (red-teaming via garak), anonymizer (PII handling for training data).
 - **Evaluate agents**: evaluator (LLM-as-judge, deterministic, agentic, RAG benchmarks), Harbor-backed eval suites.
 - **Tune agents and models**: skill optimization, prompt/hyperparameter tuning, Switchyard model routing, and fine-tuning through Customizer.
-- **Build agents**: NeMo Agent Toolkit (NAT) for LangGraph-based agents. Broader framework support on the roadmap.
+- **Build and manage agents**: Fabric connects supported agent harnesses to NeMo Platform for packaging, deployment, testing, observation, and optimization.
 
-NeMo Platform optimizes LangGraph agents wrapped in NAT today. Other frameworks require a user-written NAT wrapper. Be honest about this when users ask.
+New agents should use an explicit Fabric configuration and a supported adapter. Existing NAT workflows can still be maintained when the user asks for that path. Do not create a NAT wrapper as the default way to bring a new agent into NeMo Platform.
 
 ---
 


### PR DESCRIPTION
Linear: [AIRCORE-1121](https://linear.app/nvidia/issue/AIRCORE-1121/update-the-repository-agent-guidance-to-use-fabric)

## Why

The root `AGENTS.md` still tells coding agents that new NeMo Platform agents must be built through NAT. That conflicts with the supported Fabric path and with the new build agent skill.

Because this file guides every coding agent working in the repository, leaving the old language in place would send new builds down the wrong path.

## What changed

* New agent builds now point to LangChain Deep Agents through Fabric.
* The build agent skill description now matches what the skill actually does.
* The repository overview describes Fabric as the layer that connects supported agent harnesses to NeMo Platform.
* Existing NAT workflows can still be maintained or migrated when the user asks for that work.

This is separate from the build agent skill PR so the repository wide guidance can be reviewed on its own.

## Testing

This is a documentation only change. I checked the diff for formatting errors and searched the root guidance for the outdated NAT claims.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated project guidance for selecting AI development frameworks.
  - Clarified that Fabric with LangChain Deep Agents is preferred for new builds.
  - Documented when NAT remains applicable for explicitly requested maintenance or migration work.
  - Revised the skills catalog and repository capability descriptions to reflect the updated framework guidance and development practices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->