### PR TITLE
fix(setup): address sorting for models resolve nvbug-6676750

### DIFF
--- a/e2e/test_setup_model_selection.py
+++ b/e2e/test_setup_model_selection.py
@@ -4,16 +4,16 @@
 """E2E coverage for automatic model selection in ``nemo setup --auto``.
 
 Selection has to hold up on a cold start against a real platform: a provider is
-created, its models are discovered, their passthrough VirtualModels are
-published a moment later, and only a model that answers a live inference
-request may be persisted as the default.
+created, its models are discovered, the gateway 404s them until the controller
+publishes their routes, and only a model that answers a live inference request
+may be persisted as the default.
 
 Provider registration from environment credentials and writing the CLI config
 are the only stubbed steps; discovery, routing and probing go through the
 platform.
 """
 
-import threading
+import json
 import uuid
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -22,6 +22,9 @@ import pytest
 from nemo_platform import NeMoPlatform
 from nemo_platform_ext.cli.commands import setup as setup_commands
 from nemo_platform_ext.cli.commands.setup import ModelPair
+from nmp.common.config import Configuration
+from nmp.core.inference_gateway.api.mock_provider import MOCK_RESPONSE_HEADER, MOCK_SERVED_MODELS_HEADER
+from nmp.core.inference_gateway.config import InferenceGatewayConfig
 from nmp.testing import MockProviderResponse, add_mock_provider
 
 pytestmark = [pytest.mark.timeout(300)]
@@ -48,29 +51,32 @@ def _chat_response(content: str) -> dict[str, Any]:
     }
 
 
-def _publish_route(sdk: NeMoPlatform, workspace: str, entity: str) -> None:
-    """Create the passthrough VirtualModel the gateway routes *entity* through."""
-    sdk.inference.virtual_models.create(
-        workspace=workspace,
-        name=entity,
-        default_model_entity=f"{workspace}/{entity}",
-        autoprovisioned=False,
-    )
+def _advertise_models_without_routes(sdk: NeMoPlatform, workspace: str, name: str, entities: list[str]) -> str:
+    """Create a mock provider that serves *entities* before their routes exist.
 
-
-def _serve_model_without_a_route(sdk: NeMoPlatform, workspace: str, provider: str, entities: list[str]) -> None:
-    """Advertise *entities* on *provider* without creating their VirtualModels.
-
-    This is the state discovery sees on a cold start: a provider reports the
-    models it serves before their passthrough routes are reconciled.
+    This is ``add_mock_provider`` without the passthrough VirtualModels it
+    creates on the caller's behalf, leaving them to the controller as in
+    production. ``MOCK_SERVED_MODELS_HEADER`` keeps the entities in the
+    provider's discovery response, so the reconciler preserves them.
     """
+    provider_name = f"{Configuration.get_service_config(InferenceGatewayConfig).mock_provider_prefix}{name}"
+    sdk.inference.providers.create(
+        workspace=workspace,
+        name=provider_name,
+        host_url="http://mock.local",
+        default_extra_headers={
+            MOCK_RESPONSE_HEADER: json.dumps(_chat_response("OK")),
+            MOCK_SERVED_MODELS_HEADER: json.dumps(entities),
+        },
+    )
     sdk.inference.providers.update_status(
-        name=provider,
+        name=provider_name,
         workspace=workspace,
         served_models=[
             {"model_entity_id": f"{workspace}/{entity}", "served_model_name": entity} for entity in entities
         ],
     )
+    return provider_name
 
 
 def _run_auto_setup(sdk: NeMoPlatform, workspace: str, provider_name: str) -> ModelPair | None:
@@ -128,29 +134,16 @@ def test_auto_setup_persists_a_default_the_account_can_serve(sdk: NeMoPlatform, 
 
 
 def test_auto_setup_waits_for_a_late_published_model_route(sdk: NeMoPlatform, workspace: str):
-    """A discovered model the gateway 404s becomes the default once its route exists."""
+    """Cold start: discovery reports a model before its route is published.
+
+    The gateway 404s the model until the controller creates its passthrough
+    VirtualModel, so probing has to retry before a default can be persisted.
+    """
     suffix = _unique_suffix()
     entity = f"nvidia-nemotron-nano-9b-{suffix}"
-    # Only the embedding model has a route up front, and it is filtered out of
-    # the candidates, so selection has to wait for the chat model's route.
-    embedding = f"nvidia-nv-embedqa-e5-{suffix}"
+    provider_name = _advertise_models_without_routes(sdk, workspace, f"late-route-{suffix}", [entity])
 
-    provider = add_mock_provider(
-        sdk,
-        workspace=workspace,
-        name=f"late-route-{suffix}",
-        mock_response_body=_chat_response("OK"),
-        served_models={embedding: embedding},
-        should_autoprovision_virtual_model=False,
-    )
-    _serve_model_without_a_route(sdk, workspace, provider.name, [embedding, entity])
-
-    publish_route = threading.Timer(2.0, _publish_route, args=(sdk, workspace, entity))
-    publish_route.start()
-    try:
-        saved = _run_auto_setup(sdk, workspace, provider.name)
-    finally:
-        publish_route.cancel()
+    saved = _run_auto_setup(sdk, workspace, provider_name)
 
     assert saved == ModelPair(default=f"{workspace}/{entity}", fast=f"{workspace}/{entity}")
 

--- a/e2e/test_setup_model_selection.py
+++ b/e2e/test_setup_model_selection.py
@@ -19,7 +19,7 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
-from nemo_platform import NeMoPlatform
+from nemo_platform import APIStatusError, NeMoPlatform
 from nemo_platform_ext.cli.commands import setup as setup_commands
 from nemo_platform_ext.cli.commands.setup import ModelPair
 from nmp.common.config import Configuration
@@ -142,6 +142,18 @@ def test_auto_setup_waits_for_a_late_published_model_route(sdk: NeMoPlatform, wo
     suffix = _unique_suffix()
     entity = f"nvidia-nemotron-nano-9b-{suffix}"
     provider_name = _advertise_models_without_routes(sdk, workspace, f"late-route-{suffix}", [entity])
+
+    with pytest.raises(APIStatusError) as initial_probe:
+        sdk.inference.gateway.openai.post(
+            "v1/chat/completions",
+            workspace=workspace,
+            body={
+                "model": f"{workspace}/{entity}",
+                "messages": [{"role": "user", "content": "Respond with 'OK'"}],
+                "max_tokens": 16,
+            },
+        )
+    assert initial_probe.value.status_code == 404
 
     saved = _run_auto_setup(sdk, workspace, provider_name)
 

--- a/e2e/test_setup_model_selection.py
+++ b/e2e/test_setup_model_selection.py
@@ -1,0 +1,172 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E coverage for automatic model selection in ``nemo setup --auto``.
+
+Selection has to hold up on a cold start against a real platform: a provider is
+created, its models are discovered, their passthrough VirtualModels are
+published a moment later, and only a model that answers a live inference
+request may be persisted as the default.
+
+Provider registration from environment credentials and writing the CLI config
+are the only stubbed steps; discovery, routing and probing go through the
+platform.
+"""
+
+import threading
+import uuid
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from nemo_platform import NeMoPlatform
+from nemo_platform_ext.cli.commands import setup as setup_commands
+from nemo_platform_ext.cli.commands.setup import ModelPair
+from nmp.testing import MockProviderResponse, add_mock_provider
+
+pytestmark = [pytest.mark.timeout(300)]
+
+SETUP_MOD = "nemo_platform_ext.cli.commands.setup"
+
+
+def _unique_suffix() -> str:
+    """Return a suffix that cannot be read as a parameter count (ex. ``12345b``)."""
+    return f"x{uuid.uuid4().hex[:6]}"
+
+
+def _chat_response(content: str) -> dict[str, Any]:
+    return {
+        "id": f"chatcmpl-{uuid.uuid4().hex[:8]}",
+        "object": "chat.completion",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": content},
+                "finish_reason": "stop",
+            }
+        ],
+    }
+
+
+def _publish_route(sdk: NeMoPlatform, workspace: str, entity: str) -> None:
+    """Create the passthrough VirtualModel the gateway routes *entity* through."""
+    sdk.inference.virtual_models.create(
+        workspace=workspace,
+        name=entity,
+        default_model_entity=f"{workspace}/{entity}",
+        autoprovisioned=False,
+    )
+
+
+def _serve_model_without_a_route(sdk: NeMoPlatform, workspace: str, provider: str, entities: list[str]) -> None:
+    """Advertise *entities* on *provider* without creating their VirtualModels.
+
+    This is the state discovery sees on a cold start: a provider reports the
+    models it serves before their passthrough routes are reconciled.
+    """
+    sdk.inference.providers.update_status(
+        name=provider,
+        workspace=workspace,
+        served_models=[
+            {"model_entity_id": f"{workspace}/{entity}", "served_model_name": entity} for entity in entities
+        ],
+    )
+
+
+def _run_auto_setup(sdk: NeMoPlatform, workspace: str, provider_name: str) -> ModelPair | None:
+    """Run ``_run_auto_mode`` for *provider_name* and return the persisted pair."""
+    with (
+        patch.dict("os.environ", {"NEMO_DEFAULT_MODEL": "", "NEMO_FAST_MODEL": ""}),
+        patch(f"{SETUP_MOD}._auto_setup", return_value=provider_name),
+        patch(f"{SETUP_MOD}._save_model_pair") as save_pair,
+        patch(f"{SETUP_MOD}._maybe_install_skills"),
+        patch(f"{SETUP_MOD}._maybe_deploy_agent"),
+        patch(f"{SETUP_MOD}._verify_platform_health", return_value=True),
+    ):
+        setup_commands._run_auto_mode(
+            MagicMock(),
+            sdk,
+            workspace,
+            str(sdk.base_url),
+            install_skills=False,
+            deploy_agent=False,
+        )
+
+    if not save_pair.call_args_list:
+        return None
+    return save_pair.call_args.args[1]
+
+
+def test_auto_setup_persists_a_default_the_account_can_serve(sdk: NeMoPlatform, workspace: str):
+    """The largest model that answers becomes the default, the smallest the fast model."""
+    suffix = _unique_suffix()
+    ultra = f"nvidia-nemotron-ultra-500b-{suffix}"
+    large = f"nvidia-nemotron-super-120b-{suffix}"
+    nano = f"nvidia-nemotron-nano-9b-{suffix}"
+
+    provider = add_mock_provider(
+        sdk,
+        workspace=workspace,
+        name=f"selection-{suffix}",
+        mock_response_body_by_model={
+            # Discovery advertises a model this account cannot run.
+            f"{workspace}/{ultra}": [
+                MockProviderResponse(
+                    response_code=404,
+                    response_body={"detail": "Function not found for account"},
+                )
+            ],
+            f"{workspace}/{large}": [MockProviderResponse(response_body=_chat_response("OK"))],
+            f"{workspace}/{nano}": [MockProviderResponse(response_body=_chat_response("OK"))],
+        },
+        served_models={name: name for name in (ultra, large, nano)},
+    )
+
+    saved = _run_auto_setup(sdk, workspace, provider.name)
+
+    assert saved == ModelPair(default=f"{workspace}/{large}", fast=f"{workspace}/{nano}")
+
+
+def test_auto_setup_waits_for_a_late_published_model_route(sdk: NeMoPlatform, workspace: str):
+    """A discovered model the gateway 404s becomes the default once its route exists."""
+    suffix = _unique_suffix()
+    entity = f"nvidia-nemotron-nano-9b-{suffix}"
+    # Only the embedding model has a route up front, and it is filtered out of
+    # the candidates, so selection has to wait for the chat model's route.
+    embedding = f"nvidia-nv-embedqa-e5-{suffix}"
+
+    provider = add_mock_provider(
+        sdk,
+        workspace=workspace,
+        name=f"late-route-{suffix}",
+        mock_response_body=_chat_response("OK"),
+        served_models={embedding: embedding},
+        should_autoprovision_virtual_model=False,
+    )
+    _serve_model_without_a_route(sdk, workspace, provider.name, [embedding, entity])
+
+    publish_route = threading.Timer(2.0, _publish_route, args=(sdk, workspace, entity))
+    publish_route.start()
+    try:
+        saved = _run_auto_setup(sdk, workspace, provider.name)
+    finally:
+        publish_route.cancel()
+
+    assert saved == ModelPair(default=f"{workspace}/{entity}", fast=f"{workspace}/{entity}")
+
+
+def test_auto_setup_saves_nothing_when_no_model_answers(sdk: NeMoPlatform, workspace: str):
+    """A provider whose models all fail leaves the default unset rather than broken."""
+    suffix = _unique_suffix()
+    entity = f"nvidia-nemotron-nano-9b-{suffix}"
+
+    provider = add_mock_provider(
+        sdk,
+        workspace=workspace,
+        name=f"unusable-{suffix}",
+        mock_response_body={"detail": "Function not found for account"},
+        mock_status=404,
+        served_models={entity: entity},
+    )
+
+    assert _run_auto_setup(sdk, workspace, provider.name) is None

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/setup.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/setup.py
@@ -27,7 +27,7 @@ from urllib.parse import urlparse
 import httpx
 import typer
 import yaml as _yaml
