### PR TITLE
feat(sandboxed-gym): carry a caller-owned example id onto rollout results

### DIFF
--- a/packages/sandboxed_gym/src/sandboxed_gym/runtime/gym_host_runtime.py
+++ b/packages/sandboxed_gym/src/sandboxed_gym/runtime/gym_host_runtime.py
@@ -270,6 +270,15 @@ def bootstrap_gym_host() -> tuple[Any, Any, Any]:
 #: ``_ng_task_index`` and assigns ``_ng_rollout_index`` itself per attempt.
 NG_TASK_INDEX = "_ng_task_index"
 NG_ROLLOUT_INDEX = "_ng_rollout_index"
+#: Identifies one entry of a request's ``examples``. Opaque, owned by the caller, never read by
+#: Gym, and scoped to the request rather than durable. Gym's own indices cannot stand in for it:
+#: ``_ng_task_index`` identifies a task, so a caller running several rollouts per task has no
+#: per-example value in it, and overwriting it is not open either -- Gym groups reward-profile
+#: metrics and builds model-call capture ids by task. ``_ng_rollout_index`` would complete the
+#: pair, but Gym assigns it, so a caller cannot stamp it on the way out.
+SG_EXAMPLE_ID = "_sg_example_id"
+
+_ROW_IDENTITY_KEYS = (NG_TASK_INDEX, NG_ROLLOUT_INDEX, SG_EXAMPLE_ID)
 
 
 def _with_row_identity(result: Any, row: Any) -> Any:
@@ -283,11 +292,12 @@ def _with_row_identity(result: Any, row: Any) -> Any:
     property of this host rather than of Gym's copy rules.
 
     Additive: a value Gym returned is never overwritten, so a result that already carries its own
