### PR TITLE
docs: add 0.5 release notes

### DIFF
--- a/docs/about/release-notes/current-release.mdx
+++ b/docs/about/release-notes/current-release.mdx
@@ -145,7 +145,7 @@ source .venv/bin/activate
 nemo setup
 ```
 
-See [Setup](/documentation/get-started) for prerequisites and provider
+See [Setup](/documentation/get-started/setup) for prerequisites and provider
 configuration.
 
 For self-managed Kubernetes, start with
@@ -153,7 +153,7 @@ For self-managed Kubernetes, start with
 GRPO jobs also require Kubernetes/Ray, OpenSandbox-enabled Gym execution, and
 job-storage PVC configuration; see
 [GRPO and Reward Environments](/documentation/customizer-reference/grpo-and-reward-environments)
-and [OpenSandbox](/documentation/kubernetes-deployment/setup/helm/open-sandbox).
+and [OpenSandbox](/documentation/kubernetes-deployment/setup/helm/opensandbox).
 
 ## Upgrade from v0.4.x
 
@@ -230,6 +230,6 @@ nemo agents ethos migrate --name <agent-name>
 - Issues: [https://github.com/NVIDIA-NeMo/nemo-platform/issues](https://github.com/NVIDIA-NeMo/nemo-platform/issues)
 - GRPO and Reward Environments: [https://docs.nvidia.com/nemo-platform/documentation/customizer-reference/grpo-and-reward-environments](https://docs.nvidia.com/nemo-platform/documentation/customizer-reference/grpo-and-reward-environments)
 - GRPO Environment Packages: [https://docs.nvidia.com/nemo-platform/documentation/customizer-reference/tutorials/grpo-environment-packages](https://docs.nvidia.com/nemo-platform/documentation/customizer-reference/tutorials/grpo-environment-packages)
-- OpenSandbox setup: [https://docs.nvidia.com/nemo-platform/documentation/kubernetes-deployment/setup/helm/open-sandbox](https://docs.nvidia.com/nemo-platform/documentation/kubernetes-deployment/setup/helm/open-sandbox)
+- OpenSandbox setup: [https://docs.nvidia.com/nemo-platform/documentation/kubernetes-deployment/setup/helm/opensandbox](https://docs.nvidia.com/nemo-platform/documentation/kubernetes-deployment/setup/helm/opensandbox)
 - NeMo Fabric: [https://docs.nvidia.com/nemo/fabric/about-nemo-fabric/overview/](https://docs.nvidia.com/nemo/fabric/about-nemo-fabric/overview/)
 - NeMo Agent Toolkit: [https://docs.nvidia.com/nemo/agent-toolkit/latest/](https://docs.nvidia.com/nemo/agent-toolkit/latest/)

--- a/docs/about/release-notes/current-release.mdx
+++ b/docs/about/release-notes/current-release.mdx
@@ -2,168 +2,136 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-title: "v0.4.0"
+title: "v0.5.0 - 2026-09-04"
 description: ""
 ---
-NeMo Platform v0.4.0 introduces a research-preview optimization loop for
-improving agents from real telemetry. Agent owners can send traces to Intake,
-use agents to diagnose recurring issues, create targeted evaluation coverage,
-experiment against a local code base, and review validated candidate changes.
-The release also moves new agent workflows toward `agent.yaml` packages backed
-by [Fabric](https://github.com/NVIDIA/nemo-fabric/) while keeping NAT workflows
-available as a legacy path.
+NeMo Platform v0.5.0 focuses on productionizing the agent and customization
+workflows introduced in the previous releases. The release adds GRPO training
+with custom reward environments, completes the `rl` backend path for DPO and
+GRPO in Studio, expands Fabric-backed agent packaging and deployment, improves
+task-driven agent evaluation, and hardens local, Docker, Kubernetes, and Helm
+operations for the 0.5 release line.
 
 ## Highlights
 
-- **Research-preview agent optimization.** Analyst and Experimentalist
-  workflows now support the observe, diagnose, experiment, and evaluate loop for
-  agents under active development.
-- **Trace-driven diagnosis.** NeMo Intake ingests OTLP, chat-completions, and
-  ATIF telemetry, stores traces in ClickHouse, and attaches annotations and
-  evaluator results so agents and humans can investigate failures from the same
-  evidence.
-- **Validated candidate changes.** Experimentalist can run against a local
-  agent source tree or git source, evaluate candidates with Harbor, write
-  optimization artifacts locally, and open a draft PR when a changed
-  winner is found.
-- **Fabric-first agents.** New Platform-managed agents use the
-  `nemo-agents-spec-v1` `agent.yaml` contract. Fabric-backed agents can run
-  through supported harnesses and route model traffic through the Inference
-  Gateway; NAT remains supported for existing workflows.
-- **Experiments for review.** NeMo Experiments compares evaluation runs using
-  cost, latency, token, and evaluator-score rollups computed from Intake
-  telemetry, with Studio leaderboard and drill-down views behind the Experiments
-  feature flag.
-- **Customizer DPO.** Customizer adds DPO training through the `rl` backend,
-  powered by NeMo-RL and Ray on Kubernetes, with backend-specific
-  hyperparameter guidance for Automodel, Unsloth, and RL jobs.
+- **GRPO with custom reward environments.** Customizer can run GRPO jobs on the
+  `rl` backend against uploaded NeMo Gym reward environment FileSets, including
+  native Gym layouts, vendored wheel packages, and `verifiers` hub adapters.
+- **RL customization in Studio.** Studio can create and inspect DPO and GRPO
+  customization jobs, including GRPO reward-environment selection, compute
+  settings, status, and reward-oriented training metrics.
+- **Fabric 0.2 agent runtime.** Platform-managed agents move to Fabric 0.2.0
+  fields, with reusable environment and compute specs, environment-aware
+  deployments and execute jobs, and packaged agent images for Docker and
+  Kubernetes.
+- **Task-driven evaluation improvements.** Agent evaluation has built-in runner
+  reward metrics, clearer local and Harbor runners, richer run bundles, and
+  Intake trace inspection for evaluation authoring.
+- **Operational hardening.** Jobs and deployments have better wait/watch
+  behavior, Docker GPU cleanup is safer, NIM weight permissions are repaired at
+  startup, and the 0.5 images include dependency and container CVE remediation.
 
 ## What's included
 
-### Insight-Driven Optimization
+### Customizer
 
-- `nemo agents analyst` scans Intake traces, evaluator scores, and reviewer
-  annotations to produce evidence-backed Insights.
-- `nemo agents experimentalist` turns an Insight, or a dataset-only objective,
-  into candidate code changes, train/validation evaluations, local artifacts,
-  and an optional draft PR or MR.
-- `optimizer.yaml` provides the shared per-agent profile for the loop, including
-  the agent name, workspace, agent source, `ETHOS.md`, datasets, task
-  template, and experiment configuration.
-- `ETHOS.md` is the durable Markdown contract for intended agent behavior. It
-  can be consumed by the Analyst and Experimentalist when present. It records
-  `Principles`, `Trade-offs`, `Constraints`, `Metric Semantics`, and `Vision`
-  alongside the original inventory sections. Every canonical body section is
-  required. Parsing fails if a required heading is missing. Write `_(none)_`
-  when a section has nothing to say. Extra `##` headings and extra YAML
-  front-matter keys are allowed; the parser does not reject them. Front matter
-  includes `schema_version: 1`. `Change Scope` levers accept `with-approval`
-  alongside `yes` and `no`.
-- `ETHOS.md` keeps mission and the agent's accountable outcome in a single
-  `Purpose & Outcomes` section, so they stay together.
-- `ETHOS.md` does not use the earlier AGENT-SPEC headings `Framework`, `Model`,
-  `Signals`, or `Purpose`. Nothing read `Framework`, and a container's
-  framework label comes from `agent.yaml`. Describe how the agent runs in
-  `Harness`, or write `_(none)_`. Do not map the implementation onto a named
-  platform harness. `Model` restated configuration that changes without
-  touching the Ethos, so state permitted providers and model families in
-  `Constraints` and swap permission in `Change Scope`. `Signals` was one
-  consumer's configuration, not durable intent. How a consumer reads evidence
-  belongs in that consumer. `Purpose` merged into `Purpose & Outcomes`.
-- Coding agents that find `agents/<name>-spec/AGENT-SPEC.md` read it as
-  prior answers, write `ETHOS.md` with `nemo-ethos`, and delete the spec
-  package after the user confirms the Ethos. `nemo agents create` prints the
-  same instruction when the config still lives in a spec package.
-- `ETHOS.md` records durable intent, so run-scoped optimizer settings such as a
-  per-experiment spend ceiling belong in the optimizer's own configuration.
-  State a standing production cost ceiling in `Constraints` instead.
-- `nemo-explore` scans the repository first, then asks at least three intent
-  questions, one at a time. It always confirms `Purpose & Outcomes`,
-  `Principles`, and `Vision` with the user, even when the scan produced a
-  plausible draft, before handing off to `nemo-ethos`. After `nemo-ethos`
-  writes `ETHOS.md`, it states a short gut-check of the agent so the user can
-  judge the write before reading the full file.
-- The `nemo-spec` skill is `nemo-ethos`, matching the contract it writes.
-- Benchmark and proof assets include Terminal-Bench 2.1, Tau3 Airline, Banking,
-  Retail, and Telecom suites, plus a guided Tau3 example-agent walkthrough.
-
-### Intake and Experiments
-
-- Intake supports OTLP, chat-completions, and ATIF ingest paths for agent
-  telemetry.
-- Traces, spans, sessions, annotations, and evaluator results are queryable by
-  API and reviewable in Studio.
-- Local setup can automatically provision and reuse a local ClickHouse
-  container for Intake unless an external ClickHouse URL is configured.
-- The Helm chart includes an embedded ClickHouse option for development and
-  non-critical single-node installations, plus configuration for external
-  ClickHouse in production-oriented deployments.
-- Experiments and Evaluations are durable entities whose leaderboard metrics are
-  computed from retained Intake telemetry.
-- The `nemo-experiments-upload` skill helps coding agents publish evaluation
-  runs and verify rollups.
+- GRPO jobs are available through `nemo customization rl submit` with
+  `training.type: "grpo"`.
+- GRPO trains against a separate environment FileSet and prompt dataset
+  FileSet. The environment package declares its layout in
+  `nemo-environment.yaml`.
+- Supported environment formats are `native-v1`, `wheels-v1`, and
+  `adapter-wheels-v1`; the converter and validator help package
+  `verifiers` environments and validate environment FileSet structure before
+  upload.
+- GRPO supports full-weight and LoRA fine-tuning modes, reward and off-policy
+  time-series metrics, generation controls, batching controls, micro-batching,
+  Hugging Face config overrides, and backend-specific policy knobs.
+- DPO continues on the `rl` backend with NeMo-RL and Ray, with Studio support
+  for DPO job creation and status review.
+- Customizer docs and coding-agent skills now cover GRPO environment packages,
+  RL hyperparameters, Kubernetes/Ray setup, OpenSandbox, Volcano, and common
+  troubleshooting paths.
+- Customizer task images include the model SDK and FileSet handling needed by
+  customization jobs and model-entity publication.
 
 ### Agents and Fabric
 
