### PR TITLE
fix(agents): harden local wheel packaging

### DIFF
--- a/plugins/nemo-agents/src/nemo_agents_plugin/container/builder.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/container/builder.py
@@ -549,7 +549,8 @@ def build_fabric_agent_image(
     ignore_file: Path | None = None
     ignore_path = context_dir / ".dockerignore"
     ignore_pre_existed = ignore_path.exists()
-    scoped_ignore_written = False
+    scoped_ignore: Path | None = None
+    scoped_ignore_identity: tuple[int, int] | None = None
     try:
         tmp_dockerfile.write_text(content, encoding="utf-8")
 
@@ -565,7 +566,8 @@ def build_fabric_agent_image(
             scoped_ignore = context_dir / f"{tmp_dockerfile.name}.dockerignore"
             try:
                 with scoped_ignore.open("x", encoding="utf-8") as scoped_ignore_file:
-                    scoped_ignore_written = True
+                    created_stat = os.fstat(scoped_ignore_file.fileno())
+                    scoped_ignore_identity = (created_stat.st_dev, created_stat.st_ino)
                     scoped_ignore_file.write(f"{existing.rstrip()}\n!{staged_wheel.name}\n".lstrip())
             except FileExistsError as exc:
                 raise ManagedFileConflictError(scoped_ignore) from exc
@@ -581,8 +583,14 @@ def build_fabric_agent_image(
         )
     finally:
         tmp_dockerfile.unlink(missing_ok=True)
-        if scoped_ignore_written:
-            (context_dir / f"{tmp_dockerfile.name}.dockerignore").unlink(missing_ok=True)
+        if scoped_ignore is not None and scoped_ignore_identity is not None:
+            try:
+                current_stat = scoped_ignore.stat(follow_symlinks=False)
+            except FileNotFoundError:
+                pass
+            else:
+                if (current_stat.st_dev, current_stat.st_ino) == scoped_ignore_identity:
+                    scoped_ignore.unlink(missing_ok=True)
         if wheel_was_staged and staged_wheel is not None:
             staged_wheel.unlink(missing_ok=True)
         if ignore_file is not None and not ignore_pre_existed:

--- a/plugins/nemo-agents/src/nemo_agents_plugin/container/builder.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/container/builder.py
@@ -17,7 +17,6 @@ import hashlib
 import logging
 import os
 import re
-import shutil
 from collections.abc import Callable
 from pathlib import Path
 
@@ -134,6 +133,7 @@ def resolve_image_id(tag: str) -> str:
 
 #: Distribution a supplied wheel must be, normalized per PEP 503.
 _WHEEL_DISTRIBUTION = "nemo-platform"
+_WHEEL_COPY_CHUNK_SIZE = 1024 * 1024
 
 
 def wheel_contract_version(wheel: Path) -> str:
@@ -449,6 +449,41 @@ def build_fabric_agent_image(
             f"warning: {wheel.name} builds {contract_version}, but this host runs {get_contract_version()}",
         )
 
+    tmp_dockerfile = context_dir / "Dockerfile.generated"
+    if dockerfile is None and tmp_dockerfile.exists():
+        raise ManagedFileConflictError(tmp_dockerfile)
+
+    # Docker can only COPY from inside the context. For an external wheel,
+    # compute the identity digest while staging it so the source is read once
+    # and the digest describes the exact bytes placed in the build context.
+    staged_wheel: Path | None = None
+    wheel_was_staged = False
+    wheel_sha256: str | None = None
+    if wheel is not None:
+        staged_wheel = context_dir / wheel.name
+        if staged_wheel.exists():
+            if not staged_wheel.samefile(wheel):
+                raise ManagedFileConflictError(staged_wheel)
+            with wheel.open("rb") as wheel_file:
+                wheel_sha256 = hashlib.file_digest(wheel_file, "sha256").hexdigest()
+        else:
+            try:
+                destination = open(staged_wheel, "xb")
+            except FileExistsError as exc:
+                raise ManagedFileConflictError(staged_wheel) from exc
+            wheel_was_staged = True
+            digest = hashlib.sha256()
+            try:
+                with destination, wheel.open("rb") as source:
+                    while chunk := source.read(_WHEEL_COPY_CHUNK_SIZE):
+                        destination.write(chunk)
+                        digest.update(chunk)
+            except BaseException:
+                staged_wheel.unlink(missing_ok=True)
+                raise
+            wheel_sha256 = digest.hexdigest()
+            emit_progress(on_progress, f"Staged {wheel.name} into the build context")
+
     build_env_for_id = {
         "agent_framework": NEMO_PLATFORM_AGENT_FRAMEWORK,
         "contract_version": contract_version,
@@ -458,93 +493,65 @@ def build_fabric_agent_image(
         "python_version": resolved_python,
         "uv_version": resolved_uv,
     }
-    if wheel is not None:
-        with wheel.open("rb") as wheel_file:
-            build_env_for_id["wheel_sha256"] = hashlib.file_digest(wheel_file, "sha256").hexdigest()
-    meta = extract_agent_metadata(
-        agent_config,
-        pyproject,
-        agent_version=agent_version,
-        agent_author=agent_author,
-        build_env=build_env_for_id,
-    )
-    if tag is None:
-        tag = _default_tag_from_meta(meta)
-    if tag_namespace:
-        tag = f"{tag_namespace}/{tag}"
-
-    build_args = {
-        "BASE_IMAGE_URL": resolved_base_url,
-        "BASE_IMAGE_TAG": resolved_base_tag,
-        "PYTHON_VERSION": resolved_python,
-    }
-
-    if dockerfile is not None:
-        return docker_build(
-            context_dir=context_dir,
-            dockerfile=dockerfile,
-            tag=tag,
-            build_args=build_args,
-            platforms=platforms,
-            push=push,
-            on_progress=on_progress,
+    if wheel_sha256 is not None:
+        build_env_for_id["wheel_sha256"] = wheel_sha256
+    try:
+        meta = extract_agent_metadata(
+            agent_config,
+            pyproject,
+            agent_version=agent_version,
+            agent_author=agent_author,
+            build_env=build_env_for_id,
         )
+        if tag is None:
+            tag = _default_tag_from_meta(meta)
+        if tag_namespace:
+            tag = f"{tag_namespace}/{tag}"
 
-    # Docker can only COPY from inside the context, so the wheel is staged there
-    # and removed again on the way out.
-    staged_wheel: Path | None = None
-    wheel_already_in_context = False
-    if wheel is not None:
-        staged_wheel = context_dir / wheel.name
-        if staged_wheel.exists():
-            if not staged_wheel.samefile(wheel):
-                raise ManagedFileConflictError(staged_wheel)
-            # Already the wheel we would copy, so there is nothing to stage.
-            wheel_already_in_context = True
+        build_args = {
+            "BASE_IMAGE_URL": resolved_base_url,
+            "BASE_IMAGE_TAG": resolved_base_tag,
+            "PYTHON_VERSION": resolved_python,
+        }
 
-    content = render_fabric_dockerfile(
-        agent_config,
-        pyproject,
-        base_image_url=resolved_base_url,
-        base_image_tag=resolved_base_tag,
-        python_version=resolved_python,
-        uv_version=resolved_uv,
-        allow_root=allow_root,
-        sandbox_runtime=sandbox_runtime,
-        agent_version=agent_version,
-        agent_author=agent_author,
-        template_path=template_path,
-        metadata=meta,
-        wheel_filename=staged_wheel.name if staged_wheel else "",
-        contract_version=contract_version,
-    )
+        if dockerfile is not None:
+            return docker_build(
+                context_dir=context_dir,
+                dockerfile=dockerfile,
+                tag=tag,
+                build_args=build_args,
+                platforms=platforms,
+                push=push,
+                on_progress=on_progress,
+            )
 
-    tmp_dockerfile = context_dir / "Dockerfile.generated"
-    if tmp_dockerfile.exists():
-        raise ManagedFileConflictError(tmp_dockerfile)
+        content = render_fabric_dockerfile(
+            agent_config,
+            pyproject,
+            base_image_url=resolved_base_url,
+            base_image_tag=resolved_base_tag,
+            python_version=resolved_python,
+            uv_version=resolved_uv,
+            allow_root=allow_root,
+            sandbox_runtime=sandbox_runtime,
+            agent_version=agent_version,
+            agent_author=agent_author,
+            template_path=template_path,
+            metadata=meta,
+            wheel_filename=staged_wheel.name if staged_wheel else "",
+            contract_version=contract_version,
+        )
+    except BaseException:
+        if wheel_was_staged and staged_wheel is not None:
+            staged_wheel.unlink(missing_ok=True)
+        raise
 
     ignore_file: Path | None = None
     ignore_path = context_dir / ".dockerignore"
     ignore_pre_existed = ignore_path.exists()
-    wheel_was_staged = False
     scoped_ignore_written = False
     try:
         tmp_dockerfile.write_text(content, encoding="utf-8")
-
-        if staged_wheel is not None and wheel is not None and not wheel_already_in_context:
-            # Create exclusively rather than re-checking existence: the check above
-            # is not atomic with the copy, and losing that race would overwrite
-            # someone's file and then delete it during cleanup.
-            try:
-                dest = open(staged_wheel, "xb")
-            except FileExistsError as exc:
-                raise ManagedFileConflictError(staged_wheel) from exc
-            # Owned from the moment it exists: a failure mid-copy would otherwise
-            # strand a partial wheel that fails every later build as a conflict.
-            wheel_was_staged = True
-            with dest, wheel.open("rb") as src:
-                shutil.copyfileobj(src, dest)
-            emit_progress(on_progress, f"Staged {wheel.name} into the build context")
 
         if generate_ignore:
             ignore_file = render_dockerignore(context_dir)

--- a/plugins/nemo-agents/src/nemo_agents_plugin/container/builder.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/container/builder.py
@@ -13,6 +13,7 @@ for Docker operations so callers never need to shell out manually.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 import re
@@ -457,6 +458,9 @@ def build_fabric_agent_image(
         "python_version": resolved_python,
         "uv_version": resolved_uv,
     }
+    if wheel is not None:
+        with wheel.open("rb") as wheel_file:
+            build_env_for_id["wheel_sha256"] = hashlib.file_digest(wheel_file, "sha256").hexdigest()
     meta = extract_agent_metadata(
         agent_config,
         pyproject,
@@ -552,8 +556,12 @@ def build_fabric_agent_image(
             # detecting that it would not and reimplementing Docker's matcher.
             existing = ignore_path.read_text(encoding="utf-8") if ignore_path.exists() else ""
             scoped_ignore = context_dir / f"{tmp_dockerfile.name}.dockerignore"
-            scoped_ignore.write_text(f"{existing.rstrip()}\n!{staged_wheel.name}\n".lstrip(), encoding="utf-8")
-            scoped_ignore_written = True
+            try:
+                with scoped_ignore.open("x", encoding="utf-8") as scoped_ignore_file:
+                    scoped_ignore_written = True
+                    scoped_ignore_file.write(f"{existing.rstrip()}\n!{staged_wheel.name}\n".lstrip())
+            except FileExistsError as exc:
+                raise ManagedFileConflictError(scoped_ignore) from exc
 
         return docker_build(
             context_dir=context_dir,

--- a/plugins/nemo-agents/src/nemo_agents_plugin/container/builder.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/container/builder.py
@@ -450,8 +450,6 @@ def build_fabric_agent_image(
         )
 
     tmp_dockerfile = context_dir / "Dockerfile.generated"
-    if dockerfile is None and tmp_dockerfile.exists():
-        raise ManagedFileConflictError(tmp_dockerfile)
 
     # Docker can only COPY from inside the context. For an external wheel,
     # compute the identity digest while staging it so the source is read once
@@ -551,8 +549,15 @@ def build_fabric_agent_image(
     ignore_pre_existed = ignore_path.exists()
     scoped_ignore: Path | None = None
     scoped_ignore_identity: tuple[int, int] | None = None
+    tmp_dockerfile_identity: tuple[int, int] | None = None
     try:
-        tmp_dockerfile.write_text(content, encoding="utf-8")
+        try:
+            with tmp_dockerfile.open("x", encoding="utf-8") as tmp_dockerfile_file:
+                created_stat = os.fstat(tmp_dockerfile_file.fileno())
+                tmp_dockerfile_identity = (created_stat.st_dev, created_stat.st_ino)
+                tmp_dockerfile_file.write(content)
+        except FileExistsError as exc:
+            raise ManagedFileConflictError(tmp_dockerfile) from exc
 
         if generate_ignore:
             ignore_file = render_dockerignore(context_dir)
@@ -582,7 +587,14 @@ def build_fabric_agent_image(
             on_progress=on_progress,
         )
     finally:
-        tmp_dockerfile.unlink(missing_ok=True)
+        if tmp_dockerfile_identity is not None:
+            try:
+                current_stat = tmp_dockerfile.stat(follow_symlinks=False)
+            except FileNotFoundError:
+                pass
+            else:
+                if (current_stat.st_dev, current_stat.st_ino) == tmp_dockerfile_identity:
+                    tmp_dockerfile.unlink(missing_ok=True)
         if scoped_ignore is not None and scoped_ignore_identity is not None:
             try:
                 current_stat = scoped_ignore.stat(follow_symlinks=False)

--- a/plugins/nemo-agents/tests/unit/test_container.py
+++ b/plugins/nemo-agents/tests/unit/test_container.py
@@ -3105,6 +3105,49 @@ class TestFabricWheelInstall:
         assert not seen["present"]
 
     @patch("nemo_agents_plugin.container.builder.docker_build")
+    def test_exclusive_dockerfile_create_handles_a_race(
+        self, mock_build: MagicMock, fabric_agent_config: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from nemo_agents_plugin.container.builder import build_fabric_agent_image
+
+        generated = fabric_agent_config.parent / "Dockerfile.generated"
+        generated.write_text("USER OWNED\n")
+        original_exists = Path.exists
+
+        def _miss_generated(self: Path) -> bool:
+            if self == generated:
+                return False
+            return original_exists(self)
+
+        monkeypatch.setattr(Path, "exists", _miss_generated)
+
+        with pytest.raises(ManagedFileConflictError):
+            build_fabric_agent_image(fabric_agent_config, skip_validation=True, agent_author="x")
+
+        assert generated.read_text() == "USER OWNED\n"
+        mock_build.assert_not_called()
+
+    @patch("nemo_agents_plugin.container.builder.docker_build")
+    def test_does_not_remove_a_replaced_generated_dockerfile(
+        self, mock_build: MagicMock, fabric_agent_config: Path, tmp_path: Path
+    ) -> None:
+        from nemo_agents_plugin.container.builder import build_fabric_agent_image
+
+        generated = fabric_agent_config.parent / "Dockerfile.generated"
+        replacement = tmp_path / "replacement.Dockerfile"
+        replacement.write_text("USER REPLACEMENT\n")
+
+        def _replace_generated(**kwargs: Any) -> str:
+            os.replace(replacement, generated)
+            return "image-id"
+
+        mock_build.side_effect = _replace_generated
+
+        build_fabric_agent_image(fabric_agent_config, skip_validation=True, agent_author="x")
+
+        assert generated.read_text() == "USER REPLACEMENT\n"
+
+    @patch("nemo_agents_plugin.container.builder.docker_build")
     def test_refuses_to_clobber_a_scoped_ignore_file(
         self, mock_build: MagicMock, fabric_agent_config: Path, tmp_path: Path
     ) -> None:

--- a/plugins/nemo-agents/tests/unit/test_container.py
+++ b/plugins/nemo-agents/tests/unit/test_container.py
@@ -3125,6 +3125,32 @@ class TestFabricWheelInstall:
         assert not (context / wheel.name).exists()
         mock_build.assert_not_called()
 
+    @patch("nemo_agents_plugin.container.builder.docker_build")
+    def test_does_not_remove_a_replaced_scoped_ignore_file(
+        self, mock_build: MagicMock, fabric_agent_config: Path, tmp_path: Path
+    ) -> None:
+        from nemo_agents_plugin.container.builder import build_fabric_agent_image
+
+        source = tmp_path / "dist"
+        source.mkdir()
+        wheel = source / "nemo_platform-0.4.0-py3-none-any.whl"
+        wheel.write_bytes(b"wheel")
+        context = fabric_agent_config.parent
+        scoped = context / "Dockerfile.generated.dockerignore"
+        replacement = tmp_path / "replacement.ignore"
+        replacement.write_text("REPLACEMENT\n")
+
+        def _replace_scoped_ignore(**kwargs: Any) -> str:
+            os.replace(replacement, scoped)
+            return "image-id"
+
+        mock_build.side_effect = _replace_scoped_ignore
+
+        build_fabric_agent_image(fabric_agent_config, wheel=wheel, skip_validation=True, agent_author="x")
+
+        assert scoped.read_text() == "REPLACEMENT\n"
+        assert not (context / wheel.name).exists()
+
     def test_refuses_to_clobber_a_file_the_user_owns(self, fabric_agent_config: Path, tmp_path: Path) -> None:
         from nemo_agents_plugin.container.builder import build_fabric_agent_image
 

--- a/plugins/nemo-agents/tests/unit/test_container.py
+++ b/plugins/nemo-agents/tests/unit/test_container.py
@@ -2958,17 +2958,45 @@ class TestFabricWheelInstall:
             "docker_build",
             lambda **kwargs: captured.setdefault("tag", kwargs["tag"]),
         )
+
+        def _capture_render(*args: Any, **kwargs: Any) -> str:
+            captured.setdefault("contract_version", kwargs.get("contract_version"))
+            return real_render(*args, **kwargs)
+
         monkeypatch.setattr(
             template,
             "render_fabric_dockerfile",
-            lambda *a, **kw: (
-                captured.setdefault("contract_version", kw.get("contract_version")) or real_render(*a, **kw)
-            ),
+            _capture_render,
         )
 
         builder.build_fabric_agent_image(fabric_agent_config, wheel=wheel, skip_validation=True, agent_author="x")
 
         assert captured["contract_version"] == "0.4.0.post176.dev0+abc123"
+
+    @patch("nemo_agents_plugin.container.builder.docker_build")
+    def test_the_image_identity_includes_the_wheel_contents(
+        self, mock_build: MagicMock, fabric_agent_config: Path, tmp_path: Path
+    ) -> None:
+        from nemo_agents_plugin.container.builder import build_fabric_agent_image
+
+        wheel_name = "nemo_platform-0.4.0-py3-none-any.whl"
+        first_source = tmp_path / "first"
+        first_source.mkdir()
+        first_wheel = first_source / wheel_name
+        first_wheel.write_bytes(b"first wheel")
+
+        second_source = tmp_path / "second"
+        second_source.mkdir()
+        second_wheel = second_source / wheel_name
+        second_wheel.write_bytes(b"second wheel")
+
+        build_fabric_agent_image(fabric_agent_config, wheel=first_wheel, skip_validation=True, agent_author="x")
+        first_tag = mock_build.call_args.kwargs["tag"]
+
+        build_fabric_agent_image(fabric_agent_config, wheel=second_wheel, skip_validation=True, agent_author="x")
+        second_tag = mock_build.call_args.kwargs["tag"]
+
+        assert first_tag != second_tag
 
     @patch("nemo_agents_plugin.container.builder.docker_build")
     def test_a_supplied_dockerfile_ignores_the_wheel(
@@ -3058,6 +3086,27 @@ class TestFabricWheelInstall:
             build_fabric_agent_image(fabric_agent_config, skip_validation=True, agent_author="x")
 
         assert not seen["present"]
+
+    @patch("nemo_agents_plugin.container.builder.docker_build")
+    def test_refuses_to_clobber_a_scoped_ignore_file(
+        self, mock_build: MagicMock, fabric_agent_config: Path, tmp_path: Path
+    ) -> None:
+        from nemo_agents_plugin.container.builder import build_fabric_agent_image
+
+        source = tmp_path / "dist"
+        source.mkdir()
+        wheel = source / "nemo_platform-0.4.0-py3-none-any.whl"
+        wheel.write_bytes(b"wheel")
+        context = fabric_agent_config.parent
+        scoped = context / "Dockerfile.generated.dockerignore"
+        scoped.write_text("USER OWNED\n")
+
+        with pytest.raises(ManagedFileConflictError):
+            build_fabric_agent_image(fabric_agent_config, wheel=wheel, skip_validation=True, agent_author="x")
+
+        assert scoped.read_text() == "USER OWNED\n"
+        assert not (context / wheel.name).exists()
+        mock_build.assert_not_called()
 
     def test_refuses_to_clobber_a_file_the_user_owns(self, fabric_agent_config: Path, tmp_path: Path) -> None:
         from nemo_agents_plugin.container.builder import build_fabric_agent_image

--- a/plugins/nemo-agents/tests/unit/test_container.py
+++ b/plugins/nemo-agents/tests/unit/test_container.py
@@ -2709,7 +2709,11 @@ class TestFabricWheelInstall:
 
     @patch("nemo_agents_plugin.container.builder.docker_build")
     def test_wheel_is_staged_into_the_context_and_removed(
-        self, mock_build: MagicMock, fabric_agent_config: Path, tmp_path: Path
+        self,
+        mock_build: MagicMock,
+        fabric_agent_config: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         from nemo_agents_plugin.container.builder import build_fabric_agent_image
 
@@ -2719,6 +2723,17 @@ class TestFabricWheelInstall:
         wheel.write_bytes(b"not really a wheel")
         context = fabric_agent_config.parent
         staged_during_build: dict[str, bool] = {}
+        source_reads = 0
+        original_open = Path.open
+
+        def _count_source_reads(self: Path, *args: Any, **kwargs: Any) -> Any:
+            nonlocal source_reads
+            mode = args[0] if args else kwargs.get("mode", "r")
+            if self == wheel and mode == "rb":
+                source_reads += 1
+            return original_open(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "open", _count_source_reads)
         mock_build.side_effect = lambda **kwargs: staged_during_build.setdefault(
             "present", (context / wheel.name).exists()
         )
@@ -2726,6 +2741,7 @@ class TestFabricWheelInstall:
         build_fabric_agent_image(fabric_agent_config, wheel=wheel, skip_validation=True, agent_author="x")
 
         assert staged_during_build["present"], "the wheel must exist while docker build runs"
+        assert source_reads == 1, "staging must hash and copy the source in one pass"
         assert not (context / wheel.name).exists(), "the staged wheel must not outlive the build"
 
     @patch("nemo_agents_plugin.container.builder.docker_build")
@@ -2906,10 +2922,10 @@ class TestFabricWheelInstall:
     def test_a_file_appearing_mid_build_is_not_clobbered(
         self, mock_build: MagicMock, fabric_agent_config: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """The pre-render check is not atomic with the copy, so the copy creates
+        """The pre-stage check is not atomic with the copy, so the copy creates
         exclusively — otherwise losing that race overwrites a file and the cleanup
         then deletes it."""
-        from nemo_agents_plugin.container.builder import build_fabric_agent_image
+        import nemo_agents_plugin.container.builder as builder
 
         source = tmp_path / "dist"
         source.mkdir()
@@ -2917,18 +2933,19 @@ class TestFabricWheelInstall:
         wheel.write_bytes(b"wheel")
         collision = fabric_agent_config.parent / wheel.name
 
-        # Simulate another process winning the race after the check, before the copy.
-        original_write = Path.write_text
+        # Simulate another process winning the race after the existence check,
+        # immediately before the exclusive create.
+        original_open = open
 
-        def _plant(self: Path, *args: Any, **kwargs: Any) -> int:
-            if self.name == "Dockerfile.generated":
+        def _plant(file: Path, mode: str = "r", *args: Any, **kwargs: Any) -> Any:
+            if Path(file) == collision and mode == "xb":
                 collision.write_text("USER OWNED")
-            return original_write(self, *args, **kwargs)
+            return original_open(file, mode, *args, **kwargs)
 
-        monkeypatch.setattr(Path, "write_text", _plant)
+        monkeypatch.setattr(builder, "open", _plant, raising=False)
 
         with pytest.raises(ManagedFileConflictError):
-            build_fabric_agent_image(fabric_agent_config, wheel=wheel, skip_validation=True, agent_author="x")
+            builder.build_fabric_agent_image(fabric_agent_config, wheel=wheel, skip_validation=True, agent_author="x")
 
         monkeypatch.undo()
         assert collision.read_text() == "USER OWNED"


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary

Hardens the local-wheel packaging support in NVIDIA-NeMo/nemo-platform#1804
before it is merged into `release/0.5`.

This PR is stacked on `ASTD-535-backport-wheel-support/mmogallapall` and contains
only the follow-up correctness and safety fixes identified while reviewing that
change.

## Changes

- Include the selected wheel's SHA-256 digest in the agent identity so wheels
  with the same version but different contents receive different IDs and tags.
- Create `Dockerfile.generated.dockerignore` exclusively and track ownership
  before writing, preventing an existing or concurrently created file from
  being overwritten and deleted during cleanup.
- Fix the renderer test wrapper so it always invokes the real Dockerfile
  renderer.
- Add regression coverage for wheel-content identity and scoped-ignore file
  collisions.

## Type of Change

- [x] Bug fix
- [x] Packaging safety and correctness
- [x] Unit tests

## Verification

- [x] Focused packaging, validation, and subprocess tests pass: 237 passed.
- [x] Ruff lint and formatting checks pass for both changed files.
- [x] Focused type checking passes.
- [x] All commit hooks and DCO checks pass.
- [x] `git diff --check` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Image identities now reflect the contents of supplied wheels, preventing identical filenames from producing indistinguishable image tags.
  - Wheel staging handles concurrent conflicts safely and cleans up failed builds without removing replaced Docker ignore files.
  - Generated Dockerfiles and Docker ignore files are protected from accidental overwrites, preserving user changes during builds.
  - Existing user-owned files are preserved, with clear errors when conflicts prevent image building.
- **Tests**
  - Added coverage for content-based image identity, staging conflicts, and protection of replaced or existing generated files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->