### PR TITLE
docs: pin Studio Plugin UIs nav slug to plugins

### DIFF
--- a/docs/fern/docs.yml
+++ b/docs/fern/docs.yml
@@ -63,3 +63,8 @@ redirects:
     destination: "/documentation/models-and-inference/deploy-models"
   - source: "/latest/documentation/models-and-inference/tutorials/deploy-models"
     destination: "/latest/documentation/models-and-inference/deploy-models"
+  # NV 6722634: Plugin UIs title otherwise kebab-cases to plugin-u-is.
+  - source: "/documentation/studio/plugin-u-is"
+    destination: "/documentation/studio/plugins"
+  - source: "/latest/documentation/studio/plugin-u-is"
+    destination: "/latest/documentation/studio/plugins"

--- a/docs/fern/scripts/sync-helm-docs.mjs
+++ b/docs/fern/scripts/sync-helm-docs.mjs
@@ -33,12 +33,28 @@ const DROP_LINE =
   /^Documentation can be found at: https:\/\/docs\.nvidia\.com\/nemo-platform\.\s*$/;
 
 const DEPLOYMENT_LINK =
-  /For deployment instructions, see https:\/\/docs\.nvidia\.com\/nemo-platform\/documentation\/self-managed-deployment\/setup\./;
+  /For deployment instructions, see https:\/\/docs\.nvidia\.com\/nemo-platform\/(?:latest\/)?documentation\/(?:self-managed-deployment|kubernetes-deployment)\/setup\.?/;
 
 const DEPLOYMENT_LINK_REPLACEMENT =
   "For deployment guide, see " +
-  "[Self-Managed Deployment](/documentation/self-managed-deployment/setup) " +
+  "[Kubernetes Deployment](/documentation/kubernetes-deployment/setup) " +
   "in the NeMo Platform documentation.";