-- New agents use Platform-managed `agent.yaml` files with the
-  `nemo-agents-spec-v1` config format.
-- NeMo Fabric is the preferred runtime wrapper for new agents, with support for
-  harness adapters, shared model bindings, skills, MCP servers, tool policy, and
-  Relay/ATIF/ATOF telemetry configuration.
-- `nemo agents create`, `deploy`, `invoke`, `run`, and `package` support the
-  Fabric-backed agent path.
-- Fabric agent artifacts can be staged into Docker and Kubernetes deployments.
-- Streaming responses are supported through Fabric-backed agents.
-- Legacy NAT workflow YAMLs continue to work for existing NAT-specific
-  evaluation and deployment workflows.
+- Agents can store reusable `AgentEnvironmentSpec`, `AgentComputeSpec`, and
+  `AgentEnvironment` entities through the API, Python SDK, and CLI.
+- `nemo agents deploy --environment` can deploy an agent with a stored or
+  inline environment, merging the environment spec into the Fabric config and
+  snapshotting compute and secret references onto the deployment.
+- Agent execute jobs can use environment and compute specs, so batch execution
+  and service deployment share the same runtime configuration model.
+- Fabric-backed packaging supports Platform-managed `agent.yaml` packages,
+  staged relative artifacts, custom image entrypoints, and Docker/Kubernetes
+  deployment modes.
+- Agent gateway errors on the OpenAI-compatible surface now preserve useful
+  upstream messages and codes for OpenAI SDK clients.
+- Session ownership rules and no-auth session lifecycle access are tightened so
+  agent sessions behave predictably across authenticated and local setups.
+
+### Agent Intent and Optimization
+
+- The durable agent-intent document is now `ETHOS.md`. The old
+  `AGENT-SPEC.md` contract is replaced by Ethos terminology across agent
+  creation, analysis, experimentalist, and packaging workflows.
+- `nemo agents ethos migrate` provides a guided migration for platform-owned
+  legacy spec packages, Filesets, and optimizer profiles.
+- The Ethos schema records `Purpose & Outcomes`, `Principles`, `Trade-offs`,
+  `Constraints`, `Metric Semantics`, and `Vision`, with explicit migration
+  behavior for older agent-spec packages.
+- Agent optimization jobs support FileSets and inline configuration, and the
+  optimizer can continue using Intake evidence and Harbor-compatible evaluation
+  runs when validating candidate changes.
 
 ### Agent Evaluation
 
