### PR TITLE
feat(evaluator): give Gym trials an OTLP trace projected from ng_trajectory

### DIFF
--- a/docs/evaluator/agent-eval/writing-metrics.mdx
+++ b/docs/evaluator/agent-eval/writing-metrics.mdx
@@ -142,8 +142,10 @@ async def read_trace(input: MetricInput) -> None:
 | **filesystem** (`EVIDENCE_FINAL_STATE`, `EVIDENCE_INITIAL_STATE`) | `await evidence.filesystem(name)` | `.run_verifier(command)`, `.diff(other)` — run a check or diff two snapshots |
 | **logs** | `await evidence.logs(name)` | `.read_text(file)`, `.tail(file)` |
 
-OTLP exposes the unflattened `resourceSpans` tree; it does not provide a generic `tool_calls()` method.
-It's a responsibility of consumer to parse `resourceSpans` tree specific to OTLP exporter to extract the searched data.
+OTLP exposes the unflattened span tree as parsed `ResourceSpans` protobuf messages — the same type
+`opentelemetry-proto` defines and Intake ingests — so a reader walks `.scope_spans[].spans[]` and
+typed attributes rather than decoded JSON. It does not provide a generic `tool_calls()` method: what
+counts as a tool call is exporter-specific, so extracting them is the consumer's job.
 
 ### Asking for one trace format
 

--- a/docs/evaluator/agent-eval/writing-metrics.mdx
+++ b/docs/evaluator/agent-eval/writing-metrics.mdx
@@ -145,7 +145,9 @@ async def read_trace(input: MetricInput) -> None:
 OTLP exposes the unflattened span tree as parsed `ResourceSpans` protobuf messages — the same type
 `opentelemetry-proto` defines and Intake ingests — so a reader walks `.scope_spans[].spans[]` and
 typed attributes rather than decoded JSON. It does not provide a generic `tool_calls()` method: what
-counts as a tool call is exporter-specific, so extracting them is the consumer's job.
+counts as a tool call depends on whatever produced the spans — the Gym projection, or a harness like
+Fabric or Codex — each of which names and nests them differently, so extracting them is the
+consumer's job.
 
 ### Asking for one trace format
 

--- a/packages/nemo_evaluator_sdk/examples/run_agent_eval/example_metrics.py
+++ b/packages/nemo_evaluator_sdk/examples/run_agent_eval/example_metrics.py
@@ -22,6 +22,7 @@ from typing import Any
 
 from nemo_evaluator_sdk.agent_eval.trials import EVIDENCE_FINAL_STATE, EVIDENCE_INITIAL_STATE, EVIDENCE_TRACE
 from nemo_evaluator_sdk.metrics.protocol import MetricInput, MetricOutput, MetricOutputSpec, MetricResult
+from opentelemetry.proto.trace.v1.trace_pb2 import ResourceSpans, Span
 
 
 class TestsPassMetric:
@@ -141,110 +142,71 @@ class InefficientRetryLoopMetric:
         )
 
 