+
+const EXAMPLES_OVERLAY_LINK = /\[examples\/opensandbox\]\(examples\/opensandbox\)/;
+const EXAMPLES_OVERLAY_REPLACEMENT =
+  "[k8s/helm/examples/opensandbox](https://github.com/NVIDIA-NeMo/nemo-platform/tree/main/k8s/helm/examples/opensandbox)";
+
+function rewritePublishedDocsUrls(text) {
+  return text
+    .replace(
+      /\/documentation\/self-managed-deployment\//g,
+      "/documentation/kubernetes-deployment/",
+    )
+    .replace(
+      /(\/documentation\/kubernetes-deployment\/setup\/helm\/)opensandbox(?!-kata)/g,
+      "$1open-sandbox",
+    );
+}
 
 function stripLeadingSpdxComments(markdown) {
   const lines = markdown.split("\n");
@@ -68,7 +84,13 @@ function extractIntro(readme) {
 
     if (DROP_LINE.test(line)) continue;
 
-    out.push(line.replace(DEPLOYMENT_LINK, DEPLOYMENT_LINK_REPLACEMENT));
+    out.push(
+      rewritePublishedDocsUrls(
+        line
+          .replace(DEPLOYMENT_LINK, DEPLOYMENT_LINK_REPLACEMENT)
+          .replace(EXAMPLES_OVERLAY_LINK, EXAMPLES_OVERLAY_REPLACEMENT),
+      ),
+    );
   }
 
   while (out.length && !out[out.length - 1].trim()) out.pop();

--- a/docs/fern/versions/latest.yml
+++ b/docs/fern/versions/latest.yml
@@ -355,6 +355,7 @@ navigation:
           - page: Monitor
             path: ../../studio/monitor.mdx
           - page: Plugin UIs
+            slug: plugins
             path: ../../studio/plugins.mdx
           - page: Guardrail Configs
             path: ../../studio/guardrails.mdx

--- a/k8s/helm/README.md
+++ b/k8s/helm/README.md
@@ -6,7 +6,7 @@
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Documentation can be found at: https://docs.nvidia.com/nemo-platform.
-For deployment instructions, see https://docs.nvidia.com/nemo-platform/documentation/self-managed-deployment/setup.
+For deployment instructions, see https://docs.nvidia.com/nemo-platform/documentation/kubernetes-deployment/setup.
 
 ## Platform Secrets Encryption Key
 
@@ -124,7 +124,7 @@ and
 The chart does not install Kyverno. Multi-node NCCL device injection renders
 ClusterPolicies that Kyverno must apply. Enable exactly one cloud provider
 under `multinodeNetworking`.
-How-to: https://docs.nvidia.com/nemo-platform/latest/documentation/self-managed-deployment/setup/helm/multinode-networking
+How-to: https://docs.nvidia.com/nemo-platform/latest/documentation/kubernetes-deployment/setup/helm/multinode-networking
 
 ## Volcano
 
@@ -132,7 +132,7 @@ The chart does not install Volcano. Multi-node `volcano_job` workloads need it.
 `rbac.volcanoEnabled` defaults to true so the core controller can manage Volcano
 CRs. Skip Volcano and set `rbac.volcanoEnabled: false` if you are not running
 those jobs.
-How-to: https://docs.nvidia.com/nemo-platform/latest/documentation/self-managed-deployment/setup/helm/volcano
+How-to: https://docs.nvidia.com/nemo-platform/latest/documentation/kubernetes-deployment/setup/helm/volcano
 
 ## OpenSandbox
 
@@ -144,9 +144,9 @@ already installed server as an HTTP client (`OPEN_SANDBOX_DOMAIN`,
 namespace**. Control plane may stay in `opensandbox-system`. Copy the API-key
 Secret into the job namespace.
 
-Example overlays: [examples/opensandbox](examples/opensandbox).
-Shared-kernel (cluster default OCI runtime): https://docs.nvidia.com/nemo-platform/latest/documentation/self-managed-deployment/setup/helm/opensandbox
-Kata QEMU: https://docs.nvidia.com/nemo-platform/latest/documentation/self-managed-deployment/setup/helm/opensandbox-kata
+Example overlays: [k8s/helm/examples/opensandbox](https://github.com/NVIDIA-NeMo/nemo-platform/tree/main/k8s/helm/examples/opensandbox).
+Shared-kernel (cluster default OCI runtime): https://docs.nvidia.com/nemo-platform/latest/documentation/kubernetes-deployment/setup/helm/open-sandbox
+Kata QEMU: https://docs.nvidia.com/nemo-platform/latest/documentation/kubernetes-deployment/setup/helm/opensandbox-kata
 
 ## NetworkPolicies
 
@@ -437,7 +437,7 @@ For the complete default values, see [values.yaml](values.yaml).
 | ncclTest.iterations | int | `3` | How many times to run the full multinode NCCL test (orchestrator loop; env NCCL_TEST_ITERATIONS). Increase the test timeout on helm test if increasing this variable |
 | ncclTest.validation.minBandwidthMBpsAt1024MB | int | `8000` | Minimum allreduce bandwidth (MB/s) at 1024MB message size; 0 disables the floor check in nccl_test.py. |
 | ncclTest.waitTimeoutSeconds | int | `900` | Max seconds to wait for each worker pod to complete. |
-| networkPolicies | object | [See values.yaml](values.yaml#L143) | NetworkPolicy configuration. Enable the top-level switch to render all default policies, then disable individual policies only for cluster-specific exceptions. For a Calico-backed smoke test, see https://docs.nvidia.com/nemo-platform/documentation/self-managed-deployment/setup/helm/network-policy-smoke-test. |
+| networkPolicies | object | [See values.yaml](values.yaml#L143) | NetworkPolicy configuration. Enable the top-level switch to render all default policies, then disable individual policies only for cluster-specific exceptions. For a Calico-backed smoke test, see https://docs.nvidia.com/nemo-platform/documentation/kubernetes-deployment/setup/helm/network-policy-smoke-test. |
 | networkPolicies.api | object | [See values.yaml](values.yaml#L148) | NetworkPolicy configuration for the Platform API pods. |
 | networkPolicies.api.enabled | bool | `true` | Create NetworkPolicy resources that isolate Platform API pod ingress. |
 | networkPolicies.api.extraIngress | list | `[]` | Extra NetworkPolicy ingress rules appended to the API policy, for cluster-specific ingress controllers, gateways, monitoring, or debugging pods. |

--- a/k8s/helm/examples/opensandbox/README.md
+++ b/k8s/helm/examples/opensandbox/README.md
@@ -17,8 +17,8 @@ sandbox pods must be isolated from the host kernel. The documented example is
 Kata QEMU because it runs each sandbox in a VM with its own guest kernel; other
 isolated runtimes may work but have not been tested.
 
-Full procedure: [OpenSandbox](https://docs.nvidia.com/nemo-platform/latest/documentation/self-managed-deployment/setup/helm/opensandbox)
-and [OpenSandbox with Kata](https://docs.nvidia.com/nemo-platform/latest/documentation/self-managed-deployment/setup/helm/opensandbox-kata)
+Full procedure: [OpenSandbox](https://docs.nvidia.com/nemo-platform/latest/documentation/kubernetes-deployment/setup/helm/open-sandbox)
+and [OpenSandbox with Kata](https://docs.nvidia.com/nemo-platform/latest/documentation/kubernetes-deployment/setup/helm/opensandbox-kata)
 in the NeMo Platform documentation. `helm show readme` of this chart points at
 those pages.
 

--- a/k8s/helm/helm-docs-template/nemo-helm-readme.md.gotmpl
+++ b/k8s/helm/helm-docs-template/nemo-helm-readme.md.gotmpl
@@ -6,7 +6,7 @@
 {{ template "chart.typeBadge" . }}
 
 Documentation can be found at: https://docs.nvidia.com/nemo-platform.
-For deployment instructions, see https://docs.nvidia.com/nemo-platform/documentation/self-managed-deployment/setup.
+For deployment instructions, see https://docs.nvidia.com/nemo-platform/documentation/kubernetes-deployment/setup.
 
 ## Platform Secrets Encryption Key
 
@@ -124,7 +124,7 @@ and
 The chart does not install Kyverno. Multi-node NCCL device injection renders
 ClusterPolicies that Kyverno must apply. Enable exactly one cloud provider
 under `multinodeNetworking`.
-How-to: https://docs.nvidia.com/nemo-platform/latest/documentation/self-managed-deployment/setup/helm/multinode-networking
+How-to: https://docs.nvidia.com/nemo-platform/latest/documentation/kubernetes-deployment/setup/helm/multinode-networking
 
 ## Volcano
 
@@ -132,7 +132,7 @@ The chart does not install Volcano. Multi-node `volcano_job` workloads need it.
 `rbac.volcanoEnabled` defaults to true so the core controller can manage Volcano
 CRs. Skip Volcano and set `rbac.volcanoEnabled: false` if you are not running
 those jobs.
-How-to: https://docs.nvidia.com/nemo-platform/latest/documentation/self-managed-deployment/setup/helm/volcano
+How-to: https://docs.nvidia.com/nemo-platform/latest/documentation/kubernetes-deployment/setup/helm/volcano
 
 ## OpenSandbox
 
@@ -144,9 +144,9 @@ already installed server as an HTTP client (`OPEN_SANDBOX_DOMAIN`,
 namespace**. Control plane may stay in `opensandbox-system`. Copy the API-key
 Secret into the job namespace.
 
-Example overlays: [examples/opensandbox](examples/opensandbox).
-Shared-kernel (cluster default OCI runtime): https://docs.nvidia.com/nemo-platform/latest/documentation/self-managed-deployment/setup/helm/opensandbox
-Kata QEMU: https://docs.nvidia.com/nemo-platform/latest/documentation/self-managed-deployment/setup/helm/opensandbox-kata
+Example overlays: [k8s/helm/examples/opensandbox](https://github.com/NVIDIA-NeMo/nemo-platform/tree/main/k8s/helm/examples/opensandbox).
+Shared-kernel (cluster default OCI runtime): https://docs.nvidia.com/nemo-platform/latest/documentation/kubernetes-deployment/setup/helm/open-sandbox
+Kata QEMU: https://docs.nvidia.com/nemo-platform/latest/documentation/kubernetes-deployment/setup/helm/opensandbox-kata
 
 ## NetworkPolicies
 

--- a/k8s/helm/templates/NOTES.txt
+++ b/k8s/helm/templates/NOTES.txt
@@ -159,6 +159,6 @@ Successfully installed {{ .Chart.Name }}-{{ .Chart.Version }}, named {{ .Release
   OPEN_SANDBOX_DOMAIN={{ .Values.opensandbox.domain }} over {{ .Values.opensandbox.protocol }}.
   Copy Secret {{ .Values.opensandbox.apiKeySecret }} into this release namespace.
   The chart does not install OpenSandbox. See helm show readme and
-  https://docs.nvidia.com/nemo-platform/latest/documentation/self-managed-deployment/setup/helm/opensandbox
+  https://docs.nvidia.com/nemo-platform/latest/documentation/kubernetes-deployment/setup/helm/open-sandbox
 
 {{- end }}

--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -138,7 +138,7 @@ multinodeNetworking:
     # -- Number of RDMA devices (mlnxnics) to request per GPU
     rdmaDevicesPerGPU: 8
 
-# -- NetworkPolicy configuration. Enable the top-level switch to render all default policies, then disable individual policies only for cluster-specific exceptions. For a Calico-backed smoke test, see https://docs.nvidia.com/nemo-platform/documentation/self-managed-deployment/setup/helm/network-policy-smoke-test.
+# -- NetworkPolicy configuration. Enable the top-level switch to render all default policies, then disable individual policies only for cluster-specific exceptions. For a Calico-backed smoke test, see https://docs.nvidia.com/nemo-platform/documentation/kubernetes-deployment/setup/helm/network-policy-smoke-test.
 # @default -- This object has the following default values. The top-level switch is disabled by default so chart upgrades do not change cluster connectivity unless explicitly enabled.
 networkPolicies:
   # -- Create NetworkPolicy resources for enabled subpolicies.


### PR DESCRIPTION
## Summary
Studio documents Iron Swarm at `/documentation/studio/plugins`, but Fern kebab-cases the page title \"Plugin UIs in NeMo Studio\" to `plugin-u-is`, so that URL 404s. Pin `slug: plugins` and redirect the generated slug.

Stacked on https://github.com/NVIDIA-NeMo/nemo-platform/pull/1795. Merge the earlier docs-link PRs first, then retarget this one to `release/0.5`.

## Related Issue
- NVBug https://nvbugspro.nvidia.com/bug/6722634
- Jira https://jirasw.nvidia.com/browse/NPLAT-55

## Changes
- Pin Plugin UIs nav slug to `plugins`
- Redirect `/documentation/studio/plugin-u-is` to `/documentation/studio/plugins`

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [x] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: Fern nav slug and redirect only
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- Studio index already links to `/documentation/studio/plugins`; this PR makes that slug the published page.