-- The evaluator SDK adds Fabric runtime support, Docker Compose sandboxing,
-  native agent-eval aggregation, pass-at-k scoring, typed run metadata, and 
-  task/taskset revisions.
-- Agent evaluations can publish results to Intake so Experiments and Insights
-  can consume the same run telemetry.
-
-### Customizer
-
-- The `rl` customization backend supports full-weight DPO jobs through NeMo-RL.
-- DPO schemas expose schedule, optimizer, batch, DPO-specific loss, gradient,
-  activation-checkpointing, and parallelism controls.
-- Customizer skills and references now cover backend-specific job JSON for
-  Automodel, Unsloth, and RL, including dataset formats, batch sizing,
-  integrations, and troubleshooting.
-- Customizer adds local Optuna HPO workflows for tuning hyperparameters from a
-  developer workstation.
+- Agent-eval runner metrics such as Harbor reward, Gym reward, phase success,
+  evidence presence, and skill use are built in instead of requiring pickled
+  custom metric bundles.
+- Local SDK evaluation remains available without platform services, with a
+  runnable quickstart, on-disk run bundles, `summary.json`, `scores.jsonl`,
+  `trials.jsonl`, `tasks.jsonl`, and `report.html`.
+- The Harbor runner path is clearer: Harbor task suites run through the same
+  `AgentEvaluator` result model and use the built-in Harbor reward metric.
+- Result summaries expose per-task metric values and task outcomes, making it
+  easier to identify which tasks or trials drove aggregate scores.
+- Eval Author is now represented as coding-agent skills for Harbor discovery
+  and Intake trace inspection, rather than a standalone CLI command group.
 
 ### Studio
 
