### PR TITLE
chore(agents): cherry pick fabric agent packaging support

### DIFF
--- a/plugins/nemo-agents/README.md
+++ b/plugins/nemo-agents/README.md
@@ -192,14 +192,28 @@ has to be one an index can serve:
 
 ```bash
 uv build --package nemo-platform --wheel --out-dir dist && \
-NEMO_AGENTS_WHEEL="$(ls -t dist/nemo_platform-*.whl | head -1)" nemo agents package \
+NEMO_AGENTS_WHEEL=LATEST nemo agents package \
   --agent plugins/nemo-agents/examples/nemo-agent-config/calculator-agent/agent.yaml \
   --tag calculator-agent:local
 ```
 
+`LATEST` resolves to the newest wheel in the checkout's `dist`, so the variable
+survives the rebuild each commit forces — the version carries the commit, so a
+wheel built before your last commit no longer describes your tree. An absolute
+path still works and takes precedence, so a file actually named `LATEST` is
+never mistaken for the sentinel. If the wheel's version differs from the one
+this host runs, the build says so and continues: the wheel is installed instead
+of the pin, so the pin never has to resolve.
+
 It is an environment variable rather than a flag because packaging also runs as
-a platform job, and a flag would only ever reach the CLI. Setting it in the jobs
-execution profile's `env` makes packaging from Studio work the same way.
+a platform job, and a flag would only ever reach the CLI. The subprocess job
+inherits it, so exporting it before `nemo services run` covers Studio-triggered
+builds too:
+
+```bash
+export NEMO_AGENTS_WHEEL=LATEST
+uv run nemo services run --service-group all --controllers jobs --port 8080
+```
 
 Packaging copies the wheel into the build context for the duration of the build
 and removes it afterward. It does not overwrite an existing file with that name.