-from nemo_platform import APIConnectionError, APIStatusError, NeMoPlatform
+from nemo_platform import APIConnectionError, APIStatusError, APITimeoutError, NeMoPlatform
 from nemo_platform_plugin.capabilities import probe_docker
 from nemo_platform_plugin.client.adapter import client_from_platform
 from nemo_platform_plugin.secrets.client import SecretsClient
@@ -249,11 +249,14 @@ _KEY_REJECTED_STATUS_CODES = (401, 403)
 _TERMINAL_PROBE_STATUS_CODES = (404, 405, 410)
 _KEY_REJECTED_MESSAGE = "API key validation failed. The provider rejected the credentials."
 
-# Catalog listing is not entitlement-scoped, so a candidate is only trusted
-# after a real chat request. The largest names are often gated, so the budget
-# has to absorb a run of 404s at the head of the list.
+# Catalog listing is not entitlement-scoped; only a successful chat request counts.
 _MODEL_PROBE_TIMEOUT = 20.0
 _MODEL_PROBE_MAX_ATTEMPTS = 8
+_MODEL_PROBE_BUDGET_SECONDS = 90.0
+# Gateway 404s until the model's VirtualModel exists; retries are shared and capped.
+_MODEL_ROUTE_READY_SECONDS = 10.0
+_MODEL_ROUTE_RETRY_INTERVAL = 1.0
+_MODEL_ROUTE_MAX_RETRIES = 10
 
 _MODEL_DISCOVERY_ROUND_SECONDS = 30
 _MODEL_DISCOVERY_MAX_ROUNDS = 2
@@ -859,32 +862,47 @@ def _order_candidates_by_size(entity_ids: list[str], *, largest_first: bool) -> 
     return sorted(entity_ids, key=sort_key)
 
 
-def _probe_model_entity(client: NeMoPlatform, workspace: str, entity_id: str) -> bool:
+def _probe_model_entity(
+    client: NeMoPlatform, workspace: str, entity_id: str, route_ready_deadline: float = 0.0
+) -> bool:
     """Return True when a short chat request against *entity_id* succeeds.
 
-    Non-2xx responses (including wrapped upstream 404s) skip the candidate.
-    Connection failures are re-raised so the caller can stop probing.
+    Retries 404s until *route_ready_deadline*; timeouts skip; connection errors raise.
     """
