### PR TITLE
fix(insights): CLI understands nemo context

### DIFF
--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -10430,8 +10430,8 @@ nemo insights analysis enable [OPTIONS]
 **Options:**
 
 * `--agent`: Name of the agent to opt in to periodic analysis.
-* `--workspace`: Workspace the agent belongs to. [default: default]
-* `--base-url`: Base URL of the running NMP instance. [default: http://localhost:8080] [env: NMP_BASE_URL=]
+* `--workspace`: Workspace to operate in. Resolution order: (1) this --workspace flag or NMP_WORKSPACE; (2) the active CLI context, including a global `nemo --context` and `nemo config set --workspace`; (3) the 'default' workspace. [env: NMP_WORKSPACE=]
+* `--base-url`: Base URL of the running NMP instance. Resolution order: (1) this --base-url flag or NMP_BASE_URL; (2) the active CLI context, including a global `nemo --base-url` / `--context` and `nemo config set --base-url`; (3) http://localhost:8080. [env: NMP_BASE_URL=]
 
 **Help:**
 
@@ -10450,8 +10450,8 @@ nemo insights analysis disable [OPTIONS]
 **Options:**
 
 * `--agent`: Name of the agent to opt out of periodic analysis.
-* `--workspace`: Workspace the agent belongs to. [default: default]
-* `--base-url`: Base URL of the running NMP instance. [default: http://localhost:8080] [env: NMP_BASE_URL=]
+* `--workspace`: Workspace to operate in. Resolution order: (1) this --workspace flag or NMP_WORKSPACE; (2) the active CLI context, including a global `nemo --context` and `nemo config set --workspace`; (3) the 'default' workspace. [env: NMP_WORKSPACE=]
+* `--base-url`: Base URL of the running NMP instance. Resolution order: (1) this --base-url flag or NMP_BASE_URL; (2) the active CLI context, including a global `nemo --base-url` / `--context` and `nemo config set --base-url`; (3) http://localhost:8080. [env: NMP_BASE_URL=]
 
 **Help:**
 
@@ -10470,8 +10470,8 @@ nemo insights analysis status [OPTIONS]
 **Options:**
 
 * `--agent`: Optional agent name. Omit to list all analysis configs.
-* `--workspace`: Workspace to inspect. [default: default]
-* `--base-url`: Base URL of the running NMP instance. [default: http://localhost:8080] [env: NMP_BASE_URL=]
+* `--workspace`: Workspace to operate in. Resolution order: (1) this --workspace flag or NMP_WORKSPACE; (2) the active CLI context, including a global `nemo --context` and `nemo config set --workspace`; (3) the 'default' workspace. [env: NMP_WORKSPACE=]
+* `--base-url`: Base URL of the running NMP instance. Resolution order: (1) this --base-url flag or NMP_BASE_URL; (2) the active CLI context, including a global `nemo --base-url` / `--context` and `nemo config set --base-url`; (3) http://localhost:8080. [env: NMP_BASE_URL=]
 
 **Help:**
 
@@ -10513,8 +10513,8 @@ nemo insights analysis-runs create [OPTIONS]
 **Options:**
 
 * `--agent`: Name of the agent whose telemetry should be analyzed.
-* `--workspace`: Workspace the agent belongs to. [default: default]
-* `--base-url`: Base URL of the running NMP instance. [default: http://localhost:8080] [env: NMP_BASE_URL=]
+* `--workspace`: Workspace to operate in. Resolution order: (1) this --workspace flag or NMP_WORKSPACE; (2) the active CLI context, including a global `nemo --context` and `nemo config set --workspace`; (3) the 'default' workspace. [env: NMP_WORKSPACE=]
+* `--base-url`: Base URL of the running NMP instance. Resolution order: (1) this --base-url flag or NMP_BASE_URL; (2) the active CLI context, including a global `nemo --base-url` / `--context` and `nemo config set --base-url`; (3) http://localhost:8080. [env: NMP_BASE_URL=]
 * `--default-model`: Model Entity ref for analysis work. Default: the configured default model.
 * `--fast-model`: Model Entity ref for context summarization. Default: the configured fast model.
 * `--since`: ISO-8601 lower bound enforced on the analyst's trace/span reads.
@@ -10542,8 +10542,8 @@ nemo insights analysis-runs list [OPTIONS]
 **Options:**
 
 * `--agent`: Only list runs that analyzed this agent.
-* `--workspace`: Workspace to inspect. [default: default]
-* `--base-url`: Base URL of the running NMP instance. [default: http://localhost:8080] [env: NMP_BASE_URL=]
+* `--workspace`: Workspace to operate in. Resolution order: (1) this --workspace flag or NMP_WORKSPACE; (2) the active CLI context, including a global `nemo --context` and `nemo config set --workspace`; (3) the 'default' workspace. [env: NMP_WORKSPACE=]
+* `--base-url`: Base URL of the running NMP instance. Resolution order: (1) this --base-url flag or NMP_BASE_URL; (2) the active CLI context, including a global `nemo --base-url` / `--context` and `nemo config set --base-url`; (3) http://localhost:8080. [env: NMP_BASE_URL=]
 * `--page <INTEGER>`: Page number (1-indexed). [default: 1]
 * `--page-size <INTEGER>`: Items per page. [default: 20]
 * `--sort`: Sort field; prefix with '-' for descending. [default: -created_at]
@@ -10571,8 +10571,8 @@ nemo insights analysis-runs get [OPTIONS] NAME
 
 **Options:**
 
-* `--workspace`: Workspace the run belongs to. [default: default]
-* `--base-url`: Base URL of the running NMP instance. [default: http://localhost:8080] [env: NMP_BASE_URL=]
+* `--workspace`: Workspace to operate in. Resolution order: (1) this --workspace flag or NMP_WORKSPACE; (2) the active CLI context, including a global `nemo --context` and `nemo config set --workspace`; (3) the 'default' workspace. [env: NMP_WORKSPACE=]
+* `--base-url`: Base URL of the running NMP instance. Resolution order: (1) this --base-url flag or NMP_BASE_URL; (2) the active CLI context, including a global `nemo --base-url` / `--context` and `nemo config set --base-url`; (3) http://localhost:8080. [env: NMP_BASE_URL=]
 * `--wait`: Poll until the run's backing job reaches a terminal state.
 * `--poll-timeout <FLOAT>`: How long --wait polls before giving up. [default: 900.0]
 * `--poll-interval <FLOAT>`: Seconds between --wait polls. [default: 5.0]

--- a/plugins/nemo-insights/src/nemo_insights_plugin/cli.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/cli.py
@@ -22,7 +22,12 @@ from typing import Any, ClassVar, TypeVar
 import httpx
 import typer
 from nemo_insights_plugin.analyst.run import ClientConstructionError, run_analyst
-from nemo_insights_plugin.cli_context import BaseUrlOption
+from nemo_insights_plugin.cli_context import (
+    BaseUrlOption,
+    WorkspaceOption,
+    active_context_workspace,
+    resolve_workspace,
+)
 from nemo_insights_plugin.client import make_client
 from nemo_insights_plugin.contracts.checks import CheckResult, advisories, format_report, required_failures
 from nemo_insights_plugin.contracts.insights import InsightsFileError, validate_insights_file
@@ -53,7 +58,6 @@ from nemo_platform_plugin.jobs.schemas import PlatformJobStatus
 from nemo_platform_plugin.nooa_model_client import configured_model_refs
 from nooa import GenerationError
 
-DEFAULT_WORKSPACE = "default"
 _PREFLIGHT_PROBES: AnalysisProbes | None = None
 
 
@@ -152,8 +156,13 @@ def _resolve_analysis(
         )
     if workspace is not None:
         resolved_workspace = workspace
+    elif profile is not None:
+        # A profile always carries a workspace (its model defaults to
+        # "default"), so it cannot be told apart from an explicit one and
+        # keeps precedence over the ambient context.
+        resolved_workspace = profile.workspace
     else:
-        resolved_workspace = profile.workspace if profile is not None else DEFAULT_WORKSPACE
+        resolved_workspace = active_context_workspace()
 
     ethos_path = ethos
     ethos_error: str | None = None
@@ -394,11 +403,7 @@ class InsightsCLI(NemoCLI):
                 "--agent",
                 help="Name of the agent to opt in to periodic analysis.",
             ),
-            workspace: str = typer.Option(
-                DEFAULT_WORKSPACE,
-                "--workspace",
-                help="Workspace the agent belongs to.",
-            ),
+            workspace: WorkspaceOption = None,
             base_url: BaseUrlOption = None,
         ) -> None:
             """Enable periodic analysis for an agent."""
@@ -407,7 +412,7 @@ class InsightsCLI(NemoCLI):
                     _analysis_config_command(
                         action="enable",
                         agent=agent,
-                        workspace=workspace,
+                        workspace=resolve_workspace(workspace),
                         base_url=resolve_base_url(base_url),
                     )
                 )
@@ -420,11 +425,7 @@ class InsightsCLI(NemoCLI):
                 "--agent",
                 help="Name of the agent to opt out of periodic analysis.",
             ),
-            workspace: str = typer.Option(
-                DEFAULT_WORKSPACE,
-                "--workspace",
-                help="Workspace the agent belongs to.",
-            ),
+            workspace: WorkspaceOption = None,
             base_url: BaseUrlOption = None,
         ) -> None:
             """Disable periodic analysis for an agent."""
@@ -433,7 +434,7 @@ class InsightsCLI(NemoCLI):
                     _analysis_config_command(
                         action="disable",
                         agent=agent,
-                        workspace=workspace,
+                        workspace=resolve_workspace(workspace),
                         base_url=resolve_base_url(base_url),
                     )
                 )