-- Studio includes primary surfaces for Agents, Data Designer, Guardrails,
-  Safe Synthesizer, Intake traces, Optimizer Insights, Experiments, and Jobs,
-  with Customizer and Anonymizer surfaces available behind their feature flags.
-- Guardrails in Studio can create and delete configurations and manage
-  guardrail test cases through the checks surface.
-- Data Designer adds more seed sources, AI-assisted job configuration, preview,
-  and file transform workflows.
-- Safe Synthesizer reports include score-driven gauges.
-- Studio can load plugin web bundles through `/apis/plugins` and render them
-  inside the Studio React tree with trusted bundle URL checks.
-- NeMo Studio Assistant adds a packaged agent, chat history, tool-call rendering,
-  and reasoning display for Studio-assisted workflows.
+- Studio adds GRPO customization form support and GRPO job detail panels with
+  reward environment and training-health views.
+- Studio adds RL/DPO customization job support and removes the older Prompt
+  Tuning form from the navigation.
+- Agents pages show metrics and open Insight details from an agent detail view.
+- Data Designer adds transform flows for existing files, with field mapping,
+  format presets, previews, and custom template rows.
+- Guardrail configuration in Studio now uses explicit rail toggles, starting
+  with self-check, plus configurable rail descriptions, model selection for
+  checks, and self-check generation controls.
+- Studio can chat with virtual models and has cleaner model filtering for
+  fine-tunable and base-model views.
 
 ### Platform, CLI, and Deployment
 
-- Early access: Agent deployment to an OpenShell Gateway with customizable
-  network policies (default-deny).
-- Deployment readiness now gates on workload reachability for container-backed
-  deployments.
-- Optional scoped access keys are available for authenticated deployments.
-- The CLI adds machine-readable output controls, Intake and Experiments command
-  exposure, anonymous usage telemetry, and a Telemetry and Privacy reference
-  page.
-- Python 3.12 is now the minimum supported Python version for the source
-  checkout and `nemo-platform` distribution.
-- Auditor adds a blocking submit option and an aggregated artifacts endpoint.
+- The Python SDK gains typed clients for additional platform and plugin service
+  areas, with a `NemoClient` compatibility layer for plugin SDK resources.
+- `nemo jobs watch` and `--watch` on job creation stream job events until a
+  terminal status, with better rendering for terminal task state and Docker
+  task fallback.
+- Generated CLI reference docs include plugin commands.
+- Helm deployments can configure controller and API groups, and the docs add
+  OpenSandbox, OpenSandbox with Kata, and Volcano setup guidance.
+- Docker-backed jobs preserve cancellation intent and release GPU allocations
+  when deleted.
+- Model-serving startup repairs pulled-weight permissions before launching NIM.
+- Release images and dependency locks include 0.5 CVE remediation, CPython
+  3.13.15 backports, and extended distroless Python runtimes.
+- Pending-deletion workspaces are hidden from the list API.
 
 ## Install
 
@@ -181,9 +149,13 @@ See [Setup](/documentation/get-started) for prerequisites and provider
 configuration.
 
 For self-managed Kubernetes, start with
-[Install NeMo Platform Helm Chart](/documentation/self-managed-deployment/setup/helm/install).
+[Install NeMo Platform Helm Chart](/documentation/kubernetes-deployment/setup/helm/install).
+GRPO jobs also require Kubernetes/Ray, OpenSandbox-enabled Gym execution, and
+job-storage PVC configuration; see
+[GRPO and Reward Environments](/documentation/customizer-reference/grpo-and-reward-environments)
+and [OpenSandbox](/documentation/kubernetes-deployment/setup/helm/open-sandbox).
 
-## Upgrade from v0.3.x
+## Upgrade from v0.4.x
 
 From an existing local checkout:
 
@@ -198,6 +170,13 @@ nemo setup
 After setup, restart local services before using CLI, SDK, Studio, or plugin
 workflows against the upgraded checkout.
 
+If you have pre-0.5 platform-owned agent intent packages, migrate them from
+`AGENT-SPEC.md` to `ETHOS.md` before using newer optimization workflows:
+
+```bash
+nemo agents ethos migrate --name <agent-name>
+```
+
 ## Compatibility
 
 - Python 3.12-3.13
@@ -207,48 +186,50 @@ workflows against the upgraded checkout.
 - Self-managed Kubernetes clusters deployed with Helm
 - Docker for local services, Docker-backed platform jobs, local ClickHouse,
   Docker Sandboxes, and local model-serving workflows
+- Kubernetes/Ray runtime for NeMo-RL DPO and GRPO customization jobs
+- OpenSandbox and a job-storage PVC for sandboxed GRPO reward environments
 - ClickHouse for Intake trace storage and Experiments rollups
-- NVIDIA GPU access for local training, model serving, and GPU-backed
-  synthetic data workflows
+- NVIDIA GPU access for local training, model serving, RL training, and
+  GPU-backed synthetic data workflows
 - Node 22.18.0+ for Studio assets
-- Platform API and `nemo-platform` Python SDK `0.4.0`
+- Platform API and `nemo-platform` Python SDK `0.5.0`
 
 ## Current constraints
 
+- **Self-managed scope.** v0.5.0 documents local setup and user-managed
+  Kubernetes deployment. It is not a managed hosted-service release.
 - **Research-preview optimizer.** Analyst and Experimentalist are early agentic
   workflows. They are useful for guided optimization, but quality and autonomy
   are still research-preview and require developer review.