--- a/plugins/nemo-agents/README.md
+++ b/plugins/nemo-agents/README.md
@@ -186,6 +186,26 @@ set NEMO_AGENTS_ALLOW_UNPUBLISHED_CONTRACT_VERSION=1 if your index serves this
 version.
 ```
 
+To package from a checkout, build a wheel and point `NEMO_AGENTS_WHEEL` at it.
+The image installs that wheel instead of resolving the pin, so the version never
+has to be one an index can serve:
+
+```bash
+uv build --package nemo-platform --wheel --out-dir dist && \
+NEMO_AGENTS_WHEEL="$(ls -t dist/nemo_platform-*.whl | head -1)" nemo agents package \
+  --agent plugins/nemo-agents/examples/nemo-agent-config/calculator-agent/agent.yaml \
+  --tag calculator-agent:local
+```
+
+It is an environment variable rather than a flag because packaging also runs as
+a platform job, and a flag would only ever reach the CLI. Setting it in the jobs
+execution profile's `env` makes packaging from Studio work the same way.
+
+Packaging copies the wheel into the build context for the duration of the build
+and removes it afterward. It does not overwrite an existing file with that name.
+It applies to Fabric packaging only — NAT images install the packaged project
+itself.
+
 Supplying your own `--template` also skips the check, since a custom template
 need not pin the contract version at all.
 

--- a/plugins/nemo-agents/src/nemo_agents_plugin/container/builder.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/container/builder.py
@@ -314,6 +314,40 @@ def build_nat_agent_image(
             ignore_file.unlink(missing_ok=True)
 
 
+def _source_checkout_dist_dir() -> Path | None:
+    """Locate ``dist`` in the checkout this package is running from, if it is one."""
+    import importlib.util
+
+    spec = importlib.util.find_spec("nemo_agents_plugin")
+    locations = spec.submodule_search_locations if spec else None
+    if not locations:
+        return None
+    for parent in Path(next(iter(locations))).resolve().parents:
+        if (parent / "pyproject.toml").is_file() and (parent / "plugins").is_dir():
+            dist = parent / "dist"
+            return dist if dist.is_dir() else None
+    return None
+
+
+def resolve_latest_wheel() -> Path:
+    """Return the most recently built wheel in the source checkout's ``dist``."""
+    from nemo_agents_plugin.container.template import WHEEL_ENV, WHEEL_LATEST
+
+    dist = _source_checkout_dist_dir()
+    if dist is None:
+        raise ValueError(
+            f"{WHEEL_ENV}={WHEEL_LATEST} needs a source checkout with a 'dist' directory, "
+            "which this install is not. Point it at a wheel path instead."
+        )
+    wheels = sorted(dist.glob("nemo_platform-*.whl"), key=lambda path: path.stat().st_mtime, reverse=True)
+    if not wheels:
+        raise ValueError(
+            f"{WHEEL_ENV}={WHEEL_LATEST} found no nemo-platform wheels in {dist}. Build one with "
+            "`uv build --package nemo-platform --wheel --out-dir dist`."
+        )
+    return wheels[0]
+
+
 def build_fabric_agent_image(
     agent_config: Path,
     pyproject: Path | None = None,
@@ -375,13 +409,24 @@ def build_fabric_agent_image(
     resolved_uv = resolve_value("uv_version", uv_version)
 
     from nemo_agents_plugin.container.metadata import NEMO_PLATFORM_AGENT_FRAMEWORK, extract_agent_metadata
-    from nemo_agents_plugin.container.template import WHEEL_ENV
+    from nemo_agents_plugin.container.template import WHEEL_ENV, WHEEL_LATEST
 
     # The env var is the only caller-facing way in, so it reaches the platform
     # job as well as the CLI.
     if wheel is None:
         from_env = os.environ.get(WHEEL_ENV, "").strip()
-        wheel = Path(from_env) if from_env else None
+        if from_env and dockerfile is not None:
+            # Decided before resolving, so LATEST does not have to find a wheel
+            # this build was never going to install.
+            emit_progress(
+                on_progress, f"warning: ignoring {WHEEL_ENV}={from_env}; --dockerfile decides what is installed"
+            )
+        # A real path wins over the sentinel, so a file named LATEST is still usable.
+        elif from_env and not Path(from_env).exists() and from_env.upper() == WHEEL_LATEST:
+            wheel = resolve_latest_wheel()
+            emit_progress(on_progress, f"{WHEEL_ENV}={WHEEL_LATEST} resolved to {wheel.name}")
+        elif from_env:
+            wheel = Path(from_env)
     if wheel is not None and dockerfile is not None:
         # A supplied Dockerfile installs whatever it wants and never sees the
         # staged wheel, so the wheel must not speak for the version either.
@@ -396,6 +441,12 @@ def build_fabric_agent_image(
     # A wheel is what the image actually installs, so it — not the build host —
     # decides the version the image advertises and hashes into its id.
     contract_version = wheel_contract_version(wheel) if wheel is not None else get_contract_version()
+    if wheel is not None and contract_version != get_contract_version():
+        # Not fatal: the wheel is installed instead of the pin, so the pin never resolves.
+        emit_progress(
+            on_progress,
+            f"warning: {wheel.name} builds {contract_version}, but this host runs {get_contract_version()}",
+        )
 
     build_env_for_id = {
         "agent_framework": NEMO_PLATFORM_AGENT_FRAMEWORK,

--- a/plugins/nemo-agents/src/nemo_agents_plugin/container/builder.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/container/builder.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import logging
 import os
 import re
+import shutil
 from collections.abc import Callable
 from pathlib import Path
 
@@ -104,6 +105,57 @@ def docker_build(
 
     emit_progress(on_progress, f"Successfully built {tag}")
     return tag
+
+
+def resolve_image_id(tag: str) -> str:
+    """Return the immutable image ID currently bound to *tag*.
+
+    Callers that build then later publish should resolve this right after the
+    build call and push by ID rather than by *tag* — a concurrent job that
+    rebuilds the same (daemon-global) tag name between the two steps cannot
+    silently swap out what gets published.
+
+    Raises:
+        ContainerToolingUnavailableError: When python-on-whales is missing.
+        ImageBuildError: When *tag* cannot be inspected (e.g. the build that
+            produced it never loaded into the local daemon).
+    """
+    try:
+        from python_on_whales import docker
+    except ImportError as exc:
+        raise ContainerToolingUnavailableError("resolving the built image ID") from exc
+
+    try:
+        return docker.image.inspect(tag).id
+    except Exception as exc:
+        raise ImageBuildError(f"Unable to resolve the image ID for '{tag}': {exc}") from exc
+
+
+#: Distribution a supplied wheel must be, normalized per PEP 503.
+_WHEEL_DISTRIBUTION = "nemo-platform"
+
+
+def wheel_contract_version(wheel: Path) -> str:
+    """Return the nemo-platform version a wheel would install.
+
+    The image's ``contract-version`` label and its content-addressable
+    ``agent_id`` both describe the runtime inside it. Deriving them from the
+    build host while installing a wheel would let an image advertise one version
+    while running another, and let two genuinely different images share an id.
+
+    Parsed from the filename, which PEP 427 fixes as
+    ``{distribution}-{version}(-{build})?-{python}-{abi}-{platform}.whl``.
+    """
+    parts = wheel.stem.split("-")
+    if len(parts) < 5:
+        raise ValueError(f"not a PEP 427 wheel filename: {wheel.name}")
+    distribution, version = parts[0], parts[1]
+    if re.sub(r"[-_.]+", "-", distribution).lower() != _WHEEL_DISTRIBUTION:
+        raise ValueError(
+            f"wheel is {distribution!r}, not {_WHEEL_DISTRIBUTION!r}: {wheel.name}. "
+            "Build it with `uv build --package nemo-platform --wheel`."
+        )
+    return version
 
 
 def build_nat_agent_image(
@@ -283,8 +335,12 @@ def build_fabric_agent_image(
     platforms: list[str] | None = None,
     push: bool = False,
     on_progress: ProgressCallback | None = None,
+    wheel: Path | None = None,
 ) -> str:
     """Build a Fabric-backed NeMo agent image.
+
+    *wheel* installs a local nemo-platform wheel instead of resolving the pinned
+    contract version, which is the only way to package from a source checkout.
 
     This is intentionally separate from ``build_nat_agent_image`` so Fabric
     packaging can grow without inheriting NAT-specific args such as
@@ -319,10 +375,31 @@ def build_fabric_agent_image(
     resolved_uv = resolve_value("uv_version", uv_version)
 
     from nemo_agents_plugin.container.metadata import NEMO_PLATFORM_AGENT_FRAMEWORK, extract_agent_metadata
+    from nemo_agents_plugin.container.template import WHEEL_ENV
+
+    # The env var is the only caller-facing way in, so it reaches the platform
+    # job as well as the CLI.
+    if wheel is None:
+        from_env = os.environ.get(WHEEL_ENV, "").strip()
+        wheel = Path(from_env) if from_env else None
+    if wheel is not None and dockerfile is not None:
+        # A supplied Dockerfile installs whatever it wants and never sees the
+        # staged wheel, so the wheel must not speak for the version either.
+        emit_progress(on_progress, f"warning: ignoring {WHEEL_ENV}={wheel}; --dockerfile decides what is installed")
+        wheel = None
+    if wheel is not None:
+        if not wheel.is_file():
+            raise ValueError(f"wheel not found: {wheel}")
+        if wheel.suffix != ".whl":
+            raise ValueError(f"not a wheel: {wheel}")
+
+    # A wheel is what the image actually installs, so it — not the build host —
+    # decides the version the image advertises and hashes into its id.
+    contract_version = wheel_contract_version(wheel) if wheel is not None else get_contract_version()
 
     build_env_for_id = {
         "agent_framework": NEMO_PLATFORM_AGENT_FRAMEWORK,
-        "contract_version": get_contract_version(),
+        "contract_version": contract_version,
         "nemo_relay_cli_version": PINNED_NEMO_RELAY_CLI_VERSION,
         "base_image_url": resolved_base_url,
         "base_image_tag": resolved_base_tag,
@@ -358,6 +435,18 @@ def build_fabric_agent_image(
             on_progress=on_progress,
         )
 
+    # Docker can only COPY from inside the context, so the wheel is staged there
+    # and removed again on the way out.
+    staged_wheel: Path | None = None
+    wheel_already_in_context = False
+    if wheel is not None:
+        staged_wheel = context_dir / wheel.name
+        if staged_wheel.exists():
+            if not staged_wheel.samefile(wheel):
+                raise ManagedFileConflictError(staged_wheel)
+            # Already the wheel we would copy, so there is nothing to stage.
+            wheel_already_in_context = True
+
     content = render_fabric_dockerfile(
         agent_config,
         pyproject,
@@ -371,6 +460,8 @@ def build_fabric_agent_image(
         agent_author=agent_author,
         template_path=template_path,
         metadata=meta,
+        wheel_filename=staged_wheel.name if staged_wheel else "",
+        contract_version=contract_version,
     )
 
     tmp_dockerfile = context_dir / "Dockerfile.generated"
@@ -380,11 +471,38 @@ def build_fabric_agent_image(
     ignore_file: Path | None = None
     ignore_path = context_dir / ".dockerignore"
     ignore_pre_existed = ignore_path.exists()
+    wheel_was_staged = False
+    scoped_ignore_written = False
     try:
         tmp_dockerfile.write_text(content, encoding="utf-8")
 
+        if staged_wheel is not None and wheel is not None and not wheel_already_in_context:
+            # Create exclusively rather than re-checking existence: the check above
+            # is not atomic with the copy, and losing that race would overwrite
+            # someone's file and then delete it during cleanup.
+            try:
+                dest = open(staged_wheel, "xb")
+            except FileExistsError as exc:
+                raise ManagedFileConflictError(staged_wheel) from exc
+            # Owned from the moment it exists: a failure mid-copy would otherwise
+            # strand a partial wheel that fails every later build as a conflict.
+            wheel_was_staged = True
+            with dest, wheel.open("rb") as src:
+                shutil.copyfileobj(src, dest)
+            emit_progress(on_progress, f"Staged {wheel.name} into the build context")
+
         if generate_ignore:
             ignore_file = render_dockerignore(context_dir)
+
+        if staged_wheel is not None:
+            # BuildKit prefers `<dockerfile>.dockerignore` over `.dockerignore`,
+            # so the user's rules are carried over verbatim with the staged wheel
+            # re-included after them. Guaranteeing the wheel arrives beats
+            # detecting that it would not and reimplementing Docker's matcher.
+            existing = ignore_path.read_text(encoding="utf-8") if ignore_path.exists() else ""
+            scoped_ignore = context_dir / f"{tmp_dockerfile.name}.dockerignore"
+            scoped_ignore.write_text(f"{existing.rstrip()}\n!{staged_wheel.name}\n".lstrip(), encoding="utf-8")
+            scoped_ignore_written = True
 
         return docker_build(
             context_dir=context_dir,
@@ -397,6 +515,10 @@ def build_fabric_agent_image(
         )
     finally:
         tmp_dockerfile.unlink(missing_ok=True)
+        if scoped_ignore_written:
+            (context_dir / f"{tmp_dockerfile.name}.dockerignore").unlink(missing_ok=True)
+        if wheel_was_staged and staged_wheel is not None:
+            staged_wheel.unlink(missing_ok=True)
         if ignore_file is not None and not ignore_pre_existed:
             ignore_file.unlink(missing_ok=True)
 

--- a/plugins/nemo-agents/src/nemo_agents_plugin/container/template.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/container/template.py
@@ -97,6 +97,11 @@ _ENV_MAP: dict[str, str] = {
     "uv_version": "NEMO_AGENTS_UV_VERSION",
 }
 
+#: Local nemo-platform wheel to install instead of resolving the pinned contract
+#: version. Set by an operator rather than a caller: it names a path on the build
+#: host, and packaging runs there for the CLI and the platform job alike.
+WHEEL_ENV = "NEMO_AGENTS_WHEEL"
+
 PINNED_NEMO_RELAY_CLI_VERSION = "0.7.3"
 PINNED_NEMO_RELAY_INSTALLER_COMMIT = "40c5990361afc26ae8b901ff1f49c2b03ddd9ede"
 PINNED_NEMO_RELAY_INSTALLER_SHA256 = "ba2585a32e568643819992fa66b750004328351fce422b979d8c11cfc8bbfadb"
@@ -246,7 +251,7 @@ COPY ./ /workspace
 RUN --mount=type=cache,id=uv_cache,target=/root/.cache/uv,sharing=locked \\
     uv venv --python ${PYTHON_VERSION} /workspace/.venv && \\
     . /workspace/.venv/bin/activate && \\
-    uv pip install --prerelease=allow "nemo-platform[nemo-agents-plugin]=={{ contract_version }}" \\
+    uv pip install --no-sources --prerelease=allow {% if wheel_filename %}"/workspace/{{ wheel_filename }}[nemo-agents-plugin]"{% else %}"nemo-platform[nemo-agents-plugin]=={{ contract_version }}"{% endif %} \\
       "nemo-relay=={{ pinned_nemo_relay_cli_version }}" . && \\
     chmod -R a+rX /opt/uv /workspace/.venv
 {% else %}
@@ -254,7 +259,7 @@ RUN --mount=type=cache,id=uv_cache,target=/root/.cache/uv,sharing=locked \\
 RUN --mount=type=cache,id=uv_cache,target=/root/.cache/uv,sharing=locked \\
     uv venv --python ${PYTHON_VERSION} /workspace/.venv && \\
     . /workspace/.venv/bin/activate && \\
-    uv pip install --prerelease=allow "nemo-platform[nemo-agents-plugin]=={{ contract_version }}" \\
+    uv pip install --no-sources --prerelease=allow {% if wheel_filename %}"/workspace/{{ wheel_filename }}[nemo-agents-plugin]"{% else %}"nemo-platform[nemo-agents-plugin]=={{ contract_version }}"{% endif %} \\
       "nemo-relay=={{ pinned_nemo_relay_cli_version }}" && \\
     chmod -R a+rX /opt/uv /workspace/.venv
 {% endif %}
@@ -360,6 +365,10 @@ class NatRenderParams(SharedRenderParams):
 @dataclass
 class FabricRenderParams(SharedRenderParams):
     """Resolved parameters specific to Fabric Dockerfile rendering."""
+
+    #: Wheel to install instead of the pinned requirement, relative to the build
+    #: context. Empty means resolve ``contract_version`` from an index.
+    wheel_filename: str = ""
 
 
 # -- Public API -------------------------------------------------------------
@@ -628,8 +637,14 @@ def render_fabric_dockerfile(
     agent_author: str | None = None,
     template_path: str | None = None,
     metadata: dict[str, str] | None = None,
+    wheel_filename: str = "",
+    contract_version: str | None = None,
 ) -> str:
-    """Render a Dockerfile string for a Fabric-backed agent."""
+    """Render a Dockerfile string for a Fabric-backed agent.
+
+    *wheel_filename* names a wheel already copied into the build context; when
+    set the image installs it instead of resolving ``contract_version``.
+    """
     shared = resolve_shared_render_params(
         agent_config,
         pyproject,
@@ -643,11 +658,20 @@ def render_fabric_dockerfile(
         agent_author=agent_author,
         metadata=metadata,
     )
+    # With a wheel, the version the image installs comes from the wheel, not the
+    # build host, so labels and the agent id describe what is actually inside.
+    if contract_version:
+        shared.contract_version = contract_version
+
+    # A wheel is installed from the build context, so the version never has to
+    # be resolvable from an index.
     require_installable_contract_version(
         shared.contract_version,
-        pins_contract_version=template_path is None,
+        pins_contract_version=template_path is None and not wheel_filename,
     )
-    params = FabricRenderParams(**{f.name: getattr(shared, f.name) for f in fields(shared)})
+    params = FabricRenderParams(
+        **{f.name: getattr(shared, f.name) for f in fields(shared)}, wheel_filename=wheel_filename
+    )
 
     if template_path:
         try:
@@ -701,8 +725,10 @@ def require_installable_contract_version(contract_version: str, *, pins_contract
     raise ValueError(
         f"The installed nemo-platform version '{contract_version}' {' and '.join(reasons)}, so no "
         "package index serves it. Fabric packaging pins this exact version inside the image, so the "
-        "build would fail while resolving it. Install a released nemo-platform to package an agent, "
-        "or set NEMO_AGENTS_ALLOW_UNPUBLISHED_CONTRACT_VERSION=1 if your index serves this version."
+        "build would fail while resolving it. Point NEMO_AGENTS_WHEEL at a locally built wheel "
+        "(`uv build --package nemo-platform --wheel --out-dir dist`) to package from a source "
+        "checkout, install a released nemo-platform, or set "
+        "NEMO_AGENTS_ALLOW_UNPUBLISHED_CONTRACT_VERSION=1 if your index serves this version."
     )
 
 

--- a/plugins/nemo-agents/src/nemo_agents_plugin/container/template.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/container/template.py
@@ -102,6 +102,9 @@ _ENV_MAP: dict[str, str] = {
 #: host, and packaging runs there for the CLI and the platform job alike.
 WHEEL_ENV = "NEMO_AGENTS_WHEEL"
 
+#: Newest wheel in the checkout's ``dist``, so the value survives every rebuild.
+WHEEL_LATEST = "LATEST"
+
 PINNED_NEMO_RELAY_CLI_VERSION = "0.7.3"
 PINNED_NEMO_RELAY_INSTALLER_COMMIT = "40c5990361afc26ae8b901ff1f49c2b03ddd9ede"
 PINNED_NEMO_RELAY_INSTALLER_SHA256 = "ba2585a32e568643819992fa66b750004328351fce422b979d8c11cfc8bbfadb"

--- a/plugins/nemo-agents/tests/unit/test_container.py
+++ b/plugins/nemo-agents/tests/unit/test_container.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -2747,6 +2748,141 @@ class TestFabricWheelInstall:
 
         assert seen["present"], "the env-supplied wheel must be staged for the build"
         assert not (context / wheel.name).exists()
+
+    @patch("nemo_agents_plugin.container.builder.docker_build")
+    def test_latest_resolves_the_newest_wheel_in_dist(
+        self, mock_build: MagicMock, fabric_agent_config: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from nemo_agents_plugin.container import builder
+        from nemo_agents_plugin.container.template import WHEEL_ENV, WHEEL_LATEST
+
+        dist = tmp_path / "dist"
+        dist.mkdir()
+        older = dist / "nemo_platform-0.4.0.post1-py3-none-any.whl"
+        newer = dist / "nemo_platform-0.4.0.post2-py3-none-any.whl"
+        older.write_bytes(b"old")
+        newer.write_bytes(b"new")
+        os.utime(older, (1, 1))
+        os.utime(newer, (2, 2))
+        monkeypatch.setattr(builder, "_source_checkout_dist_dir", lambda: dist)
+        monkeypatch.setenv(WHEEL_ENV, WHEEL_LATEST)
+        context = fabric_agent_config.parent
+        seen: dict[str, bool] = {}
+        mock_build.side_effect = lambda **kwargs: seen.setdefault("present", (context / newer.name).exists())
+
+        builder.build_fabric_agent_image(fabric_agent_config, skip_validation=True, agent_author="x")
+
+        assert seen["present"], "LATEST must stage the most recently built wheel"
+
+    @patch("nemo_agents_plugin.container.builder.docker_build")
+    def test_latest_ignores_wheels_from_other_packages(
+        self, mock_build: MagicMock, fabric_agent_config: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from nemo_agents_plugin.container import builder
+        from nemo_agents_plugin.container.template import WHEEL_ENV, WHEEL_LATEST
+
+        dist = tmp_path / "dist"
+        dist.mkdir()
+        ours = dist / "nemo_platform-0.4.0-py3-none-any.whl"
+        theirs = dist / "nemo_evaluator-9.9.9-py3-none-any.whl"
+        ours.write_bytes(b"ours")
+        theirs.write_bytes(b"theirs")
+        os.utime(ours, (1, 1))
+        os.utime(theirs, (2, 2))
+        monkeypatch.setattr(builder, "_source_checkout_dist_dir", lambda: dist)
+        monkeypatch.setenv(WHEEL_ENV, WHEEL_LATEST)
+        context = fabric_agent_config.parent
+        seen: dict[str, bool] = {}
+        mock_build.side_effect = lambda **kwargs: seen.setdefault("present", (context / ours.name).exists())
+
+        builder.build_fabric_agent_image(fabric_agent_config, skip_validation=True, agent_author="x")
+
+        assert seen["present"], "a newer wheel from another package must not win the sort"
+        assert not (context / theirs.name).exists()
+
+    def test_latest_with_only_other_packages_wheels_names_the_build_command(
+        self, fabric_agent_config: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from nemo_agents_plugin.container import builder
+        from nemo_agents_plugin.container.template import WHEEL_ENV, WHEEL_LATEST
+
+        dist = tmp_path / "dist"
+        dist.mkdir()
+        (dist / "nemo_evaluator-9.9.9-py3-none-any.whl").write_bytes(b"theirs")
+        monkeypatch.setattr(builder, "_source_checkout_dist_dir", lambda: dist)
+        monkeypatch.setenv(WHEEL_ENV, WHEEL_LATEST)
+
+        with pytest.raises(ValueError) as raised:
+            builder.build_fabric_agent_image(fabric_agent_config, skip_validation=True, agent_author="x")
+
+        assert "no nemo-platform wheels" in str(raised.value)
+        assert "uv build --package nemo-platform" in str(raised.value)
+
+    @patch("nemo_agents_plugin.container.builder.docker_build")
+    def test_an_existing_path_named_latest_is_not_treated_as_the_sentinel(
+        self, mock_build: MagicMock, fabric_agent_config: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from nemo_agents_plugin.container import builder
+        from nemo_agents_plugin.container.template import WHEEL_ENV, WHEEL_LATEST
+
+        literal = tmp_path / WHEEL_LATEST
+        literal.write_bytes(b"wheel")
+        monkeypatch.setenv(WHEEL_ENV, str(literal))
+
+        with pytest.raises(ValueError, match="not a wheel"):
+            builder.build_fabric_agent_image(fabric_agent_config, skip_validation=True, agent_author="x")
+
+    def test_latest_without_a_source_checkout_says_so(
+        self, fabric_agent_config: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from nemo_agents_plugin.container import builder
+        from nemo_agents_plugin.container.template import WHEEL_ENV, WHEEL_LATEST
+
+        monkeypatch.setattr(builder, "_source_checkout_dist_dir", lambda: None)
+        monkeypatch.setenv(WHEEL_ENV, WHEEL_LATEST)
+
+        with pytest.raises(ValueError, match="needs a source checkout"):
+            builder.build_fabric_agent_image(fabric_agent_config, skip_validation=True, agent_author="x")
+
+    def test_latest_with_an_empty_dist_names_the_build_command(
+        self, fabric_agent_config: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from nemo_agents_plugin.container import builder
+        from nemo_agents_plugin.container.template import WHEEL_ENV, WHEEL_LATEST
+
+        dist = tmp_path / "dist"
+        dist.mkdir()
+        monkeypatch.setattr(builder, "_source_checkout_dist_dir", lambda: dist)
+        monkeypatch.setenv(WHEEL_ENV, WHEEL_LATEST)
+
+        with pytest.raises(ValueError, match="uv build --package nemo-platform"):
+            builder.build_fabric_agent_image(fabric_agent_config, skip_validation=True, agent_author="x")
+
+    @patch("nemo_agents_plugin.container.builder.docker_build")
+    def test_a_supplied_dockerfile_does_not_resolve_latest(
+        self, mock_build: MagicMock, fabric_agent_config: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from nemo_agents_plugin.container import builder
+        from nemo_agents_plugin.container.template import WHEEL_ENV, WHEEL_LATEST
+
+        def explode() -> Path:
+            raise AssertionError("LATEST must not be resolved for a --dockerfile build")
+
+        monkeypatch.setattr(builder, "resolve_latest_wheel", explode)
+        monkeypatch.setenv(WHEEL_ENV, WHEEL_LATEST)
+        dockerfile = tmp_path / "Dockerfile"
+        dockerfile.write_text("FROM scratch\n")
+        notices: list[str] = []
+
+        builder.build_fabric_agent_image(
+            fabric_agent_config,
+            dockerfile=dockerfile,
+            skip_validation=True,
+            agent_author="x",
+            on_progress=notices.append,
+        )
+
+        assert any(WHEEL_ENV in line and "ignoring" in line for line in notices)
 
     @pytest.mark.parametrize(
         ("filename", "create", "match"),

--- a/plugins/nemo-agents/tests/unit/test_container.py
+++ b/plugins/nemo-agents/tests/unit/test_container.py
@@ -2676,3 +2676,264 @@ class TestInstallableContractVersion:
 
         with pytest.raises(ValueError, match="local build identifier"):
             template.render_fabric_dockerfile(fabric_agent_config)
+
+
+class TestFabricWheelInstall:
+    """A source checkout reports a version no index serves, so packaging from one
+    requires installing a locally built wheel instead of resolving the pin.
+
+    The wheel arrives by env var rather than a flag so it reaches the platform
+    job as well as the CLI; a flag would fix only one of the two."""
+
+    def test_render_installs_the_wheel_instead_of_the_pin(self, fabric_agent_config: Path) -> None:
+        from nemo_agents_plugin.container.template import render_fabric_dockerfile
+
+        result = render_fabric_dockerfile(fabric_agent_config, wheel_filename="nemo_platform-0.4.0-py3-none-any.whl")
+
+        assert '"/workspace/nemo_platform-0.4.0-py3-none-any.whl[nemo-agents-plugin]"' in result
+        assert "nemo-platform[nemo-agents-plugin]==" not in result
+
+    def test_a_wheel_lifts_the_unpublished_version_guard(
+        self, fabric_agent_config: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import nemo_agents_plugin.container.template as template
+
+        monkeypatch.setattr(template, "get_contract_version", lambda: "0.4.0.post176.dev0+50998e7b84")
+
+        # Without a wheel the same version is refused.
+        with pytest.raises(ValueError, match="local build identifier"):
+            template.render_fabric_dockerfile(fabric_agent_config)
+
+        assert template.render_fabric_dockerfile(fabric_agent_config, wheel_filename="x.whl")
+
+    @patch("nemo_agents_plugin.container.builder.docker_build")
+    def test_wheel_is_staged_into_the_context_and_removed(
+        self, mock_build: MagicMock, fabric_agent_config: Path, tmp_path: Path
+    ) -> None:
+        from nemo_agents_plugin.container.builder import build_fabric_agent_image
+
+        source = tmp_path / "dist"
+        source.mkdir()
+        wheel = source / "nemo_platform-0.4.0-py3-none-any.whl"
+        wheel.write_bytes(b"not really a wheel")
+        context = fabric_agent_config.parent
+        staged_during_build: dict[str, bool] = {}
+        mock_build.side_effect = lambda **kwargs: staged_during_build.setdefault(
+            "present", (context / wheel.name).exists()
+        )
+
+        build_fabric_agent_image(fabric_agent_config, wheel=wheel, skip_validation=True, agent_author="x")
+
+        assert staged_during_build["present"], "the wheel must exist while docker build runs"
+        assert not (context / wheel.name).exists(), "the staged wheel must not outlive the build"
+
+    @patch("nemo_agents_plugin.container.builder.docker_build")
+    def test_env_var_supplies_the_wheel(
+        self, mock_build: MagicMock, fabric_agent_config: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from nemo_agents_plugin.container.builder import build_fabric_agent_image
+        from nemo_agents_plugin.container.template import WHEEL_ENV
+
+        source = tmp_path / "dist"
+        source.mkdir()
+        wheel = source / "nemo_platform-0.4.0-py3-none-any.whl"
+        wheel.write_bytes(b"wheel")
+        monkeypatch.setenv(WHEEL_ENV, str(wheel))
+        context = fabric_agent_config.parent
+        seen: dict[str, bool] = {}
+        mock_build.side_effect = lambda **kwargs: seen.setdefault("present", (context / wheel.name).exists())
+
+        build_fabric_agent_image(fabric_agent_config, skip_validation=True, agent_author="x")
+
+        assert seen["present"], "the env-supplied wheel must be staged for the build"
+        assert not (context / wheel.name).exists()
+
+    @pytest.mark.parametrize(
+        ("filename", "create", "match"),
+        [("missing.whl", False, "wheel not found"), ("notawheel.txt", True, "not a wheel")],
+    )
+    def test_bad_wheel_paths_are_rejected(
+        self, fabric_agent_config: Path, tmp_path: Path, filename: str, create: bool, match: str
+    ) -> None:
+        from nemo_agents_plugin.container.builder import build_fabric_agent_image
+
+        source = tmp_path / "dist"
+        source.mkdir()
+        wheel = source / filename
+        if create:
+            wheel.write_bytes(b"")
+
+        with pytest.raises(ValueError, match=match):
+            build_fabric_agent_image(fabric_agent_config, wheel=wheel, skip_validation=True)
+
+    @patch("nemo_agents_plugin.container.builder.docker_build")
+    def test_a_file_appearing_mid_build_is_not_clobbered(
+        self, mock_build: MagicMock, fabric_agent_config: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The pre-render check is not atomic with the copy, so the copy creates
+        exclusively — otherwise losing that race overwrites a file and the cleanup
+        then deletes it."""
+        from nemo_agents_plugin.container.builder import build_fabric_agent_image
+
+        source = tmp_path / "dist"
+        source.mkdir()
+        wheel = source / "nemo_platform-0.4.0-py3-none-any.whl"
+        wheel.write_bytes(b"wheel")
+        collision = fabric_agent_config.parent / wheel.name
+
+        # Simulate another process winning the race after the check, before the copy.
+        original_write = Path.write_text
+
+        def _plant(self: Path, *args: Any, **kwargs: Any) -> int:
+            if self.name == "Dockerfile.generated":
+                collision.write_text("USER OWNED")
+            return original_write(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "write_text", _plant)
+
+        with pytest.raises(ManagedFileConflictError):
+            build_fabric_agent_image(fabric_agent_config, wheel=wheel, skip_validation=True, agent_author="x")
+
+        monkeypatch.undo()
+        assert collision.read_text() == "USER OWNED"
+        mock_build.assert_not_called()
+
+    def test_the_image_advertises_the_wheel_version_not_the_host(
+        self, fabric_agent_config: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Labels and the content-addressable id describe the runtime inside the
+        image, so a wheel has to decide them — otherwise an image can advertise
+        one version while running another, and two different images share an id."""
+        import nemo_agents_plugin.container.builder as builder
+        import nemo_agents_plugin.container.template as template
+
+        monkeypatch.setattr(template, "get_contract_version", lambda: "9.9.9.dev0+hostonly")
+        source = tmp_path / "dist"
+        source.mkdir()
+        wheel = source / "nemo_platform-0.4.0.post176.dev0+abc123-py3-none-any.whl"
+        wheel.write_bytes(b"wheel")
+
+        assert builder.wheel_contract_version(wheel) == "0.4.0.post176.dev0+abc123"
+
+        captured: dict[str, object] = {}
+        real_render = template.render_fabric_dockerfile
+        monkeypatch.setattr(
+            builder,
+            "docker_build",
+            lambda **kwargs: captured.setdefault("tag", kwargs["tag"]),
+        )
+        monkeypatch.setattr(
+            template,
+            "render_fabric_dockerfile",
+            lambda *a, **kw: (
+                captured.setdefault("contract_version", kw.get("contract_version")) or real_render(*a, **kw)
+            ),
+        )
+
+        builder.build_fabric_agent_image(fabric_agent_config, wheel=wheel, skip_validation=True, agent_author="x")
+
+        assert captured["contract_version"] == "0.4.0.post176.dev0+abc123"
+
+    @patch("nemo_agents_plugin.container.builder.docker_build")
+    def test_a_supplied_dockerfile_ignores_the_wheel(
+        self, mock_build: MagicMock, fabric_agent_config: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A caller-supplied Dockerfile never sees the staged wheel, so letting the
+        wheel decide the version would advertise a runtime the image cannot contain."""
+        import nemo_agents_plugin.container.builder as builder
+        import nemo_agents_plugin.container.template as template
+
+        monkeypatch.setattr(template, "get_contract_version", lambda: "9.9.9")
+        source = tmp_path / "dist"
+        source.mkdir()
+        wheel = source / "nemo_platform-0.4.0.post176.dev0+abc123-py3-none-any.whl"
+        wheel.write_bytes(b"wheel")
+        dockerfile = tmp_path / "Dockerfile"
+        dockerfile.write_text("FROM scratch\n")
+        context = fabric_agent_config.parent
+
+        monkeypatch.setenv(template.WHEEL_ENV, str(wheel))
+        notices: list[str] = []
+        builder.build_fabric_agent_image(
+            fabric_agent_config,
+            dockerfile=dockerfile,
+            skip_validation=True,
+            agent_author="x",
+            on_progress=notices.append,
+        )
+        with_wheel = mock_build.call_args.kwargs["tag"]
+        assert not (context / wheel.name).exists()
+        assert any(template.WHEEL_ENV in line for line in notices)
+
+        monkeypatch.delenv(template.WHEEL_ENV)
+        builder.build_fabric_agent_image(
+            fabric_agent_config, dockerfile=dockerfile, skip_validation=True, agent_author="x"
+        )
+
+        assert with_wheel == mock_build.call_args.kwargs["tag"], "the wheel must not reach the image identity"
+
+    @pytest.mark.parametrize(
+        "filename",
+        ["some_other_package-1.0-py3-none-any.whl", "notawheelname.whl"],
+    )
+    def test_a_wheel_for_another_package_is_rejected(self, tmp_path: Path, filename: str) -> None:
+        from nemo_agents_plugin.container.builder import wheel_contract_version
+
+        with pytest.raises(ValueError):
+            wheel_contract_version(tmp_path / filename)
+
+    @pytest.mark.parametrize("rule", ["*.whl", "/*.whl", "**/*.whl", "nemo_platform-*.whl"])
+    def test_a_user_rule_cannot_exclude_the_staged_wheel(
+        self, fabric_agent_config: Path, tmp_path: Path, rule: str
+    ) -> None:
+        """A user-owned .dockerignore is preserved, and any of these rules would
+        drop the wheel from the context. BuildKit prefers the per-Dockerfile
+        ignore file, so the wheel is re-included there rather than the rules
+        being second-guessed."""
+        from nemo_agents_plugin.container.builder import build_fabric_agent_image
+
+        source = tmp_path / "dist"
+        source.mkdir()
+        wheel = source / "nemo_platform-0.4.0-py3-none-any.whl"
+        wheel.write_bytes(b"wheel")
+        context = fabric_agent_config.parent
+        (context / ".dockerignore").write_text(f"# user owned\n{rule}\n")
+        scoped = context / "Dockerfile.generated.dockerignore"
+        seen: dict[str, str] = {}
+
+        with patch("nemo_agents_plugin.container.builder.docker_build") as mock_build:
+            mock_build.side_effect = lambda **kwargs: seen.setdefault("ignore", scoped.read_text())
+            build_fabric_agent_image(fabric_agent_config, wheel=wheel, skip_validation=True, agent_author="x")
+
+        assert rule in seen["ignore"], "the user's rules must be carried over"
+        assert seen["ignore"].rstrip().endswith(f"!{wheel.name}"), "the wheel must be re-included last"
+        assert not scoped.exists(), "the scoped ignore file must not outlive the build"
+
+    def test_no_scoped_ignore_file_without_a_wheel(self, fabric_agent_config: Path) -> None:
+        from nemo_agents_plugin.container.builder import build_fabric_agent_image
+
+        context = fabric_agent_config.parent
+        seen: dict[str, bool] = {}
+
+        with patch("nemo_agents_plugin.container.builder.docker_build") as mock_build:
+            mock_build.side_effect = lambda **kwargs: seen.setdefault(
+                "present", (context / "Dockerfile.generated.dockerignore").exists()
+            )
+            build_fabric_agent_image(fabric_agent_config, skip_validation=True, agent_author="x")
+
+        assert not seen["present"]
+
+    def test_refuses_to_clobber_a_file_the_user_owns(self, fabric_agent_config: Path, tmp_path: Path) -> None:
+        from nemo_agents_plugin.container.builder import build_fabric_agent_image
+
+        source = tmp_path / "dist"
+        source.mkdir()
+        wheel = source / "nemo_platform-0.4.0-py3-none-any.whl"
+        wheel.write_bytes(b"wheel")
+        collision = fabric_agent_config.parent / wheel.name
+        collision.write_text("USER OWNED")
+
+        with pytest.raises(ManagedFileConflictError):
+            build_fabric_agent_image(fabric_agent_config, wheel=wheel, skip_validation=True)
+
+        assert collision.read_text() == "USER OWNED"

--- a/plugins/nemo-agents/tests/unit/test_fabric_package_validation.py
+++ b/plugins/nemo-agents/tests/unit/test_fabric_package_validation.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest import mock
 from unittest.mock import AsyncMock, MagicMock
 
 import nemo_agents_plugin.container.builder as builder
@@ -335,6 +336,8 @@ class TestFabricBuilderValidationHook:
             agent_author="Agent Author",
             template_path="Dockerfile.fabric.j2",
             metadata=image_metadata,
+            wheel_filename="",
+            contract_version=mock.ANY,
         )
         docker_build.assert_called_once_with(
             context_dir=tmp_path.resolve(),

--- a/services/core/jobs/src/nmp/core/jobs/controllers/backends/subprocess.py
+++ b/services/core/jobs/src/nmp/core/jobs/controllers/backends/subprocess.py
@@ -62,6 +62,8 @@ SUBPROCESS_INHERITED_ENV_ALLOWLIST = frozenset(
     {
         "PATH",
         "VIRTUAL_ENV",
+        # A path on the build host, so operator-set like the rest of this list.
+        "NEMO_AGENTS_WHEEL",
     }
 )
 

--- a/services/core/jobs/tests/controllers/test_subprocess_backend.py
+++ b/services/core/jobs/tests/controllers/test_subprocess_backend.py
@@ -163,6 +163,35 @@ def test_schedule_uses_allowlisted_host_environment(mock_nmp_client, tmp_path, m
     assert metadata.process.wait(timeout=5) == 0
 
 
+def test_schedule_passes_the_agent_wheel_through(mock_nmp_client, tmp_path, mock_platform_config, test_step_pending):
+    backend = _subprocess_backend(mock_nmp_client, tmp_path, mock_platform_config)
+    step = _step_with_command(
+        test_step_pending,
+        [
+            "/bin/sh",
+            "-c",
+            'test "$NEMO_AGENTS_WHEEL" = "/dist/nemo_platform.whl" && test -z "${SECRET_TOKEN+x}"',
+        ],
+    )
+
+    with (
+        patch.dict(
+            os.environ,
+            {"PATH": "/bin", "NEMO_AGENTS_WHEEL": "/dist/nemo_platform.whl", "SECRET_TOKEN": "do-not-leak"},
+            clear=True,
+        ),
+        patch("nmp.core.jobs.controllers.backends.subprocess.create_otel_logger", return_value=None),
+    ):
+        update = backend.schedule(step.step_spec.executor, step)
+
+    assert update.status == PlatformJobStatus.PENDING
+    metadata = backend._process_registry.get(
+        SubprocessProcessKey(step.workspace, step.job, str(step.attempt_id), step.name)
+    )
+    assert metadata is not None
+    assert metadata.process.wait(timeout=5) == 0
+
+
 def test_schedule_preserves_uds_otlp_metadata_in_runtime_env(mock_nmp_client, tmp_path, test_step_pending):
     platform_config = PlatformConfig(  # type: ignore[abstract]
         service_discovery={"files": "unix:///tmp/nemo-platform.sock"},


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary

Cherry-picks the NeMo Agents wheel support required by the skill updates in
NVIDIA-NeMo/nemo-platform#1779 and NVIDIA-NeMo/nemo-platform#1780 into
`release/0.5`.

Those skill updates document a source-checkout packaging workflow that uses
`NEMO_AGENTS_WHEEL=LATEST`. The supporting implementation is already present on
`main`, but it is not present on `release/0.5`. Cherry-picking these commits
ensures that the skill instructions work as written when the skill updates are
included in the release branch.

## Why Both Cherry-picks Are Required

- Cherry-pick NVIDIA-NeMo/nemo-platform#1669
  (`29c5edd3eab42fbcbffb657802180fc77ab3589e`) to add the underlying local-wheel
  validation, staging, installation, cleanup, and image identity support.
- Cherry-pick NVIDIA-NeMo/nemo-platform#1737
  (`e3e354963d2bba416fc990e7499fbf1c622f4102`) to add the `LATEST` resolver and
  propagate `NEMO_AGENTS_WHEEL` into subprocess jobs.
- #1737 is incremental and depends on the implementation introduced by #1669;
  cherry-picking #1737 by itself is not sufficient.

## Changes

- Cherry-pick the changes from #1669 and #1737 into `release/0.5`.
- Make the `NEMO_AGENTS_WHEEL=LATEST` workflow referenced by the skill updates
  available on the release branch.
- Include the original documentation and unit coverage for this behavior.

## Type of Change

- [x] Release branch cherry-pick
- [x] Bug fix
- [x] Build and packaging support
- [x] Documentation and tests

## Verification

- [x] Both commits were cherry-picked with `-x` provenance and DCO signoffs.
- [x] Focused packaging, validation, and subprocess tests pass: 235 passed.
- [x] Ruff lint passes for all touched Python files.
- [x] Ruff formatting checks pass for all touched Python files.
- [x] `git diff --check origin/release/0.5...HEAD` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fabric packaging now supports installing agents from a locally built wheel.
  * Added `NEMO_AGENTS_WHEEL` configuration, including automatic selection of the latest wheel with `LATEST`.
  * Local wheel settings are propagated to platform subprocess jobs.
  * Added validation for wheel paths, versions, image identity, and staging conflicts.

* **Documentation**
  * Added guidance for building and using local Fabric agent wheels, including cleanup and version handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->