### PR TITLE
fix(studio): don't apply the deployment grace period to endpoint-backed models (ASTD-554)

### DIFF
--- a/web/packages/common/src/utils/models.test.ts
+++ b/web/packages/common/src/utils/models.test.ts
@@ -93,6 +93,39 @@ describe('getModelEntityChatStatus', () => {
     expect(getModelEntityChatStatus(model)).toBe('pending');
   });
 
+  it('skips the grace period for a freshly created model that already has an api_endpoint', () => {
+    // Autodiscovered from an external provider (e.g. build.nvidia.com): the endpoint is
+    // live the moment the entity exists, so there is no deployment to wait for.
+    vi.setSystemTime(new Date('2025-01-07T12:00:00Z').getTime());
+
+    const model = createModel({
+      created_at: '2025-01-07T11:57:00Z', // 3 minutes ago
+      api_endpoint: { url: 'https://integrate.api.nvidia.com/v1/chat/completions' },
+    });
+
+    expect(getModelEntityChatStatus(model)).toBe('enabled');
+  });
+
+  it('still applies the grace period to a fresh model with no api_endpoint', () => {
+    // Deployment-backed: the artifact genuinely is still being populated.
+    vi.setSystemTime(new Date('2025-01-07T12:00:00Z').getTime());
+
+    const model = createModel({ created_at: '2025-01-07T11:57:00Z' });
+
+    expect(getModelEntityChatStatus(model, { deploymentStatus: null })).toBe('pending');
+  });
+
+  it('still reports pending while the deployment chain is loading, endpoint or not', () => {
+    vi.setSystemTime(new Date('2025-01-07T12:00:00Z').getTime());
+
+    const model = createModel({
+      created_at: '2025-01-07T11:57:00Z',
+      api_endpoint: { url: 'https://integrate.api.nvidia.com/v1/chat/completions' },
+    });
+
+    expect(getModelEntityChatStatus(model, { deploymentLoading: true })).toBe('pending');
+  });
+
   it('returns enabled when model created more than 5 minutes ago', () => {
     const now = new Date('2025-01-07T12:00:00Z').getTime();
     vi.setSystemTime(now);

--- a/web/packages/common/src/utils/models.ts
+++ b/web/packages/common/src/utils/models.ts
@@ -114,6 +114,10 @@ const TIMEZONE_REGEX = /(Z|[+-]\d{2}:?\d{2})$/;
 /**
  * Check if a model was created within the deployment grace period.
  * Models need time after creation for the backend to deploy them and populate the artifact.
+ *
+ * Only meaningful for models that are waiting on a deployment. A model that already
+ * carries an `api_endpoint.url` has no artifact pending, so callers exempt it — see
+ * {@link getModelEntityChatStatus}.
  */
 const isWithinDeploymentGracePeriod = (model: ModelEntity) => {
   if (!model.created_at) {
@@ -158,7 +162,8 @@ export type GetModelEntityChatStatusOptions = {
  *
  * Order of evaluation:
  * 1. `deploymentLoading` → `'pending'`
- * 2. Creation grace period → `'pending'`
+ * 2. Creation grace period → `'pending'`, **unless** the entity already has an
+ *    `api_endpoint.url` (endpoint-backed models have nothing to deploy).
  * 3. Entities with `base_model` or an **adapter** row need a READY deployment; `api_endpoint` alone is not enough.
  * 4. Standalone entities: `api_endpoint.url`, READY deployment, or (if deployment unknown) optimistic `'enabled'`.
  */
@@ -168,11 +173,17 @@ export function getModelEntityChatStatus(
 ): ModelChatStatus {
   const { adapter, deploymentLoading, deploymentStatus } = options ?? {};
 
-  if (deploymentLoading || isWithinDeploymentGracePeriod(model)) {
+  const hasApiEndpoint = Boolean(model.api_endpoint?.url);
+
+  // The grace period covers the gap between an entity being created and the backend
+  // populating its deployment artifact. A model autodiscovered from an external
+  // provider (build.nvidia.com, any OpenAI-compatible host) has its api_endpoint set
+  // at creation and is serveable immediately, so applying the timer there reports a
+  // deployment that does not exist and never will.
+  if (deploymentLoading || (!hasApiEndpoint && isWithinDeploymentGracePeriod(model))) {
     return 'pending';
   }
 
-  const hasApiEndpoint = Boolean(model.api_endpoint?.url);
   const needsReadyDeployment = Boolean(adapter) || Boolean(model.base_model);
 
   if (needsReadyDeployment) {


### PR DESCRIPTION
## Summary

`getModelEntityChatStatus` returned `'pending'` for any model entity created in the last five minutes, and that check ran ahead of the one that recognises a live `api_endpoint`. A model autodiscovered from an external inference provider has its endpoint populated at creation and is serveable immediately, so the timer imposed a false five-minute wait and the Chat Playground reported **"Model Deployment in Progress"** for a deployment that does not exist and never will. After this change, an entity that already carries `api_endpoint.url` skips the grace period entirely and is evaluated on its own merits.

Observed on a local instance: 83 models autodiscovered from a newly registered provider, every one with a live `api_endpoint`, all blocked for five minutes.

## Changes

- `web/packages/common/src/utils/models.ts`
  - Hoist `hasApiEndpoint` above the grace-period check and gate the timer on `!hasApiEndpoint`.
  - `deploymentLoading` still short-circuits first: a model whose provider/deployment chain is still resolving is genuinely unknown regardless of endpoint.
  - Document the exemption on `isWithinDeploymentGracePeriod` and in the `getModelEntityChatStatus` evaluation-order list.
- `web/packages/common/src/utils/models.test.ts` — three cases: exempt when an endpoint is present, timer still applies without one, and `deploymentLoading` still wins over an endpoint.

### Behavioural note

Adapters and entities with `base_model` continue to require a READY deployment. They now reach that check immediately rather than sitting at `'pending'` for five minutes first, which does not change what the user sees: that check returns `'pending'` on its own while a deployment is non-terminal.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: no published documentation describes the chat-availability grace period; the rationale is captured in code comments alongside the change.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

| Command | Result |
| --- | --- |
| `pnpm --filter @nemo/common test src/utils/models.test.ts` | 24 passed (24) |
| `pnpm --filter @nemo/common typecheck` | clean |
| `pnpm --filter @nemo/common lint` | clean |
| `pnpm --filter nemo-studio-ui test src/components/ModelChat/index.test.tsx` | 3 passed |
| `pnpm --filter nemo-studio-ui test src/routes/WorkspaceBaseModelsRoute/index.test.tsx` | 13 passed (13) |

`uv run pre-commit run -a` was not run across the whole repository. The pre-commit hook suite ran on the staged files at commit time and passed, including the copyright-header, UI lint-staged, and DCO checks.

Note: running the two `nemo-studio-ui` test files in a single invocation intermittently fails on an MSW `beforeAll` timeout in `vitest.setup.tsx`. Each file passes when run on its own; this is a cold-start flake unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Models with an available API endpoint are now enabled immediately, even when created within the deployment grace period.
  - Models without an endpoint remain pending while deployment artifacts become available.
  - Models remain pending while deployment status is still loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->