-- **Local-first issue-driven loop.** The full Insight to Experimentalist loop
-  runs from a local developer environment against local paths or a git source.
-  A remote platform can provide Intake and entity APIs, but the issue-driven
-  optimization agents do not yet run as a horizontally scaled cluster service.
-- **Evaluation backend scope.** The Experimentalist loop validates candidates
-  with Harbor-compatible train and validation datasets. Other evaluator
-  backends are not the validated path for this loop yet.
+- **GRPO runtime.** GRPO jobs require Kubernetes/Ray execution and sandboxed
+  Gym configuration. They do not have a local Docker fallback.
+- **GRPO environment packaging.** `adapter-wheels-v1` packages require network
+  access at job start for the built-in `verifiers_agent` path. Fully offline
+  `wheels-v1` jobs need a complete wheel closure for the training image's
+  Python and node architecture.
+- **DPO runtime.** Customizer `rl` DPO jobs run on Kubernetes/Ray and do not
+  have a local Docker fallback. DPO remains full-weight only.
+- **Eval Author migration.** Eval Author discovery is now skill-driven. The
+  old `nemo agents eval-author` CLI group is no longer the supported surface.
+- **Agent intent migration.** `AGENT-SPEC.md` is legacy. Use `ETHOS.md` for
+  new work and run `nemo agents ethos migrate` for platform-owned legacy
+  packages before relying on optimizer workflows.
 - **Optuna HPO runtime.** Optuna-based hyperparameter optimization runs locally
   from a developer workstation. It is not available as a horizontally scaled
   cluster service in this release.
-- **DPO runtime.** Customizer `rl` DPO jobs run on Kubernetes/Ray and do not
-  have a local Docker fallback. DPO is full-weight only; PEFT/adapter output is
-  not supported for RL jobs.
-- **Experiments feature flag.** The Experiments Studio surface is gated by
-  `VITE_FF_EXPERIMENT`, which is off by default.
+- **Access keys.** Scoped access keys remain optional and must be enabled by
+  the platform administrator.
 - **Embedded ClickHouse scope.** Helm's embedded ClickHouse is intended for
   development, evaluation, and non-critical single-node deployments. Use an
   externally managed ClickHouse for production deployments that require high
   availability, backups, or larger scale.
