### PR TITLE
chore(agents): update to agents examples to use lightning model

### DIFF
--- a/plugins/nemo-agents/examples/hello_world.yaml
+++ b/plugins/nemo-agents/examples/hello_world.yaml
@@ -11,7 +11,7 @@ llms:
    # Tell NeMo Agent Toolkit which LLM to use for the agent
    nim_llm:
       _type: nim
-      model_name: nvidia/nemotron-3-nano-30b-a3b
+      model_name: nvidia/nemotron-3.5-lightning-30b-a3b
       temperature: 0.0
       chat_template_kwargs:
          enable_thinking: false

--- a/plugins/nemo-agents/examples/nemo-agent-config/agent-relay-intake.yaml
+++ b/plugins/nemo-agents/examples/nemo-agent-config/agent-relay-intake.yaml
@@ -44,7 +44,7 @@ harnesses:
 models:
   default:
     provider: nvidia
-    model: nvidia-nemotron-3.5-lightning-30b-a3b
+    model: nvidia-nemotron-3-5-lightning-30b-a3b
     api_key_env: NVIDIA_API_KEY
 
 skills:

--- a/plugins/nemo-agents/examples/nemo-agent-config/agent-relay-intake.yaml
+++ b/plugins/nemo-agents/examples/nemo-agent-config/agent-relay-intake.yaml
@@ -23,7 +23,7 @@ harnesses:
     kind: hermes
     model:
       provider: nvidia
-      model: nvidia/nemotron-3-nano-30b-a3b
+      model: nvidia/nemotron-3.5-lightning-30b-a3b
       api_key_env: NVIDIA_API_KEY
       base_url: https://integrate.api.nvidia.com/v1
       temperature: 0.0
@@ -44,7 +44,7 @@ harnesses:
 models:
   default:
     provider: nvidia
-    model: nvidia-nemotron-3-nano-30b-a3b
+    model: nvidia-nemotron-3.5-lightning-30b-a3b
     api_key_env: NVIDIA_API_KEY
 
 skills:

--- a/plugins/nemo-agents/examples/nemo-agent-config/agent-relay.yaml
+++ b/plugins/nemo-agents/examples/nemo-agent-config/agent-relay.yaml
@@ -44,7 +44,7 @@ harnesses:
 models:
   default:
     provider: nvidia
-    model: nvidia-nemotron-3.5-lightning-30b-a3b
+    model: nvidia-nemotron-3-5-lightning-30b-a3b
     api_key_env: NVIDIA_API_KEY
 
 skills:

--- a/plugins/nemo-agents/examples/nemo-agent-config/agent-relay.yaml
+++ b/plugins/nemo-agents/examples/nemo-agent-config/agent-relay.yaml
@@ -23,7 +23,7 @@ harnesses:
     kind: hermes
     model:
       provider: nvidia
-      model: nvidia/nemotron-3-nano-30b-a3b
+      model: nvidia/nemotron-3.5-lightning-30b-a3b
       api_key_env: NVIDIA_API_KEY
       base_url: https://integrate.api.nvidia.com/v1
       temperature: 0.0
@@ -44,7 +44,7 @@ harnesses:
 models:
   default:
     provider: nvidia
-    model: nvidia-nemotron-3-nano-30b-a3b
+    model: nvidia-nemotron-3.5-lightning-30b-a3b
     api_key_env: NVIDIA_API_KEY
 
 skills:

--- a/plugins/nemo-agents/examples/nemo-agent-config/agent.yaml
+++ b/plugins/nemo-agents/examples/nemo-agent-config/agent.yaml
@@ -44,7 +44,7 @@ harnesses:
 models:
   default:
     provider: nvidia
-    model: nvidia-nemotron-3.5-lightning-30b-a3b
+    model: nvidia-nemotron-3-5-lightning-30b-a3b
     api_key_env: NVIDIA_API_KEY
 
 skills:

--- a/plugins/nemo-agents/examples/nemo-agent-config/agent.yaml
+++ b/plugins/nemo-agents/examples/nemo-agent-config/agent.yaml
@@ -23,7 +23,7 @@ harnesses:
     kind: hermes
     model:
       provider: nvidia
-      model: nvidia/nemotron-3-nano-30b-a3b
+      model: nvidia/nemotron-3.5-lightning-30b-a3b
       api_key_env: NVIDIA_API_KEY
       base_url: https://integrate.api.nvidia.com/v1
       temperature: 0.0
@@ -44,7 +44,7 @@ harnesses:
 models:
   default:
     provider: nvidia
