### PR TITLE
fix(agents): refuse a deployment mode the executor will not honour [ASTD-548]

### DIFF
--- a/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/deployments.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/deployments.py
@@ -25,6 +25,7 @@ from nemo_agents_plugin.agent_config_formats import AgentConfigFormatError, reso
 from nemo_agents_plugin.api.v2._perms import DeploymentPerms
 from nemo_agents_plugin.api.v2.dependencies import get_entity_client
 from nemo_agents_plugin.authz import scope
+from nemo_agents_plugin.config import AgentsConfig
 from nemo_agents_plugin.entities import (
     Agent,
     AgentDeployment,
@@ -38,6 +39,10 @@ from nemo_agents_plugin.environment_resolution import (
     ResolvedEnvironment,
     merge_environment_spec_into_agent_config,
     resolve_environment,
+)
+from nemo_agents_plugin.runner.deployments_backend import (
+    executor_for_mode,
+    require_executor_matches_mode,
 )
 from nemo_agents_plugin.schema import (
     CreateDeploymentRequest,
@@ -93,6 +98,15 @@ async def create_deployment(
             status_code=400,
             detail="use_image_entrypoint requires deployment_mode 'docker' or 'k8s'.",
         )
+
+    # The controller refuses this too, but only on its next reconcile — by which
+    # point a pending deployment exists and the caller has had its 201.
+    if is_container_deployment_mode(body.deployment_mode):
+        runner_config = AgentsConfig.get().deployments
+        try:
+            require_executor_matches_mode(executor_for_mode(runner_config, body.deployment_mode), body.deployment_mode)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     # 3. Resolve deployment-time config. NAT workflows need legacy injection;
     # Platform-owned agent configs stay strict and are translated by the runner.

--- a/plugins/nemo-agents/src/nemo_agents_plugin/runner/deployments_backend.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/runner/deployments_backend.py
@@ -339,6 +339,37 @@ def executor_for_mode(config: DeploymentsRunnerConfig, mode: DeploymentMode) -> 
     return config.default_executor
 
 
+def executor_backend(name: str | None) -> str | None:
+    """Return the backend key the deployments plugin would run *name* on."""
+    if not name:
+        return None
+    from nemo_deployments_plugin.config import DeploymentsConfig
+
+    for entry in DeploymentsConfig.get().executors:
+        if entry.name == name:
+            return entry.backend
+    return None
+
+
+def require_executor_matches_mode(executor: str | None, mode: DeploymentMode) -> None:
+    """Refuse a container mode that would run somewhere other than it names.
+
+    ``executor_for_mode`` falls back to ``default_executor``, so asking for k8s
+    where none is configured silently lands on docker: the deployment reports
+    running while nothing exists in the cluster, and a k8s-only failure cannot
+    reproduce. The backend keys and the deployment modes share a vocabulary, so
+    the mismatch is checkable here rather than discoverable by counting pods.
+    """
+    backend = executor_backend(executor)
+    if backend is None or backend == mode:
+        return
+    raise ValueError(
+        f"deployment_mode {mode!r} resolved to executor {executor!r}, which runs on "
+        f"{backend!r}. Set 'deployments.{mode}_executor' to an executor whose backend "
+        f"is {mode!r}, or deploy with deployment_mode {backend!r}."
+    )
+
+
 _HTTP_PROTOCOLS = frozenset({"http", "https"})
 
 
@@ -551,6 +582,12 @@ class DeploymentsRunnerBackend(RunnerBackend):
                 status="failed",
                 error=f"DeploymentsRunnerBackend does not support deployment_mode={deployment_mode!r}.",
             )
+
+        try:
+            require_executor_matches_mode(executor_for_mode(self._config, deployment_mode), deployment_mode)
+        except ValueError as exc:
+            logger.error("Refusing to deploy agent %r: %s", name, exc)
+            return DeploymentInfo(name=name, status="failed", error=str(exc))
 
         resolved_image = image or self._config.default_image
         if not resolved_image:

--- a/plugins/nemo-agents/src/nemo_agents_plugin/runner/deployments_backend.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/runner/deployments_backend.py
@@ -340,13 +340,20 @@ def executor_for_mode(config: DeploymentsRunnerConfig, mode: DeploymentMode) -> 
 
 
 def executor_backend(name: str | None) -> str | None:
-    """Return the backend key the deployments plugin would run *name* on."""
-    if not name:
-        return None
+    """Return the backend key the deployments plugin would run *name* on.
+
+    An unset name is not "no executor": ``ExecutorRegistry.resolve`` falls back to
+    the deployments plugin's own ``default_executor``, so resolving it here is what
+    makes the mode check see the executor that will actually run.
+    """
     from nemo_deployments_plugin.config import DeploymentsConfig
 
-    for entry in DeploymentsConfig.get().executors:
-        if entry.name == name:
+    config = DeploymentsConfig.get()
+    resolved = name or config.default_executor
+    if not resolved:
+        return None
+    for entry in config.executors:
+        if entry.name == resolved:
             return entry.backend
     return None
 

--- a/plugins/nemo-agents/src/nemo_agents_plugin/runner/deployments_backend.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/runner/deployments_backend.py
@@ -363,10 +363,11 @@ def require_executor_matches_mode(executor: str | None, mode: DeploymentMode) ->
     backend = executor_backend(executor)
     if backend is None or backend == mode:
         return
+    alternative = f", or deploy with deployment_mode {backend!r}" if backend in CONTAINER_DEPLOYMENT_MODES else ""
     raise ValueError(
         f"deployment_mode {mode!r} resolved to executor {executor!r}, which runs on "
         f"{backend!r}. Set 'deployments.{mode}_executor' to an executor whose backend "
-        f"is {mode!r}, or deploy with deployment_mode {backend!r}."
+        f"is {mode!r}{alternative}."
     )
 
 

--- a/plugins/nemo-agents/tests/unit/test_deployments_api.py
+++ b/plugins/nemo-agents/tests/unit/test_deployments_api.py
@@ -9,10 +9,12 @@ from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import AsyncMock
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from nemo_agents_plugin.api.v2 import deployments as deployments_router_module
 from nemo_agents_plugin.api.v2.dependencies import get_entity_client
+from nemo_agents_plugin.config import AgentsConfig
 from nemo_agents_plugin.entities import (
     NEMO_AGENTS_SPEC_CONFIG_FORMAT,
     Agent,
@@ -20,6 +22,7 @@ from nemo_agents_plugin.entities import (
     AgentDeployment,
     AgentEnvironment,
     AgentEnvironmentSpec,
+    ComputeResources,
     DeploymentStatus,
 )
 from nemo_platform_plugin.entity_client import NemoEntityConflictError, NemoEntityNotFoundError
@@ -145,6 +148,35 @@ class TestCreateDeployment:
         assert created_deployment.image == "hand-built-agent:latest"
         assert created_deployment.use_image_entrypoint is True
 
+    def test_create_rejects_a_mode_the_executor_will_not_honour(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from nemo_deployments_plugin.config import DeploymentsConfig, ExecutorConfigEntry
+
+        deployments_cfg = DeploymentsConfig.get()
+        deployments_cfg.executors = [ExecutorConfigEntry(name="default-exec", backend="docker")]
+        monkeypatch.setattr(DeploymentsConfig, "get", classmethod(lambda cls: deployments_cfg))
+        agents_cfg = AgentsConfig.get()
+        monkeypatch.setattr(agents_cfg.deployments, "default_executor", "default-exec")
+        monkeypatch.setattr(agents_cfg.deployments, "k8s_executor", None)
+        monkeypatch.setattr(AgentsConfig, "get", classmethod(lambda cls: agents_cfg))
+        mock_entity_client = AsyncMock()
+        mock_entity_client.get = AsyncMock(return_value=_make_agent())
+        client = _test_client(mock_entity_client)
+
+        resp = client.post(
+            "/apis/agents/v2/workspaces/default/deployments",
+            json={
+                "agent": "fabric-agent",
+                "name": "fabric-dep",
+                "deployment_mode": "k8s",
+                "image": "registry.example/agent:1.0",
+            },
+        )
+
+        assert resp.status_code == 400
+        assert "runs on 'docker'" in resp.json()["detail"]
+        # The controller would have failed this on reconcile; nothing should persist.
+        mock_entity_client.create.assert_not_called()
+
     def test_create_rejects_image_entrypoint_for_subprocess(self) -> None:
         mock_entity_client = AsyncMock()
         mock_entity_client.get = AsyncMock(return_value=_make_agent())
@@ -173,7 +205,7 @@ class TestCreateDeployment:
             env={"CUSTOM": "from-spec"},
             secrets={"APP_TOKEN": "default/app-token"},
         )
-        cspec = AgentComputeSpec(name="cspec", workspace="default", resources={"limits": {"cpu": "2"}})
+        cspec = AgentComputeSpec(name="cspec", workspace="default", resources=ComputeResources(limits={"cpu": "2"}))
 
         mock_entity_client = AsyncMock()
         # get order: agent (route), then AgentEnvironment, env spec, compute spec (resolver).

--- a/plugins/nemo-agents/tests/unit/test_deployments_api.py
+++ b/plugins/nemo-agents/tests/unit/test_deployments_api.py
@@ -151,8 +151,9 @@ class TestCreateDeployment:
     def test_create_rejects_a_mode_the_executor_will_not_honour(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from nemo_deployments_plugin.config import DeploymentsConfig, ExecutorConfigEntry
 
-        deployments_cfg = DeploymentsConfig.get()
-        deployments_cfg.executors = [ExecutorConfigEntry(name="default-exec", backend="docker")]
+        # A standalone config: DeploymentsConfig.get() is a cached singleton, and
+        # assigning to it would outlive this test.
+        deployments_cfg = DeploymentsConfig(executors=[ExecutorConfigEntry(name="default-exec", backend="docker")])
         monkeypatch.setattr(DeploymentsConfig, "get", classmethod(lambda cls: deployments_cfg))
         agents_cfg = AgentsConfig.get()
         monkeypatch.setattr(agents_cfg.deployments, "default_executor", "default-exec")

--- a/plugins/nemo-agents/tests/unit/test_runner_deployments.py
+++ b/plugins/nemo-agents/tests/unit/test_runner_deployments.py
@@ -261,6 +261,34 @@ def test_k8s_mode_accepts_a_k8s_capable_default(monkeypatch: pytest.MonkeyPatch)
     require_executor_matches_mode("default-exec", "k8s")
 
 
+def test_k8s_mode_with_no_runner_executors_still_checks_the_plugin_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from nemo_deployments_plugin.config import DeploymentsConfig
+
+    # executor_for_mode returns None here, but ExecutorRegistry.resolve falls back
+    # to the plugin's own default — so None is not "nothing will run".
+    cfg = _executors(("plugin-default", "docker"))
+    cfg.default_executor = "plugin-default"
+    monkeypatch.setattr(DeploymentsConfig, "get", classmethod(lambda cls: cfg))
+
+    with pytest.raises(ValueError, match="runs on 'docker'"):
+        require_executor_matches_mode(None, "k8s")
+
+
+def test_no_executor_anywhere_is_left_to_the_deployments_plugin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from nemo_deployments_plugin.config import DeploymentsConfig
+
+    cfg = _executors()
+    cfg.default_executor = None
+    monkeypatch.setattr(DeploymentsConfig, "get", classmethod(lambda cls: cfg))
+
+    # Nothing to run it on at all is ExecutorNotFoundError's message to give.
+    require_executor_matches_mode(None, "k8s")
+
+
 def test_docker_mode_on_a_docker_executor_is_allowed(monkeypatch: pytest.MonkeyPatch) -> None:
     from nemo_deployments_plugin.config import DeploymentsConfig
 

--- a/plugins/nemo-agents/tests/unit/test_runner_deployments.py
+++ b/plugins/nemo-agents/tests/unit/test_runner_deployments.py
@@ -237,6 +237,19 @@ def test_k8s_mode_on_a_docker_executor_is_refused(monkeypatch: pytest.MonkeyPatc
         require_executor_matches_mode("default-exec", "k8s")
 
 
+def test_k8s_mode_on_a_non_deployable_backend_omits_the_mode_suggestion(monkeypatch: pytest.MonkeyPatch) -> None:
+    from nemo_deployments_plugin.config import DeploymentsConfig
+
+    # 'openshell' is a deployments-plugin backend but not a DeploymentMode, so
+    # the error must not suggest deploying with a mode that can't validate.
+    cfg = _executors(("default-exec", "openshell"))
+    monkeypatch.setattr(DeploymentsConfig, "get", classmethod(lambda cls: cfg))
+
+    with pytest.raises(ValueError, match="runs on 'openshell'") as exc_info:
+        require_executor_matches_mode("default-exec", "k8s")
+    assert "deploy with deployment_mode" not in str(exc_info.value)
+
+
 def test_k8s_mode_accepts_a_k8s_capable_default(monkeypatch: pytest.MonkeyPatch) -> None:
     from nemo_deployments_plugin.config import DeploymentsConfig
 

--- a/plugins/nemo-agents/tests/unit/test_runner_deployments.py
+++ b/plugins/nemo-agents/tests/unit/test_runner_deployments.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 import yaml
 from nemo_agents_plugin.config import AgentsConfig, DeploymentsRunnerConfig
-from nemo_agents_plugin.entities import ComputeResources, Endpoint
+from nemo_agents_plugin.entities import ComputeResources, DeploymentMode, Endpoint
 from nemo_agents_plugin.fabric.gateway_credentials import PLATFORM_IGW_API_KEY_ENV, PLATFORM_IGW_API_KEY_PLACEHOLDER
 from nemo_agents_plugin.runner.deployments_backend import (
     DeploymentsRunnerBackend,
@@ -21,6 +21,7 @@ from nemo_agents_plugin.runner.deployments_backend import (
     build_deployment_config,
     executor_for_mode,
     map_status,
+    require_executor_matches_mode,
     resolve_agent_gateway_url,
     rewrite_config_base_urls,
     rewrite_fabric_config_base_urls,
@@ -218,6 +219,55 @@ def test_executor_for_mode_prefers_mode_specific() -> None:
     assert executor_for_mode(cfg, "k8s") == "k8s-exec"
 
 
+def _executors(*pairs: tuple[str, str]) -> Any:
+    from nemo_deployments_plugin.config import DeploymentsConfig, ExecutorConfigEntry
+
+    cfg = DeploymentsConfig.get()
+    cfg.executors = [ExecutorConfigEntry(name=n, backend=b) for n, b in pairs]
+    return cfg
+
+
+def test_k8s_mode_on_a_docker_executor_is_refused(monkeypatch: pytest.MonkeyPatch) -> None:
+    from nemo_deployments_plugin.config import DeploymentsConfig
+
+    cfg = _executors(("default-exec", "docker"))
+    monkeypatch.setattr(DeploymentsConfig, "get", classmethod(lambda cls: cfg))
+
+    with pytest.raises(ValueError, match="runs on 'docker'"):
+        require_executor_matches_mode("default-exec", "k8s")
+
+
+def test_k8s_mode_accepts_a_k8s_capable_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    from nemo_deployments_plugin.config import DeploymentsConfig
+
+    # The naive check — "is k8s_executor set" — would reject this, but a default
+    # executor backed by k8s honours the requested mode.
+    cfg = _executors(("default-exec", "k8s"))
+    monkeypatch.setattr(DeploymentsConfig, "get", classmethod(lambda cls: cfg))
+
+    require_executor_matches_mode("default-exec", "k8s")
+
+
+def test_docker_mode_on_a_docker_executor_is_allowed(monkeypatch: pytest.MonkeyPatch) -> None:
+    from nemo_deployments_plugin.config import DeploymentsConfig
+
+    cfg = _executors(("docker-exec", "docker"))
+    monkeypatch.setattr(DeploymentsConfig, "get", classmethod(lambda cls: cfg))
+
+    require_executor_matches_mode("docker-exec", "docker")
+
+
+def test_an_unknown_executor_is_left_to_the_deployments_plugin(monkeypatch: pytest.MonkeyPatch) -> None:
+    from nemo_deployments_plugin.config import DeploymentsConfig
+
+    # Naming an executor that is not configured is the deployments plugin's error
+    # to report; guessing here would turn its message into a worse one.
+    cfg = _executors(("something-else", "docker"))
+    monkeypatch.setattr(DeploymentsConfig, "get", classmethod(lambda cls: cfg))
+
+    require_executor_matches_mode("not-configured", "k8s")
+
+
 def test_config_mount_path_default_is_under_writable_workspace() -> None:
     assert DeploymentsRunnerConfig().config_mount_path == "/tmp/nemo/config.yaml"
 
@@ -363,7 +413,9 @@ def test_build_deployment_config_no_secrets_adds_no_secret_env() -> None:
     "reserved_name",
     ["NMP_WORKSPACE", "NMP_AGENT_NAME", "NMP_BASE_URL", "PYTHONPATH", "AGENT_CONFIG_PATH", "NAT_CONFIG_PATH"],
 )
-def test_build_deployment_config_rejects_secret_name_colliding_with_reserved(reserved_name: str, mode: str) -> None:
+def test_build_deployment_config_rejects_secret_name_colliding_with_reserved(
+    reserved_name: str, mode: DeploymentMode
+) -> None:
     # A secret env var whose name collides with a platform-generated container
     # env var is rejected up front (behavior would otherwise differ by substrate).
     with pytest.raises(ReservedSecretEnvVarError, match=reserved_name):

--- a/plugins/nemo-agents/tests/unit/test_runner_deployments.py
+++ b/plugins/nemo-agents/tests/unit/test_runner_deployments.py
@@ -219,12 +219,18 @@ def test_executor_for_mode_prefers_mode_specific() -> None:
     assert executor_for_mode(cfg, "k8s") == "k8s-exec"
 
 
-def _executors(*pairs: tuple[str, str]) -> Any:
+def _executors(*pairs: tuple[str, str], default: str | None = None) -> Any:
+    """A standalone DeploymentsConfig.
+
+    Not ``DeploymentsConfig.get()``: that is a cached singleton, and assigning to
+    it outlives the test that did so.
+    """
     from nemo_deployments_plugin.config import DeploymentsConfig, ExecutorConfigEntry
 
-    cfg = DeploymentsConfig.get()
-    cfg.executors = [ExecutorConfigEntry(name=n, backend=b) for n, b in pairs]
-    return cfg
+    return DeploymentsConfig(
+        executors=[ExecutorConfigEntry(name=n, backend=b) for n, b in pairs],
+        default_executor=default,
+    )
 
 
 def test_k8s_mode_on_a_docker_executor_is_refused(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -268,8 +274,7 @@ def test_k8s_mode_with_no_runner_executors_still_checks_the_plugin_default(
 
     # executor_for_mode returns None here, but ExecutorRegistry.resolve falls back
     # to the plugin's own default — so None is not "nothing will run".
-    cfg = _executors(("plugin-default", "docker"))
-    cfg.default_executor = "plugin-default"
+    cfg = _executors(("plugin-default", "docker"), default="plugin-default")
     monkeypatch.setattr(DeploymentsConfig, "get", classmethod(lambda cls: cfg))
 
     with pytest.raises(ValueError, match="runs on 'docker'"):
@@ -282,7 +287,6 @@ def test_no_executor_anywhere_is_left_to_the_deployments_plugin(
     from nemo_deployments_plugin.config import DeploymentsConfig
 
     cfg = _executors()
-    cfg.default_executor = None
     monkeypatch.setattr(DeploymentsConfig, "get", classmethod(lambda cls: cfg))
 
     # Nothing to run it on at all is ExecutorNotFoundError's message to give.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Deploying an agent with `deployment_mode: "k8s"` on a platform with no k8s executor produced a **Docker container on the platform host**, reported `status: running`, and created no pod. Nothing said the requested mode had been substituted.

Reproduced against a local platform and a kind cluster:

```
POST /deployments {"deployment_mode":"k8s","image":"localhost:5001/nemo-agents/default/regpush:test"}
→ 201, status: running, deployment_mode: k8s

kubectl get pods -A   → no agent pod
docker ps             → dep-default-k8s-regpush-4dc095c4
```

The deployment record says `k8s`. The thing running is a container.

## Cause

`executor_for_mode` falls back to `default_executor` when the mode-specific one is unset:

```python
if mode == "k8s":
    return config.k8s_executor or config.default_executor
```

The mode is not lost in transit — it is explicitly discarded. With `k8s_executor` unset and `default_executor` pointing at a docker executor, a k8s request runs on docker.

## Why this is worse than failing

A deployment that misreports where it runs makes every downstream observation untrustworthy. A k8s-only defect cannot reproduce on a "k8s" deployment that is not on k8s — ASTD-530 was exactly such a defect, and this would have hidden it.

It cost time here directly: a deploy intended to exercise the ASTD-530 fix silently ran on docker, and would have been reported as passing k8s verification had the pod list not been checked.

## Related Issue

ASTD-548

## Changes

- `runner/deployments_backend.py`: `executor_backend` resolves an executor name to its backend key; `require_executor_matches_mode` refuses a mismatch, naming both sides and the config key that fixes it.
- The deployment path calls it before creating anything, so a refused request leaves no entities behind.

### Notes for reviewers

- **The check is on the backend key, not on whether `k8s_executor` is set.** A `default_executor` backed by k8s honours the requested mode perfectly well, and the naive check would reject it. `ExecutorConfigEntry.backend` carries the key, and `BACKEND_CLASSES` registers `docker`, `k8s`, `openshell` — the same vocabulary as the deployment modes, which is what makes the comparison meaningful rather than a string coincidence. A test pins the k8s-capable-default case specifically.
- **An executor this plugin cannot find is left alone.** Naming an unconfigured executor is the deployments plugin's error to report; guessing here would replace its message with a worse one. Also tested.
- **Same argument as #1727** (ASTD-532): the server knows the request cannot be honoured, so it should say so at submit time rather than accept it and do something else. Different condition, same class of defect, same file.
- **Studio cannot fix this.** It sends `deployment_mode: "k8s"` and gets a record back saying `k8s`; the executor that ran it is not exposed, and the frontend has no view of executor configuration.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: the error message carries the guidance, and no prose documents executor-to-mode mapping today.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

| Command | Result |
|---|---|
| `uv run pytest plugins/nemo-agents/tests/unit/test_runner_deployments.py` | 80 passed |
| `uv run pytest plugins/nemo-agents/tests/unit` | 1633 passed; 6 failed |
| ruff / ruff-format / ty / copyright / import rules | Passed |

**The 6 failures are pre-existing.** Confirmed by stashing this branch and re-running: the same 6 fail on a clean tree, and this branch takes the suite from 1629 to 1633 passing. They are the sandbox `bind()` failures in `test_port_allocation.py` plus four in `test_container.py` / `test_fabric_package_validation.py`.

**The new test was checked against a deliberately broken build.** Neutering the comparison in `require_executor_matches_mode` fails `test_k8s_mode_on_a_docker_executor_is_refused`; restoring it passes.

Blocked pre-commit hooks, both environmental and neither related to this change:

- **`uv-lock`** — requires exactly uv 0.9.14 on `PATH`; this machine has 0.9.30. No dependency files are touched here.
- **`helm-docs`** — the binary is not installed locally. No Helm files are touched.

**Not verified against a real k8s executor.** The refusal path is proven; the accept-and-actually-deploy-to-k8s path needs a platform configured with the kubernetes runtime, which is a different setup than the one this was reproduced on.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deployment creation now validates that the selected executor supports the requested Docker or Kubernetes mode.
  * When no executor is specified, the configured default executor is used and validated.
  * Incompatible, unknown, or non-deployable executor configurations are rejected immediately with an HTTP 400 error.
  * Invalid deployment requests no longer create pending deployments that later fail during processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->