@@ -446,11 +447,7 @@ class InsightsCLI(NemoCLI):
                 "--agent",
                 help="Optional agent name. Omit to list all analysis configs.",
             ),
-            workspace: str = typer.Option(
-                DEFAULT_WORKSPACE,
-                "--workspace",
-                help="Workspace to inspect.",
-            ),
+            workspace: WorkspaceOption = None,
             base_url: BaseUrlOption = None,
         ) -> None:
             """Show periodic analysis opt-in state."""
@@ -459,7 +456,7 @@ class InsightsCLI(NemoCLI):
                     _analysis_config_command(
                         action="status",
                         agent=agent,
-                        workspace=workspace,
+                        workspace=resolve_workspace(workspace),
                         base_url=resolve_base_url(base_url),
                     )
                 )
@@ -478,11 +475,7 @@ class InsightsCLI(NemoCLI):
                 "--agent",
                 help="Name of the agent whose telemetry should be analyzed.",
             ),
-            workspace: str = typer.Option(
-                DEFAULT_WORKSPACE,
-                "--workspace",
-                help="Workspace the agent belongs to.",
-            ),
+            workspace: WorkspaceOption = None,
             base_url: BaseUrlOption = None,
             default_model: str | None = typer.Option(
                 None,
@@ -538,7 +531,7 @@ class InsightsCLI(NemoCLI):
             payload, completed = _run_command(
                 _create_analysis_run(
                     agent=agent,
-                    workspace=workspace,
+                    workspace=resolve_workspace(workspace),
                     base_url=resolve_base_url(base_url),
                     default_model=default_model,
                     fast_model=fast_model,
@@ -562,11 +555,7 @@ class InsightsCLI(NemoCLI):
                 "--agent",
                 help="Only list runs that analyzed this agent.",
             ),
-            workspace: str = typer.Option(
-                DEFAULT_WORKSPACE,
-                "--workspace",
-                help="Workspace to inspect.",
-            ),
+            workspace: WorkspaceOption = None,
             base_url: BaseUrlOption = None,
             page: int = typer.Option(1, "--page", help="Page number (1-indexed)."),
             page_size: int = typer.Option(20, "--page-size", help="Items per page."),
@@ -581,7 +570,7 @@ class InsightsCLI(NemoCLI):
                 _run_command(
                     _list_analysis_runs(
                         agent=agent,
-                        workspace=workspace,
+                        workspace=resolve_workspace(workspace),
                         base_url=resolve_base_url(base_url),
                         page=page,
                         page_size=page_size,
@@ -593,11 +582,7 @@ class InsightsCLI(NemoCLI):
         @runs_app.command("get")
         def get_analysis_run(
             name: str = typer.Argument(..., help="Name of the analysis run."),
-            workspace: str = typer.Option(
-                DEFAULT_WORKSPACE,
-                "--workspace",
-                help="Workspace the run belongs to.",
-            ),
+            workspace: WorkspaceOption = None,
             base_url: BaseUrlOption = None,
             wait: bool = typer.Option(
                 False,
@@ -623,7 +608,7 @@ class InsightsCLI(NemoCLI):
             payload, completed = _run_command(
                 _get_analysis_run(
                     name=name,
-                    workspace=workspace,
+                    workspace=resolve_workspace(workspace),
                     base_url=resolve_base_url(base_url),
                     wait=wait,
                     poll_timeout=poll_timeout,

--- a/plugins/nemo-insights/src/nemo_insights_plugin/cli.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/cli.py
@@ -11,7 +11,6 @@ The module-level :func:`analyze` and :func:`doctor` callbacks are the verb bodie
 
 import asyncio
 import json
-import os
 from collections.abc import AsyncIterator, Callable, Coroutine
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
@@ -23,11 +22,11 @@ from typing import Any, ClassVar, TypeVar
 import httpx
 import typer
 from nemo_insights_plugin.analyst.run import ClientConstructionError, run_analyst
+from nemo_insights_plugin.cli_context import BaseUrlOption
 from nemo_insights_plugin.client import make_client
 from nemo_insights_plugin.contracts.checks import CheckResult, advisories, format_report, required_failures
 from nemo_insights_plugin.contracts.insights import InsightsFileError, validate_insights_file
 from nemo_insights_plugin.contracts.profile import (
-    DEFAULT_BASE_URL,
     EnvFileError,
     ProfileError,
     discover_profile,
@@ -400,12 +399,7 @@ class InsightsCLI(NemoCLI):
                 "--workspace",
                 help="Workspace the agent belongs to.",
             ),
-            base_url: str = typer.Option(
-                os.environ.get("NMP_BASE_URL", DEFAULT_BASE_URL),
-                "--base-url",
-                help="Base URL of the running NMP instance.",
-                envvar="NMP_BASE_URL",
-            ),
+            base_url: BaseUrlOption = None,
         ) -> None:
             """Enable periodic analysis for an agent."""
             typer.echo(
@@ -414,7 +408,7 @@ class InsightsCLI(NemoCLI):
                         action="enable",
                         agent=agent,
                         workspace=workspace,
-                        base_url=base_url,
+                        base_url=resolve_base_url(base_url),
                     )
                 )
             )
@@ -431,12 +425,7 @@ class InsightsCLI(NemoCLI):
                 "--workspace",
                 help="Workspace the agent belongs to.",
             ),
-            base_url: str = typer.Option(
-                os.environ.get("NMP_BASE_URL", DEFAULT_BASE_URL),
-                "--base-url",
-                help="Base URL of the running NMP instance.",
-                envvar="NMP_BASE_URL",
-            ),
+            base_url: BaseUrlOption = None,
         ) -> None:
             """Disable periodic analysis for an agent."""
             typer.echo(
@@ -445,7 +434,7 @@ class InsightsCLI(NemoCLI):
                         action="disable",
                         agent=agent,
                         workspace=workspace,
-                        base_url=base_url,
+                        base_url=resolve_base_url(base_url),
                     )
                 )
             )
@@ -462,12 +451,7 @@ class InsightsCLI(NemoCLI):
                 "--workspace",
                 help="Workspace to inspect.",
             ),