-    model: nvidia-nemotron-3-nano-30b-a3b
+    model: nvidia-nemotron-3.5-lightning-30b-a3b
     api_key_env: NVIDIA_API_KEY
 
 skills:

--- a/plugins/nemo-agents/examples/nemo-agent-config/calculator-agent/agent-with-mcp.yaml
+++ b/plugins/nemo-agents/examples/nemo-agent-config/calculator-agent/agent-with-mcp.yaml
@@ -23,7 +23,7 @@ harnesses:
 models:
   default:
     provider: nvidia
-    model: nvidia-nemotron-3-nano-30b-a3b
+    model: nvidia-nemotron-3.5-lightning-30b-a3b
     api_key_env: NVIDIA_API_KEY
 
 skills:

--- a/plugins/nemo-agents/examples/nemo-agent-config/calculator-agent/agent-with-mcp.yaml
+++ b/plugins/nemo-agents/examples/nemo-agent-config/calculator-agent/agent-with-mcp.yaml
@@ -23,7 +23,7 @@ harnesses:
 models:
   default:
     provider: nvidia
-    model: nvidia-nemotron-3.5-lightning-30b-a3b
+    model: nvidia-nemotron-3-5-lightning-30b-a3b
     api_key_env: NVIDIA_API_KEY
 
 skills:

--- a/plugins/nemo-agents/examples/nemo-agent-config/calculator-agent/agent.yaml
+++ b/plugins/nemo-agents/examples/nemo-agent-config/calculator-agent/agent.yaml
@@ -22,7 +22,7 @@ harnesses:
 models:
   default:
     provider: nvidia
-    model: nvidia-nemotron-3.5-lightning-30b-a3b
+    model: nvidia-nemotron-3-5-lightning-30b-a3b
     api_key_env: NVIDIA_API_KEY
 
 skills:

--- a/plugins/nemo-agents/examples/nemo-agent-config/calculator-agent/agent.yaml
+++ b/plugins/nemo-agents/examples/nemo-agent-config/calculator-agent/agent.yaml
@@ -22,7 +22,7 @@ harnesses:
 models:
   default:
     provider: nvidia
-    model: nvidia-nemotron-3-nano-30b-a3b
+    model: nvidia-nemotron-3.5-lightning-30b-a3b
     api_key_env: NVIDIA_API_KEY
 
 skills:

--- a/plugins/nemo-agents/examples/nemo-agent-config/email-security-triage/agent.yaml
+++ b/plugins/nemo-agents/examples/nemo-agent-config/email-security-triage/agent.yaml
@@ -192,7 +192,7 @@ harnesses:
 models:
   default:
     provider: nvidia
-    model: nvidia-nemotron-3-nano-30b-a3b
+    model: nvidia-nemotron-3.5-lightning-30b-a3b
     api_key_env: NVIDIA_API_KEY
     temperature: 0.0
 

--- a/plugins/nemo-agents/examples/nemo-agent-config/email-security-triage/agent.yaml
+++ b/plugins/nemo-agents/examples/nemo-agent-config/email-security-triage/agent.yaml
@@ -192,7 +192,7 @@ harnesses:
 models:
   default:
     provider: nvidia
-    model: nvidia-nemotron-3.5-lightning-30b-a3b
+    model: nvidia-nemotron-3-5-lightning-30b-a3b
     api_key_env: NVIDIA_API_KEY
     temperature: 0.0
 

--- a/plugins/nemo-agents/examples/react-agent/react-agent.yml
+++ b/plugins/nemo-agents/examples/react-agent/react-agent.yml
@@ -4,7 +4,7 @@
 # nemotron-agent.yml
 #
 # A ReAct agent with Wikipedia search and datetime tools, backed by
-# nvidia/nemotron-3-nano-30b-a3b — a compact reasoning model from NVIDIA.
+# nvidia/nemotron-3.5-lightning-30b-a3b — a compact reasoning model from NVIDIA.
 #
 # Quick local test (no platform, requires NVIDIA API key):
 #   export NVIDIA_API_KEY=nvapi-...
@@ -20,7 +20,7 @@
 #       --input "Who invented the telephone? Also what time is it?"
 #
 # Model entity name (auto-created by models controller from nvidia-build discovery):
-#   nvidia/nemotron-3-nano-30b-a3b  →  nvidia-nemotron-3-nano-30b-a3b
+#   nvidia/nemotron-3.5-lightning-30b-a3b  →  nvidia-nemotron-3.5-lightning-30b-a3b
 
 functions:
   wiki:

--- a/plugins/nemo-agents/examples/react-agent/react-agent.yml
+++ b/plugins/nemo-agents/examples/react-agent/react-agent.yml
@@ -20,7 +20,7 @@
 #       --input "Who invented the telephone? Also what time is it?"
 #
 # Model entity name (auto-created by models controller from nvidia-build discovery):
-#   nvidia/nemotron-3.5-lightning-30b-a3b  →  nvidia-nemotron-3.5-lightning-30b-a3b
+#   nvidia/nemotron-3.5-lightning-30b-a3b  →  nvidia-nemotron-3-5-lightning-30b-a3b
 
 functions:
   wiki:

--- a/plugins/nemo-agents/examples/react-agent/react-eval.yml
+++ b/plugins/nemo-agents/examples/react-agent/react-eval.yml
@@ -13,7 +13,7 @@
 llms:
   llm:
     _type: openai
-    model_name: nvidia-nemotron-3-nano-30b-a3b
+    model_name: nvidia-nemotron-3.5-lightning-30b-a3b
     temperature: 0.0
     max_tokens: 1024
 

--- a/plugins/nemo-agents/examples/react-agent/react-eval.yml
+++ b/plugins/nemo-agents/examples/react-agent/react-eval.yml
@@ -13,7 +13,7 @@
 llms:
   llm:
     _type: openai
-    model_name: nvidia-nemotron-3.5-lightning-30b-a3b
+    model_name: nvidia-nemotron-3-5-lightning-30b-a3b
     temperature: 0.0
     max_tokens: 1024
 

--- a/plugins/nemo-agents/examples/react-agent/react-optimize.yml
+++ b/plugins/nemo-agents/examples/react-agent/react-optimize.yml
@@ -34,7 +34,7 @@ llms:
   # platform, override via --base-url or NEMO_BASE_URL.
   llm:
     _type: openai
-    model_name: nvidia-nemotron-3.5-lightning-30b-a3b
+    model_name: nvidia-nemotron-3-5-lightning-30b-a3b
     temperature: 0.0
     optimizable_params:
       - temperature

--- a/plugins/nemo-agents/examples/react-agent/react-optimize.yml
+++ b/plugins/nemo-agents/examples/react-agent/react-optimize.yml
@@ -34,7 +34,7 @@ llms:
   # platform, override via --base-url or NEMO_BASE_URL.
   llm:
     _type: openai
-    model_name: nvidia-nemotron-3-nano-30b-a3b
+    model_name: nvidia-nemotron-3.5-lightning-30b-a3b
     temperature: 0.0
     optimizable_params:
       - temperature


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary

Fixes the NeMo Platform model entity used by NeMo Agents examples for Nemotron
3.5 Lightning.

The NVIDIA provider exposes the served model as:

```text
nvidia/nemotron-3.5-lightning-30b-a3b
```

The models controller normalizes both the slash and period when it creates the
Platform model entity:

```text
default/nvidia-nemotron-3-5-lightning-30b-a3b
```

The affected examples instead referenced
`nvidia-nemotron-3.5-lightning-30b-a3b`. Inference through the Platform gateway
therefore failed with a 404 because no VirtualModel existed under that name.

## Changes

- Replace `nvidia-nemotron-3.5-lightning-30b-a3b` with the correctly normalized
  `nvidia-nemotron-3-5-lightning-30b-a3b` Platform entity.
- Update the multi-harness, Relay, Relay Intake, calculator, calculator with MCP,
  and email security triage agent configurations.
- Update the React agent model mapping, evaluation configuration, and
  optimization configuration.
- Keep the direct NVIDIA provider model ID unchanged as
  `nvidia/nemotron-3.5-lightning-30b-a3b`.

## Type of Change

- [x] Bug fix
- [x] Example configuration update
- [ ] Runtime code change
- [ ] CI, build, or test infrastructure

## Verification

- [x] `nemo inference models list` reports
  `default/nvidia-nemotron-3-5-lightning-30b-a3b`.
- [x] The DeepAgents calculator agent was created and deployed in subprocess
  mode on `release/0.5` with `nemo-fabric==0.2.0`.
- [x] Calculator invocation returned `96`.
- [x] Targeted Fabric calculator and translator tests pass: 25 passed.
- [x] `git diff --check` passes.
- [x] No secrets, API keys, or credentials are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Updates**
  - Updated NeMo agent example configurations to use the Nemotron 3.5 Lightning 30B A3B model instead of Nemotron 3 Nano.
  - Updated calculator, email security triage, relay, Hello World, and React agent examples, evaluations, and optimization configurations.
  - Preserved existing telemetry and evaluator reasoning settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->