-def _otlp_tool_calls(resource_spans: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def _otlp_tool_calls(resource_spans: list[ResourceSpans]) -> list[dict[str, Any]]:
     """Extract fully identified OTLP tool calls in start-time order.
 
     Args:
-        resource_spans: OTLP resource-span export units.
+        resource_spans: Parsed OTLP resource spans.
 
     Returns:
         Tool name and argument mappings ordered by span start time.
     """
     found: list[tuple[int, int, dict[str, Any]]] = []
-    index = 0
-    for resource_span in resource_spans:
-        for scope_span in _otlp_dict_items(resource_span.get("scopeSpans")):
-            for span in _otlp_dict_items(scope_span.get("spans")):
-                call = _otlp_tool_call(span)
-                if call is None:
-                    continue
-                found.append((_otlp_start_ns(span), index, call))
-                index += 1
+    for index, span in enumerate(
+        span
+        for resource_span in resource_spans
+        for scope_span in resource_span.scope_spans
+        for span in scope_span.spans
+    ):
+        call = _otlp_tool_call(span)
+        if call is not None:
+            # Index breaks ties so spans sharing a start time keep their recorded order.
+            found.append((span.start_time_unix_nano, index, call))
     found.sort(key=lambda item: (item[0], item[1]))
     return [item[2] for item in found]
 
 
-def _otlp_tool_call(span: dict[str, Any]) -> dict[str, Any] | None:
+def _otlp_tool_call(span: Span) -> dict[str, Any] | None:
     """Project one recognized OTLP tool span into retry-comparison fields.
 
     Args:
-        span: Decoded OTLP span object.
+        span: An OTLP span.
 
     Returns:
         Tool name and arguments, or ``None`` when the span is not a tool call.
     """
-    attrs = _otlp_attr_map(span.get("attributes"))
+    attrs = _otlp_attr_map(span)
     kind = attrs.get("openinference.span.kind")
     operation = attrs.get("gen_ai.operation.name")
     if kind != "TOOL" and operation != "execute_tool":
         return None
-    name = attrs.get("tool.name") or attrs.get("gen_ai.tool.name") or span.get("name") or "tool"
+    name = attrs.get("tool.name") or attrs.get("gen_ai.tool.name") or span.name or "tool"
     function_name = str(name)
     argument_keys = ("input.value", "tool.parameters", "gen_ai.tool.call.arguments")
     raw = next((attrs[key] for key in argument_keys if key in attrs), None)
     if raw is None:
         raise ValueError(f"OTLP tool call {function_name!r} has no arguments; retry identity is unavailable")
-    arguments: dict[str, Any]
-    if isinstance(raw, dict):
-        arguments = raw
-    elif isinstance(raw, str):
+    if isinstance(raw, str):
         try:
             parsed = json.loads(raw)
         except ValueError:
-            parsed = {"_raw": raw}
-        arguments = parsed if isinstance(parsed, dict) else {"_raw": parsed}
-    else:
-        arguments = {"_raw": raw}
-    return {"function_name": function_name, "arguments": arguments}
+            return {"function_name": function_name, "arguments": {"_raw": raw}}
+        return {"function_name": function_name, "arguments": parsed if isinstance(parsed, dict) else {"_raw": parsed}}
+    return {"function_name": function_name, "arguments": {"_raw": raw}}
 
 
-def _otlp_start_ns(span: dict[str, Any]) -> int:
-    """Coerce an OTLP span start timestamp for stable tool-call ordering.
+def _otlp_attr_map(span: Span) -> dict[str, Any]:
+    """Read a span's scalar string and integer attributes by key.
 
     Args:
-        span: Decoded OTLP span object.
-
-    Returns:
-        Nanosecond timestamp, or zero when missing or malformed.
-    """
-    raw = span.get("startTimeUnixNano") or 0
-    try:
-        return int(raw)
-    except (TypeError, ValueError):
-        return 0
-
-
-def _otlp_attr_map(attributes: Any) -> dict[str, Any]:
-    """Decode scalar string and integer OTLP attributes by key.
-
-    Args:
-        attributes: Candidate OTLP key-value attribute list.
+        span: An OTLP span.
 
     Returns:
         Supported attribute values keyed by attribute name.
     """
-    out: dict[str, Any] = {}
-    for item in _otlp_dict_items(attributes):
-        key = item.get("key")
-        value = item.get("value")
-        if not isinstance(key, str):
-            continue
-        if isinstance(value, dict) and "stringValue" in value:
-            out[key] = value["stringValue"]
-        elif isinstance(value, dict) and "intValue" in value:
-            out[key] = value["intValue"]
-    return out
-
-
-def _otlp_dict_items(value: Any) -> list[dict[str, Any]]:
-    """Return only dictionary elements from an OTLP repeated field.
-
-    Args:
-        value: Candidate decoded repeated field.
-
-    Returns:
-        Dictionary elements, or an empty list for malformed containers.
-    """
-    if not isinstance(value, list):
-        return []
-    return [item for item in value if isinstance(item, dict)]
+    values: dict[str, Any] = {}
+    for attribute in span.attributes:
+        field = attribute.value.WhichOneof("value")
+        if field in ("string_value", "int_value"):
+            values[attribute.key] = getattr(attribute.value, field)
+    return values

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/metrics.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/metrics.py
@@ -40,6 +40,7 @@ from nemo_evaluator_sdk.values.evidence import (
 )
 from nemo_evaluator_sdk.values.metrics import MetricBase
 from nemo_evaluator_sdk.values.otlp import span_text_strings
+from opentelemetry.proto.trace.v1.trace_pb2 import ResourceSpans
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 
 logger = logging.getLogger(__name__)
@@ -204,7 +205,7 @@ async def _atif_used(evidence: CandidateEvidence, name: str, locations: list[str
     return any(_trajectory_references(trajectory, location) for location in locations)
 
 
-def _otlp_references(resource_spans: list[dict[str, Any]], needle: str) -> bool:
+def _otlp_references(resource_spans: list[ResourceSpans], needle: str) -> bool:
     """Whether any string attribute on the trace's spans or events contains ``needle``."""
     return any(needle in blob for blob in span_text_strings(resource_spans))
 

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/config.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/config.py
@@ -29,6 +29,8 @@ DEFAULT_REWARD_KEY = "reward"
 #: once, and that path is what the subprocesses run — so a child whose PATH differs from ours cannot
 #: end up executing a different Gym.
 _HYDRA_SUBDIR = "gym_hydra"
+#: Where Gym writes its per-rollout model-call captures, under the run's work dir.
+_CAPTURE_SUBDIR = "model_calls"
 #: `gym env start`'s combined output, under the run's work dir. Named here because a *collection*
 #: failure often has to point at it: the eval logs show the symptom, this shows the cause.
 _SECRET_KEY_MARKERS = ("api_key", "apikey", "token", "secret", "password", "passwd", "credential")
@@ -202,7 +204,19 @@ def _selection_args(config: GymRuntimeConfig, work_dir: Path) -> list[str]:
     # silently misread or rejected outright. Verified against Hydra's own parser — unquoted,
     # `/tmp/a,b` becomes a ChoiceSweep and `/tmp/x[1]` raises OverrideParseException.
     selection.append(f"hydra.run.dir={_hydra_scalar(str(work_dir / _HYDRA_SUBDIR))}")
+    # Off (Gym's default) a rollout reports one usage block summed over the turn and no timing at
+    # all; on, each model exchange is captured with its own tokens and latency. Asserted over
+    # `hydra_params` rather than defaulted, because turning it off degrades every trace silently.
+    # ``++`` for the same reason `_flatten_overrides` uses it: these keys are absent from the merged
+    # config until something sets them, and a bare `+` fails once they are present.
+    selection.append(f"++observability_enabled={_hydra_scalar(True)}")
+    selection.append(f"++model_call_capture_dir={_hydra_scalar(str(model_call_capture_dir(work_dir)))}")
     return selection
+
+
+def model_call_capture_dir(work_dir: Path) -> Path:
+    """Where Gym writes one ``<rollout_id>.capture.jsonl`` per rollout. Gym requires an absolute path."""
+    return (work_dir / _CAPTURE_SUBDIR).resolve()
 
 
 class GymRuntimeConfig(BaseModel):

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/records.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/records.py
@@ -20,6 +20,8 @@ logger = logging.getLogger(__name__)
 
 NG_TASK_INDEX = "_ng_task_index"
 NG_ROLLOUT_INDEX = "_ng_rollout_index"
+#: Gym appends this to a capture key past the first attempt, so it is part of the join.
+NG_ATTEMPT_INDEX = "_ng_attempt_index"
 #: Fields excluded from a row's content hash (runtime-injected, not task-defining).
 _RUNTIME_KEYS = frozenset({NG_TASK_INDEX, NG_ROLLOUT_INDEX})
 

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/results.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/results.py
@@ -17,19 +17,33 @@ from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
+from google.protobuf.json_format import MessageToDict
 from nemo_evaluator_sdk.agent_eval.runtimes.gym.config import DEFAULT_REWARD_KEY
 from nemo_evaluator_sdk.agent_eval.runtimes.gym.records import (
     _ENV_LOG_NAME,
+    NG_ATTEMPT_INDEX,
     NG_ROLLOUT_INDEX,
     NG_TASK_INDEX,
     _read_jsonl,
 )
 from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalTask
 from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial, AgentEvalTrialStatus, AgentOutput
-from nemo_evaluator_sdk.values.evidence import CandidateEvidence, EvidenceDescriptor
+from nemo_evaluator_sdk.ng_trajectory_otlp import rollout_to_resource_spans
+from nemo_evaluator_sdk.values.evidence import (
+    EVIDENCE_FORMAT_OTLP,
+    EVIDENCE_TRACE,
+    CandidateEvidence,
+    EvidenceDescriptor,
+)
 from nemo_evaluator_sdk.values.results import AggregateRangeScore, AggregateScalarScore, AggregateScore
+from opentelemetry.proto.trace.v1.trace_pb2 import ResourceSpans
 
 logger = logging.getLogger(__name__)
+
+#: Evidence key for Gym's own model-call capture, kept beside the OTLP view projected from it.
+#: Named for NeMo Gym's documented `ng_trajectory` schema; 0.5.0 writes it as one
+#: `<rollout_id>.capture.jsonl` per rollout rather than as a field on the rollout record.
+NG_TRAJECTORY_EVIDENCE = "ng_trajectory"
 
 
 _TOKEN_USAGE_KEYS = ("total_tokens", "input_tokens", "output_tokens", "prompt_tokens", "completion_tokens")
@@ -38,10 +52,6 @@ _TOKEN_USAGE_KEYS = ("total_tokens", "input_tokens", "output_tokens", "prompt_to
 _INPUT_TOKEN_KEYS = ("total_tokens", "input_tokens", "prompt_tokens")
 
 
-#: Gym's index fields on each rollout record. ``_ng_task_index`` is the only join back to the input
-#: rows that survives a round-trip: Gym mutates ``responses_create_params`` (even the prompt) and
-#: copies only a fixed allowlist of row keys onto the result, so no field we invent comes back. Gym
-#: *honors* a caller-supplied ``_ng_task_index``, which is what makes the join here deterministic.
 def _agent_never_ran(record: Mapping[str, Any]) -> bool:
     """True when a result record shows the agent produced nothing *and* never called the model.
 
@@ -118,6 +128,105 @@ def _require_full_coverage(tasks: Sequence[AgentEvalTask], *, covered_task_ids: 
         f"  gym logs:  {rollouts_path.parent} (gym_env.log, gym_eval.stdout.log, gym_eval.stderr.log)\n"
         f"  unrepresented task id(s): {missing}"
     )
+
+
+def _rollout_evidence(
+    record: Mapping[str, Any],
+    *,
+    rollouts_path: Path,
+    task_id: str,
+    trial_id: str,
+    capture_dir: Path | None = None,
+) -> CandidateEvidence:
+    """The rollouts file every trial shares, plus this rollout's own trace.
+
+    The trace is derived from the record rather than captured, so it is carried inline rather than
+    written beside the rollouts file. It is registered under the format-qualified key as well as the
+    plain one, so a metric asking for ``format="otlp"`` and one asking for whatever is primary reach
+    the same handle.
+    """
+    descriptors: dict[str, EvidenceDescriptor] = {
+        "rollouts": EvidenceDescriptor(kind="filesystem", format="file", ref=str(rollouts_path))
+    }
+    capture_path = _capture_path(record, capture_dir)
+    if capture_dir is not None and capture_path is None:
+        # Capture is switched on by the runner, so an absent one is Gym not doing what it was
+        # asked. The trial still scores; its trace just loses the timing capture exists to provide.
+        logger.warning(
+            "No model-call capture for trial %s under %s; its trace will carry no per-call timing.",
+            trial_id,
+            capture_dir,
+        )
+    model_calls = _read_model_calls(capture_path, trial_id=trial_id)
+    if capture_path is not None:
+        # Kept as its own evidence, by reference: the OTLP view below is a projection of it, and a
+        # projection is not a reason to lose what it was projected from.
+        descriptors[NG_TRAJECTORY_EVIDENCE] = EvidenceDescriptor(
+            kind="filesystem", format="file", ref=str(capture_path)
+        )
+    resource_spans = _rollout_resource_spans(record, task_id=task_id, trial_id=trial_id, model_calls=model_calls)
+    if resource_spans is not None:
+        # Rendered to JSON here and only here, because an ``EvidenceDescriptor`` holds JSON.
+        trace = EvidenceDescriptor(
+            kind=EVIDENCE_TRACE,
+            format=EVIDENCE_FORMAT_OTLP,
+            data=[MessageToDict(entry) for entry in resource_spans],
+        )
+        descriptors[EVIDENCE_TRACE] = trace
+        descriptors[f"{EVIDENCE_TRACE}:{EVIDENCE_FORMAT_OTLP}"] = trace
+    return CandidateEvidence(descriptors=descriptors)
+
+
+def _rollout_resource_spans(
+    record: Mapping[str, Any], *, task_id: str, trial_id: str, model_calls: Sequence[Mapping[str, Any]] = ()
+) -> list[ResourceSpans] | None:
+    """Project one rollout onto OTLP resource spans, or ``None`` when it will not convert.
+
+    Seeded on the trial id because span identity has to be unique per attempt: Gym does not always
+    record ``_ng_rollout_index``, and ``_rollout_trial_id`` is what already resolves that.
+    """
+    try:
+        return rollout_to_resource_spans(record, rollout_id=trial_id, task_id=task_id, model_calls=model_calls)
+    except (TypeError, ValueError) as error:
+        # A trace is a second view of a result Gym already reported; losing it must not lose the
+        # trial, whose reward and output stand on their own.
+        logger.warning("Could not build an OTLP trace for trial %s: %s", trial_id, error)
+        return None
+
+
+def _capture_path(record: Mapping[str, Any], capture_dir: Path | None) -> Path | None:
+    """The model-call capture Gym wrote for this rollout, or ``None`` when there is not one.
+
+    Gym keys a capture by ``"{task}-{rollout}"``, suffixed ``-a{attempt}`` past the first attempt
+    (``nemo_gym.rollout_correlation``). Both indices are on the record, so the join is exact rather
+    than a search.
+    """
+    if capture_dir is None:
+        return None
+    task, rollout = record.get(NG_TASK_INDEX), record.get(NG_ROLLOUT_INDEX)
+    if not isinstance(task, int) or not isinstance(rollout, int):
+        return None
+    rollout_id = f"{task}-{rollout}"
+    attempt = record.get(NG_ATTEMPT_INDEX)
+    if isinstance(attempt, int) and attempt > 0:
+        rollout_id = f"{rollout_id}-a{attempt}"
+    path = capture_dir / f"{rollout_id}.capture.jsonl"
+    return path if path.exists() else None
+
+
+def _read_model_calls(capture_path: Path | None, *, trial_id: str) -> list[dict[str, Any]]:
+    """This rollout's captured model exchanges, or none when unreadable.
+
+    Tolerant on purpose: the capture is a bonus view over a result Gym already reported, so a
+    truncated file costs the trial its per-call timing, not the trial.
+    """
+    if capture_path is None:
+        return []
+    try:
+        return _read_jsonl(capture_path, tolerant=True)
+    except OSError as error:
+        logger.warning("Could not read the model-call capture for trial %s: %s", trial_id, error)
+        return []
 
 
 def _failures_path_for(rollouts_path: Path) -> Path:
@@ -344,6 +453,7 @@ def _trials_from_rollouts(
     index_to_task_id: Mapping[int, str],
     *,
     reward_key: str = DEFAULT_REWARD_KEY,
+    capture_dir: Path | None = None,
 ) -> list[AgentEvalTrial]:
     """Fan Gym's rollout records out into one :class:`AgentEvalTrial` per attempt.
 
@@ -383,9 +493,6 @@ def _trials_from_rollouts(
     # missing/null index must not collapse multiple attempts for one task onto the same trial id.
     synth_seq: dict[str, int] = {}
 
-    success_evidence = CandidateEvidence(
-        descriptors={"rollouts": EvidenceDescriptor(kind="filesystem", format="file", ref=str(rollouts_path))}
-    )
     unattributed_successes = 0
     empty_output_count = 0
     #: Tasks with at least one trial where the agent never ran. Tracked separately from trial
@@ -423,13 +530,20 @@ def _trials_from_rollouts(
                 "the agent produced no output and consumed no tokens, so the model was never called; "
                 f"the reported score of {reward!r} is not a measurement of this agent"
             )
+        trial_id = _rollout_trial_id(task_id, raw_rollout_index, synth_seq, missing_label="noidx")
         trials.append(
             AgentEvalTrial(
-                id=_rollout_trial_id(task_id, raw_rollout_index, synth_seq, missing_label="noidx"),
+                id=trial_id,
                 task_id=task_id,
                 status=status,
                 output=AgentOutput(response=record.get("response"), metadata={"agent_ref": record.get("agent_ref")}),
-                evidence=success_evidence,
+                evidence=_rollout_evidence(
+                    record,
+                    rollouts_path=rollouts_path,
+                    task_id=task_id,
+                    trial_id=trial_id,
+                    capture_dir=capture_dir,
+                ),
                 metadata=metadata,
             )
         )

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/results.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/results.py
@@ -438,13 +438,23 @@ def _resolve_task_id(
     return task_id
 
 
-def _rollout_trial_id(task_id: str, raw_rollout_index: Any, synth_seq: dict[str, int], *, missing_label: str) -> str:
+def _rollout_trial_id(
+    task_id: str, raw_rollout_index: Any, synth_seq: dict[str, int], *, missing_label: str, attempt: Any = None
+) -> str:
     """Per-attempt trial id: use the record's ``_ng_rollout_index`` when it's a real int, else a
-    per-task-unique ``{missing_label}{n}`` suffix so records lacking an index don't collide on one id."""
+    per-task-unique ``{missing_label}{n}`` suffix so records lacking an index don't collide on one id.
+
+    A retry reuses its task and rollout indices, so the attempt index is part of the identity too:
+    without it a failed attempt and the retry that replaced it land on one id, and since span ids are
+    derived from this one, a consumer keyed on span identity would keep only the last. Suffixed
+    ``-a{attempt}`` past the first attempt, matching how Gym keys the capture in ``_capture_path`` so
+    the two agree on what "this attempt" means.
+    """
+    suffix = f"-a{attempt}" if isinstance(attempt, int) and attempt > 0 else ""
     if isinstance(raw_rollout_index, int) and not isinstance(raw_rollout_index, bool):
-        return f"{task_id}:{raw_rollout_index}"
+        return f"{task_id}:{raw_rollout_index}{suffix}"
     seq = synth_seq[task_id] = synth_seq.get(task_id, 0) + 1
-    return f"{task_id}:{missing_label}{seq}"
+    return f"{task_id}:{missing_label}{seq}{suffix}"
 
 
 def _trials_from_rollouts(
@@ -530,7 +540,9 @@ def _trials_from_rollouts(
                 "the agent produced no output and consumed no tokens, so the model was never called; "
                 f"the reported score of {reward!r} is not a measurement of this agent"
             )
-        trial_id = _rollout_trial_id(task_id, raw_rollout_index, synth_seq, missing_label="noidx")
+        trial_id = _rollout_trial_id(
+            task_id, raw_rollout_index, synth_seq, missing_label="noidx", attempt=record.get(NG_ATTEMPT_INDEX)
+        )
         trials.append(
             AgentEvalTrial(
                 id=trial_id,
@@ -567,7 +579,13 @@ def _trials_from_rollouts(
             raw_rollout_index = record.get(NG_ROLLOUT_INDEX)
             trials.append(
                 AgentEvalTrial(
-                    id=_rollout_trial_id(task_id, raw_rollout_index, synth_seq, missing_label="fail"),
+                    id=_rollout_trial_id(
+                        task_id,
+                        raw_rollout_index,
+                        synth_seq,
+                        missing_label="fail",
+                        attempt=record.get(NG_ATTEMPT_INDEX),
+                    ),
                     task_id=task_id,
                     status=AgentEvalTrialStatus.FAILED,
                     output=AgentOutput(

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/runtime.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/runtime.py
@@ -25,6 +25,7 @@ from nemo_evaluator_sdk.agent_eval.runtimes.gym.config import (
     _hydra_scalar,
     _redact_hydra_params,
     _selection_args,
+    model_call_capture_dir,
 )
 from nemo_evaluator_sdk.agent_eval.runtimes.gym.dataset import _materialize_dataset, _source_datasets
 from nemo_evaluator_sdk.agent_eval.runtimes.gym.process import (
@@ -156,7 +157,13 @@ class GymAgentTaskRunner:
 
         await self._run_two_step(input_path, rollouts_path, work_dir)
         self._run_aggregations = _read_run_aggregations(rollouts_path)
-        trials = _trials_from_rollouts(rollouts_path, tasks, index_to_task_id, reward_key=cfg.reward_key)
+        trials = _trials_from_rollouts(
+            rollouts_path,
+            tasks,
+            index_to_task_id,
+            reward_key=cfg.reward_key,
+            capture_dir=model_call_capture_dir(work_dir),
+        )
         _require_full_coverage(tasks, covered_task_ids={trial.task_id for trial in trials}, rollouts_path=rollouts_path)
         return trials
 

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/sandboxed.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/sandboxed.py
@@ -20,6 +20,9 @@ host's ``/rollouts/run`` and writes the returned records where the parser expect
 Attribution survives that hop because the host copies each example's ``_ng_task_index`` onto its
 result. Nothing here joins by position.
 
+One thing does not survive yet (AALGO-593): the host does not enable Gym's model-call capture, so trials from
+this runner carry a trace projected from the rollout record alone, without per-call timing.
+
 The host itself is provisioned by ``sandboxed-gym``: start a session, take its rollout URL and
 token off the descriptor, and hand them to this runner.
 """
@@ -244,6 +247,12 @@ class SandboxedGymAgentTaskRunner:
         )
 
         self._run_aggregations = _read_run_aggregations(rollouts_path)
-        trials = _trials_from_rollouts(rollouts_path, tasks, index_to_task_id, reward_key=cfg.reward_key)
+        # No capture_dir yet (AALGO-593): the host does not switch Gym's model-call capture on, so
+        # its captures never leave the sandbox and traces from this runner carry no per-call timing.
+        # Unimplemented rather than impossible -- the host drives Gym through its Python API, whose
+        # global config takes the same observability keys the CLI runtime sets.
+        trials = _trials_from_rollouts(
+            rollouts_path, tasks, index_to_task_id, reward_key=cfg.reward_key, capture_dir=None
+        )
         _require_full_coverage(tasks, covered_task_ids={trial.task_id for trial in trials}, rollouts_path=rollouts_path)
         return trials

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/harbor_trial_adapter.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/harbor_trial_adapter.py
@@ -38,11 +38,11 @@ from nemo_evaluator_sdk.values.evidence import (
     read_atif,
 )
 from nemo_evaluator_sdk.values.otlp import (
-    export_request_from_resource_spans,
     final_output_text,
+    parse_resource_spans,
     resource_spans_from_text,
 )
-from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
+from opentelemetry.proto.trace.v1.trace_pb2 import ResourceSpans
 
 logger = logging.getLogger(__name__)
 
@@ -124,8 +124,8 @@ def _trial_from_harbor_result(
 
     # Discovery names an OTLP trace from its artifact path alone; only reading it proves it
     # parses. Both the primary trace and the answer follow from that one read.
-    otlp_request = _read_otlp(otlp_trace)
-    primary_trace = otlp_trace if otlp_request is not None else atif_trace
+    otlp_spans = _read_otlp(otlp_trace)
+    primary_trace = otlp_trace if otlp_spans is not None else atif_trace
     if primary_trace is not None:
         descriptors[EVIDENCE_TRACE] = primary_trace
 
@@ -134,7 +134,7 @@ def _trial_from_harbor_result(
         task_id=task_id,
         status=status,
         output=AgentOutput(
-            output_text=_trial_output_text(otlp_request, atif_trace),
+            output_text=_trial_output_text(otlp_spans, atif_trace),
             metadata={"harbor_trial_dir": str(trial_dir)},
         ),
         evidence=CandidateEvidence(descriptors=descriptors),
@@ -143,17 +143,15 @@ def _trial_from_harbor_result(
     )
 
 
-def _trial_output_text(
-    otlp_request: ExportTraceServiceRequest | None, atif_trace: EvidenceDescriptor | None
-) -> str | None:
+def _trial_output_text(otlp_spans: list[ResourceSpans] | None, atif_trace: EvidenceDescriptor | None) -> str | None:
     """The agent's answer for the trial, from its OTLP trace when that carries one.
 
     ATIF remains the fallback because an agent may emit no OTLP trace, and OTLP spans that
     carry no output attribute yield nothing to read. Both being absent is normal: oracle and
     nop produce neither.
     """
-    if otlp_request is not None:
-        answer = final_output_text(otlp_request)
+    if otlp_spans is not None:
+        answer = final_output_text(otlp_spans)
         if answer:
             return answer
     if atif_trace is None or atif_trace.ref is None:
@@ -161,13 +159,13 @@ def _trial_output_text(
     return _final_agent_message(read_atif(Path(atif_trace.ref)))
 
 
-def _read_otlp(descriptor: EvidenceDescriptor | None) -> ExportTraceServiceRequest | None:
+def _read_otlp(descriptor: EvidenceDescriptor | None) -> list[ResourceSpans] | None:
     """Parse a trial's OTLP trace, or ``None`` when it is absent or will not read."""
     if descriptor is None or descriptor.ref is None:
         return None
     path = Path(descriptor.ref)
     try:
-        return export_request_from_resource_spans(resource_spans_from_text(path.read_text(encoding="utf-8")))
+        return parse_resource_spans(resource_spans_from_text(path.read_text(encoding="utf-8")))
     except (OSError, ValueError) as error:
         logger.warning("Ignoring unreadable OTLP trace %s: %s", path, error)
         return None

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/ng_trajectory_otlp/README.md
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/ng_trajectory_otlp/README.md
@@ -1,0 +1,49 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# ng_trajectory_otlp
+
+Converts NeMo-Gym rollout records into OTLP spans.
+
+Gym writes one JSONL record per rollout: an OpenAI Responses API request/response pair plus the
+reward and the indices that join it back to the input dataset. That is a result, not a trace — it
+carries no span tree and no timings. This subpackage projects what the record *does* evidence onto
+the OTLP span vocabulary: an AGENT span for the rollout, an LLM span for the model call, and a TOOL
+span per function call the model made.
+
+```python
+from nemo_evaluator_sdk.ng_trajectory_otlp import rollout_to_resource_spans
+
+resource_spans = rollout_to_resource_spans(record, rollout_id="task-1:0", task_id="task-1")
+```
+
+It returns generated `ResourceSpans` messages.
+
+```python
+ExportTraceServiceRequest(resource_spans=resource_spans)
+```
+
+The Gym runtime renders the message to JSON only to store it, because an `EvidenceDescriptor` holds
+JSON; `OTLPTraceHandle` parses it straight back.
+
+## Keep it liftable
+
+It lives here because the Gym runtime is its only caller, not because it belongs to this SDK. It
+imports nothing from the rest of `nemo_evaluator_sdk` and depends only on `opentelemetry-proto`, so
+it can be extracted into its own distribution the day a producer outside the evaluator wants it. Its
+tests import only this subpackage, which is what keeps that honest. Adding an SDK import here would
+quietly take it away.
+
+`rollout_id` is load-bearing. Span ids are derived from it so that converting a record twice yields
+the same ids and a re-publish replaces spans rather than duplicating them — which means two rollouts
+sharing an id collide, and a consumer keyed on span identity keeps only the last. A task id is not
+enough: one task can be attempted repeatedly, and Gym does not always record which attempt a record
+belongs to.
+
+## What it does not do
+
+* **Invent timings.** Gym records none, so spans carry no start time. A consumer that needs one
+  supplies it (the evaluator's publish path fills in the run's start time).
+* **Reconstruct concurrency.** One rollout is one linear exchange as recorded; parallel tool calls
+  are not distinguishable in the source.
+* **Report usage Gym did not state.** Absent token counts stay absent rather than becoming zero.

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/ng_trajectory_otlp/README.md
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/ng_trajectory_otlp/README.md
@@ -14,13 +14,17 @@ span per function call the model made.
 ```python
 from nemo_evaluator_sdk.ng_trajectory_otlp import rollout_to_resource_spans
 
+# A record is one line of the rollouts JSONL Gym wrote; this is the smallest one that converts.
+record = {"response": {"output_text": "Answer."}}
 resource_spans = rollout_to_resource_spans(record, rollout_id="task-1:0", task_id="task-1")
 ```
 
 It returns generated `ResourceSpans` messages.
 
 ```python
-ExportTraceServiceRequest(resource_spans=resource_spans)
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
+
+request = ExportTraceServiceRequest(resource_spans=resource_spans)
 ```
 
 The Gym runtime renders the message to JSON only to store it, because an `EvidenceDescriptor` holds

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/ng_trajectory_otlp/__init__.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/ng_trajectory_otlp/__init__.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Project NeMo-Gym rollout records onto OTLP spans.
+
+Self-contained on purpose: nothing here imports the rest of this SDK, and its only dependency is
+``opentelemetry-proto``, so the projection can be lifted into its own distribution if a producer
+outside the evaluator ever wants it. Keep it that way.
+"""
+
+from nemo_evaluator_sdk.ng_trajectory_otlp.convert import SPAN_KIND_ATTRIBUTE, rollout_to_resource_spans
+
+__all__ = [
+    "SPAN_KIND_ATTRIBUTE",
+    "rollout_to_resource_spans",
+]

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/ng_trajectory_otlp/convert.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/ng_trajectory_otlp/convert.py
@@ -1,0 +1,314 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Project one NeMo-Gym rollout record onto OTLP spans.
+
+Gym records a rollout as an OpenAI Responses API request/response pair, not as a trace: there is no
+span tree and no timing anywhere in the record. What can be said honestly is that the agent ran
+(one AGENT span), that a model was called (one LLM span carrying the usage the response reports),
+and that any tool the model invoked was executed (one TOOL span per call). That is what this
+builds; it does not synthesise structure the record does not evidence.
+
+The result is the generated protobuf message rather than its JSON rendering, so a mistyped field or
+a wrong-width id fails here rather than somewhere downstream, and ids stay bytes instead of picking
+up a hex-or-base64 ambiguity on the way. It is a ``ResourceSpans`` and not an
+``ExportTraceServiceRequest``: the latter is the envelope of OTLP's Export RPC, and whether these
+spans are ever sent over a wire is the caller's business, not this projection's.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator, Mapping, Sequence
+from hashlib import sha256
+from math import isfinite
+from typing import Any
+
+from opentelemetry.proto.common.v1.common_pb2 import AnyValue, KeyValue
+from opentelemetry.proto.resource.v1.resource_pb2 import Resource
+from opentelemetry.proto.trace.v1.trace_pb2 import ResourceSpans, ScopeSpans, Span, Status
+
+SPAN_KIND_ATTRIBUTE = "openinference.span.kind"
+
+_SCOPE_NAME = "ng_trajectory_otlp"
+_TRACE_ID_BYTES = 16
+_SPAN_ID_BYTES = 8
+
+# Both vocabularies are in play: Gym's model servers speak the Responses API's
+# ``input_tokens``/``output_tokens`` or Chat Completions' ``prompt_tokens``/``completion_tokens``
+# depending on the adapter, and reading only one set reports a real call as zero.
+_PROMPT_TOKEN_KEYS = ("input_tokens", "prompt_tokens")
+_COMPLETION_TOKEN_KEYS = ("output_tokens", "completion_tokens")
+
+
+def rollout_to_resource_spans(
+    record: Mapping[str, Any],
+    *,
+    rollout_id: str,
+    task_id: str | None = None,
+    model_calls: Sequence[Mapping[str, Any]] = (),
+) -> list[ResourceSpans]:
+    """Return the OTLP spans for one rollout, under a single resource.
+
+    Ids are derived from ``rollout_id`` rather than generated, so converting the same record twice
+    yields the same ids and a re-publish replaces its spans instead of duplicating them. That makes
+    ``rollout_id`` load-bearing: two rollouts sharing one collide, and a consumer keyed on span
+    identity would store only the last. A task id is not enough — one task can be attempted
+    repeatedly, and Gym does not always record which attempt a record is.
+
+    Args:
+        record: One Gym rollout record.
+        rollout_id: Identifies this attempt uniquely among all rollouts in the run.
+        task_id: The task this rollout answers, used to name the root span.
+        model_calls: This rollout's captured model exchanges, when Gym recorded them. Each becomes
+            its own timed LLM span; without them the rollout record supports only one untimed span
+            carrying the turn's summed usage.
+
+    Returns:
+        The rollout's resource spans, ready to hand to ``ExportTraceServiceRequest`` or to store:
+        one AGENT root span with its LLM and TOOL children.
+    """
+    trace_id = _id_bytes(rollout_id, "trace", width=_TRACE_ID_BYTES)
+    root_id = _id_bytes(rollout_id, "root", width=_SPAN_ID_BYTES)
+    raw_response = record.get("response")
+    # Gym records `response` as the Responses API payload, but some adapters write the answer as a
+    # bare string. Both are answers; only the mapping carries usage and tool calls.
+    answer = raw_response if isinstance(raw_response, str) and raw_response else None
+    response = raw_response if isinstance(raw_response, Mapping) else {}
+
+    llm_spans = [
+        _captured_llm_span(call, trace_id=trace_id, parent_id=root_id, seed=rollout_id, ordinal=ordinal)
+        for ordinal, call in enumerate(model_calls)
+    ] or [_llm_span(record, response, trace_id=trace_id, parent_id=root_id, seed=rollout_id, answer=answer)]
+    spans = [
+        _root_span(record, response, trace_id=trace_id, span_id=root_id, task_id=task_id, answer=answer),
+        *llm_spans,
+        *_tool_spans(response, trace_id=trace_id, parent_id=root_id, seed=rollout_id),
+    ]
+    return [
+        ResourceSpans(
+            resource=Resource(attributes=_attributes({"service.name": _SCOPE_NAME})),
+            scope_spans=[ScopeSpans(spans=spans)],
+        )
+    ]
+
+
+def _root_span(
+    record: Mapping[str, Any],
+    response: Mapping[str, Any],
+    *,
+    trace_id: bytes,
+    span_id: bytes,
+    task_id: str | None,
+    answer: str | None,
+) -> Span:
+    """The span standing for the whole rollout, carrying the answer a content metric scores."""
+    attributes: dict[str, Any] = {SPAN_KIND_ATTRIBUTE: "AGENT"}
+    if (prompt := _request_text(record)) is not None:
+        attributes["input.value"] = prompt
+    if (text := answer or response_output_text(response)) is not None:
+        attributes["output.value"] = text
+    reward = record.get("reward")
+    if isinstance(reward, (int, float)) and not isinstance(reward, bool):
+        attributes["nemo.gym.reward"] = reward
+    return Span(trace_id=trace_id, span_id=span_id, name=task_id or "rollout", attributes=_attributes(attributes))
+
+
+def _llm_span(
+    record: Mapping[str, Any],
+    response: Mapping[str, Any],
+    *,
+    trace_id: bytes,
+    parent_id: bytes,
+    seed: str,
+    answer: str | None,
+) -> Span:
+    """The model call the response reports, with whichever usage vocabulary it used."""
+    attributes: dict[str, Any] = {SPAN_KIND_ATTRIBUTE: "LLM"}
+    params = record.get("responses_create_params")
+    model = response.get("model") or (params.get("model") if isinstance(params, Mapping) else None)
+    if isinstance(model, str):
+        attributes["gen_ai.request.model"] = model
+    usage = response.get("usage")
+    if isinstance(usage, Mapping):
+        if (prompt := _token_count(usage, _PROMPT_TOKEN_KEYS)) is not None:
+            attributes["gen_ai.usage.input_tokens"] = prompt
+        if (completion := _token_count(usage, _COMPLETION_TOKEN_KEYS)) is not None:
+            attributes["gen_ai.usage.output_tokens"] = completion
+    if (text := answer or response_output_text(response)) is not None:
+        attributes["output.value"] = text
+    return Span(
+        trace_id=trace_id,
+        span_id=_id_bytes(seed, "llm", width=_SPAN_ID_BYTES),
+        parent_span_id=parent_id,
+        name="model call",
+        attributes=_attributes(attributes),
+    )
+
+
+def _captured_llm_span(call: Mapping[str, Any], *, trace_id: bytes, parent_id: bytes, seed: str, ordinal: int) -> Span:
+    """One captured model exchange, with the timing only the capture records.
+
+    The rollout record reports a single usage block summed over the turn, so per-call tokens and
+    latency exist here or nowhere.
+    """
+    attributes: dict[str, Any] = {SPAN_KIND_ATTRIBUTE: "LLM"}
+    model_ref = call.get("model_ref")
+    model = model_ref.get("name") if isinstance(model_ref, Mapping) else None
+    if isinstance(model, str):
+        attributes["gen_ai.request.model"] = model
+    response = call.get("response")
+    usage = response.get("usage") if isinstance(response, Mapping) else None
+    if isinstance(usage, Mapping):
+        if (prompt := _token_count(usage, _PROMPT_TOKEN_KEYS)) is not None:
+            attributes["gen_ai.usage.input_tokens"] = prompt
+        if (completion := _token_count(usage, _COMPLETION_TOKEN_KEYS)) is not None:
+            attributes["gen_ai.usage.output_tokens"] = completion
+        details = usage.get("input_tokens_details")
+        if isinstance(details, Mapping) and (cached := _token_count(details, ("cached_tokens",))) is not None:
+            attributes["gen_ai.usage.cache_read.input_tokens"] = cached
+    if isinstance(ttft := call.get("latency_ttft_ms"), (int, float)) and not isinstance(ttft, bool):
+        # No OTLP semantic convention names time-to-first-token on a span, so this stays namespaced
+        # rather than borrowing a metric's name and implying a meaning it does not have.
+        attributes["nemo.gym.latency_ttft_ms"] = float(ttft)
+    span = Span(
+        trace_id=trace_id,
+        span_id=_id_bytes(seed, f"call:{ordinal}", width=_SPAN_ID_BYTES),
+        parent_span_id=parent_id,
+        name="model call",
+        attributes=_attributes(attributes),
+    )
+    if (start := _nanos(call.get("started_at"))) is not None:
+        span.start_time_unix_nano = start
+    if (end := _nanos(call.get("completed_at"))) is not None:
+        span.end_time_unix_nano = end
+    status = call.get("status_code")
+    if isinstance(status, int) and not 200 <= status < 300:
+        span.status.code = Status.STATUS_CODE_ERROR
+        if isinstance(category := call.get("error_category"), str):
+            span.status.message = category
+    return span
+
+
+def _nanos(value: Any) -> int | None:
+    """Convert a capture's epoch-seconds timestamp to the unix nanos OTLP spans carry.
+
+    Scales the whole and fractional parts separately. Multiplying an epoch float by a billion in
+    one step spends the mantissa on the seconds and rounds the nanoseconds: 1788534870.75 comes
+    back as ...750000128.
+    """
+    if not isinstance(value, (int, float)) or isinstance(value, bool) or not isfinite(value) or value <= 0:
+        # ``json.loads`` accepts ``Infinity`` and ``NaN``, and ``int(inf)`` raises OverflowError --
+        # which is neither a TypeError nor a ValueError, so it would escape the caller's guard and
+        # take the whole rollout with it rather than costing this one timestamp.
+        return None
+    seconds = int(value)
+    return seconds * 1_000_000_000 + round((value - seconds) * 1_000_000_000)
+
+
+def _tool_spans(response: Mapping[str, Any], *, trace_id: bytes, parent_id: bytes, seed: str) -> Iterator[Span]:
+    """One TOOL span per function call the model made, paired with its result where recorded."""
+    items = response.get("output")
+    if not isinstance(items, list):
+        return
+    results = {
+        item.get("call_id"): item.get("output")
+        for item in items
+        if isinstance(item, Mapping) and item.get("type") == "function_call_output"
+    }
+    ordinal = 0
+    for item in items:
+        if not isinstance(item, Mapping) or item.get("type") != "function_call":
+            continue
+        name = item.get("name")
+        if not isinstance(name, str) or not name:
+            # A call with no usable name cannot be attributed to a tool, and inventing one would
+            # make a metric asking "was this tool used" answer about a tool that does not exist.
+            continue
+        attributes: dict[str, Any] = {SPAN_KIND_ATTRIBUTE: "TOOL", "tool.name": name}
+        if isinstance(call_id := item.get("call_id"), str):
+            attributes["tool_call.id"] = call_id
+        if isinstance(arguments := item.get("arguments"), str):
+            attributes["input.value"] = arguments
+        if isinstance(result := results.get(item.get("call_id")), str):
+            attributes["output.value"] = result
+        yield Span(
+            trace_id=trace_id,
+            span_id=_id_bytes(seed, f"tool:{ordinal}", width=_SPAN_ID_BYTES),
+            parent_span_id=parent_id,
+            name=name,
+            attributes=_attributes(attributes),
+        )
+        ordinal += 1
+
+
+def response_output_text(response: Mapping[str, Any]) -> str | None:
+    """Return the assistant's text from a Responses API payload, or ``None`` when it has none.
+
+    Prefers the ``output_text`` convenience field, then the text parts of the last message item.
+    A tool call is not an answer, so an output list carrying only calls yields nothing.
+    """
+    if isinstance(text := response.get("output_text"), str) and text:
+        return text
+    items = response.get("output")
+    if not isinstance(items, list):
+        return None
+    for item in reversed(items):
+        if not isinstance(item, Mapping) or item.get("type") not in (None, "message"):
+            continue
+        content = item.get("content")
+        if isinstance(content, str) and content:
+            return content
+        if not isinstance(content, list):
+            continue
+        parts: list[str] = []
+        for part in content:
+            if isinstance(part, Mapping) and isinstance(text := part.get("text"), str) and text:
+                parts.append(text)
+        if parts:
+            return "".join(parts)
+    return None
+
+
+def _request_text(record: Mapping[str, Any]) -> str | None:
+    """Return the prompt the rollout was given, as text."""
+    params = record.get("responses_create_params")
+    if not isinstance(params, Mapping):
+        return None
+    value = params.get("input")
+    if isinstance(value, str):
+        return value or None
+    if value in (None, [], {}):
+        instructions = params.get("instructions")
+        return instructions if isinstance(instructions, str) and instructions else None
+    return json.dumps(value, default=str)
+
+
+def _token_count(usage: Mapping[str, Any], keys: tuple[str, ...]) -> int | None:
+    """Return the first reported count among ``keys``, preserving an explicit zero."""
+    for key in keys:
+        value = usage.get(key)
+        if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+            return value
+    return None
+
+
+def _attributes(values: Mapping[str, Any]) -> list[KeyValue]:
+    """Render a mapping as OTLP attributes, typed by value."""
+    return [KeyValue(key=key, value=_any_value(value)) for key, value in values.items()]
+
+
+def _any_value(value: Any) -> AnyValue:
+    # bool before int: bool is an int subclass, so the reverse order writes True as an int_value.
+    if isinstance(value, bool):
+        return AnyValue(bool_value=value)
+    if isinstance(value, int):
+        return AnyValue(int_value=value)
+    if isinstance(value, float):
+        return AnyValue(double_value=value)
+    return AnyValue(string_value=value if isinstance(value, str) else json.dumps(value, default=str))
+
+
+def _id_bytes(seed: str, role: str, *, width: int) -> bytes:
+    """A stable id of exactly ``width`` bytes for one part of a rollout's trace."""
+    return sha256(f"{seed}/{role}".encode()).digest()[:width]

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/ng_trajectory_otlp/convert.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/ng_trajectory_otlp/convert.py
@@ -211,10 +211,15 @@ def _tool_spans(response: Mapping[str, Any], *, trace_id: bytes, parent_id: byte
     items = response.get("output")
     if not isinstance(items, list):
         return
+    # Keyed on the call id, so an output without a usable one is dropped rather than filed under
+    # ``None``: every such output would share that key, and a call whose own id is missing would
+    # then read the last one back as its result and attribute another tool's output to itself.
     results = {
         item.get("call_id"): item.get("output")
         for item in items
-        if isinstance(item, Mapping) and item.get("type") == "function_call_output"
+        if isinstance(item, Mapping)
+        and item.get("type") == "function_call_output"
+        and isinstance(item.get("call_id"), str)
     }
     ordinal = 0
     for item in items:

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/evidence.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/evidence.py
@@ -19,12 +19,12 @@ from pathlib import Path
 from typing import Any, Literal, TypeAlias, overload
 from urllib.parse import urlparse
 
-from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
+from opentelemetry.proto.trace.v1.trace_pb2 import ResourceSpans
 from pydantic import BaseModel, ConfigDict, Field, JsonValue, PrivateAttr, model_validator
 
 from nemo_evaluator_sdk.values.atif import FinalMetrics, Step, ToolCall, Trajectory
 from nemo_evaluator_sdk.values.otlp import (
-    export_request_from_resource_spans,
+    parse_resource_spans,
     resource_spans_from_request,
     resource_spans_from_text,
     validate_resource_spans,
@@ -375,44 +375,40 @@ class OTLPTraceHandle:
 
     def __init__(self, descriptor: EvidenceDescriptor) -> None:
         self._descriptor = descriptor
-        self._resource_spans: list[dict[str, Any]] | None = None
-        self._export_request: ExportTraceServiceRequest | None = None
+        self._resource_spans: list[ResourceSpans] | None = None
 
-    async def export_request(self) -> ExportTraceServiceRequest:
-        """Return the trace as the typed OTLP request, parsed once.
+    async def resource_spans(self) -> list[ResourceSpans]:
+        """Return the trace as typed OTLP resource spans, read and parsed once.
 
-        Serializing this is what OTLP ingest accepts, so a consumer that publishes and one
-        that reads share a representation instead of re-encoding between two.
-        """
-        if self._export_request is None:
-            resource_spans = await self.resource_spans()
-            self._export_request = await asyncio.to_thread(export_request_from_resource_spans, resource_spans)
-        return self._export_request
+        This is the representation producers and consumers share. A caller sending them to OTLP
+        ingest wraps them in an ``ExportTraceServiceRequest``, which is that RPC's envelope and
+        nothing a reader needs.
 
-    async def resource_spans(self) -> list[dict[str, Any]]:
-        """Return concatenated OTLP ``resourceSpans``, loading and validating once.
-
-        Returns:
-            Resource-span objects in request and file order.
+        Raises:
+            ValueError: The evidence is missing, unreadable, or not valid OTLP.
         """
         if self._resource_spans is None:
-            self._resource_spans = await asyncio.to_thread(self._load_resource_spans)
+            self._resource_spans = await asyncio.to_thread(self._read)
         return self._resource_spans
 
-    def _load_resource_spans(self) -> list[dict[str, Any]]:
-        """Load inline or local OTLP evidence into its resource-span export units.
+    def _read(self) -> list[ResourceSpans]:
+        """Load inline or local OTLP evidence and parse it.
 
-        Returns:
-            Validated resource-span objects from every request.
+        The decoded JSON is a step on the way in, never a representation this hands out: OTLP is
+        a schema, and a reader that has honoured it cannot be handed a dict that has not.
         """
         descriptor = self._descriptor
         if descriptor.data is not None:
-            if isinstance(descriptor.data, list):
-                return validate_resource_spans(descriptor.data)
-            return resource_spans_from_request(descriptor.data)
-        if descriptor.ref is None:
+            payload = (
+                validate_resource_spans(descriptor.data)
+                if isinstance(descriptor.data, list)
+                else resource_spans_from_request(descriptor.data)
+            )
+        elif descriptor.ref is None:
             raise ValueError("trace evidence descriptor requires ref or data")
-        return resource_spans_from_text(_local_filesystem_ref(descriptor.ref).read_text(encoding="utf-8"))
+        else:
+            payload = resource_spans_from_text(_local_filesystem_ref(descriptor.ref).read_text(encoding="utf-8"))
+        return parse_resource_spans(payload)
 
 
 class ATIFTraceHandle:

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/otlp.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/otlp.py
@@ -18,7 +18,8 @@ from typing import Any, TypeAlias, cast
 
 from google.protobuf import json_format
 from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
-from opentelemetry.proto.trace.v1.trace_pb2 import Span, Status
+from opentelemetry.proto.common.v1.common_pb2 import AnyValue
+from opentelemetry.proto.trace.v1.trace_pb2 import ResourceSpans, Span, Status
 
 _MESSAGE_ATTRIBUTE_KEY = "gen_ai.output.messages"
 _SPAN_KIND_ATTRIBUTE = "openinference.span.kind"
@@ -123,32 +124,36 @@ def resource_spans_from_text(raw: str) -> list[dict[str, Any]]:
     return resource_spans
 
 
-def export_request_from_resource_spans(resource_spans: list[dict[str, Any]]) -> ExportTraceServiceRequest:
-    """Parse OTLP/JSON resource spans into one export request.
+def parse_resource_spans(resource_spans: list[dict[str, Any]]) -> list[ResourceSpans]:
+    """Parse OTLP/JSON resource spans into their protobuf messages.
+
+    Returns the spans themselves rather than an ``ExportTraceServiceRequest``: that is the envelope
+    of OTLP's Export RPC, and only a caller actually sending them over a wire needs one.
 
     Args:
         resource_spans: Decoded OTLP/JSON ``resourceSpans`` objects.
 
     Returns:
-        Every span in a single request, ready to serialize for OTLP ingest.
+        The parsed resource spans, in the order given.
 
     Raises:
         ValueError: The payload does not match the OTLP schema.
     """
     try:
-        return json_format.ParseDict(
+        request = json_format.ParseDict(
             {"resourceSpans": [_base64_ids(resource_span) for resource_span in resource_spans]},
             ExportTraceServiceRequest(),
             # A producer on a newer OTLP schema stays readable rather than failing wholesale.
             ignore_unknown_fields=True,
         )
+        return list(request.resource_spans)
     except json_format.ParseError as error:
         raise ValueError(f"invalid OTLP payload: {error}") from error
     except RecursionError as error:
         raise ValueError("OTLP payload is nested too deeply to convert") from error
 
 
-def final_output_text(request: ExportTraceServiceRequest) -> str | None:
+def final_output_text(resource_spans: list[ResourceSpans]) -> str | None:
     """Return the agent's final answer from an OTLP trace.
 
     A root span represents the run as a whole, so its output is the answer when it has one.
@@ -157,14 +162,12 @@ def final_output_text(request: ExportTraceServiceRequest) -> str | None:
     trace of nothing but tool calls has no answer rather than a misattributed one.
 
     Args:
-        request: Parsed OTLP export request.
+        resource_spans: Parsed OTLP resource spans.
 
     Returns:
         The answer text, or ``None`` when no span carries one.
     """
-    spans = [
-        span for rs in request.resource_spans for ss in rs.scope_spans for span in ss.spans if _is_answer_span(span)
-    ]
+    spans = [span for rs in resource_spans for ss in rs.scope_spans for span in ss.spans if _is_answer_span(span)]
     by_recency = sorted(spans, key=lambda span: span.end_time_unix_nano, reverse=True)
     roots = [span for span in by_recency if not span.parent_span_id]
     for span in roots + by_recency:
@@ -231,25 +234,23 @@ def _assistant_text(raw: str) -> str | None:
     return None
 
 
-def span_text_strings(resource_spans: list[dict[str, Any]]) -> Iterator[str]:
+def span_text_strings(resource_spans: list[ResourceSpans]) -> Iterator[str]:
     """Yield every string carried by the spans' and span events' attributes.
 
-    Reads decoded OTLP/JSON rather than the parsed protobuf: a caller searching for text
-    needs the strings a trace does carry, and one span with a malformed unrelated field
-    should not hide every other span's attributes behind a parse failure.
-
     Args:
-        resource_spans: Decoded OTLP/JSON ``resourceSpans`` objects.
+        resource_spans: Parsed OTLP resource spans.
 
     Yields:
         String leaves, including those nested in array and key-value attribute values.
     """
     for resource_span in resource_spans:
-        for scope_span in _objects(resource_span.get("scopeSpans")):
-            for span in _objects(scope_span.get("spans")):
-                yield from _attribute_strings(span.get("attributes"))
-                for event in _objects(span.get("events")):
-                    yield from _attribute_strings(event.get("attributes"))
+        for scope_span in resource_span.scope_spans:
+            for span in scope_span.spans:
+                for attribute in span.attributes:
+                    yield from _any_value_strings(attribute.value)
+                for event in span.events:
+                    for attribute in event.attributes:
+                        yield from _any_value_strings(attribute.value)
 
 
 def _objects(value: Any) -> list[dict[str, Any]]:
@@ -259,29 +260,22 @@ def _objects(value: Any) -> list[dict[str, Any]]:
     return [cast(dict[str, Any], item) for item in value if isinstance(item, dict)]
 
 
-def _attribute_strings(attributes: Any) -> Iterator[str]:
-    """Yield the string leaves of a decoded OTLP attribute list."""
-    for attribute in _objects(attributes):
-        yield from _any_value_strings(attribute.get("value"))
+def _any_value_strings(value: AnyValue) -> Iterator[str]:
+    """Yield the string leaves of one ``AnyValue``, in no particular order.
 
-
-def _any_value_strings(value: Any) -> Iterator[str]:
-    """Yield the string leaves of one decoded OTLP ``AnyValue``, in no particular order.
-
-    An ``AnyValue`` nests without limit, so this walks an explicit stack rather than
-    recursing: a producer's nesting depth must not become this process's recursion limit.
+    Walks an explicit stack rather than recursing, so nesting depth is bounded by what the
+    protobuf parser already accepted rather than by this process's recursion limit.
     """
     pending = [value]
     while pending:
         current = pending.pop()
-        if not isinstance(current, dict):
-            continue
-        if isinstance(text := current.get("stringValue"), str):
-            yield text
-        elif isinstance(array := current.get("arrayValue"), dict):
-            pending.extend(_objects(array.get("values")))
-        elif isinstance(kvlist := current.get("kvlistValue"), dict):
-            pending.extend(item.get("value") for item in _objects(kvlist.get("values")))
+        field = current.WhichOneof("value")
+        if field == "string_value":
+            yield current.string_value
+        elif field == "array_value":
+            pending.extend(current.array_value.values)
+        elif field == "kvlist_value":
+            pending.extend(item.value for item in current.kvlist_value.values)
 
 
 def _loads(text: str) -> Any:
@@ -296,102 +290,6 @@ def _loads(text: str) -> Any:
         raise ValueError("OTLP JSON is nested too deeply to parse") from error
 
 
-def set_span_attributes(request: ExportTraceServiceRequest, attributes: Mapping[str, AttributeValue]) -> None:
-    """Set attributes on every span of a trace, replacing any the producer set.
-
-    Span attributes are written rather than resource attributes because Intake merges the two
-    layers as ``{**resource, **span}``. A producer that publishes one of these keys itself
-    would win from the resource layer and silently redirect whatever the value identifies.
-    """
-    for span in _spans(request):
-        _set_attributes(span, attributes)
-
-
-def set_root_span_attributes(request: ExportTraceServiceRequest, attributes: Mapping[str, AttributeValue]) -> None:
-    """Set attributes on the trace's root span alone, if it has exactly one.
-
-    Totals for a whole run belong on the one span that represents it. Writing them to every
-    span would have any rollup that sums across a trace count them once per span.
-    """
-    root = _root_span(request)
-    if root is not None:
-        _set_attributes(root, attributes)
-
-
-def set_root_span_error(request: ExportTraceServiceRequest, *, message: str | None = None) -> None:
-    """Mark the trace's root span as failed, if it has exactly one.
-
-    Intake reads span status, not attributes, to decide a span failed.
-    """
-    root = _root_span(request)
-    if root is None:
-        return
-    root.status.code = Status.STATUS_CODE_ERROR
-    if message is not None:
-        root.status.message = message
-
-
-def fill_missing_start_times(request: ExportTraceServiceRequest, *, start_time_unix_nano: int) -> None:
-    """Give spans without a start time one, so re-publishing the same trace replaces it.
-
-    Intake stores a span with no start time against its own ingest clock, and start time is
-    part of the key its spans table replaces on — so an absent one makes every publish a new
-    row rather than a replacement of the last.
-    """
-    for span in _spans(request):
-        if not span.start_time_unix_nano:
-            span.start_time_unix_nano = start_time_unix_nano
-
-
-def _root_span(request: ExportTraceServiceRequest) -> Span | None:
-    """The single parentless span of a trace, or ``None`` when there is not exactly one."""
-    roots = [span for span in _spans(request) if not span.parent_span_id]
-    return roots[0] if len(roots) == 1 else None
-
-
-def _spans(request: ExportTraceServiceRequest) -> Iterator[Span]:
-    """Yield every span in the request, in resource and scope order."""
-    for resource_span in request.resource_spans:
-        for scope_span in resource_span.scope_spans:
-            yield from scope_span.spans
-
-
-def _set_attributes(span: Span, attributes: Mapping[str, AttributeValue]) -> None:
-    """Write attributes onto one span, replacing keys it already carries."""
-    existing = {attribute.key: attribute for attribute in span.attributes}
-    for key, value in attributes.items():
-        attribute = existing.get(key)
-        if attribute is None:
-            attribute = span.attributes.add()
-            attribute.key = key
-        if isinstance(value, bool):
-            attribute.value.bool_value = value
-        elif isinstance(value, int):
-            attribute.value.int_value = value
-        elif isinstance(value, float):
-            attribute.value.double_value = value
-        else:
-            attribute.value.string_value = value
-
-
-def root_span_id(request: ExportTraceServiceRequest) -> str | None:
-    """Return the hex id of the trace's root span, or ``None`` when it has no single root.
-
-    A trace with several roots has no one span that stands for the whole run, so there is
-    nothing to attach a trial-level score to.
-    """
-    roots = [span for span in _spans(request) if not span.parent_span_id]
-    if len(roots) != 1:
-        return None
-    span_id = bytes(roots[0].span_id)
-    # Intake requires a present, non-zero id and drops the span otherwise, which would leave
-    # anything scored against this id pointing at a span that was never stored.
-    if not any(span_id):
-        return None
-    return span_id.hex()
-
-
-# Byte lengths of the OTLP id fields, which decide whether a string is hex for that field.
 _ID_BYTE_LENGTHS = {"traceId": 16, "spanId": 8, "parentSpanId": 8}
 
 
@@ -423,3 +321,101 @@ def _base64_span_ids(span: dict[str, Any]) -> None:
         except ValueError:
             continue
         span[field] = b64encode(raw).decode("ascii")
+
+
+def set_span_attributes(resource_spans: list[ResourceSpans], attributes: Mapping[str, AttributeValue]) -> None:
+    """Set attributes on every span of a trace, replacing any the producer set.
+
+    Span attributes are written rather than resource attributes because Intake merges the two
+    layers as ``{**resource, **span}``. A producer that publishes one of these keys itself
+    would win from the resource layer and silently redirect whatever the value identifies.
+    """
+    for span in _spans(resource_spans):
+        _set_attributes(span, attributes)
+
+
+def set_root_span_attributes(resource_spans: list[ResourceSpans], attributes: Mapping[str, AttributeValue]) -> None:
+    """Set attributes on the trace's root span alone, if it has exactly one.
+
+    Totals for a whole run belong on the one span that represents it. Writing them to every
+    span would have any rollup that sums across a trace count them once per span.
+    """
+    root = _root_span(resource_spans)
+    if root is not None:
+        _set_attributes(root, attributes)
+
+
+def set_root_span_error(resource_spans: list[ResourceSpans], *, message: str | None = None) -> None:
+    """Mark the trace's root span as failed, if it has exactly one.
+
+    Intake reads span status, not attributes, to decide a span failed.
+    """
+    root = _root_span(resource_spans)
+    if root is None:
+        return
+    root.status.code = Status.STATUS_CODE_ERROR
+    if message is not None:
+        root.status.message = message
+
+
+def fill_missing_start_times(resource_spans: list[ResourceSpans], *, start_time_unix_nano: int) -> None:
+    """Give spans without a start time one, so re-publishing the same trace replaces it.
+
+    Intake stores a span with no start time against its own ingest clock, and start time is
+    part of the key its spans table replaces on — so an absent one makes every publish a new
+    row rather than a replacement of the last.
+    """
+    for span in _spans(resource_spans):
+        if not span.start_time_unix_nano:
+            span.start_time_unix_nano = start_time_unix_nano
+
+
+def _root_span(resource_spans: list[ResourceSpans]) -> Span | None:
+    """The single parentless span of a trace, or ``None`` when there is not exactly one."""
+    roots = [span for span in _spans(resource_spans) if not span.parent_span_id]
+    return roots[0] if len(roots) == 1 else None
+
+
+def _spans(resource_spans: list[ResourceSpans]) -> Iterator[Span]:
+    """Yield every span, in resource and scope order."""
+    for resource_span in resource_spans:
+        for scope_span in resource_span.scope_spans:
+            yield from scope_span.spans
+
+
+def _set_attributes(span: Span, attributes: Mapping[str, AttributeValue]) -> None:
+    """Write attributes onto one span, replacing keys it already carries."""
+    existing = {attribute.key: attribute for attribute in span.attributes}
+    for key, value in attributes.items():
+        attribute = existing.get(key)
+        if attribute is None:
+            attribute = span.attributes.add()
+            attribute.key = key
+        if isinstance(value, bool):
+            attribute.value.bool_value = value
+        elif isinstance(value, int):
+            attribute.value.int_value = value
+        elif isinstance(value, float):
+            attribute.value.double_value = value
+        else:
+            attribute.value.string_value = value
+
+
+def root_span_id(resource_spans: list[ResourceSpans]) -> str | None:
+    """Return the hex id of the trace's root span, or ``None`` when it has no single root.
+
+    A trace with several roots has no one span that stands for the whole run, so there is
+    nothing to attach a trial-level score to.
+    """
+    roots = [span for span in _spans(resource_spans) if not span.parent_span_id]
+    if len(roots) != 1:
+        return None
+    span_id = bytes(roots[0].span_id)
+    # Intake requires a present, non-zero id and drops the span otherwise, which would leave
+    # anything scored against this id pointing at a span that was never stored.
+    if not any(span_id):
+        return None
+    return span_id.hex()
+
+
+# Byte lengths of the OTLP id fields, which decide whether a string is hex for that field.

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_evidence.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_evidence.py
@@ -374,15 +374,15 @@ async def test_trace_handle_reads_otlp_jsonl_and_inline_data(tmp_path: Path) -> 
 
     resource_spans = await handle.resource_spans()
     assert len(resource_spans) == 2
-    assert resource_spans[0]["schemaUrl"] == "keep-me"
-    assert resource_spans[1]["scopeSpans"][0]["spans"][0]["name"] == "child"
+    assert resource_spans[0].schema_url == "keep-me"
+    assert resource_spans[1].scope_spans[0].spans[0].name == "child"
 
     inline = CandidateEvidence(
         descriptors={"trace": EvidenceDescriptor(kind="trace", format="otlp", data=[{"scopeSpans": []}])}
     )
     inline_handle = await inline.trace("trace")
     assert isinstance(inline_handle, OTLPTraceHandle)
-    assert await inline_handle.resource_spans() == [{"scopeSpans": []}]
+    assert [rs.scope_spans for rs in await inline_handle.resource_spans()] == [[]]
 
 
 @pytest.mark.asyncio
@@ -398,7 +398,7 @@ async def test_trace_handle_reads_pretty_printed_otlp_object(tmp_path: Path) -> 
 
     handle = await evidence.trace()
     assert isinstance(handle, OTLPTraceHandle)
-    assert await handle.resource_spans() == [{"scopeSpans": []}]
+    assert [rs.scope_spans for rs in await handle.resource_spans()] == [[]]
 
 
 @pytest.mark.asyncio

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_example_metrics.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_example_metrics.py
@@ -154,15 +154,13 @@ async def test_inefficient_retry_loop_reads_time_ordered_otlp_tool_spans() -> No
 
 
 @pytest.mark.asyncio
-async def test_inefficient_retry_loop_ignores_non_tool_and_malformed_otlp_spans() -> None:
+async def test_inefficient_retry_loop_ignores_non_tool_otlp_spans() -> None:
     evidence = _otlp_evidence(
         [
             _otlp_tool_span("search", {"q": "same"}, 10),
             _otlp_tool_span("search", {"q": "same"}, 20, kind="CHAIN"),
-            "not-a-span",
             _otlp_tool_span("search", {"q": "different"}, 30),
-        ],
-        {"scopeSpans": "not-a-list"},
+        ]
     )
 
     result = await example_metrics.InefficientRetryLoopMetric(threshold=1).compute_scores(
@@ -171,6 +169,17 @@ async def test_inefficient_retry_loop_ignores_non_tool_and_malformed_otlp_spans(
 
     assert result.outputs[0].value is True
     assert result.outputs[1].value == 1
+
+
+@pytest.mark.asyncio
+async def test_inefficient_retry_loop_refuses_a_trace_it_cannot_parse() -> None:
+    # Reading the spans as OTLP rather than as loose JSON means a structurally invalid trace stops
+    # the metric instead of being scored around. Retry identity comes from the spans it could not
+    # read, so an answer here would be a guess -- the same stance as the no-arguments case below.
+    evidence = _otlp_evidence([_otlp_tool_span("search", {"q": "same"}, 10)], {"scopeSpans": "not-a-list"})
+
+    with pytest.raises(ValueError, match="invalid OTLP payload"):
+        await example_metrics.InefficientRetryLoopMetric(threshold=1).compute_scores(_input_with_evidence(evidence))
 
 
 @pytest.mark.asyncio

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_gym_runtime.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_gym_runtime.py
@@ -408,6 +408,57 @@ def test_materialize_dataset_reassembles_row_without_storing_params_twice(tmp_pa
     assert {k: v for k, v in row.items() if k != NG_TASK_INDEX} == source
 
 
+@pytest.mark.asyncio
+async def test_a_rollout_carries_an_otlp_trace_the_sdk_can_read(tmp_path: Path) -> None:
+    # Gym records a result, not a trace, so the OTLP view is projected from the record. It earns its
+    # place only if the SDK's own reader accepts it and finds the agent's answer.
+    from nemo_evaluator_sdk.values.evidence import EVIDENCE_FORMAT_OTLP, EVIDENCE_TRACE
+    from nemo_evaluator_sdk.values.otlp import final_output_text
+
+    dataset = tmp_path / "dataset.jsonl"
+    dataset.write_text(json.dumps({"responses_create_params": {"input": "What is 2 + 2?"}}) + "\n", encoding="utf-8")
+    tasks = discover_gym_tasks(dataset)
+    index_map = _materialize_dataset(tasks, tmp_path / "gym_input.jsonl")
+    bundle = tmp_path / "rollouts.jsonl"
+    bundle.write_text(
+        json.dumps(
+            {
+                NG_TASK_INDEX: 0,
+                NG_ROLLOUT_INDEX: 0,
+                "reward": 1.0,
+                "responses_create_params": {"input": "What is 2 + 2?"},
+                "response": {
+                    "usage": {"input_tokens": 12, "output_tokens": 3},
+                    "output": [
+                        {"type": "function_call", "call_id": "c1", "name": "calculator", "arguments": "{}"},
+                        {"type": "function_call_output", "call_id": "c1", "output": "4"},
+                        {"type": "message", "content": [{"type": "output_text", "text": "The answer is 4."}]},
+                    ],
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    trial = _trials_from_rollouts(bundle, tasks, index_map)[0]
+
+    assert trial.evidence is not None
+    handle = await trial.evidence.trace(EVIDENCE_TRACE, format=EVIDENCE_FORMAT_OTLP)
+    resource_spans = await handle.resource_spans()
+    # The agent's answer, not the tool's "4": only AGENT/CHAIN/LLM spans are eligible.
+    assert final_output_text(resource_spans) == "The answer is 4."
+    kinds = [
+        attribute.value.string_value
+        for resource_span in resource_spans
+        for scope_spans in resource_span.scope_spans
+        for span in scope_spans.spans
+        for attribute in span.attributes
+        if attribute.key == "openinference.span.kind"
+    ]
+    assert kinds == ["AGENT", "LLM", "TOOL"]
+
+
 def test_success_records_without_rollout_index_get_distinct_ids(tmp_path: Path) -> None:
     # Mirror of the failure-path guard: two successful attempts for one task lacking _ng_rollout_index
     # must not collapse to a single trial id.
@@ -422,6 +473,35 @@ def test_success_records_without_rollout_index_get_distinct_ids(tmp_path: Path) 
     assert len(trials) == 2
     assert len({trial.id for trial in trials}) == 2  # distinct ids despite missing rollout index
     assert all(trial.task_id == ordered[0] for trial in trials)
+
+
+@pytest.mark.asyncio
+async def test_indexless_rollouts_of_one_task_get_distinct_trace_ids(tmp_path: Path) -> None:
+    # Span identity is derived, and Intake's spans table replaces on it, so two attempts sharing
+    # an id would store only the last. Gym does not always record _ng_rollout_index, which leaves
+    # the trial id to carry the distinction.
+    tasks = discover_gym_tasks(EXAMPLE)
+    _, index_map = _index_map(tasks, tmp_path)
+    bundle = tmp_path / "rollouts.jsonl"
+    bundle.write_text(
+        json.dumps({NG_TASK_INDEX: 0, "reward": 1.0, "response": "first"})
+        + "\n"
+        + json.dumps({NG_TASK_INDEX: 0, "reward": 0.0, "response": "second"})
+        + "\n",
+        encoding="utf-8",
+    )
+
+    trials = _trials_from_rollouts(bundle, tasks, index_map)
+
+    roots = []
+    for trial in trials:
+        assert trial.evidence is not None
+        spans = await (await trial.evidence.trace("trace", format="otlp")).resource_spans()
+        roots.append(spans[0].scope_spans[0].spans[0])
+
+    assert len(roots) == 2
+    assert len({root.trace_id for root in roots}) == 2
+    assert len({root.span_id for root in roots}) == 2
 
 
 def test_indexless_failures_get_distinct_trial_ids(tmp_path: Path) -> None:

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_gym_runtime.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_gym_runtime.py
@@ -41,7 +41,7 @@ from nemo_evaluator_sdk.agent_eval.runtimes.gym.process import (
     _pending_servers,
     _pump_stream,
 )
-from nemo_evaluator_sdk.agent_eval.runtimes.gym.records import NG_ROLLOUT_INDEX, NG_TASK_INDEX
+from nemo_evaluator_sdk.agent_eval.runtimes.gym.records import NG_ATTEMPT_INDEX, NG_ROLLOUT_INDEX, NG_TASK_INDEX
 from nemo_evaluator_sdk.agent_eval.runtimes.gym.results import (
     _INPUT_TOKEN_KEYS,
     _TOKEN_USAGE_KEYS,
@@ -502,6 +502,61 @@ async def test_indexless_rollouts_of_one_task_get_distinct_trace_ids(tmp_path: P
     assert len(roots) == 2
     assert len({root.trace_id for root in roots}) == 2
     assert len({root.span_id for root in roots}) == 2
+
+
+@pytest.mark.asyncio
+async def test_retried_rollout_gets_ids_distinct_from_its_first_attempt(tmp_path: Path) -> None:
+    # A retry reuses its task and rollout indices, so only _ng_attempt_index separates it from the
+    # attempt it replaced. Without it both land on one trial id — and since trace and span ids are
+    # derived from that id, Intake's replace-on-identity would keep only the last attempt's evidence.
+    tasks = discover_gym_tasks(EXAMPLE)
+    _, index_map = _index_map(tasks, tmp_path)
+    bundle = tmp_path / "rollouts.jsonl"
+    bundle.write_text(
+        json.dumps({NG_TASK_INDEX: 0, NG_ROLLOUT_INDEX: 0, NG_ATTEMPT_INDEX: 0, "reward": 0.0, "response": "first"})
+        + "\n"
+        + json.dumps({NG_TASK_INDEX: 0, NG_ROLLOUT_INDEX: 0, NG_ATTEMPT_INDEX: 1, "reward": 1.0, "response": "retry"})
+        + "\n",
+        encoding="utf-8",
+    )
+
+    trials = _trials_from_rollouts(bundle, tasks, index_map)
+
+    assert len(trials) == 2
+    assert len({trial.id for trial in trials}) == 2
+    # The suffix rule matches _capture_path, so the trial id and the capture key agree on the attempt.
+    assert sorted(trial.id for trial in trials) == sorted([f"{trials[0].task_id}:0", f"{trials[0].task_id}:0-a1"])
+
+    roots = []
+    for trial in trials:
+        assert trial.evidence is not None
+        spans = await (await trial.evidence.trace("trace", format="otlp")).resource_spans()
+        roots.append(spans[0].scope_spans[0].spans[0])
+    assert len({root.trace_id for root in roots}) == 2
+    assert len({root.span_id for root in roots}) == 2
+
+
+def test_retry_in_rollouts_does_not_collide_with_its_failed_attempt(tmp_path: Path) -> None:
+    # The two loops share an id space: Gym writes the abandoned attempt to the failures sidecar and
+    # the retry to rollouts, both under the same task and rollout indices.
+    tasks = discover_gym_tasks(EXAMPLE)
+    ordered, index_map = _index_map(tasks, tmp_path)
+    bundle = tmp_path / "rollouts.jsonl"
+    bundle.write_text(
+        json.dumps({NG_TASK_INDEX: 0, NG_ROLLOUT_INDEX: 0, NG_ATTEMPT_INDEX: 1, "reward": 1.0}) + "\n",
+        encoding="utf-8",
+    )
+    failures = tmp_path / "rollouts_failures.jsonl"
+    failures.write_text(
+        json.dumps({NG_TASK_INDEX: 0, NG_ROLLOUT_INDEX: 0, NG_ATTEMPT_INDEX: 0, "error": "boom"}) + "\n",
+        encoding="utf-8",
+    )
+
+    trials = _trials_from_rollouts(bundle, tasks, index_map)
+
+    assert len(trials) == 2
+    assert len({trial.id for trial in trials}) == 2
+    assert all(trial.task_id == ordered[0] for trial in trials)
 
 
 def test_indexless_failures_get_distinct_trial_ids(tmp_path: Path) -> None:

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_skill_used_metric.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_skill_used_metric.py
@@ -225,9 +225,10 @@ async def test_empty_skills_list_scores_not_present() -> None:
 
 
 @pytest.mark.asyncio
-async def test_a_malformed_unrelated_span_field_does_not_hide_the_skill() -> None:
-    # A false negative here corrupts a skill A/B result, so the search reads the strings a
-    # trace does carry rather than requiring every unrelated field to parse.
+async def test_a_trace_that_will_not_parse_scores_false_rather_than_guessing() -> None:
+    # Read as OTLP like every other reader, so a malformed field refuses the trace rather than
+    # being worked around. `_any_skill_used` then tries the ATIF view and, finding none, logs
+    # which formats failed before scoring False -- a loud miss rather than a silent one.
     sample = {
         "skills": [_PROV],
         "evidence": CandidateEvidence(
@@ -261,4 +262,4 @@ async def test_a_malformed_unrelated_span_field_does_not_hide_the_skill() -> Non
         ),
     }
 
-    assert await _score(sample) == {"skill_present": True, "skill_used": True}
+    assert await _score(sample) == {"skill_present": True, "skill_used": False}

--- a/packages/nemo_evaluator_sdk/tests/ng_trajectory_otlp/test_convert.py
+++ b/packages/nemo_evaluator_sdk/tests/ng_trajectory_otlp/test_convert.py
@@ -1,0 +1,229 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the Gym rollout -> OTLP/JSON projection.
+
+Imports nothing from the SDK but the subpackage under test, which is what keeps it liftable.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from nemo_evaluator_sdk.ng_trajectory_otlp import rollout_to_resource_spans
+from opentelemetry.proto.trace.v1.trace_pb2 import Span, Status
+
+
+def _spans(record: dict[str, Any], *, rollout_id: str = "trial-1", **kwargs: Any) -> list[Span]:
+    resource_spans = rollout_to_resource_spans(record, rollout_id=rollout_id, **kwargs)
+    return list(resource_spans[0].scope_spans[0].spans)
+
+
+def _attributes(span: Span) -> dict[str, Any]:
+    """Attribute values unwrapped from their ``AnyValue`` oneof, so a test reads what was written."""
+    values: dict[str, Any] = {}
+    for attribute in span.attributes:
+        # None only for an AnyValue with nothing set, which nothing here writes.
+        field = attribute.value.WhichOneof("value")
+        assert field is not None, f"{attribute.key} carries no value"
+        values[attribute.key] = getattr(attribute.value, field)
+    return values
+
+
+def _kind(span: Span) -> str:
+    return _attributes(span)["openinference.span.kind"]
+
+
+def _message(text: str) -> dict[str, Any]:
+    return {"type": "message", "content": [{"type": "output_text", "text": text}]}
+
+
+def test_a_rollout_becomes_an_agent_root_with_a_model_call_beneath_it() -> None:
+    spans = _spans({"response": {"output_text": "hi"}}, task_id="task-1")
+
+    assert [_kind(span) for span in spans] == ["AGENT", "LLM"]
+    assert spans[0].name == "task-1"
+    assert spans[0].parent_span_id == b""
+    assert spans[1].parent_span_id == spans[0].span_id
+    assert {span.trace_id for span in spans} == {spans[0].trace_id}
+
+
+def test_the_root_carries_the_answer_a_content_metric_scores() -> None:
+    spans = _spans({"response": {"output": [_message("The answer is 4.")]}})
+
+    assert _attributes(spans[0])["output.value"] == "The answer is 4."
+
+
+def test_an_output_of_only_tool_calls_is_not_an_answer() -> None:
+    # A tool result is not the agent's answer; claiming otherwise would score the tool's output.
+    record = {
+        "response": {
+            "output": [
+                {"type": "function_call", "call_id": "c1", "name": "search", "arguments": "{}"},
+                {"type": "function_call_output", "call_id": "c1", "output": "42"},
+            ]
+        }
+    }
+
+    assert "output.value" not in _attributes(_spans(record)[0])
+
+
+def test_a_function_call_becomes_a_tool_span_paired_with_its_result() -> None:
+    record = {
+        "response": {
+            "output": [
+                {"type": "function_call", "call_id": "c1", "name": "search", "arguments": '{"q":"otlp"}'},
+                {"type": "function_call_output", "call_id": "c1", "output": "found"},
+                _message("done"),
+            ]
+        }
+    }
+
+    tool = next(span for span in _spans(record) if _kind(span) == "TOOL")
+
+    assert tool.name == "search"
+    assert _attributes(tool) == {
+        "openinference.span.kind": "TOOL",
+        "tool.name": "search",
+        "tool_call.id": "c1",
+        "input.value": '{"q":"otlp"}',
+        "output.value": "found",
+    }
+
+
+def test_a_function_call_without_a_name_is_dropped_rather_than_named_for_us() -> None:
+    record = {"response": {"output": [{"type": "function_call", "call_id": "c1", "arguments": "{}"}]}}
+
+    assert [_kind(span) for span in _spans(record)] == ["AGENT", "LLM"]
+
+
+@pytest.mark.parametrize(
+    ("usage", "expected"),
+    [
+        ({"input_tokens": 12, "output_tokens": 3}, (12, 3)),
+        ({"prompt_tokens": 12, "completion_tokens": 3}, (12, 3)),
+        ({"input_tokens": 0, "output_tokens": 0}, (0, 0)),
+    ],
+)
+def test_token_usage_is_read_in_either_vocabulary(usage: dict[str, Any], expected: tuple[int, int]) -> None:
+    # Gym's model servers speak the Responses API's names or Chat Completions', by adapter.
+    llm = _spans({"response": {"usage": usage}})[1]
+    attributes = _attributes(llm)
+
+    assert (int(attributes["gen_ai.usage.input_tokens"]), int(attributes["gen_ai.usage.output_tokens"])) == expected
+
+
+def test_absent_usage_is_left_unreported_rather_than_called_zero() -> None:
+    attributes = _attributes(_spans({"response": {}})[1])
+
+    assert "gen_ai.usage.input_tokens" not in attributes
+    assert "gen_ai.usage.output_tokens" not in attributes
+
+
+@pytest.mark.parametrize(
+    ("value", "expected_field"),
+    [(0.5, "double_value"), (1, "int_value"), (True, "bool_value")],
+)
+def test_an_attribute_lands_in_the_any_value_field_matching_its_type(value: Any, expected_field: str) -> None:
+    # bool is an int subclass, so an ordering slip would write True into int_value.
+    spans = _spans({"reward": value, "response": {}})
+    reward = next((attribute for attribute in spans[0].attributes if attribute.key == "nemo.gym.reward"), None)
+
+    if isinstance(value, bool):
+        # A reward is a measurement, not a flag: a bool is refused rather than coerced to 1.
+        assert reward is None
+    else:
+        assert reward is not None
+        assert reward.value.WhichOneof("value") == expected_field
+
+
+def test_ids_are_stable_across_conversions_and_distinct_across_rollouts() -> None:
+    # Re-publishing a trial must replace its spans, which needs the ids to be a function of the
+    # rollout rather than of when it was converted -- and two rollouts must never share them, or
+    # a consumer keyed on span identity stores only the last.
+    first = _spans({"response": {}}, rollout_id="task-1:0", task_id="task-1")
+    again = _spans({"response": {}}, rollout_id="task-1:0", task_id="task-1")
+    retry = _spans({"response": {}}, rollout_id="task-1:1", task_id="task-1")
+
+    assert [span.span_id for span in first] == [span.span_id for span in again]
+    assert first[0].trace_id != retry[0].trace_id
+    assert {span.span_id for span in first}.isdisjoint({span.span_id for span in retry})
+
+
+def test_an_answer_recorded_as_a_bare_string_is_still_the_answer() -> None:
+    # Not every Gym adapter writes the Responses API payload; some record the answer directly.
+    spans = _spans({"response": "Lyon"})
+
+    assert _attributes(spans[0])["output.value"] == "Lyon"
+
+
+def _capture(**overrides: Any) -> dict[str, Any]:
+    call = {
+        "model_call_id": "c0",
+        "model_ref": {"type": "responses_api_models", "name": "policy_model"},
+        "status_code": 200,
+        "started_at": 1788534870.5,
+        "completed_at": 1788534870.75,
+        "latency_ttft_ms": 12.5,
+        "response": {"usage": {"input_tokens": 5, "output_tokens": 2, "input_tokens_details": {"cached_tokens": 3}}},
+    }
+    return {**call, **overrides}
+
+
+def test_each_captured_model_call_becomes_its_own_timed_span() -> None:
+    # The rollout record reports one usage block summed over the turn, so per-call tokens and
+    # timing exist in the capture or nowhere.
+    spans = _spans({"response": {}}, model_calls=[_capture(), _capture(model_call_id="c1")])
+
+    llm = [span for span in spans if _kind(span) == "LLM"]
+    assert len(llm) == 2
+    assert llm[0].start_time_unix_nano == 1788534870_500_000_000
+    assert llm[0].end_time_unix_nano == 1788534870_750_000_000
+    assert llm[0].span_id != llm[1].span_id
+
+
+def test_a_captured_call_reports_its_own_tokens_including_the_cached_ones() -> None:
+    attributes = _attributes(
+        [span for span in _spans({"response": {}}, model_calls=[_capture()]) if _kind(span) == "LLM"][0]
+    )
+
+    assert attributes["gen_ai.usage.input_tokens"] == 5
+    assert attributes["gen_ai.usage.output_tokens"] == 2
+    assert attributes["gen_ai.usage.cache_read.input_tokens"] == 3
+    assert attributes["nemo.gym.latency_ttft_ms"] == pytest.approx(12.5)
+
+
+def test_a_failed_model_call_marks_its_span_an_error() -> None:
+    span = [
+        s
+        for s in _spans({"response": {}}, model_calls=[_capture(status_code=503, error_category="upstream")])
+        if _kind(s) == "LLM"
+    ][0]
+
+    assert span.status.code == Status.STATUS_CODE_ERROR
+    assert span.status.message == "upstream"
+
+
+def test_without_a_capture_the_rollout_still_yields_one_untimed_model_call() -> None:
+    # Observability is what produces captures; a run without it must still yield a usable trace.
+    llm = [
+        span
+        for span in _spans({"response": {"usage": {"input_tokens": 9, "output_tokens": 1}}})
+        if _kind(span) == "LLM"
+    ]
+
+    assert len(llm) == 1
+    assert llm[0].start_time_unix_nano == 0
+    assert _attributes(llm[0])["gen_ai.usage.input_tokens"] == 9
+
+
+@pytest.mark.parametrize("timestamp", [float("inf"), float("-inf"), float("nan")])
+def test_a_non_finite_capture_timestamp_costs_the_timestamp_not_the_trace(timestamp: float) -> None:
+    # json.loads accepts Infinity and NaN, and int(inf) raises OverflowError -- which the caller's
+    # (TypeError, ValueError) guard does not catch, so it would abort collecting the whole rollout.
+    spans = _spans({"response": {}}, model_calls=[_capture(started_at=timestamp, completed_at=timestamp)])
+
+    llm = [span for span in spans if _kind(span) == "LLM"]
+    assert len(llm) == 1
+    assert llm[0].start_time_unix_nano == 0

--- a/packages/nemo_evaluator_sdk/tests/ng_trajectory_otlp/test_convert.py
+++ b/packages/nemo_evaluator_sdk/tests/ng_trajectory_otlp/test_convert.py
@@ -92,6 +92,41 @@ def test_a_function_call_becomes_a_tool_span_paired_with_its_result() -> None:
     }
 
 
+def test_a_call_without_an_id_does_not_inherit_an_unkeyed_output() -> None:
+    # Results are joined by call id. An output missing one used to be filed under ``None``, which a
+    # call also missing one would then read back — reporting another tool's output as its own.
+    record = {
+        "response": {
+            "output": [
+                {"type": "function_call", "name": "search", "arguments": "{}"},
+                {"type": "function_call_output", "output": "someone else's result"},
+            ]
+        }
+    }
+
+    tool = next(span for span in _spans(record) if _kind(span) == "TOOL")
+
+    assert "output.value" not in _attributes(tool)
+    assert "tool_call.id" not in _attributes(tool)
+
+
+def test_a_non_string_call_id_is_not_used_as_a_join_key() -> None:
+    # The id attribute is already guarded on ``str``; the join has to agree, or a call keeps an
+    # id too malformed to report while still using it to claim a result.
+    record = {
+        "response": {
+            "output": [
+                {"type": "function_call", "call_id": 7, "name": "search", "arguments": "{}"},
+                {"type": "function_call_output", "call_id": 7, "output": "found"},
+            ]
+        }
+    }
+
+    tool = next(span for span in _spans(record) if _kind(span) == "TOOL")
+
+    assert "output.value" not in _attributes(tool)
+
+
 def test_a_function_call_without_a_name_is_dropped_rather_than_named_for_us() -> None:
     record = {"response": {"output": [{"type": "function_call", "call_id": "c1", "arguments": "{}"}]}}
 
@@ -227,3 +262,41 @@ def test_a_non_finite_capture_timestamp_costs_the_timestamp_not_the_trace(timest
     llm = [span for span in spans if _kind(span) == "LLM"]
     assert len(llm) == 1
     assert llm[0].start_time_unix_nano == 0
+
+
+def test_a_message_whose_content_is_plain_text_is_still_the_answer() -> None:
+    # The Responses API allows content to be a bare string rather than a list of parts.
+    spans = _spans({"response": {"output": [{"type": "message", "content": "Four."}]}})
+
+    assert _attributes(spans[0])["output.value"] == "Four."
+
+
+def test_an_answer_is_taken_from_the_last_message_that_has_one() -> None:
+    # A trailing item with unusable content must not mask an earlier real answer.
+    record = {"response": {"output": [_message("Four."), {"type": "message", "content": {"unusable": True}}]}}
+
+    assert _attributes(_spans(record)[0])["output.value"] == "Four."
+
+
+def test_a_prompt_falls_back_to_instructions_when_input_is_empty() -> None:
+    # Gym rollouts that carry only a system prompt leave `input` empty rather than absent.
+    record = {"responses_create_params": {"input": [], "instructions": "Answer briefly."}, "response": {}}
+
+    assert _attributes(_spans(record)[0])["input.value"] == "Answer briefly."
+
+
+def test_a_capture_reporting_no_usable_token_counts_omits_them() -> None:
+    # An absent count and a zero count are different claims; only the zero should reach the span.
+    spans = _spans({"response": {}}, model_calls=[_capture(response={"usage": {"something_else": 3}})])
+
+    attributes = _attributes([span for span in spans if _kind(span) == "LLM"][0])
+    assert "gen_ai.usage.input_tokens" not in attributes
+    assert "gen_ai.usage.output_tokens" not in attributes
+
+
+def test_the_answer_is_the_agent_s_last_message_not_its_first() -> None:
+    # A multi-turn rollout ends with the answer; taking the first message would score the agent's
+    # opening move, which is often a plan or a restatement of the question.
+    record = {"response": {"output": [_message("Let me check."), _message("Four.")]}}
+
+    assert _attributes(_spans(record)[0])["output.value"] == "Four."

--- a/packages/nemo_evaluator_sdk/tests/values/test_otlp.py
+++ b/packages/nemo_evaluator_sdk/tests/values/test_otlp.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+from base64 import b64decode
 from typing import Any
 
 import pytest
@@ -384,3 +385,30 @@ def test_each_attribute_value_type_maps_to_its_any_value_field() -> None:
     assert values["f"].double_value == pytest.approx(1.5)
     assert values["b"].bool_value is True
     assert values["b"].WhichOneof("value") == "bool_value"
+
+
+def test_a_payload_nested_past_the_parser_s_limit_is_rejected_as_a_value_error() -> None:
+    # protobuf guards against deeply nested messages by raising RecursionError, which is neither a
+    # ParseError nor a ValueError -- so without its own except it escapes every caller's guard and
+    # takes down a run over one unreadable trace.
+    value: dict[str, Any] = {"stringValue": "deep"}
+    for _ in range(200):
+        value = {"kvlistValue": {"values": [{"key": "k", "value": value}]}}
+    span = {
+        "traceId": _HEX_TRACE_ID,
+        "spanId": _HEX_SPAN_ID,
+        "name": "root",
+        "attributes": [{"key": "a", "value": value}],
+    }
+
+    with pytest.raises(ValueError, match="nested too deeply"):
+        _parsed(span)
+
+
+def test_an_id_field_of_the_right_length_but_not_hex_is_left_alone() -> None:
+    # Length alone does not make a string hex. Converting on length would corrupt an id already in
+    # another encoding, so a non-hex string is passed through for the parser to interpret itself --
+    # here as the base64 it also happens to be.
+    parsed = _parsed({"traceId": "z" * 32, "spanId": _HEX_SPAN_ID, "name": "root"})
+
+    assert parsed[0].scope_spans[0].spans[0].trace_id == b64decode("z" * 32)

--- a/packages/nemo_evaluator_sdk/tests/values/test_otlp.py
+++ b/packages/nemo_evaluator_sdk/tests/values/test_otlp.py
@@ -6,8 +6,8 @@ from typing import Any
 
 import pytest
 from nemo_evaluator_sdk.values.otlp import (
-    export_request_from_resource_spans,
     final_output_text,
+    parse_resource_spans,
     resource_spans_from_text,
     root_span_id,
     set_span_attributes,
@@ -35,7 +35,7 @@ def _span(
 
 
 def _answer(*spans: dict[str, Any]) -> str | None:
-    return final_output_text(export_request_from_resource_spans([{"scopeSpans": [{"spans": list(spans)}]}]))
+    return final_output_text(parse_resource_spans([{"scopeSpans": [{"spans": list(spans)}]}]))
 
 
 def _messages(text: str) -> str:
@@ -151,7 +151,7 @@ def test_a_request_without_resource_spans_is_rejected() -> None:
 
 def test_a_payload_that_is_not_otlp_is_rejected_as_a_value_error() -> None:
     with pytest.raises(ValueError, match="invalid OTLP payload"):
-        export_request_from_resource_spans([{"scopeSpans": "not-a-list"}])
+        parse_resource_spans([{"scopeSpans": "not-a-list"}])
 
 
 def test_a_non_string_output_attribute_is_skipped_rather_than_coerced() -> None:
@@ -163,7 +163,7 @@ def test_a_non_string_output_attribute_is_skipped_rather_than_coerced() -> None:
         "attributes": [{"key": "output.value", "value": {"intValue": "7"}}],
     }
 
-    assert final_output_text(export_request_from_resource_spans([{"scopeSpans": [{"spans": [span]}]}])) is None
+    assert final_output_text(parse_resource_spans([{"scopeSpans": [{"spans": [span]}]}])) is None
 
 
 def test_the_root_of_each_trace_is_considered_when_a_file_holds_several() -> None:
@@ -232,7 +232,7 @@ def test_span_text_strings_reaches_every_nesting_the_attribute_schema_allows() -
         }
     ]
 
-    assert sorted(span_text_strings(resource_spans)) == [
+    assert sorted(span_text_strings(parse_resource_spans(resource_spans))) == [
         "in-array",
         "in-kvlist-array",
         "on-event",
@@ -240,17 +240,12 @@ def test_span_text_strings_reaches_every_nesting_the_attribute_schema_allows() -
     ]
 
 
-def test_span_text_strings_tolerates_malformed_containers() -> None:
-    assert list(span_text_strings([{"scopeSpans": "not-a-list"}])) == []
-    assert list(span_text_strings([{"scopeSpans": [{"spans": [{"attributes": "nope"}]}]}])) == []
-
-
 _HEX_TRACE_ID = "0123456789abcdef0123456789abcdef"
 _HEX_SPAN_ID = "0102030405060708"
 
 
 def _parsed(*spans: dict[str, Any]):
-    return export_request_from_resource_spans([{"scopeSpans": [{"spans": list(spans)}]}])
+    return parse_resource_spans([{"scopeSpans": [{"spans": list(spans)}]}])
 
 
 def test_otlp_json_hex_ids_survive_the_protobuf_parse() -> None:
@@ -258,7 +253,7 @@ def test_otlp_json_hex_ids_survive_the_protobuf_parse() -> None:
     # implements; read as base64 a 16-character span id becomes twelve unrelated bytes.
     span = _parsed({"traceId": _HEX_TRACE_ID, "spanId": _HEX_SPAN_ID, "name": "root"})
 
-    parsed = span.resource_spans[0].scope_spans[0].spans[0]
+    parsed = span[0].scope_spans[0].spans[0]
     assert parsed.trace_id.hex() == _HEX_TRACE_ID
     assert parsed.span_id.hex() == _HEX_SPAN_ID
 
@@ -272,7 +267,7 @@ def test_parent_and_link_ids_are_decoded_the_same_way() -> None:
         "links": [{"traceId": _HEX_TRACE_ID, "spanId": _HEX_SPAN_ID}],
     }
 
-    parsed = _parsed(child).resource_spans[0].scope_spans[0].spans[0]
+    parsed = _parsed(child)[0].scope_spans[0].spans[0]
 
     assert parsed.parent_span_id.hex() == _HEX_SPAN_ID
     assert parsed.links[0].span_id.hex() == _HEX_SPAN_ID
@@ -283,39 +278,15 @@ def test_a_base64_id_is_left_alone() -> None:
     # protobuf encoding is not corrupted.
     parsed = _parsed({"traceId": _HEX_TRACE_ID, "spanId": "AQIDBAUGBwg=", "name": "root"})
 
-    assert parsed.resource_spans[0].scope_spans[0].spans[0].span_id.hex() == _HEX_SPAN_ID
+    assert parsed[0].scope_spans[0].spans[0].span_id.hex() == _HEX_SPAN_ID
 
 
 def test_the_callers_resource_spans_are_not_mutated() -> None:
     resource_spans = [{"scopeSpans": [{"spans": [{"traceId": _HEX_TRACE_ID, "spanId": _HEX_SPAN_ID, "name": "root"}]}]}]
 
-    export_request_from_resource_spans(resource_spans)
+    parse_resource_spans(resource_spans)
 
     assert resource_spans[0]["scopeSpans"][0]["spans"][0]["spanId"] == _HEX_SPAN_ID
-
-
-def _nested_attribute_payload(depth: int) -> str:
-    value = '{"arrayValue":{"values":[' * depth + '{"stringValue":"leaf"}' + "]}}" * depth
-    return (
-        '{"resourceSpans":[{"scopeSpans":[{"spans":[{"traceId":"%s","spanId":"%s","name":"s",'
-        '"attributes":[{"key":"k","value":%s}]}]}]}]}' % (_HEX_TRACE_ID, _HEX_SPAN_ID, value)
-    )
-
-
-def test_a_deeply_nested_attribute_fails_conversion_as_a_value_error() -> None:
-    # json.loads accepts this depth, so the decode-time guard does not fire; the conversion
-    # recurses and must not leak RecursionError past a caller guarding on ValueError.
-    resource_spans = resource_spans_from_text(_nested_attribute_payload(400))
-
-    with pytest.raises(ValueError, match="nested too deeply"):
-        export_request_from_resource_spans(resource_spans)
-
-
-@pytest.mark.parametrize("depth", [400, 2000])
-def test_span_text_strings_walks_any_depth(depth: int) -> None:
-    resource_spans = resource_spans_from_text(_nested_attribute_payload(depth))
-
-    assert list(span_text_strings(resource_spans)) == ["leaf"]
 
 
 @pytest.mark.parametrize("kind", ["TOOL", "EVALUATOR", "RETRIEVER", "GUARDRAIL"])
@@ -395,7 +366,7 @@ def test_set_span_attributes_overrides_what_the_producer_wrote() -> None:
 
     set_span_attributes(request, {"gen_ai.conversation.id": "run:trial", "nemo.evaluation.name": "exp"})
 
-    for span in request.resource_spans[0].scope_spans[0].spans:
+    for span in request[0].scope_spans[0].spans:
         attributes = {attribute.key: attribute.value.string_value for attribute in span.attributes}
         assert attributes["gen_ai.conversation.id"] == "run:trial"
         assert attributes["nemo.evaluation.name"] == "exp"
@@ -407,7 +378,7 @@ def test_each_attribute_value_type_maps_to_its_any_value_field() -> None:
 
     set_span_attributes(request, {"s": "text", "i": 7, "f": 1.5, "b": True})
 
-    values = {a.key: a.value for a in request.resource_spans[0].scope_spans[0].spans[0].attributes}
+    values = {a.key: a.value for a in request[0].scope_spans[0].spans[0].attributes}
     assert values["s"].string_value == "text"
     assert values["i"].int_value == 7
     assert values["f"].double_value == pytest.approx(1.5)

--- a/plugins/nemo-evaluator/src/nemo_evaluator/intake/mapping.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/intake/mapping.py
@@ -55,6 +55,7 @@ from nemo_platform.types.intake.ingest.atif_create_params import AtifCreateParam
 from nemo_platform.types.intake.ingest.atif_final_metrics_param import AtifFinalMetricsParam
 from nemo_platform.types.intake.ingest.atif_step_agent_param import AtifStepAgentParam
 from nemo_platform.types.intake.ingest.atif_step_param import AtifStepParam
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
 
 logger = logging.getLogger(__name__)
 
@@ -163,12 +164,12 @@ async def otlp_ingest_for_trial(
     except KeyError:
         return None
     try:
-        request = await handle.export_request()
+        resource_spans = await handle.resource_spans()
     except (OSError, ValueError) as error:
         logger.warning("Ignoring unreadable OTLP trace for trial %s: %s", trial.id, error)
         return None
 
-    span_id = root_span_id(request)
+    span_id = root_span_id(resource_spans)
     if span_id is None:
         logger.warning(
             "Ignoring OTLP trace for trial %s: it has no single root span with a usable id to score.", trial.id
@@ -176,18 +177,19 @@ async def otlp_ingest_for_trial(
         return None
 
     set_span_attributes(
-        request,
+        resource_spans,
         {
             _SESSION_ID_ATTRIBUTE: session_id,
             _EVALUATION_NAME_ATTRIBUTE: evaluation_name,
             _TEST_CASE_NAME_ATTRIBUTE: trial.task_id,
         },
     )
-    set_root_span_attributes(request, _trial_totals(trial, measurements))
+    set_root_span_attributes(resource_spans, _trial_totals(trial, measurements))
     if trial.error is not None:
-        set_root_span_error(request, message=trial.error.message)
-    fill_missing_start_times(request, start_time_unix_nano=int(started_at.timestamp() * 1_000_000_000))
-    return request.SerializeToString(), span_id
+        set_root_span_error(resource_spans, message=trial.error.message)
+    fill_missing_start_times(resource_spans, start_time_unix_nano=int(started_at.timestamp() * 1_000_000_000))
+    # The Export RPC envelope goes on only here, at the point these actually cross a wire.
+    return ExportTraceServiceRequest(resource_spans=resource_spans).SerializeToString(), span_id
 
 
 def _trial_totals(trial: AgentEvalTrial, measurements: TrialMeasurements) -> dict[str, str | int | float]:


### PR DESCRIPTION
Part 1 of 2. Stacked follow-up: #1815 (the rename).

## What

Gym reports each rollout in its own `ng_trajectory` shape, so a metric could not read a Gym trial the way it reads a Harbor one. This projects each rollout onto OTLP resource spans, so both runners feed the same typed trace evidence.

- **`nemo_evaluator_sdk.ng_trajectory_otlp`** — the projection. Imports nothing from the rest of the SDK and depends only on `opentelemetry-proto`, so it can be lifted out if Gym or anyone else wants it. Liftable, deliberately not lifted.
- **Per-call spans.** Gym only records timing and per-call token usage when observability is on, so the runtime asserts `observability_enabled` and a `model_call_capture_dir` and reads the captures back: one LLM span per model call, with `gen_ai.usage.*` and TTFT. It overrides a caller's `hydra_params` on purpose — turning it off degrades every trace silently.
- **`ng_trajectory` evidence** is kept in its own right, by reference. A projection is not a reason to lose what it was projected from.
- **One representation.** The trace is `list[ResourceSpans]` throughout. `ExportTraceServiceRequest` is the Export RPC envelope and is now built only at the wire boundary in `intake/mapping.py`. `resource_spans_json` is gone.

## Commits

1. `feat` — the projection and the runtime wiring.
2. `test` — a coverage pass over paths the first round missed, kept separate so the findings are readable on their own.
3. `merge` — `origin/main`, to pick up the CI fix below.
4. `chore` — **an unrelated repo-wide CI fix; see "One out-of-scope commit" at the bottom.**

## Validation

Real `gym eval run` output, not fixtures: `mcqa` (1 LLM span, 35.06ms) and `workplace_assistant` for the TOOL path (2 LLM spans, 26.96ms / 3.00ms). Descriptors on a real trial: `['ng_trajectory', 'rollouts', 'trace', 'trace:otlp']`. `final_output_text` returns the agent's answer rather than a tool's output.

**2805 passed, 38 skipped.** CI is fully green.

Coverage on the new and rewritten modules, measured across the SDK *and* plugin suites together (SDK-only under-reports, since Intake exercises several of these functions):

| module | before the test commit | after |
|---|---|---|
| `ng_trajectory_otlp/convert.py` | 89.6% | **94.6%** |
| `values/otlp.py` | 94.3% | **95.5%** |

Every new test was verified by breaking the code and confirming it goes red. The one worth calling out: nothing covered the `RecursionError` guard in `parse_resource_spans`. A payload nested past protobuf's limit raises an error that is neither a `ParseError` nor a `ValueError`, so without that guard it escapes every caller and takes a run down over one unreadable trace.

## Known gaps

- **Sandboxed Gym runs get no captures** ([AALGO-593](https://linear.app/nvidia/issue/AALGO-593/enable-gym-model-call-capture-on-the-sandboxed-host-so-sandboxed-runs)). The host doesn't enable Gym's capture, so captures never leave the sandbox and those traces carry no per-call timing. Not a regression — that path had no trace at all before — and marked at the call site.
- **`convert.py`'s `_any_value` bool branch is unreachable** and is the only uncovered line left. The comment on it defends a real trap (bool is an int subclass, so an int check ordered first writes `True` as `1`), but every caller excludes bool upstream. Kept for whoever lifts the package out; flagging it so it isn't mistaken for tested code. Happy to delete it instead.
- **The gym package still imports underscore-prefixed names across modules.** Real smell, fixed in #1815 rather than mixed in here.

## One out-of-scope commit

`chore: re-vendor nemo-platform extras after nemo-insights loosened its pins` has nothing to do with the OTLP work. It is here because `main` was red and this PR inherited the failure.

`plugins/nemo-insights/pyproject.toml` moved two nemo-fabric adapter deps from `==0.3.0b1` to `>=0.3.0b1`, but `packages/nemo_platform/pyproject.toml` is **generated** from the plugin pyprojects by `make vendor` and was never regenerated. So the declared extras — and `uv.lock`, derived from them — still carried the old pins.

That made two CI jobs demand opposite things: `Check uv lock` compared the lock against the stale pyproject and rejected `>=`, while `lint-sdk-vendored` / `lint-pre-commit-all` regenerated the pyproject and rejected `==`. Both were right; the input was stale, not the output. `make vendor && uv lock` (uv 0.9.14) fixes both, and this is the first commit on which they pass together.

**This also fixes `main`**, which is still red for everyone else. Say the word and I will pull it into its own PR to main instead, so the right reviewers see it and it unblocks other branches sooner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added conversion of Gym rollout records into OTLP traces with agent, LLM, and tool spans.
  - Included model-call captures, prompts, outputs, token usage, timing, errors, and deterministic identifiers.
  - Gym trial evidence now includes per-rollout files, captures, and projected OTLP traces.
  - OTLP evidence now exposes parsed, typed resource spans.
  - Retry attempts receive distinct trial and trace identifiers.

- **Bug Fixes**
  - Improved handling of missing, unreadable, malformed, or unparsable traces without discarding trials.

- **Documentation**
  - Added OTLP conversion usage, limitations, and evidence-processing guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->