-            base_url: str = typer.Option(
-                os.environ.get("NMP_BASE_URL", DEFAULT_BASE_URL),
-                "--base-url",
-                help="Base URL of the running NMP instance.",
-                envvar="NMP_BASE_URL",
-            ),
+            base_url: BaseUrlOption = None,
         ) -> None:
             """Show periodic analysis opt-in state."""
             typer.echo(
@@ -476,7 +460,7 @@ class InsightsCLI(NemoCLI):
                         action="status",
                         agent=agent,
                         workspace=workspace,
-                        base_url=base_url,
+                        base_url=resolve_base_url(base_url),
                     )
                 )
             )
@@ -499,12 +483,7 @@ class InsightsCLI(NemoCLI):
                 "--workspace",
                 help="Workspace the agent belongs to.",
             ),
-            base_url: str = typer.Option(
-                os.environ.get("NMP_BASE_URL", DEFAULT_BASE_URL),
-                "--base-url",
-                help="Base URL of the running NMP instance.",
-                envvar="NMP_BASE_URL",
-            ),
+            base_url: BaseUrlOption = None,
             default_model: str | None = typer.Option(
                 None,
                 "--default-model",
@@ -560,7 +539,7 @@ class InsightsCLI(NemoCLI):
                 _create_analysis_run(
                     agent=agent,
                     workspace=workspace,
-                    base_url=base_url,
+                    base_url=resolve_base_url(base_url),
                     default_model=default_model,
                     fast_model=fast_model,
                     ethos=ethos,
@@ -588,12 +567,7 @@ class InsightsCLI(NemoCLI):
                 "--workspace",
                 help="Workspace to inspect.",
             ),
-            base_url: str = typer.Option(
-                os.environ.get("NMP_BASE_URL", DEFAULT_BASE_URL),
-                "--base-url",
-                help="Base URL of the running NMP instance.",
-                envvar="NMP_BASE_URL",
-            ),
+            base_url: BaseUrlOption = None,
             page: int = typer.Option(1, "--page", help="Page number (1-indexed)."),
             page_size: int = typer.Option(20, "--page-size", help="Items per page."),
             sort: str = typer.Option(
@@ -608,7 +582,7 @@ class InsightsCLI(NemoCLI):
                     _list_analysis_runs(
                         agent=agent,
                         workspace=workspace,
-                        base_url=base_url,
+                        base_url=resolve_base_url(base_url),
                         page=page,
                         page_size=page_size,
                         sort=sort,
@@ -624,12 +598,7 @@ class InsightsCLI(NemoCLI):
                 "--workspace",
                 help="Workspace the run belongs to.",
             ),
-            base_url: str = typer.Option(
-                os.environ.get("NMP_BASE_URL", DEFAULT_BASE_URL),
-                "--base-url",
-                help="Base URL of the running NMP instance.",
-                envvar="NMP_BASE_URL",
-            ),
+            base_url: BaseUrlOption = None,
             wait: bool = typer.Option(
                 False,
                 "--wait",
@@ -655,7 +624,7 @@ class InsightsCLI(NemoCLI):
                 _get_analysis_run(
                     name=name,
                     workspace=workspace,
-                    base_url=base_url,
+                    base_url=resolve_base_url(base_url),
                     wait=wait,
                     poll_timeout=poll_timeout,
                     poll_interval=poll_interval,

--- a/plugins/nemo-insights/src/nemo_insights_plugin/cli_context.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/cli_context.py
@@ -14,6 +14,7 @@ and they are invisible to a fresh config load.
 """
 
 import logging
+from collections.abc import Callable
 from typing import Annotated, Any
 
 import click
@@ -22,11 +23,22 @@ from nemo_insights_plugin.contracts.profile import DEFAULT_BASE_URL
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_WORKSPACE = "default"
+
 BASE_URL_HELP = (
     "Base URL of the running NMP instance. Resolution order: "
     "(1) this --base-url flag or NMP_BASE_URL; "
-    "(2) the active CLI context (`nemo config set --base-url`); "
-    f"(3) {DEFAULT_BASE_URL} (default)."
+    "(2) the active CLI context, including a global `nemo --base-url` / `--context` "
+    "and `nemo config set --base-url`; "
+    f"(3) {DEFAULT_BASE_URL}."
+)
+
+WORKSPACE_HELP = (
+    "Workspace to operate in. Resolution order: "
+    "(1) this --workspace flag or NMP_WORKSPACE; "
+    "(2) the active CLI context, including a global `nemo --context` "
+    "and `nemo config set --workspace`; "
+    f"(3) the {DEFAULT_WORKSPACE!r} workspace."
 )
 
 # One definition of the option so its flag, env var and help text cannot drift
@@ -35,6 +47,13 @@ BASE_URL_HELP = (
 BaseUrlOption = Annotated[
     str | None,
     typer.Option("--base-url", envvar="NMP_BASE_URL", help=BASE_URL_HELP),
+]
+
+# Likewise for the workspace. Every insights command means the same thing by
+# it, so one definition keeps the six help strings from drifting apart.
+WorkspaceOption = Annotated[
+    str | None,
+    typer.Option("--workspace", envvar="NMP_WORKSPACE", help=WORKSPACE_HELP),
 ]
 
 
@@ -49,26 +68,36 @@ def current_cli_state() -> Any:
     return ctx.obj if ctx is not None else None
 
 
-def base_url_from_context() -> str | None:
-    """Return the base URL held by the shared CLI context, if any.
+def _from_sdk_context(read: Callable[[Any], str | None], what: str) -> str | None:
+    """Read one value off the shared CLI context, or None when unavailable.
 
-    Resolves the SDK context directly rather than through ``get_base_url``,
-    which reports every failure as "no URL here". That turns a deliberate
-    abort — ``--context`` naming a context that does not exist — into a
-    silent fallback onto whichever platform the default context points at.
+    Resolves the SDK context directly rather than through helpers like
+    ``get_base_url``, which report every failure as "nothing here". That would
+    turn a deliberate abort — ``--context`` naming a context that does not
+    exist — into a silent fallback onto whatever the default context says.
     """
     state = current_cli_state()
     if state is None or not hasattr(state, "get_sdk_context"):
         return None
     try:
-        return str(state.get_sdk_context().cluster.base_url)
+        return read(state.get_sdk_context())
     except (click.exceptions.Exit, click.exceptions.Abort):
         # The CLI is exiting on purpose and has already said why; re-raise so
-        # the command fails instead of quietly targeting somewhere else.
+        # the command fails instead of quietly using somewhere else.
         raise
     except Exception:
-        logger.debug("Failed to resolve base URL from CLI context", exc_info=True)
+        logger.debug("Failed to resolve %s from CLI context", what, exc_info=True)
         return None
+
+
+def base_url_from_context() -> str | None:
+    """Return the base URL held by the shared CLI context, if any."""
+    return _from_sdk_context(lambda ctx: str(ctx.cluster.base_url), "base URL")
+
+
+def workspace_from_context() -> str | None:
+    """Return the workspace held by the shared CLI context, if any."""
+    return _from_sdk_context(lambda ctx: ctx.workspace, "workspace")
 
 
 def active_context_base_url() -> str:
@@ -99,3 +128,30 @@ def active_context_base_url() -> str:
     # pydantic's HttpUrl appends a trailing slash to a bare host; that is an
     # artifact of the model, not something the user configured.
     return str(base_url).rstrip("/")
+
+
+def active_context_workspace() -> str:
+    """Return the workspace of the active ``nemo config`` context.
+
+    Same shape as :func:`active_context_base_url`: ambient CLI context first
+    so global flags win, then a direct config read, then the built-in default.
+    """
+    from_context = workspace_from_context()
+    if from_context:
+        return from_context
+
+    from nemo_platform_ext.config.config import get_context
+
+    try:
+        return get_context().workspace or DEFAULT_WORKSPACE
+    except (ValueError, OSError):
+        return DEFAULT_WORKSPACE
+
+
+def resolve_workspace(explicit: str | None) -> str:
+    """Apply explicit-flag, then active-context precedence for the workspace.
+
+    NMP_WORKSPACE is handled by Typer's ``envvar`` on the flag and again by
+    the config layer, so it lands ahead of the context either way.
+    """
+    return explicit if explicit is not None else active_context_workspace()

--- a/plugins/nemo-insights/src/nemo_insights_plugin/cli_context.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/cli_context.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared CLI-context resolution for the ``nemo insights`` command group.
+
+The base URL a command talks to comes from the shared CLI context object
+on ``typer.Context.obj``, so ``nemo insights`` targets the same deployment
+as every other ``nemo`` command.
+
+Reading the *ambient* Click context (rather than re-reading the config file)
+is what makes the global ``nemo --base-url ...`` and ``nemo --context ...``
+flags apply here: the root callback stashes them as overrides on that object,
+and they are invisible to a fresh config load.
+"""
+
+import logging
+from typing import Annotated, Any
+
+import click
+import typer
+from nemo_insights_plugin.contracts.profile import DEFAULT_BASE_URL
+
+logger = logging.getLogger(__name__)
+
+BASE_URL_HELP = (
+    "Base URL of the running NMP instance. Resolution order: "
+    "(1) this --base-url flag or NMP_BASE_URL; "
+    "(2) the active CLI context (`nemo config set --base-url`); "
+    f"(3) {DEFAULT_BASE_URL} (default)."
+)
+
+# One definition of the option so its flag, env var and help text cannot drift
+# between commands. ``None`` means "unset", which lets ``resolve_base_url``
+# fall through to the CLI context.
+BaseUrlOption = Annotated[
+    str | None,
+    typer.Option("--base-url", envvar="NMP_BASE_URL", help=BASE_URL_HELP),
+]
+
+
+def current_cli_state() -> Any:
+    """Return the shared CLI context object (``typer.Context.obj``) if present.
+
+    ``None`` when the plugin runs outside a Click invocation — a direct unit
+    test, or the analyst job runtime — so callers fall back to their own
+    defaults instead of failing.
+    """
+    ctx = click.get_current_context(silent=True)
+    return ctx.obj if ctx is not None else None
+
+
+def base_url_from_context() -> str | None:
+    """Return the base URL held by the shared CLI context, if any.
+
+    Resolves the SDK context directly rather than through ``get_base_url``,
+    which reports every failure as "no URL here". That turns a deliberate
+    abort — ``--context`` naming a context that does not exist — into a
+    silent fallback onto whichever platform the default context points at.
+    """
+    state = current_cli_state()
+    if state is None or not hasattr(state, "get_sdk_context"):
+        return None
+    try:
+        return str(state.get_sdk_context().cluster.base_url)
+    except (click.exceptions.Exit, click.exceptions.Abort):
+        # The CLI is exiting on purpose and has already said why; re-raise so
+        # the command fails instead of quietly targeting somewhere else.
+        raise
+    except Exception:
+        logger.debug("Failed to resolve base URL from CLI context", exc_info=True)
+        return None
+
+
+def active_context_base_url() -> str:
+    """Return the base URL of the active ``nemo config`` context.
+
+    Prefers the ambient CLI context so global flags win, and falls back to a
+    direct config read for callers with no Click context of their own. When
+    there is no usable config at all — no file, an unreadable one, or a
+    context naming a missing cluster — this yields :data:`DEFAULT_BASE_URL`.
+    A caller reaching here has already run out of explicit sources, so a
+    broken config should not be more fatal than an absent one.
+    """
+    from_context = base_url_from_context()
+    if from_context is not None:
+        return from_context.rstrip("/")
+
+    # Imported lazily: the platform config package pulls in the whole CLI
+    # config stack, which a plain `nemo insights --help` should not pay for.
+    from nemo_platform_ext.config.config import get_context
+
+    try:
+        base_url = get_context().cluster.base_url
+    except (ValueError, OSError):
+        # ValueError covers an unparsable or internally inconsistent config
+        # (Config.load wraps YAML errors); OSError covers an NMP_CONFIG_FILE
+        # pointing at a file that is missing or unreadable.
+        return DEFAULT_BASE_URL
+    # pydantic's HttpUrl appends a trailing slash to a bare host; that is an
+    # artifact of the model, not something the user configured.
+    return str(base_url).rstrip("/")

--- a/plugins/nemo-insights/src/nemo_insights_plugin/contracts/profile.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/contracts/profile.py
@@ -4,7 +4,7 @@
 """Shared mechanics for optimizer.yaml without a universal profile schema."""
 
 import os
-from collections.abc import Mapping, MutableMapping
+from collections.abc import Callable, Mapping, MutableMapping
 from pathlib import Path
 from typing import TypeVar
 
@@ -106,9 +106,28 @@ def resolve_ethos_path(profile_dir: Path, configured: str | None) -> Path | None
     return None
 
 
-def resolve_base_url(explicit: str | None, env: Mapping[str, str] = os.environ) -> str:
-    """Apply explicit, NMP_BASE_URL, then localhost precedence."""
+def resolve_base_url(
+    explicit: str | None,
+    env: Mapping[str, str] = os.environ,
+    *,
+    fallback: Callable[[], str] | None = None,
+) -> str:
+    """Apply explicit, NMP_BASE_URL, then active-CLI-context precedence.
+
+    This mirrors how the platform CLI resolves its own base URL, so that
+    ``nemo insights`` talks to the same deployment as ``nemo workspaces``
+    without needing NMP_BASE_URL exported alongside a configured context.
+
+    *fallback* defaults to the active CLI context, imported lazily so this
+    module stays free of CLI imports; tests pass their own.
+    """
     if explicit is not None:
         return explicit
     env_url = env.get("NMP_BASE_URL")
-    return env_url if env_url is not None else DEFAULT_BASE_URL
+    if env_url is not None:
+        return env_url
+    if fallback is None:
+        from nemo_insights_plugin.cli_context import active_context_base_url
+
+        fallback = active_context_base_url
+    return fallback()

--- a/plugins/nemo-insights/tests/conftest.py
+++ b/plugins/nemo-insights/tests/conftest.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared fixtures for the insights tests."""
+
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+
+def _config_yaml(base_url: str, workspace: str | None) -> str:
+    workspace_line = f"    workspace: {workspace}\n" if workspace is not None else ""
+    return (
+        "current_context: test\n"
+        "contexts:\n"
+        f"  - name: test\n    cluster: test-cluster\n    user: test-user\n{workspace_line}"
+        "clusters:\n"
+        f"  - name: test-cluster\n    base_url: {base_url}\n"
+        "users:\n"
+        "  - name: test-user\n    type: oauth\n    token: test-token\n"
+    )
+
+
+@pytest.fixture(autouse=True)
+def isolated_nmp_config(tmp_path_factory: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Resolve base URL and workspace against a context-free config by default.
+
+    Both now fall back to the active ``nemo config`` context, so without this
+    the developer's own ``~/.config/nmp/config.yaml`` would decide what every
+    "no flag given" test sees — passing locally and failing in CI, or worse.
+    """
+    config = tmp_path_factory.mktemp("nmp-config") / "config.yaml"
+    config.write_text("{}\n", encoding="utf-8")
+    monkeypatch.setenv("NMP_CONFIG_FILE", str(config))
+    monkeypatch.delenv("NMP_BASE_URL", raising=False)
+    monkeypatch.delenv("NMP_WORKSPACE", raising=False)
+
+
+@pytest.fixture
+def use_nmp_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Callable[..., Path]:
+    """Point NMP_CONFIG_FILE at a config with one populated context."""
+
+    def use(*, base_url: str = "http://config.example", workspace: str | None = None) -> Path:
+        config = tmp_path / "nmp-config.yaml"
+        config.write_text(_config_yaml(base_url, workspace), encoding="utf-8")
+        monkeypatch.setenv("NMP_CONFIG_FILE", str(config))
+        return config
+
+    return use

--- a/plugins/nemo-insights/tests/contracts/test_profile_contract.py
+++ b/plugins/nemo-insights/tests/contracts/test_profile_contract.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 import pytest
 from nemo_insights_plugin.contracts.profile import (
-    DEFAULT_BASE_URL,
     EnvFileError,
     ProfileError,
     discover_profile,
@@ -134,7 +133,7 @@ def test_load_env_file_wraps_permission_errors(
     path.write_text("KEY=value\n", encoding="utf-8")
     original_read_text = Path.read_text
 
-    def deny(candidate: Path, *args: object, **kwargs: object) -> str:
+    def deny(candidate: Path, *args: str | None, **kwargs: str | None) -> str:
         if candidate == path:
             raise PermissionError("permission denied")
         return original_read_text(candidate, *args, **kwargs)
@@ -161,10 +160,13 @@ def test_resolve_ethos_uses_configured_then_conventional_precedence(tmp_path: Pa
         resolve_ethos_path(tmp_path, "./missing.md")
 
 
-def test_resolve_base_url_uses_only_explicit_nmp_and_default() -> None:
+def test_resolve_base_url_uses_only_explicit_nmp_and_context() -> None:
     env = {"NMP_BASE_URL": "http://nmp", "NEMO_BASE_URL": "http://ignored"}
 
-    assert resolve_base_url("http://flag", env) == "http://flag"
-    assert resolve_base_url(None, env) == "http://nmp"
-    assert resolve_base_url(None, {"NEMO_BASE_URL": "http://ignored"}) == DEFAULT_BASE_URL
-    assert resolve_base_url("", env) == ""  # explicit empty string is not silently replaced
+    def context() -> str:
+        return "http://context"
+
+    assert resolve_base_url("http://flag", env, fallback=context) == "http://flag"
+    assert resolve_base_url(None, env, fallback=context) == "http://nmp"
+    assert resolve_base_url(None, {"NEMO_BASE_URL": "http://ignored"}, fallback=context) == "http://context"
+    assert resolve_base_url("", env, fallback=context) == ""  # explicit empty string is not silently replaced

--- a/plugins/nemo-insights/tests/test_cli_context.py
+++ b/plugins/nemo-insights/tests/test_cli_context.py
@@ -8,14 +8,19 @@ the CLI followed the configured context, so every command failed against a
 remote deployment that `nemo workspaces list` reached fine.
 """
 
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
 
 import click
 import pytest
-from nemo_insights_plugin.cli_context import active_context_base_url, base_url_from_context
+from nemo_insights_plugin.cli_context import (
+    DEFAULT_WORKSPACE,
+    active_context_base_url,
+    base_url_from_context,
+    resolve_workspace,
+)
 from nemo_insights_plugin.contracts.profile import DEFAULT_BASE_URL
 
 
@@ -26,32 +31,19 @@ def cli_state(obj: object) -> Iterator[None]:
         yield
 
 
-def write_config(path: Path, base_url: str) -> Path:
-    path.write_text(
-        "current_context: prod\n"
-        "contexts:\n"
-        "  - name: prod\n    cluster: prod-cluster\n    user: prod-user\n"
-        "clusters:\n"
-        f"  - name: prod-cluster\n    base_url: {base_url}\n"
-        "users:\n"
-        "  - name: prod-user\n    type: oauth\n    token: t\n",
-        encoding="utf-8",
-    )
-    return path
-
-
 def test_base_url_from_context_is_none_outside_a_cli_invocation() -> None:
     assert base_url_from_context() is None
 
 
-def test_ambient_context_wins_over_the_config_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_ambient_context_wins_over_the_config_file(
+    use_nmp_config: Callable[..., Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Global `nemo --base-url` / `--context` reach us only through the context object.
 
     They are recorded as overrides there and are invisible to a fresh config
     read, so preferring the file would silently drop them.
     """
-    monkeypatch.setenv("NMP_CONFIG_FILE", str(write_config(tmp_path / "config.yaml", "https://from-file.example")))
-    monkeypatch.delenv("NMP_BASE_URL", raising=False)
+    use_nmp_config(base_url="https://from-file.example")
 
     with cli_state(
         SimpleNamespace(
@@ -63,22 +55,22 @@ def test_ambient_context_wins_over_the_config_file(tmp_path: Path, monkeypatch: 
 
 
 def test_falls_back_to_the_config_file_without_a_usable_context(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    use_nmp_config: Callable[..., Path], monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setenv("NMP_CONFIG_FILE", str(write_config(tmp_path / "config.yaml", "https://from-file.example")))
-    monkeypatch.delenv("NMP_BASE_URL", raising=False)
+    use_nmp_config(base_url="https://from-file.example")
 
     assert active_context_base_url() == "https://from-file.example"
     with cli_state(SimpleNamespace()):  # a context object with no get_sdk_context
         assert active_context_base_url() == "https://from-file.example"
 
 
-def test_a_raising_context_object_does_not_fail_the_command(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_a_raising_context_object_does_not_fail_the_command(
+    use_nmp_config: Callable[..., Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
     def explode() -> object:
         raise RuntimeError("unreadable context")
 
-    monkeypatch.setenv("NMP_CONFIG_FILE", str(write_config(tmp_path / "config.yaml", "https://from-file.example")))
-    monkeypatch.delenv("NMP_BASE_URL", raising=False)
+    use_nmp_config(base_url="https://from-file.example")
 
     with cli_state(SimpleNamespace(get_sdk_context=explode)):
         assert active_context_base_url() == "https://from-file.example"
@@ -86,12 +78,13 @@ def test_a_raising_context_object_does_not_fail_the_command(tmp_path: Path, monk
 
 def test_localhost_is_the_last_resort(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("NMP_CONFIG_FILE", str(tmp_path / "missing.yaml"))
-    monkeypatch.delenv("NMP_BASE_URL", raising=False)
 
     assert active_context_base_url() == DEFAULT_BASE_URL
 
 
-def test_a_deliberate_cli_abort_is_not_swallowed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_a_deliberate_cli_abort_is_not_swallowed(
+    use_nmp_config: Callable[..., Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
     """`--context nope` must fail here exactly as it does for `nemo workspaces list`.
 
     Falling back to the config file would run the command against the default
@@ -101,8 +94,34 @@ def test_a_deliberate_cli_abort_is_not_swallowed(tmp_path: Path, monkeypatch: py
     def abort() -> object:
         raise click.exceptions.Exit(1)
 
-    monkeypatch.setenv("NMP_CONFIG_FILE", str(write_config(tmp_path / "config.yaml", "https://from-file.example")))
-    monkeypatch.delenv("NMP_BASE_URL", raising=False)
+    use_nmp_config(base_url="https://from-file.example")
 
     with cli_state(SimpleNamespace(get_sdk_context=abort)), pytest.raises(click.exceptions.Exit):
         active_context_base_url()
+
+
+def test_workspace_comes_from_the_context_not_a_hardcoded_default(
+    use_nmp_config: Callable[..., Path],
+) -> None:
+    """`--workspace` unset means the context's workspace, not the string "default".
+
+    Defaulting to "default" quietly queried the wrong workspace for anyone
+    whose context names another one.
+    """
+    use_nmp_config(workspace="team-space")
+
+    assert resolve_workspace(None) == "team-space"
+    assert resolve_workspace("explicit-space") == "explicit-space"
+
+
+def test_workspace_falls_back_to_default_without_a_context(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NMP_CONFIG_FILE", str(tmp_path / "missing.yaml"))
+
+    assert resolve_workspace(None) == DEFAULT_WORKSPACE
+
+
+def test_ambient_workspace_wins_over_the_config_file(use_nmp_config: Callable[..., Path]) -> None:
+    use_nmp_config(workspace="from-file")
+
+    with cli_state(SimpleNamespace(get_sdk_context=lambda: SimpleNamespace(workspace="from-flag"))):
+        assert resolve_workspace(None) == "from-flag"

--- a/plugins/nemo-insights/tests/test_cli_context.py
+++ b/plugins/nemo-insights/tests/test_cli_context.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Base-URL resolution against the shared CLI context.
+
+The bug these cover: `nemo insights` defaulted to localhost while the rest of
+the CLI followed the configured context, so every command failed against a
+remote deployment that `nemo workspaces list` reached fine.
+"""
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+
+import click
+import pytest
+from nemo_insights_plugin.cli_context import active_context_base_url, base_url_from_context
+from nemo_insights_plugin.contracts.profile import DEFAULT_BASE_URL
+
+
+@contextmanager
+def cli_state(obj: object) -> Iterator[None]:
+    """Push a Click context carrying *obj*, the way the `nemo` root callback does."""
+    with click.Context(click.Command("insights"), obj=obj):
+        yield
+
+
+def write_config(path: Path, base_url: str) -> Path:
+    path.write_text(
+        "current_context: prod\n"
+        "contexts:\n"
+        "  - name: prod\n    cluster: prod-cluster\n    user: prod-user\n"
+        "clusters:\n"
+        f"  - name: prod-cluster\n    base_url: {base_url}\n"
+        "users:\n"
+        "  - name: prod-user\n    type: oauth\n    token: t\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_base_url_from_context_is_none_outside_a_cli_invocation() -> None:
+    assert base_url_from_context() is None
+
+
+def test_ambient_context_wins_over_the_config_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Global `nemo --base-url` / `--context` reach us only through the context object.
+
+    They are recorded as overrides there and are invisible to a fresh config
+    read, so preferring the file would silently drop them.
+    """
+    monkeypatch.setenv("NMP_CONFIG_FILE", str(write_config(tmp_path / "config.yaml", "https://from-file.example")))
+    monkeypatch.delenv("NMP_BASE_URL", raising=False)
+
+    with cli_state(
+        SimpleNamespace(
+            get_sdk_context=lambda: SimpleNamespace(cluster=SimpleNamespace(base_url="https://from-flag.example/"))
+        )
+    ):
+        # Trailing slash stripped: pydantic adds one, the user did not.
+        assert active_context_base_url() == "https://from-flag.example"
+
+
+def test_falls_back_to_the_config_file_without_a_usable_context(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("NMP_CONFIG_FILE", str(write_config(tmp_path / "config.yaml", "https://from-file.example")))
+    monkeypatch.delenv("NMP_BASE_URL", raising=False)
+
+    assert active_context_base_url() == "https://from-file.example"
+    with cli_state(SimpleNamespace()):  # a context object with no get_sdk_context
+        assert active_context_base_url() == "https://from-file.example"
+
+
+def test_a_raising_context_object_does_not_fail_the_command(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def explode() -> object:
+        raise RuntimeError("unreadable context")
+
+    monkeypatch.setenv("NMP_CONFIG_FILE", str(write_config(tmp_path / "config.yaml", "https://from-file.example")))
+    monkeypatch.delenv("NMP_BASE_URL", raising=False)
+
+    with cli_state(SimpleNamespace(get_sdk_context=explode)):
+        assert active_context_base_url() == "https://from-file.example"
+
+
+def test_localhost_is_the_last_resort(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NMP_CONFIG_FILE", str(tmp_path / "missing.yaml"))
+    monkeypatch.delenv("NMP_BASE_URL", raising=False)
+
+    assert active_context_base_url() == DEFAULT_BASE_URL
+
+
+def test_a_deliberate_cli_abort_is_not_swallowed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """`--context nope` must fail here exactly as it does for `nemo workspaces list`.
+
+    Falling back to the config file would run the command against the default
+    context — a different platform than the one the user named.
+    """
+
+    def abort() -> object:
+        raise click.exceptions.Exit(1)
+
+    monkeypatch.setenv("NMP_CONFIG_FILE", str(write_config(tmp_path / "config.yaml", "https://from-file.example")))
+    monkeypatch.delenv("NMP_BASE_URL", raising=False)
+
+    with cli_state(SimpleNamespace(get_sdk_context=abort)), pytest.raises(click.exceptions.Exit):
+        active_context_base_url()

--- a/plugins/nemo-insights/tests/test_cli_profile.py
+++ b/plugins/nemo-insights/tests/test_cli_profile.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -48,36 +48,6 @@ def restore_profile_env() -> Iterator[None]:
             value = original[key]
             if value is not None:
                 os.environ[key] = value
-
-
-def write_nmp_config(path: Path, base_url: str | None) -> Path:
-    """Write a config file with one context, or none when base_url is None."""
-    if base_url is None:
-        path.write_text("{}\n", encoding="utf-8")
-        return path
-    path.write_text(
-        "current_context: test\n"
-        "contexts:\n"
-        "  - name: test\n    cluster: test-cluster\n    user: test-user\n    workspace: default\n"
-        "clusters:\n"
-        f"  - name: test-cluster\n    base_url: {base_url}\n"
-        "users:\n"
-        "  - name: test-user\n    type: oauth\n    token: test-token\n",
-        encoding="utf-8",
-    )
-    return path
-
-
-@pytest.fixture(autouse=True)
-def context_free_nmp_config(tmp_path_factory: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Resolve base URLs against a context-free config by default.
-
-    Base-URL resolution falls back to the active ``nemo config`` context, so
-    without this the developer's own ``~/.config/nmp/config.yaml`` would decide
-    what every no-URL-given case here sees.
-    """
-    config = write_nmp_config(tmp_path_factory.mktemp("nmp-config") / "config.yaml", None)
-    monkeypatch.setenv("NMP_CONFIG_FILE", str(config))
 
 
 @pytest.fixture(autouse=True)
@@ -362,7 +332,7 @@ def test_doctor_resolves_base_url_after_profile_env_loading(
 def test_doctor_falls_back_to_the_active_context_not_localhost(
     app: typer.Typer,
     profile_tree: Path,
-    tmp_path: Path,
+    use_nmp_config: Callable[..., Path],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """With no flag and no NMP_BASE_URL, follow the same context `nemo` does.
@@ -383,9 +353,7 @@ def test_doctor_falls_back_to_the_active_context_not_localhost(
             workspace_ok=record_workspace_probe,
         ),
     )
-    config = write_nmp_config(tmp_path / "config.yaml", "https://cluster.example")
-    monkeypatch.setenv("NMP_CONFIG_FILE", str(config))
-    monkeypatch.delenv("NMP_BASE_URL", raising=False)
+    use_nmp_config(base_url="https://cluster.example")
     monkeypatch.chdir(profile_tree)
 
     result = runner.invoke(app, ["doctor"])

--- a/plugins/nemo-insights/tests/test_cli_profile.py
+++ b/plugins/nemo-insights/tests/test_cli_profile.py
@@ -50,6 +50,36 @@ def restore_profile_env() -> Iterator[None]:
                 os.environ[key] = value
 
 
+def write_nmp_config(path: Path, base_url: str | None) -> Path:
+    """Write a config file with one context, or none when base_url is None."""
+    if base_url is None:
+        path.write_text("{}\n", encoding="utf-8")
+        return path
+    path.write_text(
+        "current_context: test\n"
+        "contexts:\n"
+        "  - name: test\n    cluster: test-cluster\n    user: test-user\n    workspace: default\n"
+        "clusters:\n"
+        f"  - name: test-cluster\n    base_url: {base_url}\n"
+        "users:\n"
+        "  - name: test-user\n    type: oauth\n    token: test-token\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+@pytest.fixture(autouse=True)
+def context_free_nmp_config(tmp_path_factory: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Resolve base URLs against a context-free config by default.
+
+    Base-URL resolution falls back to the active ``nemo config`` context, so
+    without this the developer's own ``~/.config/nmp/config.yaml`` would decide
+    what every no-URL-given case here sees.
+    """
+    config = write_nmp_config(tmp_path_factory.mktemp("nmp-config") / "config.yaml", None)
+    monkeypatch.setenv("NMP_CONFIG_FILE", str(config))
+
+
 @pytest.fixture(autouse=True)
 def quiet_preflight(monkeypatch: pytest.MonkeyPatch, restore_profile_env: None) -> None:
     async def queryable(base_url: str, workspace: str, agent: str) -> bool:
@@ -327,6 +357,41 @@ def test_doctor_resolves_base_url_after_profile_env_loading(
     assert result.exit_code == 0, result.output
     assert http_urls == [expected]
     assert workspace_urls == [expected]
+
+
+def test_doctor_falls_back_to_the_active_context_not_localhost(
+    app: typer.Typer,
+    profile_tree: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no flag and no NMP_BASE_URL, follow the same context `nemo` does.
+
+    Defaulting to localhost here made every insights command fail against a
+    configured remote deployment while the rest of the CLI worked.
+    """
+    probed: list[str] = []
+
+    async def record_workspace_probe(base_url: str, workspace: str, agent: str) -> bool:
+        return True
+
+    monkeypatch.setattr(
+        cli,
+        "_PREFLIGHT_PROBES",
+        AnalysisProbes(
+            http_ok=lambda base_url: probed.append(base_url) or True,
+            workspace_ok=record_workspace_probe,
+        ),
+    )
+    config = write_nmp_config(tmp_path / "config.yaml", "https://cluster.example")
+    monkeypatch.setenv("NMP_CONFIG_FILE", str(config))
+    monkeypatch.delenv("NMP_BASE_URL", raising=False)
+    monkeypatch.chdir(profile_tree)
+
+    result = runner.invoke(app, ["doctor"])
+
+    assert result.exit_code == 0, result.output
+    assert probed == ["https://cluster.example"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
Instead of defaulting to localhost when no `NMP_BASE_URL` or `--base-url` is set, the insights CLI commands now respect the current `nemo config current-context`. Same holds for `--workspace` (e.g. if your CLI context sets a non-`"default"` default workspace).


## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Insights CLI commands now resolve workspaces from explicit options, environment settings, profiles, or the active CLI context.
  * Base URLs can be selected through explicit options, environment settings, or the active CLI context, with documented fallback behavior.
  * Explicit workspace and base URL values take precedence over contextual settings.
* **Documentation**
  * Updated CLI reference documentation to describe workspace and base URL resolution behavior.
* **Bug Fixes**
  * Preserved intentional CLI cancellation behavior during context resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->