-    index is untouched and existing consumers see exactly the fields they saw before.
+    index is untouched and existing consumers see exactly the fields they saw before. A caller that
+    stamps no ``SG_EXAMPLE_ID`` gets results without one.
     """
     if not isinstance(result, dict) or not isinstance(row, dict):
         return result
-    missing = {key: row[key] for key in (NG_TASK_INDEX, NG_ROLLOUT_INDEX) if key in row and result.get(key) is None}
+    missing = {key: row[key] for key in _ROW_IDENTITY_KEYS if key in row and result.get(key) is None}
     return {**result, **missing} if missing else result
 
 

--- a/packages/sandboxed_gym/tests/test_gym_host_runtime.py
+++ b/packages/sandboxed_gym/tests/test_gym_host_runtime.py
@@ -301,6 +301,38 @@ def test_a_non_mapping_result_is_left_alone(result):
     assert runtime._with_row_identity(result, {"_ng_task_index": 1}) is result
 
 
+def test_a_caller_example_id_is_carried_onto_the_result():
+    """The case Gym's own indices cannot express: several examples under one task.
+
+    Both examples below share ``_ng_task_index``, so a consumer joining on it sees a duplicate
+    and cannot tell the two apart. ``SG_EXAMPLE_ID`` is what distinguishes them, and Gym never
+    sets it, so a result carries it only because this host copied it across.
+    """
+    rows = [
+        {"_ng_task_index": 4, runtime.SG_EXAMPLE_ID: 17},
+        {"_ng_task_index": 4, runtime.SG_EXAMPLE_ID: 18},
+    ]
+    results = [runtime._with_row_identity({"_ng_task_index": 4, "reward": 1.0}, row) for row in rows]
+
+    assert [result[runtime.SG_EXAMPLE_ID] for result in results] == [17, 18]
+    # Gym's own identity is passed through untouched, not displaced by the caller's.
+    assert [result["_ng_task_index"] for result in results] == [4, 4]
+
+
+def test_a_caller_example_id_returned_by_gym_is_not_overwritten():
+    """Same additive rule as the Gym indices: what came back wins over what went out."""
+    result = runtime._with_row_identity({runtime.SG_EXAMPLE_ID: 99}, {runtime.SG_EXAMPLE_ID: 17})
+
+    assert result[runtime.SG_EXAMPLE_ID] == 99
+
+
+def test_an_example_without_a_caller_id_gains_no_key():
+    """Existing callers stamp nothing, so their results must look exactly as they did before."""
+    result = runtime._with_row_identity({"reward": 1.0}, {"_ng_task_index": 4})
+
+    assert runtime.SG_EXAMPLE_ID not in result
+
+
 # --------------------------------------------------------------------------------------------
 # wheels-v1 dependency install
 # --------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The Gym host copies `_ng_task_index` / `_ng_rollout_index` onto each rollout result so a caller can join results to prompts by tag rather than by arrival order. That works when the caller's identity *is* a Gym task — the Evaluator case, which stamps one index per task and joins on it in `agent_eval/runtimes/gym/results.py`.

It does not work for a caller running several rollouts per task, because the task index is then shared and the join sees duplicates. This adds `_sg_example_id`, an opaque key the caller owns and Gym never reads, carried onto results by the same additive rule. Before: such a caller has no unique tag and must fall back to joining on position. After: it stamps `_sg_example_id` on each example and joins on it.

## Related Issue

Part of [AALGO-583](https://linear.app/nvidia/issue/AALGO-583/share-the-sandboxed-gym-implementation-as-a-sandboxed-gym-wheel) — sharing the sandboxed gym implementation as a `sandboxed_gym` wheel. Found while building the NeMo-RL branch that consumes the wheel (step 4); NeMo-RL is the first consumer whose examples are not 1:1 with Gym tasks.

## Changes

- `runtime/gym_host_runtime.py`: add `SG_EXAMPLE_ID = "_sg_example_id"` and `_ROW_IDENTITY_KEYS`; `_with_row_identity` now copies all three keys instead of the two Gym ones.
- `tests/test_gym_host_runtime.py`: three tests — the key is carried for examples sharing a task index; a value Gym returned is not overwritten; a caller that stamps nothing gets no new key.

### Why not reuse Gym's indices

NeMo-RL stamps one `_ng_task_index` per prompt and then repeats each row `num_generations` times, so the copies share a task index while each needs its own identity.

- `_ng_task_index` is therefore not unique per example for this caller, and it is not free to overwrite — Gym groups reward-profile metrics and builds model-call capture ids by task (`nemo_gym/reward_profile.py`, `base_responses_api_model.py`).
- `_ng_rollout_index` would complete the pair, but Gym assigns it per attempt, so a caller cannot stamp it on the way out or map it back without assuming the ordering this mechanism exists to eliminate.

The key sits outside Gym's `_ng_` namespace on purpose. The host copies it from the row it already holds, so unlike `_ng_task_index` passthrough the join does not depend on Gym's field allowlist at all.

### On the name

It identifies one entry of the request's `examples`, which is the wire vocabulary, and it is request-scoped rather than durable. `_sg_row_id` was the first draft and was rejected: "row" invites the reading that it identifies a *dataset* row — which is the prompt, which is what `_ng_task_index` already is, i.e. the opposite of the distinction being drawn.

### Compatibility

Additive and opt-in. A row without `_sg_example_id` produces a result without it, so existing consumers — Evaluator included — see byte-identical results. The third test pins that.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: the contract is documented where it lives, on `SG_EXAMPLE_ID` and `_with_row_identity`. No user-facing doc describes the result shape today.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `uv run --frozen pytest packages/sandboxed_gym/tests -q` → **235 passed, 2 skipped**
- `uv run pre-commit run -a` → **15 hooks passed, 0 failed**. Note: the `uv-lock` hook pins uv 0.9.14 and fails on 0.9.30; re-run with 0.9.14 on `PATH` to get the green above. This change touches no `pyproject.toml`, and `Check for uv.lock drift` passes either way.
- `uv run ruff check` / `ruff format --check` on `packages/sandboxed_gym` → clean
- `uv build --package sandboxed-gym` → wheel ships the new constant
- Mutation-checked the tests: reverting `_ROW_IDENTITY_KEYS` to the Gym-only pair fails `test_a_caller_example_id_is_carried_onto_the_result`; making the copy overwrite instead of additive fails both not-overwritten tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for caller-provided identifiers to associate rollout results with individual examples.
  * Rollout results now preserve existing example identifiers and fill in missing identifiers when provided.
  * Example identifiers distinguish separate examples that share the same task index.

* **Bug Fixes**
  * Prevented caller-provided identifiers from overwriting identifiers already returned in rollout results.
  * Results without an example identifier remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->