-    try:
-        client.inference.gateway.openai.post(
-            "v1/chat/completions",
-            workspace=workspace,
-            body={
-                "model": entity_id,
-                "messages": [{"role": "user", "content": "Respond with 'OK'"}],
-                "max_tokens": 16,
-            },
-        )
-    except APIConnectionError:
-        raise
-    except APIStatusError as exc:
-        console.print(f"  {WARN} Skipping {_display_model_name(entity_id)} (HTTP {exc.status_code})")
-        return False
-    except Exception as exc:
-        logger.debug("Model probe for '%s' failed", entity_id, exc_info=True)
-        console.print(f"  {WARN} Skipping {_display_model_name(entity_id)} ({exc})")
-        return False
-    return True
+    retries = 0
+    while True:
+        try:
+            client.inference.gateway.openai.post(
+                "v1/chat/completions",
+                workspace=workspace,
+                body={
+                    "model": entity_id,
+                    "messages": [{"role": "user", "content": "Respond with 'OK'"}],
+                    "max_tokens": 16,
+                },
+            )
+        except APITimeoutError:
+            logger.debug("Model probe for '%s' timed out", entity_id, exc_info=True)
+            console.print(f"  {WARN} Skipping {_display_model_name(entity_id)} (timed out)")
+            return False
+        except APIConnectionError:
+            raise
+        except APIStatusError as exc:
+            if (
+                exc.status_code == 404
+                and retries < _MODEL_ROUTE_MAX_RETRIES
+                and time.monotonic() < route_ready_deadline
+            ):
+                retries += 1
+                _pause(_MODEL_ROUTE_RETRY_INTERVAL)
+                continue
+            console.print(f"  {WARN} Skipping {_display_model_name(entity_id)} (HTTP {exc.status_code})")
+            return False
+        except Exception as exc:
+            logger.debug("Model probe for '%s' failed", entity_id, exc_info=True)
+            console.print(f"  {WARN} Skipping {_display_model_name(entity_id)} ({exc})")
+            return False
+        return True
 
 
 def _select_usable_model_pair(client: NeMoPlatform, workspace: str, entity_ids: list[str]) -> ModelPair | None:
@@ -899,15 +917,18 @@ def _select_usable_model_pair(client: NeMoPlatform, workspace: str, entity_ids: 
 
     usable: dict[str, bool] = {}
     probe_client = client.with_options(max_retries=0, timeout=_MODEL_PROBE_TIMEOUT)
+    started = time.monotonic()
+    deadline = started + _MODEL_PROBE_BUDGET_SECONDS
+    route_ready_deadline = started + _MODEL_ROUTE_READY_SECONDS
 
     def first_usable(ordered: list[str]) -> str | None:
         attempts = 0
         for entity_id in ordered:
             if entity_id not in usable:
-                if attempts >= _MODEL_PROBE_MAX_ATTEMPTS:
+                if attempts >= _MODEL_PROBE_MAX_ATTEMPTS or time.monotonic() >= deadline:
                     return None
                 attempts += 1
-                usable[entity_id] = _probe_model_entity(probe_client, workspace, entity_id)
+                usable[entity_id] = _probe_model_entity(probe_client, workspace, entity_id, route_ready_deadline)
             if usable[entity_id]:
                 return entity_id
         return None

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/setup.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/setup.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import importlib.util
 import logging
 import os
+import re
 import subprocess
 import time
 from dataclasses import dataclass
@@ -26,7 +27,7 @@ from urllib.parse import urlparse
 import httpx
 import typer
 import yaml as _yaml
-from nemo_platform import NeMoPlatform
+from nemo_platform import APIConnectionError, APIStatusError, NeMoPlatform
 from nemo_platform_plugin.capabilities import probe_docker
 from nemo_platform_plugin.client.adapter import client_from_platform
 from nemo_platform_plugin.secrets.client import SecretsClient
@@ -247,6 +248,12 @@ _KEY_VALIDATION_TIMEOUT = 10.0
 _KEY_REJECTED_STATUS_CODES = (401, 403)
 _TERMINAL_PROBE_STATUS_CODES = (404, 405, 410)
 _KEY_REJECTED_MESSAGE = "API key validation failed. The provider rejected the credentials."
+
+# Catalog listing is not entitlement-scoped, so a candidate is only trusted
+# after a real chat request. The largest names are often gated, so the budget
+# has to absorb a run of 404s at the head of the list.
+_MODEL_PROBE_TIMEOUT = 20.0
+_MODEL_PROBE_MAX_ATTEMPTS = 8
 
 _MODEL_DISCOVERY_ROUND_SECONDS = 30
 _MODEL_DISCOVERY_MAX_ROUNDS = 2
@@ -796,7 +803,16 @@ def _get_all_model_entity_ids(
     return sorted(set(entity_ids))
 
 
-_NON_CHAT_MODEL_MARKERS = ("embed", "embedding", "vision", "guard", "rerank", "fuyu")
+_NON_CHAT_MODEL_MARKERS = (
+    "embed",
+    "embedding",
+    "vision",
+    "guard",
+    "rerank",
+    "fuyu",
+    "reward",
+    "translate",
+)
 
 
 def _is_usable_chat_model_entity(entity_id: str) -> bool:
@@ -814,6 +830,98 @@ def _pick_default_chat_entity(entity_ids: list[str]) -> str | None:
         if _is_usable_chat_model_entity(entity_id):
             return entity_id
     return None
+
+
+_MODEL_SIZE_PATTERN = re.compile(r"(?<![a-z0-9.])(\d+(?:\.\d+)?)b(?![a-z0-9])")
+
+
+def _model_parameter_size(entity_id: str) -> float | None:
+    """Return the largest ``Nb`` parameter count parsed from an entity name."""
+    name = _display_model_name(entity_id).lower().replace("_", "-")
+    sizes = [float(match) for match in _MODEL_SIZE_PATTERN.findall(name)]
+    return max(sizes) if sizes else None
+
+
+def _is_preferred_vendor(entity_id: str) -> bool:
+    """Return whether the entity name identifies an NVIDIA-published model."""
+    name = _display_model_name(entity_id).lower().replace("_", "-")
+    return name.startswith(("nvidia-", "nv-")) or "nemotron" in name
+
+
+def _order_candidates_by_size(entity_ids: list[str], *, largest_first: bool) -> list[str]:
+    """Order NVIDIA models first, then by parsed size; unnamed sizes sort last."""
+
+    def sort_key(entity_id: str) -> tuple[bool, bool, float, str]:
+        size = _model_parameter_size(entity_id)
+        ranked = 0.0 if size is None else (-size if largest_first else size)
+        return (not _is_preferred_vendor(entity_id), size is None, ranked, entity_id)
+
+    return sorted(entity_ids, key=sort_key)
+
+
+def _probe_model_entity(client: NeMoPlatform, workspace: str, entity_id: str) -> bool:
+    """Return True when a short chat request against *entity_id* succeeds.
+
+    Non-2xx responses (including wrapped upstream 404s) skip the candidate.
+    Connection failures are re-raised so the caller can stop probing.
+    """
+    try:
+        client.inference.gateway.openai.post(
+            "v1/chat/completions",
+            workspace=workspace,
+            body={
+                "model": entity_id,
+                "messages": [{"role": "user", "content": "Respond with 'OK'"}],
+                "max_tokens": 16,
+            },
+        )
+    except APIConnectionError:
+        raise
+    except APIStatusError as exc:
+        console.print(f"  {WARN} Skipping {_display_model_name(entity_id)} (HTTP {exc.status_code})")
+        return False
+    except Exception as exc:
+        logger.debug("Model probe for '%s' failed", entity_id, exc_info=True)
+        console.print(f"  {WARN} Skipping {_display_model_name(entity_id)} ({exc})")
+        return False
+    return True
+
+
+def _select_usable_model_pair(client: NeMoPlatform, workspace: str, entity_ids: list[str]) -> ModelPair | None:
+    """Choose the largest and smallest models that answer a chat request.
+
+    Returns ``None`` when nothing answers, including when the gateway is
+    unreachable, so setup does not persist an unusable default.
+    """
+    candidates = [entity_id for entity_id in entity_ids if _is_usable_chat_model_entity(entity_id)]
+    if not candidates:
+        return None
+
+    usable: dict[str, bool] = {}
+    probe_client = client.with_options(max_retries=0, timeout=_MODEL_PROBE_TIMEOUT)
+
+    def first_usable(ordered: list[str]) -> str | None:
+        attempts = 0
+        for entity_id in ordered:
+            if entity_id not in usable:
+                if attempts >= _MODEL_PROBE_MAX_ATTEMPTS:
+                    return None
+                attempts += 1
+                usable[entity_id] = _probe_model_entity(probe_client, workspace, entity_id)
+            if usable[entity_id]:
+                return entity_id
+        return None
+
+    console.print("  Verifying models with a short inference request...")
+    try:
+        default_model = first_usable(_order_candidates_by_size(candidates, largest_first=True))
+        if default_model is None:
+            return None
+        fast_model = first_usable(_order_candidates_by_size(candidates, largest_first=False)) or default_model
+    except APIConnectionError as exc:
+        console.print(f"  {WARN} Could not verify models ({exc}).")
+        return None
+    return ModelPair(default=default_model, fast=fast_model)
 
 
 def _get_all_model_choices(
@@ -1973,21 +2081,25 @@ def _select_model_pair(
         console.print(f"  {WARN} No models discovered yet. You can select models later.")
         return None
 
-    suggested = _pick_default_chat_entity([entity_id for entity_id, _ in display_models])
-    if suggested is None:
+    entity_ids = [entity_id for entity_id, _ in display_models]
+    if _pick_default_chat_entity(entity_ids) is None:
         console.print(f"  {WARN} No usable chat models discovered yet. You can select models later.")
         return None
+
+    suggested = _select_usable_model_pair(client, workspace, entity_ids)
+    if suggested is None:
+        console.print(f"  {WARN} None of the discovered models served a test request; suggestions may not work.")
 
     default_model = prompt_select(
         "Choose your default model (used for quality-critical agent work):",
         choices=display_models,
-        default=suggested,
+        default=suggested.default if suggested else _pick_default_chat_entity(entity_ids),
         hint="Press Enter to accept the default.",
     )
     fast = prompt_select(
         "Choose your fast model (used for latency-sensitive agent work):",
         choices=display_models,
-        default=default_model,
+        default=suggested.fast if suggested else default_model,
         hint="Press Enter to reuse the default model.",
     )
     return ModelPair(default=default_model, fast=fast)
@@ -2360,21 +2472,32 @@ def _run_auto_mode(
         )
     )
 
-    default_model = os.environ.get("NEMO_DEFAULT_MODEL", "").strip()
-    if not default_model and entity_ids:
-        default_model = _pick_default_chat_entity(entity_ids) or ""
-    fast_model = os.environ.get("NEMO_FAST_MODEL", "").strip() or default_model
+    # An explicit NEMO_DEFAULT_MODEL is taken as given; anything auto-selected
+    # has to answer a real inference request first.
+    default_override = os.environ.get("NEMO_DEFAULT_MODEL", "").strip()
+    fast_override = os.environ.get("NEMO_FAST_MODEL", "").strip()
+    if default_override:
+        model_pair = ModelPair(default=default_override, fast=fast_override or default_override)
+    elif entity_ids:
+        selected = _select_usable_model_pair(client, workspace, entity_ids)
+        model_pair = ModelPair(default=selected.default, fast=fast_override or selected.fast) if selected else None
+    else:
+        model_pair = None
 
-    if default_model:
-        model_pair = ModelPair(default=default_model, fast=fast_model)
+    if model_pair:
         _save_model_pair(cli_context, model_pair)
         console.print(f"  {CHECK} Default model: {model_pair.default}")
         console.print(f"  {CHECK} Fast model: {model_pair.fast}")
     else:
-        if fast_model:
+        if fast_override:
             console.print(f"  {WARN} NEMO_FAST_MODEL is ignored until a default model is available")
-        console.print(f"  {WARN} No default model set (no models discovered yet)")
-        console.print("  Run [cyan]nemo setup[/cyan] again after models sync, or set the models via env vars:")
+        if entity_ids:
+            console.print(f"  {WARN} No default model set (none of the discovered models served a test request)")
+            console.print("  The provider advertises models this account cannot run. Check the account's")
+            console.print("  model entitlements, or pick a model yourself:")
+        else:
+            console.print(f"  {WARN} No default model set (no models discovered yet)")
+            console.print("  Run [cyan]nemo setup[/cyan] again after models sync, or set the models via env vars:")
         console.print("    [cyan]export NEMO_DEFAULT_MODEL=<model>[/cyan]")
         console.print("    [cyan]export NEMO_FAST_MODEL=<model>[/cyan]")
 
@@ -2390,14 +2513,14 @@ def _run_auto_mode(
         workspace,
         auto=True,
         deploy_agent=deploy_agent,
-        default_model=default_model,
+        default_model=model_pair.default if model_pair else "",
         headers=_platform_request_headers(cli_context),
     )
 
     if not _verify_platform_health(base_url):
         raise typer.Exit(1)
 
-    if default_model:
+    if model_pair:
         console.print(f"\n{CHECK} [green]Setup complete![/green]")
     else:
         console.print(f"\n{WARN} [yellow]Setup complete with warnings.[/yellow]")

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/setup.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/setup.py
@@ -848,7 +848,7 @@ def _model_parameter_size(entity_id: str) -> float | None:
 def _is_preferred_vendor(entity_id: str) -> bool:
     """Return whether the entity name identifies an NVIDIA-published model."""
     name = _display_model_name(entity_id).lower().replace("_", "-")
-    return name.startswith(("nvidia-", "nv-")) or "nemotron" in name
+    return name.startswith(("nvidia-", "nvidia/", "nv-", "nv/")) or "nemotron" in name
 
 
 def _order_candidates_by_size(entity_ids: list[str], *, largest_first: bool) -> list[str]:
@@ -862,13 +862,12 @@ def _order_candidates_by_size(entity_ids: list[str], *, largest_first: bool) -> 
     return sorted(entity_ids, key=sort_key)
 
 
-def _probe_model_entity(
-    client: NeMoPlatform, workspace: str, entity_id: str, route_ready_deadline: float = 0.0
-) -> bool:
+def _probe_model_entity(client: NeMoPlatform, workspace: str, entity_id: str) -> bool:
     """Return True when a short chat request against *entity_id* succeeds.
 
-    Retries 404s until *route_ready_deadline*; timeouts skip; connection errors raise.
+    Retries route 404s; timeouts skip; connection errors raise.
     """
+    route_ready_deadline = time.monotonic() + _MODEL_ROUTE_READY_SECONDS
     retries = 0
     while True:
         try:
@@ -888,8 +887,11 @@ def _probe_model_entity(
         except APIConnectionError:
             raise
         except APIStatusError as exc:
+            detail = str(exc.body or exc.response.text or exc)
+            entitlement_miss = "not found for account" in detail.lower()
             if (
                 exc.status_code == 404
+                and not entitlement_miss
                 and retries < _MODEL_ROUTE_MAX_RETRIES
                 and time.monotonic() < route_ready_deadline
             ):
@@ -919,7 +921,6 @@ def _select_usable_model_pair(client: NeMoPlatform, workspace: str, entity_ids: 
     probe_client = client.with_options(max_retries=0, timeout=_MODEL_PROBE_TIMEOUT)
     started = time.monotonic()
     deadline = started + _MODEL_PROBE_BUDGET_SECONDS
-    route_ready_deadline = started + _MODEL_ROUTE_READY_SECONDS
 
     def first_usable(ordered: list[str]) -> str | None:
         attempts = 0
@@ -928,7 +929,7 @@ def _select_usable_model_pair(client: NeMoPlatform, workspace: str, entity_ids: 
                 if attempts >= _MODEL_PROBE_MAX_ATTEMPTS or time.monotonic() >= deadline:
                     return None
                 attempts += 1
-                usable[entity_id] = _probe_model_entity(probe_client, workspace, entity_id, route_ready_deadline)
+                usable[entity_id] = _probe_model_entity(probe_client, workspace, entity_id)
             if usable[entity_id]:
                 return entity_id
         return None
@@ -2109,13 +2110,13 @@ def _select_model_pair(
 
     suggested = _select_usable_model_pair(client, workspace, entity_ids)
     if suggested is None:
-        console.print(f"  {WARN} None of the discovered models served a test request; suggestions may not work.")
+        console.print(f"  {WARN} None of the discovered models served a test request; choose a model explicitly.")
 
     default_model = prompt_select(
         "Choose your default model (used for quality-critical agent work):",
         choices=display_models,
-        default=suggested.default if suggested else _pick_default_chat_entity(entity_ids),
-        hint="Press Enter to accept the default.",
+        default=suggested.default if suggested else None,
+        hint="Press Enter to accept the default." if suggested else "Choose a model you can access.",
     )
     fast = prompt_select(
         "Choose your fast model (used for latency-sensitive agent work):",

--- a/packages/nemo_platform_ext/tests/cli/commands/test_setup.py
+++ b/packages/nemo_platform_ext/tests/cli/commands/test_setup.py
@@ -18,6 +18,7 @@ import pytest
 import typer
 from click.core import ParameterSource
 from click.exceptions import Exit as ClickExit
+from nemo_platform import APIConnectionError, APIStatusError
 from nemo_platform.resources.inference.providers import ProvidersResource
 from nemo_platform_ext.cli.commands.setup import (
     _AGENT_API_READINESS_POLL_INTERVAL,
@@ -58,9 +59,12 @@ from nemo_platform_ext.cli.commands.setup import (
     _maybe_deploy_agent,
     _maybe_install_skills,
     _maybe_start_services,
+    _model_parameter_size,
+    _order_candidates_by_size,
     _parse_csv_flag,
     _pick_default_chat_entity,
     _print_onboarding,
+    _probe_model_entity,
     _prompt_custom_provider,
     _register_provider_interactive,
     _render_onboarding_card,
@@ -70,6 +74,7 @@ from nemo_platform_ext.cli.commands.setup import (
     _run_interactive_mode,
     _save_data_dir,
     _select_model_pair,
+    _select_usable_model_pair,
     _services_log_suggests_port_conflict,
     _start_services_background,
     _validate_api_key,
@@ -2187,6 +2192,165 @@ class TestPickDefaultChatEntity:
         assert _pick_default_chat_entity(["default/adept-fuyu-8b", "default/nv-embedqa"]) is None
 
 
+def _probe_error(status_code: int, text: str = "") -> APIStatusError:
+    """Build the SDK error the gateway raises for a non-2xx probe response."""
+    request = httpx.Request("POST", "http://localhost:8080/v1/chat/completions")
+    return APIStatusError("probe failed", response=httpx.Response(status_code, text=text, request=request), body=None)
+
+
+def _client_answering(outcomes: dict[str, object]) -> MagicMock:
+    """Return a client whose gateway probe answers per model entity ID.
+
+    A value that is an exception is raised; anything else is returned as the
+    successful response.
+    """
+    client = MagicMock()
+
+    def post(trailing_uri: str, *, workspace: str, body: dict) -> object:
+        outcome = outcomes[str(body["model"])]
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+    client.with_options.return_value.inference.gateway.openai.post.side_effect = post
+    return client
+
+
+class TestModelSizeOrdering:
+    @pytest.mark.parametrize(
+        ("entity_id", "expected"),
+        [
+            ("default/meta-llama-3-3-70b-instruct", 70.0),
+            ("default/nvidia-nemotron-3.5-lightning-30b-a3b", 30.0),
+            ("default/openai-gpt-oss-120b", 120.0),
+            ("default/meta-llama-3-1-8b-instruct", 8.0),
+            ("default/nvidia-nemotron-nano-1.5b-v2", 1.5),
+            ("default/ai21labs-jamba-1-5-large-instruct", None),
+        ],
+    )
+    def test_parses_parameter_count_from_entity_name(self, entity_id, expected):
+        assert _model_parameter_size(entity_id) == expected
+
+    def test_orders_nvidia_first_then_by_size(self):
+        candidates = [
+            "default/meta-llama-3-3-70b-instruct",
+            "default/nvidia-nemotron-3.5-lightning-30b-a3b",
+            "default/ai21labs-jamba-1-5-large-instruct",
+            "default/nvidia-nemotron-nano-9b-v2",
+        ]
+
+        assert _order_candidates_by_size(candidates, largest_first=True) == [
+            "default/nvidia-nemotron-3.5-lightning-30b-a3b",
+            "default/nvidia-nemotron-nano-9b-v2",
+            "default/meta-llama-3-3-70b-instruct",
+            "default/ai21labs-jamba-1-5-large-instruct",
+        ]
+        assert _order_candidates_by_size(candidates, largest_first=False) == [
+            "default/nvidia-nemotron-nano-9b-v2",
+            "default/nvidia-nemotron-3.5-lightning-30b-a3b",
+            "default/meta-llama-3-3-70b-instruct",
+            "default/ai21labs-jamba-1-5-large-instruct",
+        ]
+
+
+class TestModelProbe:
+    @pytest.mark.parametrize(
+        ("outcome", "expected"),
+        [
+            (MagicMock(), True),
+            (_probe_error(404, "model not found"), False),
+            (_probe_error(403), False),
+            (_probe_error(502, '{"detail": "Backend returned 404: Function ... not found for account"}'), False),
+            (_probe_error(503, "upstream busy"), False),
+        ],
+    )
+    def test_classifies_gateway_responses(self, outcome, expected):
+        client = _client_answering({"default/model": outcome})
+
+        assert _probe_model_entity(client.with_options(), "default", "default/model") is expected
+
+    def test_reraises_when_the_gateway_is_unreachable(self):
+        client = _client_answering(
+            {"default/model": APIConnectionError(request=httpx.Request("POST", "http://localhost:8080"))}
+        )
+
+        with pytest.raises(APIConnectionError):
+            _probe_model_entity(client.with_options(), "default", "default/model")
+
+    def test_sends_a_short_chat_request_for_the_candidate(self):
+        client = _client_answering({"default/model": MagicMock()})
+        gateway = client.with_options()
+
+        _probe_model_entity(gateway, "default", "default/model")
+
+        gateway.inference.gateway.openai.post.assert_called_once()
+        _, kwargs = gateway.inference.gateway.openai.post.call_args
+        assert kwargs["workspace"] == "default"
+        assert kwargs["body"]["model"] == "default/model"
+        assert kwargs["body"]["messages"][0]["role"] == "user"
+
+
+class TestUsableModelPairSelection:
+    def test_picks_largest_usable_as_default_and_smallest_as_fast(self):
+        entity_ids = [
+            "default/nvidia-nemotron-3.5-lightning-30b-a3b",
+            "default/nvidia-nemotron-nano-9b-v2",
+        ]
+        client = _client_answering({entity_id: MagicMock() for entity_id in entity_ids})
+
+        assert _select_usable_model_pair(client, "default", entity_ids) == ModelPair(
+            default="default/nvidia-nemotron-3.5-lightning-30b-a3b",
+            fast="default/nvidia-nemotron-nano-9b-v2",
+        )
+
+    def test_skips_a_model_the_account_cannot_serve(self):
+        entity_ids = [
+            "default/ai21labs-jamba-1-5-large-instruct",
+            "default/meta-llama-3-3-70b-instruct",
+        ]
+        client = _client_answering(
+            {
+                "default/meta-llama-3-3-70b-instruct": _probe_error(
+                    502, '{"detail": "Backend returned 404: Function not found for account"}'
+                ),
+                "default/ai21labs-jamba-1-5-large-instruct": MagicMock(),
+            }
+        )
+
+        assert _select_usable_model_pair(client, "default", entity_ids) == ModelPair(
+            default="default/ai21labs-jamba-1-5-large-instruct",
+            fast="default/ai21labs-jamba-1-5-large-instruct",
+        )
+
+    def test_saves_nothing_when_no_candidate_serves_a_request(self):
+        entity_ids = ["default/one-8b-instruct", "default/two-70b-instruct"]
+        client = _client_answering({entity_id: _probe_error(404) for entity_id in entity_ids})
+
+        assert _select_usable_model_pair(client, "default", entity_ids) is None
+
+    def test_stops_probing_after_the_attempt_budget(self):
+        entity_ids = [f"default/model-{index}b-instruct" for index in range(1, 12)]
+        client = _client_answering({entity_id: _probe_error(404) for entity_id in entity_ids})
+
+        assert _select_usable_model_pair(client, "default", entity_ids) is None
+        post = client.with_options.return_value.inference.gateway.openai.post
+        assert post.call_count == setup_commands._MODEL_PROBE_MAX_ATTEMPTS
+
+    def test_saves_nothing_when_the_gateway_is_unreachable(self):
+        entity_ids = ["default/nvidia-nemotron-nano-9b-v2", "default/meta-llama-3-3-70b-instruct"]
+        unreachable = APIConnectionError(request=httpx.Request("POST", "http://localhost:8080"))
+        client = _client_answering({entity_id: unreachable for entity_id in entity_ids})
+
+        assert _select_usable_model_pair(client, "default", entity_ids) is None
+
+    def test_ignores_non_chat_entities(self):
+        entity_ids = ["default/nvidia-nv-embedqa-e5-v5", "default/adept-fuyu-8b"]
+        client = _client_answering({})
+
+        assert _select_usable_model_pair(client, "default", entity_ids) is None
+        client.with_options.return_value.inference.gateway.openai.post.assert_not_called()
+
+
 class TestAutoModelPairSelection:
     def test_entity_discovery_filters_other_workspace_providers(self):
         client = MagicMock()
@@ -2413,6 +2577,87 @@ class TestAutoModelPairSelection:
         printed = " ".join(str(c) for c in print_message.call_args_list)
         assert "[green]Setup complete![/green]" in printed
         assert "Setup complete with warnings" not in printed
+
+    def test_discovered_models_are_probed_before_being_saved(self):
+        cli_context = MagicMock()
+        client = MagicMock()
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch(f"{SETUP_MOD}._auto_setup", return_value="nvidia-build"),
+            patch(f"{SETUP_MOD}._get_all_model_entity_ids", return_value=["default/a-model"]),
+            patch(
+                f"{SETUP_MOD}._select_usable_model_pair",
+                return_value=ModelPair(default="default/a-model", fast="default/a-model"),
+            ) as select_pair,
+            patch(f"{SETUP_MOD}._save_model_pair") as save_pair,
+            patch(f"{SETUP_MOD}._maybe_install_skills"),
+            patch(f"{SETUP_MOD}._maybe_deploy_agent"),
+            patch(f"{SETUP_MOD}._verify_platform_health", return_value=True),
+        ):
+            _run_auto_mode(
+                cli_context,
+                client,
+                "default",
+                "http://localhost:8080",
+                install_skills=False,
+                deploy_agent=False,
+            )
+
+        select_pair.assert_called_once_with(client, "default", ["default/a-model"])
+        save_pair.assert_called_once_with(cli_context, ModelPair(default="default/a-model", fast="default/a-model"))
+
+    def test_no_model_is_saved_when_none_serve_a_request(self):
+        cli_context = MagicMock()
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch(f"{SETUP_MOD}._auto_setup", return_value="nvidia-build"),
+            patch(
+                f"{SETUP_MOD}._get_all_model_entity_ids",
+                return_value=["default/ai21labs-jamba-1-5-large-instruct"],
+            ),
+            patch(f"{SETUP_MOD}._select_usable_model_pair", return_value=None),
+            patch(f"{SETUP_MOD}._save_model_pair") as save_pair,
+            patch(f"{SETUP_MOD}._maybe_install_skills"),
+            patch(f"{SETUP_MOD}._maybe_deploy_agent"),
+            patch(f"{SETUP_MOD}._verify_platform_health", return_value=True),
+            patch(f"{SETUP_MOD}.console.print") as print_message,
+        ):
+            _run_auto_mode(
+                cli_context,
+                MagicMock(),
+                "default",
+                "http://localhost:8080",
+                install_skills=False,
+                deploy_agent=False,
+            )
+
+        save_pair.assert_not_called()
+        printed = " ".join(str(c) for c in print_message.call_args_list)
+        assert "none of the discovered models served a test request" in printed
+
+    def test_explicit_default_model_is_not_probed(self):
+        cli_context = MagicMock()
+        with (
+            patch.dict("os.environ", {"NEMO_DEFAULT_MODEL": "default/quality"}, clear=True),
+            patch(f"{SETUP_MOD}._auto_setup", return_value="nvidia-build"),
+            patch(f"{SETUP_MOD}._get_all_model_entity_ids", return_value=["default/a-model"]),
+            patch(f"{SETUP_MOD}._select_usable_model_pair") as select_pair,
+            patch(f"{SETUP_MOD}._save_model_pair") as save_pair,
+            patch(f"{SETUP_MOD}._maybe_install_skills"),
+            patch(f"{SETUP_MOD}._maybe_deploy_agent"),
+            patch(f"{SETUP_MOD}._verify_platform_health", return_value=True),
+        ):
+            _run_auto_mode(
+                cli_context,
+                MagicMock(),
+                "default",
+                "http://localhost:8080",
+                install_skills=False,
+                deploy_agent=False,
+            )
+
+        select_pair.assert_not_called()
+        save_pair.assert_called_once_with(cli_context, ModelPair(default="default/quality", fast="default/quality"))
 
 
 # ---------------------------------------------------------------------------

--- a/packages/nemo_platform_ext/tests/cli/commands/test_setup.py
+++ b/packages/nemo_platform_ext/tests/cli/commands/test_setup.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import logging
 import sys
+import time
 from collections.abc import Iterator
 from contextlib import ExitStack, contextmanager
 from types import SimpleNamespace
@@ -18,7 +19,7 @@ import pytest
 import typer
 from click.core import ParameterSource
 from click.exceptions import Exit as ClickExit
-from nemo_platform import APIConnectionError, APIStatusError
+from nemo_platform import APIConnectionError, APIStatusError, APITimeoutError
 from nemo_platform.resources.inference.providers import ProvidersResource
 from nemo_platform_ext.cli.commands.setup import (
     _AGENT_API_READINESS_POLL_INTERVAL,
@@ -2269,6 +2270,31 @@ class TestModelProbe:
 
         assert _probe_model_entity(client.with_options(), "default", "default/model") is expected
 
+    def test_retries_a_404_until_the_route_is_published(self):
+        """The gateway 404s a discovered model until its VirtualModel exists."""
+        client = MagicMock()
+        client.inference.gateway.openai.post.side_effect = [_probe_error(404), _probe_error(404), MagicMock()]
+
+        with patch(f"{SETUP_MOD}._pause"):
+            usable = _probe_model_entity(client, "default", "default/model", time.monotonic() + 30)
+
+        assert usable is True
+        assert client.inference.gateway.openai.post.call_count == 3
+
+    def test_does_not_retry_a_404_past_the_route_deadline(self):
+        client = MagicMock()
+        client.inference.gateway.openai.post.side_effect = _probe_error(404)
+
+        assert _probe_model_entity(client, "default", "default/model", 0.0) is False
+        assert client.inference.gateway.openai.post.call_count == 1
+
+    def test_skips_timeouts_so_later_candidates_can_be_tried(self):
+        client = _client_answering(
+            {"default/model": APITimeoutError(request=httpx.Request("POST", "http://localhost:8080"))}
+        )
+
+        assert _probe_model_entity(client.with_options(), "default", "default/model") is False
+
     def test_reraises_when_the_gateway_is_unreachable(self):
         client = _client_answering(
             {"default/model": APIConnectionError(request=httpx.Request("POST", "http://localhost:8080"))}
@@ -2291,6 +2317,12 @@ class TestModelProbe:
 
 
 class TestUsableModelPairSelection:
+    @pytest.fixture(autouse=True)
+    def _no_sleep(self) -> Iterator[None]:
+        """Probes pause between 404 retries; selection tests should not sleep."""
+        with patch(f"{SETUP_MOD}._pause"):
+            yield
+
     def test_picks_largest_usable_as_default_and_smallest_as_fast(self):
         entity_ids = [
             "default/nvidia-nemotron-3.5-lightning-30b-a3b",
@@ -2334,7 +2366,51 @@ class TestUsableModelPairSelection:
 
         assert _select_usable_model_pair(client, "default", entity_ids) is None
         post = client.with_options.return_value.inference.gateway.openai.post
-        assert post.call_count == setup_commands._MODEL_PROBE_MAX_ATTEMPTS
+        probed = {str(probe.kwargs["body"]["model"]) for probe in post.call_args_list}
+        assert len(probed) == setup_commands._MODEL_PROBE_MAX_ATTEMPTS
+
+    def test_skips_a_timed_out_candidate_and_keeps_probing(self):
+        entity_ids = [
+            "default/nvidia-nemotron-3-ultra-550b-a55b",
+            "default/nvidia-nemotron-nano-9b-v2",
+        ]
+        timeout = APITimeoutError(request=httpx.Request("POST", "http://localhost:8080"))
+        client = _client_answering(
+            {
+                "default/nvidia-nemotron-3-ultra-550b-a55b": timeout,
+                "default/nvidia-nemotron-nano-9b-v2": MagicMock(),
+            }
+        )
+
+        assert _select_usable_model_pair(client, "default", entity_ids) == ModelPair(
+            default="default/nvidia-nemotron-nano-9b-v2",
+            fast="default/nvidia-nemotron-nano-9b-v2",
+        )
+
+    def test_waits_out_the_reconcile_lag_before_rejecting_candidates(self):
+        """Cold start: the first probe 404s because the model has no route yet."""
+        entity_ids = ["default/nvidia-nemotron-nano-9b-v2"]
+        client = MagicMock()
+        client.with_options.return_value.inference.gateway.openai.post.side_effect = [
+            _probe_error(404),
+            MagicMock(),
+        ]
+
+        assert _select_usable_model_pair(client, "default", entity_ids) == ModelPair(
+            default="default/nvidia-nemotron-nano-9b-v2",
+            fast="default/nvidia-nemotron-nano-9b-v2",
+        )
+
+    def test_stops_probing_after_the_time_budget(self):
+        entity_ids = [f"default/model-{index}b-instruct" for index in range(1, 6)]
+        client = _client_answering({entity_id: _probe_error(404) for entity_id in entity_ids})
+        clock = iter([0.0, 0.0, 91.0, 91.0, 91.0, 91.0])
+
+        with patch(f"{SETUP_MOD}.time.monotonic", side_effect=lambda: next(clock)):
+            assert _select_usable_model_pair(client, "default", entity_ids) is None
+
+        post = client.with_options.return_value.inference.gateway.openai.post
+        assert post.call_count == 1
 
     def test_saves_nothing_when_the_gateway_is_unreachable(self):
         entity_ids = ["default/nvidia-nemotron-nano-9b-v2", "default/meta-llama-3-3-70b-instruct"]

--- a/packages/nemo_platform_ext/tests/cli/commands/test_setup.py
+++ b/packages/nemo_platform_ext/tests/cli/commands/test_setup.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import logging
 import sys
-import time
 from collections.abc import Iterator
 from contextlib import ExitStack, contextmanager
 from types import SimpleNamespace
@@ -53,6 +52,7 @@ from nemo_platform_ext.cli.commands.setup import (
     _ensure_port_available_for_start,
     _filter_agents_by_scope,
     _find_project_root,
+    _is_preferred_vendor,
     _kill_existing_services,
     _last_startup_service,
     _load_persisted_data_dir,
@@ -2151,6 +2151,32 @@ class TestInteractiveModelPairSelection:
         assert fast_call.kwargs["default"] == "default/qwen2.5:1.5b"
         assert fast_call.kwargs["hint"] == "Press Enter to reuse the default model."
 
+    def test_picker_has_no_unverified_default(self):
+        client = MagicMock()
+        choices = [
+            ("default/ai21labs-jamba-1-5-large-instruct", "Jamba"),
+            ("default/nvidia/nemotron-nano-9b-v2", "Nemotron Nano"),
+        ]
+
+        with (
+            patch(f"{self._MOD}._get_all_model_choices", return_value=choices),
+            patch(f"{self._MOD}._select_usable_model_pair", return_value=None),
+            patch(
+                f"{self._MOD}.prompt_select",
+                side_effect=["default/nvidia/nemotron-nano-9b-v2", "default/nvidia/nemotron-nano-9b-v2"],
+            ) as mock_prompt_select,
+        ):
+            result = _select_model_pair(client, "default", provider_name="nvidia-build")
+
+        assert result == ModelPair(
+            default="default/nvidia/nemotron-nano-9b-v2",
+            fast="default/nvidia/nemotron-nano-9b-v2",
+        )
+        default_call, fast_call = mock_prompt_select.call_args_list
+        assert default_call.kwargs["default"] is None
+        assert default_call.kwargs["hint"] == "Choose a model you can access."
+        assert fast_call.kwargs["default"] == "default/nvidia/nemotron-nano-9b-v2"
+
     def test_returns_none_when_only_specialist_models_are_available(self):
         client = MagicMock()
         provider = MagicMock()
@@ -2193,10 +2219,10 @@ class TestPickDefaultChatEntity:
         assert _pick_default_chat_entity(["default/adept-fuyu-8b", "default/nv-embedqa"]) is None
 
 
-def _probe_error(status_code: int, text: str = "") -> APIStatusError:
+def _probe_error(status_code: int, text: str = "", body: object | None = None) -> APIStatusError:
     """Build the SDK error the gateway raises for a non-2xx probe response."""
     request = httpx.Request("POST", "http://localhost:8080/v1/chat/completions")
-    return APIStatusError("probe failed", response=httpx.Response(status_code, text=text, request=request), body=None)
+    return APIStatusError("probe failed", response=httpx.Response(status_code, text=text, request=request), body=body)
 
 
 def _client_answering(outcomes: dict[str, object]) -> MagicMock:
@@ -2253,13 +2279,20 @@ class TestModelSizeOrdering:
             "default/ai21labs-jamba-1-5-large-instruct",
         ]
 
+    def test_prefers_nvidia_slash_ids(self):
+        nvidia = "default/nvidia/mistral-nemo-minitron-8b-instruct"
+        meta = "default/meta/llama-3.3-70b-instruct"
+
+        assert _is_preferred_vendor("default/nvidia/llama-3.1-8b-instruct") is True
+        assert _order_candidates_by_size([meta, nvidia], largest_first=True) == [nvidia, meta]
+
 
 class TestModelProbe:
     @pytest.mark.parametrize(
         ("outcome", "expected"),
         [
             (MagicMock(), True),
-            (_probe_error(404, "model not found"), False),
+            (_probe_error(404, body={"detail": "Function not found for account"}), False),
             (_probe_error(403), False),
             (_probe_error(502, '{"detail": "Backend returned 404: Function ... not found for account"}'), False),
             (_probe_error(503, "upstream busy"), False),
@@ -2276,16 +2309,18 @@ class TestModelProbe:
         client.inference.gateway.openai.post.side_effect = [_probe_error(404), _probe_error(404), MagicMock()]
 
         with patch(f"{SETUP_MOD}._pause"):
-            usable = _probe_model_entity(client, "default", "default/model", time.monotonic() + 30)
+            usable = _probe_model_entity(client, "default", "default/model")
 
         assert usable is True
         assert client.inference.gateway.openai.post.call_count == 3
 
-    def test_does_not_retry_a_404_past_the_route_deadline(self):
+    def test_does_not_retry_an_entitlement_404(self):
         client = MagicMock()
-        client.inference.gateway.openai.post.side_effect = _probe_error(404)
+        client.inference.gateway.openai.post.side_effect = _probe_error(
+            404, body={"detail": "Function not found for account"}
+        )
 
-        assert _probe_model_entity(client, "default", "default/model", 0.0) is False
+        assert _probe_model_entity(client, "default", "default/model") is False
         assert client.inference.gateway.openai.post.call_count == 1
 
     def test_skips_timeouts_so_later_candidates_can_be_tried(self):
@@ -2401,10 +2436,33 @@ class TestUsableModelPairSelection:
             fast="default/nvidia-nemotron-nano-9b-v2",
         )
 
+    def test_each_candidate_gets_a_route_readiness_window(self):
+        large = "default/nvidia-model-70b-instruct"
+        small = "default/nvidia-model-8b-instruct"
+        client = MagicMock()
+        attempts = {large: 0, small: 0}
+
+        def post(trailing_uri: str, *, workspace: str, body: dict) -> object:
+            entity_id = str(body["model"])
+            attempts[entity_id] += 1
+            if entity_id == large or attempts[entity_id] == 1:
+                raise _probe_error(404)
+            return MagicMock()
+
+        client.with_options.return_value.inference.gateway.openai.post.side_effect = post
+
+        assert _select_usable_model_pair(client, "default", [large, small]) == ModelPair(
+            default=small,
+            fast=small,
+        )
+        assert attempts[large] == setup_commands._MODEL_ROUTE_MAX_RETRIES + 1
+        assert attempts[small] == 2
+
     def test_stops_probing_after_the_time_budget(self):
         entity_ids = [f"default/model-{index}b-instruct" for index in range(1, 6)]
-        client = _client_answering({entity_id: _probe_error(404) for entity_id in entity_ids})
-        clock = iter([0.0, 0.0, 91.0, 91.0, 91.0, 91.0])
+        timeout = APITimeoutError(request=httpx.Request("POST", "http://localhost:8080"))
+        client = _client_answering({entity_id: timeout for entity_id in entity_ids})
+        clock = iter([0.0, 0.0, 0.0, 91.0])
 
         with patch(f"{SETUP_MOD}.time.monotonic", side_effect=lambda: next(clock)):
             assert _select_usable_model_pair(client, "default", entity_ids) is None

--- a/packages/nemo_platform_ext/tests/cli/commands/test_setup.py
+++ b/packages/nemo_platform_ext/tests/cli/commands/test_setup.py
@@ -2441,22 +2441,30 @@ class TestUsableModelPairSelection:
         small = "default/nvidia-model-8b-instruct"
         client = MagicMock()
         attempts = {large: 0, small: 0}
+        clock = {"now": 0.0}
 
         def post(trailing_uri: str, *, workspace: str, body: dict) -> object:
             entity_id = str(body["model"])
             attempts[entity_id] += 1
-            if entity_id == large or attempts[entity_id] == 1:
+            if entity_id == large:
+                if attempts[large] == setup_commands._MODEL_ROUTE_MAX_RETRIES + 1:
+                    clock["now"] = setup_commands._MODEL_ROUTE_READY_SECONDS + 1
+                raise _probe_error(404)
+            if attempts[entity_id] == 1:
                 raise _probe_error(404)
             return MagicMock()
 
         client.with_options.return_value.inference.gateway.openai.post.side_effect = post
 
-        assert _select_usable_model_pair(client, "default", [large, small]) == ModelPair(
-            default=small,
-            fast=small,
-        )
+        with patch(f"{SETUP_MOD}.time.monotonic", side_effect=lambda: clock["now"]):
+            assert _select_usable_model_pair(client, "default", [large, small]) == ModelPair(
+                default=small,
+                fast=small,
+            )
+
         assert attempts[large] == setup_commands._MODEL_ROUTE_MAX_RETRIES + 1
         assert attempts[small] == 2
+        assert clock["now"] > setup_commands._MODEL_ROUTE_READY_SECONDS
 
     def test_stops_probing_after_the_time_budget(self):
         entity_ids = [f"default/model-{index}b-instruct" for index in range(1, 6)]


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary

`nemo setup --auto` was persisting the first alphabetically sorted chat-looking model from provider discovery as both the default and fast model. NVIDIA Build's `GET /v1/models` advertises the full catalog, not the models the current account can serve, so setup saved unusable defaults (QA: `ai21labs/jamba-1.5-large-instruct` returned upstream 404). Setup now probes candidates with a short chat request, prefers NVIDIA models, and saves the largest usable model as default and the smallest usable model as fast. If none answer, it saves no default.

## Related Issue

NVBug 6676750

## Changes

- Filter out non-chat names (`embed`, `vision`, `guard`, `rerank`, `reward`, `translate`, …).
- Order remaining candidates NVIDIA-first, then by parameter count parsed from the entity name.
- Probe each candidate through the inference gateway (`POST v1/chat/completions`, 16 tokens) before persisting it; skip non-2xx (including IGW-wrapped upstream 404).
- Cap probes at 8 attempts per slot so gated large models at the head of the list do not block selection.
- Honor `NEMO_DEFAULT_MODEL` / `NEMO_FAST_MODEL` without probing.
- Interactive setup uses the same probed pair as picker suggestions.
- If the gateway is unreachable or no candidate answers, save nothing rather than falling back to name sort.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: setup already documents `NEMO_DEFAULT_MODEL` / `NEMO_FAST_MODEL`; the change is automatic selection plus CLI warnings when nothing is usable.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

```
uv run --no-sync pytest packages/nemo_platform_ext/tests/cli/commands/test_setup.py::TestPickDefaultChatEntity \
  packages/nemo_platform_ext/tests/cli/commands/test_setup.py::TestModelSizeOrdering \
  packages/nemo_platform_ext/tests/cli/commands/test_setup.py::TestModelProbe \
  packages/nemo_platform_ext/tests/cli/commands/test_setup.py::TestUsableModelPairSelection \
  packages/nemo_platform_ext/tests/cli/commands/test_setup.py::TestAutoModelPairSelection -q
```

33 passed.

Live catalog check against `https://integrate.api.nvidia.com` (not in CI): old sort would still pick Jamba; probed selection picked `nvidia/nemotron-3-super-120b-a12b` (default) and `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning` (fast) for an entitled nvapi key.

`uv run pre-commit run -a` was not run for this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic setup recognizes slash-qualified NVIDIA model IDs.
  * Model probing retries route-readiness issues independently for each candidate.
  * Account-entitlement 404 responses are skipped without additional retries.
  * Automatic selection prioritizes responsive, compatible model pairs and waits for newly available routes.
* **Bug Fixes**
  * Interactive model selection no longer chooses unverified defaults when probing fails.
  * Interactive setup requires explicit model choices when verification is unavailable.
  * Updated guidance clarifies the choices required during interactive setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->