-- **Python support.** Python 3.11 is no longer part of the supported source
-  checkout or `nemo-platform` distribution matrix.
-
-## Known issues
-
-- **Deep Agents trials can be scored as failures.** Agent-eval trials run
-  through the NeMo Fabric Deep Agents adapter can be recorded as failures even
-  when the agent completed successfully. This will be fixed in the next release.
 
 ## Links
 
 - Repository: [https://github.com/NVIDIA-NeMo/nemo-platform](https://github.com/NVIDIA-NeMo/nemo-platform)
 - Issues: [https://github.com/NVIDIA-NeMo/nemo-platform/issues](https://github.com/NVIDIA-NeMo/nemo-platform/issues)
+- GRPO and Reward Environments: [https://docs.nvidia.com/nemo-platform/documentation/customizer-reference/grpo-and-reward-environments](https://docs.nvidia.com/nemo-platform/documentation/customizer-reference/grpo-and-reward-environments)
+- GRPO Environment Packages: [https://docs.nvidia.com/nemo-platform/documentation/customizer-reference/tutorials/grpo-environment-packages](https://docs.nvidia.com/nemo-platform/documentation/customizer-reference/tutorials/grpo-environment-packages)
+- OpenSandbox setup: [https://docs.nvidia.com/nemo-platform/documentation/kubernetes-deployment/setup/helm/open-sandbox](https://docs.nvidia.com/nemo-platform/documentation/kubernetes-deployment/setup/helm/open-sandbox)
 - NeMo Fabric: [https://docs.nvidia.com/nemo/fabric/about-nemo-fabric/overview/](https://docs.nvidia.com/nemo/fabric/about-nemo-fabric/overview/)
 - NeMo Agent Toolkit: [https://docs.nvidia.com/nemo/agent-toolkit/latest/](https://docs.nvidia.com/nemo/agent-toolkit/latest/)

--- a/docs/about/release-notes/index.mdx
+++ b/docs/about/release-notes/index.mdx
@@ -7,7 +7,8 @@ description: ""
 ---
 Check out the latest release notes for NeMo Platform.
 
-- [Release 0.4.0](/documentation/reference/release-notes/current-release)
+- [Release 0.5.0](/documentation/reference/release-notes/current-release)
+- [Release 0.4.0](/documentation/reference/release-notes/release-0-4-0)
 - [Release 0.3.0](/documentation/reference/release-notes/release-0-3-0)
 - [Release 0.2.0](/documentation/reference/release-notes/release-0-2-0)
 - [Release 0.1.0](/documentation/reference/release-notes/release-0-1-0)

--- a/docs/about/release-notes/release-0-4-0.mdx
+++ b/docs/about/release-notes/release-0-4-0.mdx
@@ -1,0 +1,254 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+title: "v0.4.0 - 2026-08-12"
+description: ""
+---
+NeMo Platform v0.4.0 introduces a research-preview optimization loop for
+improving agents from real telemetry. Agent owners can send traces to Intake,
+use agents to diagnose recurring issues, create targeted evaluation coverage,
+experiment against a local code base, and review validated candidate changes.
+The release also moves new agent workflows toward `agent.yaml` packages backed
+by [Fabric](https://github.com/NVIDIA/nemo-fabric/) while keeping NAT workflows
+available as a legacy path.
+
+## Highlights
+
+- **Research-preview agent optimization.** Analyst and Experimentalist
+  workflows now support the observe, diagnose, experiment, and evaluate loop for
+  agents under active development.
+- **Trace-driven diagnosis.** NeMo Intake ingests OTLP, chat-completions, and
+  ATIF telemetry, stores traces in ClickHouse, and attaches annotations and
+  evaluator results so agents and humans can investigate failures from the same
+  evidence.
+- **Validated candidate changes.** Experimentalist can run against a local
+  agent source tree or git source, evaluate candidates with Harbor, write
+  optimization artifacts locally, and open a draft PR when a changed
+  winner is found.
+- **Fabric-first agents.** New Platform-managed agents use the
+  `nemo-agents-spec-v1` `agent.yaml` contract. Fabric-backed agents can run
+  through supported harnesses and route model traffic through the Inference
+  Gateway; NAT remains supported for existing workflows.
+- **Experiments for review.** NeMo Experiments compares evaluation runs using
+  cost, latency, token, and evaluator-score rollups computed from Intake
+  telemetry, with Studio leaderboard and drill-down views behind the Experiments
+  feature flag.
+- **Customizer DPO.** Customizer adds DPO training through the `rl` backend,
+  powered by NeMo-RL and Ray on Kubernetes, with backend-specific
+  hyperparameter guidance for Automodel, Unsloth, and RL jobs.
+
+## What's included
+
+### Insight-Driven Optimization
+
+- `nemo agents analyst` scans Intake traces, evaluator scores, and reviewer
+  annotations to produce evidence-backed Insights.
+- `nemo agents experimentalist` turns an Insight, or a dataset-only objective,
+  into candidate code changes, train/validation evaluations, local artifacts,
+  and an optional draft PR or MR.
+- `optimizer.yaml` provides the shared per-agent profile for the loop, including
+  the agent name, workspace, agent source, `ETHOS.md`, datasets, task
+  template, and experiment configuration.
+- `ETHOS.md` is the durable Markdown contract for intended agent behavior. It
+  can be consumed by the Analyst and Experimentalist when present. It records
+  `Principles`, `Trade-offs`, `Constraints`, `Metric Semantics`, and `Vision`
+  alongside the original inventory sections. Every canonical body section is
+  required. Parsing fails if a required heading is missing. Write `_(none)_`
+  when a section has nothing to say. Extra `##` headings and extra YAML
+  front-matter keys are allowed; the parser does not reject them. Front matter
+  includes `schema_version: 1`. `Change Scope` levers accept `with-approval`
+  alongside `yes` and `no`.
+- `ETHOS.md` keeps mission and the agent's accountable outcome in a single
+  `Purpose & Outcomes` section, so they stay together.
+- `ETHOS.md` does not use the earlier AGENT-SPEC headings `Framework`, `Model`,
+  `Signals`, or `Purpose`. Nothing read `Framework`, and a container's
+  framework label comes from `agent.yaml`. Describe how the agent runs in
+  `Harness`, or write `_(none)_`. Do not map the implementation onto a named
+  platform harness. `Model` restated configuration that changes without
+  touching the Ethos, so state permitted providers and model families in
+  `Constraints` and swap permission in `Change Scope`. `Signals` was one
+  consumer's configuration, not durable intent. How a consumer reads evidence
+  belongs in that consumer. `Purpose` merged into `Purpose & Outcomes`.
+- Coding agents that find `agents/<name>-spec/AGENT-SPEC.md` read it as
+  prior answers, write `ETHOS.md` with `nemo-ethos`, and delete the spec
+  package after the user confirms the Ethos. `nemo agents create` prints the
+  same instruction when the config still lives in a spec package.
+- `ETHOS.md` records durable intent, so run-scoped optimizer settings such as a
+  per-experiment spend ceiling belong in the optimizer's own configuration.
+  State a standing production cost ceiling in `Constraints` instead.
+- `nemo-explore` scans the repository first, then asks at least three intent
+  questions, one at a time. It always confirms `Purpose & Outcomes`,
+  `Principles`, and `Vision` with the user, even when the scan produced a
+  plausible draft, before handing off to `nemo-ethos`. After `nemo-ethos`
+  writes `ETHOS.md`, it states a short gut-check of the agent so the user can
+  judge the write before reading the full file.
+- The `nemo-spec` skill is `nemo-ethos`, matching the contract it writes.
+- Benchmark and proof assets include Terminal-Bench 2.1, Tau3 Airline, Banking,
+  Retail, and Telecom suites, plus a guided Tau3 example-agent walkthrough.
+
+### Intake and Experiments
+
+- Intake supports OTLP, chat-completions, and ATIF ingest paths for agent
+  telemetry.
+- Traces, spans, sessions, annotations, and evaluator results are queryable by
+  API and reviewable in Studio.
+- Local setup can automatically provision and reuse a local ClickHouse
+  container for Intake unless an external ClickHouse URL is configured.
+- The Helm chart includes an embedded ClickHouse option for development and
+  non-critical single-node installations, plus configuration for external
+  ClickHouse in production-oriented deployments.
+- Experiments and Evaluations are durable entities whose leaderboard metrics are
+  computed from retained Intake telemetry.
+- The `nemo-experiments-upload` skill helps coding agents publish evaluation
+  runs and verify rollups.
+
+### Agents and Fabric
+
+- New agents use Platform-managed `agent.yaml` files with the
+  `nemo-agents-spec-v1` config format.
+- NeMo Fabric is the preferred runtime wrapper for new agents, with support for
+  harness adapters, shared model bindings, skills, MCP servers, tool policy, and
+  Relay/ATIF/ATOF telemetry configuration.
+- `nemo agents create`, `deploy`, `invoke`, `run`, and `package` support the
+  Fabric-backed agent path.
+- Fabric agent artifacts can be staged into Docker and Kubernetes deployments.
+- Streaming responses are supported through Fabric-backed agents.
+- Legacy NAT workflow YAMLs continue to work for existing NAT-specific
+  evaluation and deployment workflows.
+
+### Agent Evaluation
+
+- The evaluator SDK adds Fabric runtime support, Docker Compose sandboxing,
+  native agent-eval aggregation, pass-at-k scoring, typed run metadata, and
+  task/taskset revisions.
+- Agent evaluations can publish results to Intake so Experiments and Insights
+  can consume the same run telemetry.
+
+### Customizer
+
+- The `rl` customization backend supports full-weight DPO jobs through NeMo-RL.
+- DPO schemas expose schedule, optimizer, batch, DPO-specific loss, gradient,
+  activation-checkpointing, and parallelism controls.
+- Customizer skills and references now cover backend-specific job JSON for
+  Automodel, Unsloth, and RL, including dataset formats, batch sizing,
+  integrations, and troubleshooting.
+- Customizer adds local Optuna HPO workflows for tuning hyperparameters from a
+  developer workstation.
+
+### Studio
+
+- Studio includes primary surfaces for Agents, Data Designer, Guardrails,
+  Safe Synthesizer, Intake traces, Optimizer Insights, Experiments, and Jobs,
+  with Customizer and Anonymizer surfaces available behind their feature flags.
+- Guardrails in Studio can create and delete configurations and manage
+  guardrail test cases through the checks surface.
+- Data Designer adds more seed sources, AI-assisted job configuration, preview,
+  and file transform workflows.
+- Safe Synthesizer reports include score-driven gauges.
+- Studio can load plugin web bundles through `/apis/plugins` and render them
+  inside the Studio React tree with trusted bundle URL checks.
+- NeMo Studio Assistant adds a packaged agent, chat history, tool-call rendering,
+  and reasoning display for Studio-assisted workflows.
+
+### Platform, CLI, and Deployment
+
+- Early access: Agent deployment to an OpenShell Gateway with customizable
+  network policies (default-deny).
+- Deployment readiness now gates on workload reachability for container-backed
+  deployments.
+- Optional scoped access keys are available for authenticated deployments.
+- The CLI adds machine-readable output controls, Intake and Experiments command
+  exposure, anonymous usage telemetry, and a Telemetry and Privacy reference
+  page.
+- Python 3.12 is now the minimum supported Python version for the source
+  checkout and `nemo-platform` distribution.
+- Auditor adds a blocking submit option and an aggregated artifacts endpoint.
+
+## Install
+
+For a fresh local checkout:
+
+```bash
+git clone https://github.com/NVIDIA-NeMo/nemo-platform.git
+cd nemo-platform
+make bootstrap
+source .venv/bin/activate
+nemo setup
+```
+
+See [Setup](/documentation/get-started) for prerequisites and provider
+configuration.
+
+For self-managed Kubernetes, start with
+[Install NeMo Platform Helm Chart](/documentation/kubernetes-deployment/setup/helm/install).
+
+## Upgrade from v0.3.x
+
+From an existing local checkout:
+
+```bash
+git fetch
+git checkout main
+make bootstrap
+source .venv/bin/activate
+nemo setup
+```
+
+After setup, restart local services before using CLI, SDK, Studio, or plugin
+workflows against the upgraded checkout.
+
+## Compatibility
+
+- Python 3.12-3.13
+- macOS and Linux for local CLI, SDK, Studio, and hosted-provider workflows
+- Linux x86_64 for local NVIDIA GPU workloads
+- CUDA 13-capable NVIDIA drivers for local GPU workloads
+- Self-managed Kubernetes clusters deployed with Helm
+- Docker for local services, Docker-backed platform jobs, local ClickHouse,
+  Docker Sandboxes, and local model-serving workflows
+- ClickHouse for Intake trace storage and Experiments rollups
+- NVIDIA GPU access for local training, model serving, and GPU-backed
+  synthetic data workflows
+- Node 22.18.0+ for Studio assets
+- Platform API and `nemo-platform` Python SDK `0.4.0`
+
+## Current constraints
+
+- **Research-preview optimizer.** Analyst and Experimentalist are early agentic
+  workflows. They are useful for guided optimization, but quality and autonomy
+  are still research-preview and require developer review.
+- **Local-first issue-driven loop.** The full Insight to Experimentalist loop
+  runs from a local developer environment against local paths or a git source.
+  A remote platform can provide Intake and entity APIs, but the issue-driven
+  optimization agents do not yet run as a horizontally scaled cluster service.
+- **Evaluation backend scope.** The Experimentalist loop validates candidates
+  with Harbor-compatible train and validation datasets. Other evaluator
+  backends are not the validated path for this loop yet.
+- **Optuna HPO runtime.** Optuna-based hyperparameter optimization runs locally
+  from a developer workstation. It is not available as a horizontally scaled
+  cluster service in this release.
+- **DPO runtime.** Customizer `rl` DPO jobs run on Kubernetes/Ray and do not
+  have a local Docker fallback. DPO is full-weight only; PEFT/adapter output is
+  not supported for RL jobs.
+- **Experiments feature flag.** The Experiments Studio surface is gated by
+  `VITE_FF_EXPERIMENT`, which is off by default.
+- **Embedded ClickHouse scope.** Helm's embedded ClickHouse is intended for
+  development, evaluation, and non-critical single-node deployments. Use an
+  externally managed ClickHouse for production deployments that require high
+  availability, backups, or larger scale.
+- **Python support.** Python 3.11 is no longer part of the supported source
+  checkout or `nemo-platform` distribution matrix.
+
+## Known issues
+
+- **Deep Agents trials can be scored as failures.** Agent-eval trials run
+  through the NeMo Fabric Deep Agents adapter can be recorded as failures even
+  when the agent completed successfully. This will be fixed in the next release.
+
+## Links
+
+- Repository: [https://github.com/NVIDIA-NeMo/nemo-platform](https://github.com/NVIDIA-NeMo/nemo-platform)
+- Issues: [https://github.com/NVIDIA-NeMo/nemo-platform/issues](https://github.com/NVIDIA-NeMo/nemo-platform/issues)
+- NeMo Fabric: [https://docs.nvidia.com/nemo/fabric/about-nemo-fabric/overview/](https://docs.nvidia.com/nemo/fabric/about-nemo-fabric/overview/)
+- NeMo Agent Toolkit: [https://docs.nvidia.com/nemo/agent-toolkit/latest/](https://docs.nvidia.com/nemo/agent-toolkit/latest/)

--- a/docs/about/release-notes/release-0-4-0.mdx
+++ b/docs/about/release-notes/release-0-4-0.mdx
@@ -177,7 +177,7 @@ source .venv/bin/activate
 nemo setup
 ```
 
-See [Setup](/documentation/get-started) for prerequisites and provider
+See [Setup](/documentation/get-started/setup) for prerequisites and provider
 configuration.
 
 For self-managed Kubernetes, start with

--- a/docs/fern/versions/latest.yml
+++ b/docs/fern/versions/latest.yml
@@ -390,6 +390,7 @@ navigation:
                   - page: Volcano
                     path: ../../set-up/helm/volcano.mdx
                   - page: OpenSandbox
+                    slug: opensandbox
                     path: ../../set-up/helm/opensandbox.mdx
                   - page: OpenSandbox with Kata
                     slug: opensandbox-kata

--- a/docs/fern/versions/latest.yml
+++ b/docs/fern/versions/latest.yml
@@ -481,6 +481,9 @@ navigation:
             contents:
               - page: Current Release
                 path: ../../about/release-notes/current-release.mdx
+              - page: v0.4.0
+                slug: release-0-4-0
+                path: ../../about/release-notes/release-0-4-0.mdx
               - page: v0.3.0
                 slug: release-0-3-0
                 path: ../../about/release-notes/release-0-3-0.mdx


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
Update the current release notes for NeMo Platform v0.5.0 and archive the previous v0.4.0 notes. This keeps the release-note index and Fern navigation aligned with the 0.5 release branch.

## Changes
- Replaces the current release-note page with v0.5.0 content covering Customizer GRPO/DPO, Studio, Fabric-backed agents, evaluation, Ethos migration, and platform hardening.
- Adds a v0.4.0 archive page copied from the previous current release notes.
- Updates the release-note index and Fern navigation to include v0.5.0 current notes and the v0.4.0 archive.
- Adds an explicit OpenSandbox nav slug and uses canonical Setup/OpenSandbox release-note links.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [x] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: documentation-only release-note update
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `make docs-check` — passed
- `make docs-broken-links` — completed; no release-note entries remain in the broken-link report. The command still reports 77 pre-existing broken links outside the changed release-note files.
- `flox -q activate -- uv run pre-commit run -a` — passed
- DCO audit over `origin/release/0.5..HEAD` — passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated release notes for version 0.5.0, covering reward environments, reinforcement learning support in Studio, agent packaging, evaluation improvements, and operational updates.
  - Expanded guidance for customization, agents, deployment, installation, migration, compatibility, constraints, and reference materials.
  - Added a dedicated version 0.4.0 release-notes page and updated release navigation.
  - Updated installation and OpenSandbox references to canonical documentation URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->