### PR TITLE
refactor(evaluator): make the gym package's cross-module names public

### DIFF
--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/config.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/config.py
@@ -25,10 +25,10 @@ logger = logging.getLogger(__name__)
 DEFAULT_REWARD_KEY = "reward"
 #: Gym's CLI, expected on PATH. Not configurable: these runner configs become serialized job specs,
 #: and a path into somebody's venv is meaningless on the other side of that boundary. Note this name
-#: is only ever *resolved*, never executed: :func:`_gym_executable` turns it into an absolute path
+#: is only ever *resolved*, never executed: :func:`gym_executable` turns it into an absolute path
 #: once, and that path is what the subprocesses run — so a child whose PATH differs from ours cannot
 #: end up executing a different Gym.
-_HYDRA_SUBDIR = "gym_hydra"
+HYDRA_SUBDIR = "gym_hydra"
 #: Where Gym writes its per-rollout model-call captures, under the run's work dir.
 _CAPTURE_SUBDIR = "model_calls"
 #: `gym env start`'s combined output, under the run's work dir. Named here because a *collection*
@@ -67,11 +67,11 @@ def _hydra_dict(value: Mapping[str, Any]) -> str:
                 "followed by letters, digits, '_', '.', or '-' survives the round trip. Set this "
                 "key through the override path instead of nesting it inside a list."
             )
-        rendered.append(f"{key}:{_hydra_scalar(item)}")
+        rendered.append(f"{key}:{hydra_scalar(item)}")
     return "{" + ",".join(rendered) + "}"
 
 
-def _hydra_scalar(value: Any) -> str:
+def hydra_scalar(value: Any) -> str:
     """Render a leaf value the way Hydra's override grammar reads it back.
 
     Hydra's grammar is typed, so an unquoted string is not necessarily a string: ``true`` parses as a
@@ -94,7 +94,7 @@ def _hydra_scalar(value: Any) -> str:
     if isinstance(value, Mapping):
         return _hydra_dict(value)
     if isinstance(value, (list, tuple)):
-        return "[" + ",".join(_hydra_scalar(item) for item in value) + "]"
+        return "[" + ",".join(hydra_scalar(item) for item in value) + "]"
     if isinstance(value, str):
         # A trailing backslash would escape the closing quote and leave the value unterminated, and
         # there is no spelling that avoids it — better to say so than to emit something unparseable.
@@ -126,11 +126,11 @@ def _flatten_overrides(overrides: Mapping[str, Any], _prefix: str = "") -> list[
         if isinstance(value, Mapping) and value:
             arguments.extend(_flatten_overrides(value, f"{path}."))
         else:
-            arguments.append(f"++{path}={_hydra_scalar(value)}")
+            arguments.append(f"++{path}={hydra_scalar(value)}")
     return arguments
 
 
-def _redact_hydra_params(overrides: Mapping[str, Any], _prefix: str = "") -> dict[str, Any]:
+def redact_hydra_params(overrides: Mapping[str, Any], _prefix: str = "") -> dict[str, Any]:
     """Redact credential-looking values from overrides before they are recorded as provenance.
 
     ``hydra_params`` is a free-form escape hatch forwarded to Gym, so nothing stops a caller passing
@@ -149,7 +149,7 @@ def _redact_hydra_params(overrides: Mapping[str, Any], _prefix: str = "") -> dic
     for key, value in overrides.items():
         path = f"{_prefix}{key}"
         if isinstance(value, Mapping):
-            redacted[key] = _redact_hydra_params(value, f"{path}.")
+            redacted[key] = redact_hydra_params(value, f"{path}.")
         elif any(marker in path.casefold() for marker in _SECRET_KEY_MARKERS):
             redacted[key] = _REDACTED
         elif isinstance(value, (list, tuple)):
@@ -160,15 +160,15 @@ def _redact_hydra_params(overrides: Mapping[str, Any], _prefix: str = "") -> dic
 
 
 def _redact_list_item(item: Any, path: str) -> Any:
-    """Redact inside one element of a list-valued override. See :func:`_redact_hydra_params`."""
+    """Redact inside one element of a list-valued override. See :func:`redact_hydra_params`."""
     if isinstance(item, Mapping):
-        return _redact_hydra_params(item, f"{path}.")
+        return redact_hydra_params(item, f"{path}.")
     if isinstance(item, (list, tuple)):
         return [_redact_list_item(nested, path) for nested in item]
     return item
 
 
-def _selection_args(config: GymRuntimeConfig, work_dir: Path) -> list[str]:
+def selection_args(config: GymRuntimeConfig, work_dir: Path) -> list[str]:
     """The environment/agent/model selection passed to Gym.
 
     Built once and handed verbatim to both ``gym env validate`` and ``gym env start``, so what is
@@ -203,14 +203,14 @@ def _selection_args(config: GymRuntimeConfig, work_dir: Path) -> list[str]:
     # sweep separator and `[` as a list opener, so an unquoted work dir containing either is
     # silently misread or rejected outright. Verified against Hydra's own parser — unquoted,
     # `/tmp/a,b` becomes a ChoiceSweep and `/tmp/x[1]` raises OverrideParseException.
-    selection.append(f"hydra.run.dir={_hydra_scalar(str(work_dir / _HYDRA_SUBDIR))}")
+    selection.append(f"hydra.run.dir={hydra_scalar(str(work_dir / HYDRA_SUBDIR))}")
     # Off (Gym's default) a rollout reports one usage block summed over the turn and no timing at
     # all; on, each model exchange is captured with its own tokens and latency. Asserted over
     # `hydra_params` rather than defaulted, because turning it off degrades every trace silently.
     # ``++`` for the same reason `_flatten_overrides` uses it: these keys are absent from the merged
     # config until something sets them, and a bare `+` fails once they are present.
-    selection.append(f"++observability_enabled={_hydra_scalar(True)}")
-    selection.append(f"++model_call_capture_dir={_hydra_scalar(str(model_call_capture_dir(work_dir)))}")
+    selection.append(f"++observability_enabled={hydra_scalar(True)}")
+    selection.append(f"++model_call_capture_dir={hydra_scalar(str(model_call_capture_dir(work_dir)))}")
     return selection
 
 

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/dataset.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/dataset.py
@@ -4,7 +4,7 @@
 """Gym rows to Evaluator tasks, and back to a dataset Gym will collect against.
 
 Task identity is the content hash of a row, and attribution is an index this module *assigns*
-rather than infers — see :func:`_materialize_dataset`. Both halves live together because they are
+rather than infers — see :func:`materialize_dataset`. Both halves live together because they are
 two directions of one translation: what breaks one silently breaks the other.
 """
 
@@ -18,9 +18,9 @@ from pathlib import Path
 from typing import Any
 
 from nemo_evaluator_sdk.agent_eval.runtimes.gym.records import (
-    _RUNTIME_KEYS,
     NG_TASK_INDEX,
-    _read_jsonl,
+    RUNTIME_KEYS,
+    read_jsonl,
 )
 from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalTask
 
@@ -34,7 +34,7 @@ def _canonical_row_hash(row: Mapping[str, Any]) -> str:
     rollups stay consistent), and a changed row becomes a new task. No
     dataset-revision component — identity is the row content alone.
     """
-    payload = {key: value for key, value in row.items() if key not in _RUNTIME_KEYS}
+    payload = {key: value for key, value in row.items() if key not in RUNTIME_KEYS}
     encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
     return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
 
@@ -138,7 +138,7 @@ def discover_gym_tasks(dataset: str | Path, *, metrics: Sequence[Any] | None = N
     seen: set[str] = set()
     duplicates = 0
     promptless = 0
-    for position, row in enumerate(_read_jsonl(dataset), 1):
+    for position, row in enumerate(read_jsonl(dataset), 1):
         params = row.get("responses_create_params")
         if not isinstance(params, Mapping):
             raise ValueError(
@@ -169,7 +169,7 @@ def discover_gym_tasks(dataset: str | Path, *, metrics: Sequence[Any] | None = N
                     "gym_row_extras": {
                         key: value
                         for key, value in row.items()
-                        if key != "responses_create_params" and key not in _RUNTIME_KEYS
+                        if key != "responses_create_params" and key not in RUNTIME_KEYS
                     },
                 },
             )
@@ -198,10 +198,10 @@ def discover_gym_tasks(dataset: str | Path, *, metrics: Sequence[Any] | None = N
     return tasks
 
 
-def _source_datasets(tasks: Sequence[AgentEvalTask]) -> str:
+def source_datasets(tasks: Sequence[AgentEvalTask]) -> str:
     """Human-readable summary of the dataset(s) the tasks were discovered from, for a log line.
 
-    Purely provenance. Gym reads the dataset :func:`_materialize_dataset` writes from the tasks
+    Purely provenance. Gym reads the dataset :func:`materialize_dataset` writes from the tasks
     themselves, so nothing here gates the run: tasks drawn from two datasets are legitimate (the
     materialized file is their union), and a task with no stamped path runs fine. Never raises —
     a missing or inconsistent label is not a reason to fail an otherwise valid evaluation.
@@ -214,7 +214,7 @@ def _source_datasets(tasks: Sequence[AgentEvalTask]) -> str:
     return ", ".join(sorted(stamped)) if stamped else "<tasks with no stamped dataset path>"
 
 
-def _materialize_dataset(tasks: Sequence[AgentEvalTask], dest: Path) -> dict[int, str]:
+def materialize_dataset(tasks: Sequence[AgentEvalTask], dest: Path) -> dict[int, str]:
     """Write the normalized dataset Gym will read, and return its ``_ng_task_index`` → task-id map.
 
     One line per requested task, in task order, carrying the task's full source row plus an explicitly
@@ -246,7 +246,7 @@ def _materialize_dataset(tasks: Sequence[AgentEvalTask], dest: Path) -> dict[int
                 "attempts come from GymRuntimeConfig.num_repeats"
             )
         seen_task_ids.add(task.id)
-        payload = {key: value for key, value in extras.items() if key not in _RUNTIME_KEYS}
+        payload = {key: value for key, value in extras.items() if key not in RUNTIME_KEYS}
         payload["responses_create_params"] = params
         payload[NG_TASK_INDEX] = index
         lines.append(json.dumps(payload, default=str))

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/process.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/process.py
@@ -28,17 +28,17 @@ logger = logging.getLogger(__name__)
 _GYM_CLI = "gym"
 #: Bound on `gym env validate`. It merges config without starting anything and returns in about a
 #: second; this only exists so a wedged invocation cannot stall the run before it begins.
-_VALIDATE_TIMEOUT_S = 120.0
+VALIDATE_TIMEOUT_S = 120.0
 #: Where Gym's Hydra run directories are redirected, relative to the run's work dir.
 #: Token-count keys read to decide whether a model was called at all. Both vocabularies, because
 #: Gym's model servers report in either depending on the adapter: the Responses API spells them
 #: `input_tokens`/`output_tokens`, Chat Completions `prompt_tokens`/`completion_tokens`.
-_LOG_TAIL_LINES = 40
+LOG_TAIL_LINES = 40
 
 
 #: Substrings that mark an override as carrying a credential. Matched case-insensitively against the
 #: full dotted path, so nesting cannot hide one behind an innocuous leaf name.
-def _gym_executable() -> str:
+def gym_executable() -> str:
     """Locate the ``gym`` CLI on PATH, or fail saying what to do about it.
 
     Deliberately PATH-only, with no config field pointing at a checkout or a particular venv: these
@@ -64,7 +64,7 @@ def _gym_executable() -> str:
 _PENDING_SERVERS_RE = re.compile(r"(\d+)\s*/\s*(\d+) servers ready\. Waiting for servers to spin up: \[([^\]]*)\]")
 
 
-def _pending_servers(text: str) -> tuple[int, int, tuple[str, ...]] | None:
+def pending_servers(text: str) -> tuple[int, int, tuple[str, ...]] | None:
     """Recover ``(ready, total, still-pending)`` from the *last* readiness line Gym logged.
 
     The last line is the one that matters: earlier polls list servers that have since come up.
@@ -84,7 +84,7 @@ def _pending_servers(text: str) -> tuple[int, int, tuple[str, ...]] | None:
         return None
 
 
-async def _pump_stream(
+async def pump_stream(
     stream: asyncio.StreamReader | None,
     path: Path,
     *,
@@ -95,10 +95,10 @@ async def _pump_stream(
     """Stream a subprocess pipe to ``path`` while mirroring it to the module logger at ``DEBUG``.
 
     Reads in chunks rather than by line so a pathologically long line can't overrun asyncio's stream
-    limit, and retains only the last :data:`_LOG_TAIL_LINES` lines in memory (via ``tails[key]``) for
+    limit, and retains only the last :data:`LOG_TAIL_LINES` lines in memory (via ``tails[key]``) for
     inclusion in a failure message — the file on disk is the complete record.
     """
-    tail: deque[str] = deque(maxlen=_LOG_TAIL_LINES)
+    tail: deque[str] = deque(maxlen=LOG_TAIL_LINES)
     if tails is not None:
         tails[key] = tail
     if stream is None:
@@ -125,12 +125,12 @@ async def _pump_stream(
             emit(buffer)
 
 
-async def _drain_pumps(pumps: Sequence[asyncio.Task[None]], *, grace_s: float, what: str) -> None:
+async def drain_pumps(pumps: Sequence[asyncio.Task[None]], *, grace_s: float, what: str) -> None:
     """Await log pumps after teardown, but never block on them indefinitely.
 
     A pump ends at pipe EOF, which requires *every* inheritor of the write end to close it. Gym's
     descendants inherit it, and Ray daemonizes ``gcs_server`` into its own session where our
-    process-group signals can't reach it (see :func:`_terminate`) — so a leaked grandchild can hold
+    process-group signals can't reach it (see :func:`terminate`) — so a leaked grandchild can hold
     the pipe open forever. Waiting unconditionally would hang the whole run inside a ``finally``.
 
     Bounded instead: give the pumps ``grace_s`` to flush, then cancel and move on. Everything read
@@ -163,7 +163,7 @@ def _signal_group(pgid: int, sig: int) -> None:
         pass
 
 
-async def _terminate(proc: asyncio.subprocess.Process, *, grace_s: float = 30.0) -> None:
+async def terminate(proc: asyncio.subprocess.Process, *, grace_s: float = 30.0) -> None:
     """Tear down a backgrounded Gym subprocess *and its whole process group*.
 
     ``gym env start`` fans out into a Ray cluster + uvicorn servers, and Gym stops them from a
@@ -190,7 +190,7 @@ async def _terminate(proc: asyncio.subprocess.Process, *, grace_s: float = 30.0)
         await proc.wait()
 
 
-def _gym_invocation_env(config: GymRuntimeConfig) -> dict[str, str]:
+def gym_invocation_env(config: GymRuntimeConfig) -> dict[str, str]:
     """The environment the ``gym`` CLI is invoked with.
 
     Three layers, lowest precedence first:

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/records.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/records.py
@@ -23,11 +23,11 @@ NG_ROLLOUT_INDEX = "_ng_rollout_index"
 #: Gym appends this to a capture key past the first attempt, so it is part of the join.
 NG_ATTEMPT_INDEX = "_ng_attempt_index"
 #: Fields excluded from a row's content hash (runtime-injected, not task-defining).
-_RUNTIME_KEYS = frozenset({NG_TASK_INDEX, NG_ROLLOUT_INDEX})
+RUNTIME_KEYS = frozenset({NG_TASK_INDEX, NG_ROLLOUT_INDEX})
 
 
 #: Lines of subprocess output retained in memory for inclusion in a failure message.
-def _read_jsonl(path: str | Path, *, tolerant: bool = False) -> list[dict[str, Any]]:
+def read_jsonl(path: str | Path, *, tolerant: bool = False) -> list[dict[str, Any]]:
     """Read a jsonl file. With ``tolerant=True``, skip (and log) malformed lines instead of raising —
 
     used for Gym's ``*_failures.jsonl`` sidecar, which is written during abnormal termination and can
@@ -51,4 +51,4 @@ def _read_jsonl(path: str | Path, *, tolerant: bool = False) -> list[dict[str, A
 #: `gym env start`'s combined output, under the run's work dir. Named here with the other
 #: artifacts because a *collection* failure often has to point at it: the eval logs show the
 #: symptom, this shows the cause.
-_ENV_LOG_NAME = "gym_env.log"
+ENV_LOG_NAME = "gym_env.log"

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/results.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/results.py
@@ -20,11 +20,11 @@ from typing import Any
 from google.protobuf.json_format import MessageToDict
 from nemo_evaluator_sdk.agent_eval.runtimes.gym.config import DEFAULT_REWARD_KEY
 from nemo_evaluator_sdk.agent_eval.runtimes.gym.records import (
-    _ENV_LOG_NAME,
+    ENV_LOG_NAME,
     NG_ATTEMPT_INDEX,
     NG_ROLLOUT_INDEX,
     NG_TASK_INDEX,
-    _read_jsonl,
+    read_jsonl,
 )
 from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalTask
 from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial, AgentEvalTrialStatus, AgentOutput
@@ -103,7 +103,7 @@ def _agent_never_ran(record: Mapping[str, Any]) -> bool:
     return bool(input_side) and all(value == 0 for value in input_side)
 
 
-def _require_full_coverage(tasks: Sequence[AgentEvalTask], *, covered_task_ids: set[str], rollouts_path: Path) -> None:
+def require_full_coverage(tasks: Sequence[AgentEvalTask], *, covered_task_ids: set[str], rollouts_path: Path) -> None:
     """Fail the run when Gym produced no trial at all for some requested task.
 
     :class:`AgentEvaluator` already refuses to score a task with no trial
@@ -223,7 +223,7 @@ def _read_model_calls(capture_path: Path | None, *, trial_id: str) -> list[dict[
     if capture_path is None:
         return []
     try:
-        return _read_jsonl(capture_path, tolerant=True)
+        return read_jsonl(capture_path, tolerant=True)
     except OSError as error:
         logger.warning("Could not read the model-call capture for trial %s: %s", trial_id, error)
         return []
@@ -239,7 +239,7 @@ def _aggregate_metrics_path_for(rollouts_path: Path) -> Path:
     return rollouts_path.with_name(rollouts_path.stem + "_aggregate_metrics.json")
 
 
-def _read_run_aggregations(rollouts_path: Path) -> dict[str, Any] | None:
+def read_run_aggregations(rollouts_path: Path) -> dict[str, Any] | None:
     """Parse Gym's ``rollouts_aggregate_metrics.json``, or ``None`` when absent/unparseable.
 
     Gym's file is a list with one entry per agent (``agent_ref`` / ``agent_metrics`` / ``key_metrics`` /
@@ -286,7 +286,7 @@ _GYM_STAT_FAMILY = ("mean", "max", "min", "median", "std")
 _GYM_REDUNDANT_METRICS = frozenset({"reward"})
 
 
-def _aggregate_scores_from_gym(aggregations: Mapping[str, Any] | None) -> list[AggregateScore]:
+def aggregate_scores_from_gym(aggregations: Mapping[str, Any] | None) -> list[AggregateScore]:
     """Map Gym's run-level ``agent_metrics`` onto typed aggregate scores named ``runner.gym.<metric>``.
 
     Reads ``agent_metrics``, not ``key_metrics``: ``key_metrics`` is a *subset* of it chosen by the
@@ -372,7 +372,7 @@ def _as_float(value: Any) -> float | None:
     return float(value) if math.isfinite(value) else None
 
 
-def _ensure_fresh_output(rollouts_path: Path) -> None:
+def ensure_fresh_output(rollouts_path: Path) -> None:
     """Enforce one Gym run per output dir (the AgentEvaluator convention).
 
     Gym appends to the failures sidecar (``open("ab")``) and doesn't clear it between runs, so reusing
@@ -409,13 +409,13 @@ def _resolve_task_id(
     Returns None when the record carries no usable index (kill-shaped failures can lack one).
 
     An index we never stamped is handled by ``strict``. In the **successes** file (``strict=True``)
-    it is fatal: every row Gym read came from :func:`_materialize_dataset`, so an unknown index means
+    it is fatal: every row Gym read came from :func:`materialize_dataset`, so an unknown index means
     Gym reindexed the dataset rather than honoring our stamp, and every reward attribution is
     therefore suspect. In the **failures sidecar** (``strict=False``) it is merely unattributable and
     is counted instead — that file is written during abnormal termination and read tolerantly by
     design, so one odd record must not discard the successes already parsed. That relaxation cannot
     inflate a result: failure records carry no reward, and a task left with no trial still trips
-    :func:`_require_full_coverage`.
+    :func:`require_full_coverage`.
     """
     index = record.get(NG_TASK_INDEX)
     if not isinstance(index, int) or isinstance(index, bool):
@@ -457,7 +457,7 @@ def _rollout_trial_id(
     return f"{task_id}:{missing_label}{seq}{suffix}"
 
 
-def _trials_from_rollouts(
+def trials_from_rollouts(
     rollouts_path: Path,
     tasks: Sequence[AgentEvalTask],
     index_to_task_id: Mapping[int, str],
@@ -470,10 +470,10 @@ def _trials_from_rollouts(
     Reads *both* Gym output files: successes from ``rollouts.jsonl`` (COMPLETED, carrying the reward)
     and failures from the ``*_failures.jsonl`` sidecar (FAILED — so a failed attempt is counted and
     diagnosed rather than silently dropped). Every record is attributed to its task by
-    ``_ng_task_index`` → ``index_to_task_id``, the map we stamped in :func:`_materialize_dataset`.
+    ``_ng_task_index`` → ``index_to_task_id``, the map we stamped in :func:`materialize_dataset`.
     """
     if not rollouts_path.exists():
-        # `_ensure_fresh_output` removed any stale file before the run, and `_collect_rollouts`
+        # `ensure_fresh_output` removed any stale file before the run, and `_collect_rollouts`
         # already raised on a non-zero exit — so reaching here means Gym reported success and wrote
         # nothing. Opening the path regardless would surface that as a bare FileNotFoundError
         # naming a file the reader has no reason to know about, which is the same illegibility the
@@ -482,7 +482,7 @@ def _trials_from_rollouts(
             f"`gym eval run` reported success but wrote no results to {rollouts_path}, so there is "
             "nothing to score. This usually means collection stopped before any attempt completed.\n"
             f"See {rollouts_path.parent / 'gym_eval.stdout.log'} for what collection did, and "
-            f"{rollouts_path.parent / _ENV_LOG_NAME} for a traceback from the environment's own "
+            f"{rollouts_path.parent / ENV_LOG_NAME} for a traceback from the environment's own "
             "servers."
         )
     known_task_ids = {task.id for task in tasks}
@@ -508,11 +508,11 @@ def _trials_from_rollouts(
     #: Tasks with at least one trial where the agent never ran. Tracked separately from trial
     #: status, since the failures sidecar also produces FAILED trials for unrelated reasons.
     empty_output_task_ids: set[str] = set()
-    for record in _read_jsonl(rollouts_path):
+    for record in read_jsonl(rollouts_path):
         task_id = _resolve_task_id(record, index_to_task_id)
         if task_id is None:
             # No usable index (an unknown one raises). Skipping is right, but silence is not: with
-            # num_repeats > 1 the task keeps its other trials, so _require_full_coverage won't fire and
+            # num_repeats > 1 the task keeps its other trials, so require_full_coverage won't fire and
             # the task would simply be scored on fewer attempts than were actually run.
             unattributed_successes += 1
             continue
@@ -569,7 +569,7 @@ def _trials_from_rollouts(
             }
         )
         # tolerant: a truncated line in the abnormal-termination sidecar must not sink the good trials.
-        for record in _read_jsonl(failures_path, tolerant=True):
+        for record in read_jsonl(failures_path, tolerant=True):
             # strict=False to match this loop's tolerant read: an odd record is counted, not fatal.
             task_id = _resolve_task_id(record, index_to_task_id, strict=False)
             if task_id is None:
@@ -625,7 +625,7 @@ def _trials_from_rollouts(
                 "and nothing was measured. The scores reported for them describe an agent that did "
                 "not run.\n"
                 "This is normally the environment failing to start its agent rather than a bad "
-                f"model: check the per-server startup output in {rollouts_path.parent / _ENV_LOG_NAME} "
+                f"model: check the per-server startup output in {rollouts_path.parent / ENV_LOG_NAME} "
                 "for a traceback from the environment's own agent server.\n"
                 f"Results as collected: {rollouts_path}"
             )
@@ -653,7 +653,7 @@ def _trials_from_rollouts(
             NG_TASK_INDEX,
         )
 
-    # Reported here, enforced by _require_full_coverage in run_tasks (which knows the run's log paths).
+    # Reported here, enforced by require_full_coverage in run_tasks (which knows the run's log paths).
     missing = known_task_ids - {trial.task_id for trial in trials}
     if missing:
         logger.warning("No Gym rollout produced a trial for %d requested task(s): %s", len(missing), sorted(missing))

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/runtime.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/runtime.py
@@ -20,31 +20,31 @@ from pathlib import Path
 from typing import Any
 
 from nemo_evaluator_sdk.agent_eval.runtimes.gym.config import (
-    _HYDRA_SUBDIR,
+    HYDRA_SUBDIR,
     GymRuntimeConfig,
-    _hydra_scalar,
-    _redact_hydra_params,
-    _selection_args,
+    hydra_scalar,
     model_call_capture_dir,
+    redact_hydra_params,
+    selection_args,
 )
-from nemo_evaluator_sdk.agent_eval.runtimes.gym.dataset import _materialize_dataset, _source_datasets
+from nemo_evaluator_sdk.agent_eval.runtimes.gym.dataset import materialize_dataset, source_datasets
 from nemo_evaluator_sdk.agent_eval.runtimes.gym.process import (
-    _LOG_TAIL_LINES,
-    _VALIDATE_TIMEOUT_S,
-    _drain_pumps,
-    _gym_executable,
-    _gym_invocation_env,
-    _pending_servers,
-    _pump_stream,
-    _terminate,
+    LOG_TAIL_LINES,
+    VALIDATE_TIMEOUT_S,
+    drain_pumps,
+    gym_executable,
+    gym_invocation_env,
+    pending_servers,
+    pump_stream,
+    terminate,
 )
-from nemo_evaluator_sdk.agent_eval.runtimes.gym.records import _ENV_LOG_NAME
+from nemo_evaluator_sdk.agent_eval.runtimes.gym.records import ENV_LOG_NAME
 from nemo_evaluator_sdk.agent_eval.runtimes.gym.results import (
-    _aggregate_scores_from_gym,
-    _ensure_fresh_output,
-    _read_run_aggregations,
-    _require_full_coverage,
-    _trials_from_rollouts,
+    aggregate_scores_from_gym,
+    ensure_fresh_output,
+    read_run_aggregations,
+    require_full_coverage,
+    trials_from_rollouts,
 )
 from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalRunConfig, AgentEvalTask
 from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial, RunnerInfo
@@ -89,14 +89,14 @@ class GymAgentTaskRunner:
         natively as ``gym_reward.reward``, and two differently-derived numbers under one name invites
         exactly the confusion the namespace is there to prevent.
         """
-        return _aggregate_scores_from_gym(self._run_aggregations)
+        return aggregate_scores_from_gym(self._run_aggregations)
 
     def runner_info(self) -> RunnerInfo:
         """Identify this runner and the Gym settings that shape its results.
 
         Credentials normally live in the Gym checkout's gitignored ``env.yaml`` and never reach this
         object — but ``hydra_params`` and ``env_vars`` are free-form escape hatches, so their values
-        are redacted by key (see :func:`_redact_hydra_params`) rather than trusted. ``env_vars``
+        are redacted by key (see :func:`redact_hydra_params`) rather than trusted. ``env_vars``
         needs it at least as much: environment variables are the conventional way to pass an API
         key, so a caller doing the obvious thing would otherwise write one into the run bundle.
         """
@@ -112,8 +112,8 @@ class GymAgentTaskRunner:
                 "num_repeats": cfg.num_repeats,
                 "concurrency": cfg.concurrency,
                 "bind_resources_server": cfg.bind_resources_server,
-                "hydra_params": _redact_hydra_params(cfg.hydra_params),
-                "env_vars": _redact_hydra_params(cfg.env_vars),
+                "hydra_params": redact_hydra_params(cfg.hydra_params),
+                "env_vars": redact_hydra_params(cfg.env_vars),
                 "reward_key": cfg.reward_key,
             },
         )
@@ -127,7 +127,7 @@ class GymAgentTaskRunner:
         self._run_aggregations = None  # reset per run so a reused runner never leaks a prior run's numbers
         # Provenance for the log line only — the file Gym actually reads is the normalized one we
         # materialize below from the tasks themselves.
-        source_dataset = _source_datasets(tasks)
+        source_dataset = source_datasets(tasks)
 
         # config.parallelism still governs how the evaluator *scores* the trials we return (its scoring
         # semaphore). It is deliberately not mapped onto Gym's rollout `--concurrency`: those are different
@@ -141,13 +141,13 @@ class GymAgentTaskRunner:
         work_dir.mkdir(parents=True, exist_ok=True)
 
         rollouts_path = work_dir / "rollouts.jsonl"
-        _ensure_fresh_output(rollouts_path)
+        ensure_fresh_output(rollouts_path)
 
         # Hand Gym a dataset we control: one row per requested task, each carrying the _ng_task_index
         # we assign. Gym honors a pre-stamped index, so the rollout->task join becomes a total map
         # instead of a positional guess about Gym's raw-line dedup (see the module docstring).
         input_path = work_dir / "gym_input.jsonl"
-        index_to_task_id = _materialize_dataset(tasks, input_path)
+        index_to_task_id = materialize_dataset(tasks, input_path)
         logger.info(
             "Materialized %d task(s) from %s into %s for Gym collection.",
             len(index_to_task_id),
@@ -156,15 +156,15 @@ class GymAgentTaskRunner:
         )
 
         await self._run_two_step(input_path, rollouts_path, work_dir)
-        self._run_aggregations = _read_run_aggregations(rollouts_path)
-        trials = _trials_from_rollouts(
+        self._run_aggregations = read_run_aggregations(rollouts_path)
+        trials = trials_from_rollouts(
             rollouts_path,
             tasks,
             index_to_task_id,
             reward_key=cfg.reward_key,
             capture_dir=model_call_capture_dir(work_dir),
         )
-        _require_full_coverage(tasks, covered_task_ids={trial.task_id for trial in trials}, rollouts_path=rollouts_path)
+        require_full_coverage(tasks, covered_task_ids={trial.task_id for trial in trials}, rollouts_path=rollouts_path)
         return trials
 
     async def _validate_config(
@@ -192,17 +192,17 @@ class GymAgentTaskRunner:
             env=dict(subprocess_env),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
-            # Its own process group, like the other two Gym invocations. `_terminate` signals the
+            # Its own process group, like the other two Gym invocations. `terminate` signals the
             # group via `killpg`, so without this a validate timeout would signal *our* group — the
             # SDK process included.
             start_new_session=True,
         )
         try:
-            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=_VALIDATE_TIMEOUT_S)
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=VALIDATE_TIMEOUT_S)
         except TimeoutError:
-            await _terminate(proc, grace_s=self._config.shutdown_grace_s)
+            await terminate(proc, grace_s=self._config.shutdown_grace_s)
             raise RuntimeError(
-                f"`gym env validate` did not finish within {_VALIDATE_TIMEOUT_S}s for resources-server "
+                f"`gym env validate` did not finish within {VALIDATE_TIMEOUT_S}s for resources-server "
                 f"{self._config.resources_server!r}"
             ) from None
 
@@ -218,16 +218,16 @@ class GymAgentTaskRunner:
     async def _run_two_step(self, input_path: Path, output_path: Path, work_dir: Path) -> None:
         """Start the Gym servers, collect against them with ``--no-serve``, then tear them down."""
         cfg = self._config
-        gym = _gym_executable()
-        env_log = work_dir / _ENV_LOG_NAME
+        gym = gym_executable()
+        env_log = work_dir / ENV_LOG_NAME
 
         # Gym launches each server from its own subdir with its own .venv. Ray (>=2.56) otherwise
         # detects a `uv run` ancestor and tries to replicate that uv project onto its workers,
         # asserting the project pyproject.toml lives in the driver's cwd — which aborts startup. That
         # hook is wrong for Gym (servers manage their own deps), so disable it for the subprocesses.
-        subprocess_env = _gym_invocation_env(cfg)
+        subprocess_env = gym_invocation_env(cfg)
 
-        selection = _selection_args(cfg, work_dir)
+        selection = selection_args(cfg, work_dir)
 
         await self._validate_config(gym, selection, subprocess_env, work_dir)
 
@@ -244,14 +244,14 @@ class GymAgentTaskRunner:
             stderr=asyncio.subprocess.STDOUT,
             start_new_session=True,
         )
-        env_pump = asyncio.create_task(_pump_stream(env_proc.stdout, env_log, label="gym env start"))
+        env_pump = asyncio.create_task(pump_stream(env_proc.stdout, env_log, label="gym env start"))
         try:
             await self._wait_for_servers(env_log, env_proc)
             await self._collect_rollouts(gym, input_path, output_path, work_dir, subprocess_env)
         finally:
-            await _terminate(env_proc, grace_s=cfg.shutdown_grace_s)
+            await terminate(env_proc, grace_s=cfg.shutdown_grace_s)
             # Bounded: a leaked grandchild holding the inherited pipe must not wedge teardown.
-            await _drain_pumps([env_pump], grace_s=cfg.shutdown_grace_s, what="gym env start")
+            await drain_pumps([env_pump], grace_s=cfg.shutdown_grace_s, what="gym env start")
 
     async def _collect_rollouts(
         self, gym: str, input_path: Path, output_path: Path, work_dir: Path, subprocess_env: dict[str, str]
@@ -283,10 +283,10 @@ class GymAgentTaskRunner:
             "--concurrency",
             str(cfg.concurrency),
             # `gym eval run` is a Hydra app too, and unlike validate/start it does not go through
-            # _selection_args — so without this it writes `outputs/<date>/<time>/` into the caller's
+            # selection_args — so without this it writes `outputs/<date>/<time>/` into the caller's
             # cwd on every single collection. Quoted for the same reason as there: a work dir
             # containing `,` or `[` is otherwise misread as sweep syntax.
-            f"hydra.run.dir={_hydra_scalar(str(work_dir / _HYDRA_SUBDIR))}",
+            f"hydra.run.dir={hydra_scalar(str(work_dir / HYDRA_SUBDIR))}",
         ]
         stdout_log = work_dir / "gym_eval.stdout.log"
         stderr_log = work_dir / "gym_eval.stderr.log"
@@ -299,12 +299,8 @@ class GymAgentTaskRunner:
         )
         tails: dict[str, deque[str]] = {}
         pumps = [
-            asyncio.create_task(
-                _pump_stream(eval_proc.stdout, stdout_log, label="gym eval", tails=tails, key="stdout")
-            ),
-            asyncio.create_task(
-                _pump_stream(eval_proc.stderr, stderr_log, label="gym eval", tails=tails, key="stderr")
-            ),
+            asyncio.create_task(pump_stream(eval_proc.stdout, stdout_log, label="gym eval", tails=tails, key="stdout")),
+            asyncio.create_task(pump_stream(eval_proc.stderr, stderr_log, label="gym eval", tails=tails, key="stderr")),
         ]
         try:
             await asyncio.wait_for(eval_proc.wait(), timeout=cfg.collection_timeout_s)
@@ -315,8 +311,8 @@ class GymAgentTaskRunner:
             ) from exc
         finally:
             # Terminate first so the pipes close, then drain (bounded) to flush whatever was buffered.
-            await _terminate(eval_proc, grace_s=cfg.shutdown_grace_s)
-            await _drain_pumps(pumps, grace_s=cfg.shutdown_grace_s, what="gym eval run")
+            await terminate(eval_proc, grace_s=cfg.shutdown_grace_s)
+            await drain_pumps(pumps, grace_s=cfg.shutdown_grace_s, what="gym eval run")
         if eval_proc.returncode != 0:
             tail = "\n".join(tails.get("stderr") or tails.get("stdout") or [])
             # A collection failure is frequently *server*-side: the resources-server raises, the
@@ -324,13 +320,13 @@ class GymAgentTaskRunner:
             # gym_env.log. Naming the two eval logs alone sends the reader to the one place the
             # cause is not. (Observed on wmt_translation: a 500 here, `PermissionError: /opt/Gym`
             # there.)
-            env_log = work_dir / _ENV_LOG_NAME
+            env_log = work_dir / ENV_LOG_NAME
             raise RuntimeError(
                 f"`gym eval run` failed (rc={eval_proc.returncode}). Collection output: {stdout_log} "
                 f"and {stderr_log}\n"
                 f"If the tail below is an HTTP error from a Gym server, the cause is server-side: "
                 f"see {env_log}, whose lines are prefixed with the server that emitted them.\n"
-                f"--- last {_LOG_TAIL_LINES} line(s) ---\n{tail}"
+                f"--- last {LOG_TAIL_LINES} line(s) ---\n{tail}"
             )
 
     async def _wait_for_servers(self, env_log: Path, env_proc: asyncio.subprocess.Process) -> None:
@@ -369,7 +365,7 @@ class GymAgentTaskRunner:
         how to extend it instead of leaving the reader to find the knob.
         """
         cfg = self._config
-        pending = _pending_servers(env_log_text)
+        pending = pending_servers(env_log_text)
         if pending is None:
             detail = (
                 "Gym never reported server readiness, so it likely failed before starting them "

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/sandboxed.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/sandboxed.py
@@ -39,13 +39,13 @@ from typing import Any
 
 import httpx
 from nemo_evaluator_sdk.agent_eval.runtimes.gym.config import DEFAULT_REWARD_KEY
-from nemo_evaluator_sdk.agent_eval.runtimes.gym.dataset import _materialize_dataset, _source_datasets
+from nemo_evaluator_sdk.agent_eval.runtimes.gym.dataset import materialize_dataset, source_datasets
 from nemo_evaluator_sdk.agent_eval.runtimes.gym.results import (
-    _aggregate_scores_from_gym,
-    _ensure_fresh_output,
-    _read_run_aggregations,
-    _require_full_coverage,
-    _trials_from_rollouts,
+    aggregate_scores_from_gym,
+    ensure_fresh_output,
+    read_run_aggregations,
+    require_full_coverage,
+    trials_from_rollouts,
 )
 from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalRunConfig, AgentEvalTask
 from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial, RunnerInfo
@@ -106,7 +106,7 @@ class SandboxedGymAgentTaskRunner:
         returns rollout records writes no such file. Implemented anyway so this runner satisfies the
         same protocol as the CLI one and starts reporting if the host grows the sidecar.
         """
-        return _aggregate_scores_from_gym(self._run_aggregations)
+        return aggregate_scores_from_gym(self._run_aggregations)
 
     def runner_info(self) -> RunnerInfo:
         """Identify the runner and the host it collected from.
@@ -238,12 +238,12 @@ class SandboxedGymAgentTaskRunner:
         work_dir.mkdir(parents=True, exist_ok=True)
 
         rollouts_path = work_dir / "rollouts.jsonl"
-        _ensure_fresh_output(rollouts_path)
+        ensure_fresh_output(rollouts_path)
 
         # Same materialization the CLI runner uses, so the rows the host sees are the rows Gym
         # would have read, and `_ng_task_index` is stamped by the same code.
         input_path = work_dir / "gym_input.jsonl"
-        index_to_task_id = _materialize_dataset(tasks, input_path)
+        index_to_task_id = materialize_dataset(tasks, input_path)
         examples = [json.loads(line) for line in input_path.read_text(encoding="utf-8").splitlines() if line.strip()]
         if cfg.agent_ref_name:
             # Only where the row is silent: a dataset that names its own agent per row keeps doing so,
@@ -253,7 +253,7 @@ class SandboxedGymAgentTaskRunner:
         logger.info(
             "Collecting %d example(s) from %s via sandboxed Gym host %s.",
             len(examples),
-            _source_datasets(tasks),
+            source_datasets(tasks),
             cfg.rollout_url,
         )
 
@@ -266,13 +266,13 @@ class SandboxedGymAgentTaskRunner:
             encoding="utf-8",
         )
 
-        self._run_aggregations = _read_run_aggregations(rollouts_path)
+        self._run_aggregations = read_run_aggregations(rollouts_path)
         # No capture_dir yet (AALGO-593): the host does not switch Gym's model-call capture on, so
         # its captures never leave the sandbox and traces from this runner carry no per-call timing.
         # Unimplemented rather than impossible -- the host drives Gym through its Python API, whose
         # global config takes the same observability keys the CLI runtime sets.
-        trials = _trials_from_rollouts(
+        trials = trials_from_rollouts(
             rollouts_path, tasks, index_to_task_id, reward_key=cfg.reward_key, capture_dir=None
         )
-        _require_full_coverage(tasks, covered_task_ids={trial.task_id for trial in trials}, rollouts_path=rollouts_path)
+        require_full_coverage(tasks, covered_task_ids={trial.task_id for trial in trials}, rollouts_path=rollouts_path)
         return trials

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_gym_aggregate_scores.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_gym_aggregate_scores.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 
-from nemo_evaluator_sdk.agent_eval.runtimes.gym.results import _aggregate_scores_from_gym
+from nemo_evaluator_sdk.agent_eval.runtimes.gym.results import aggregate_scores_from_gym
 from nemo_evaluator_sdk.values.results import AggregateRangeScore, AggregateScalarScore, AggregateScore
 
 
@@ -23,7 +23,7 @@ def _by_name(scores: Sequence[AggregateScore]) -> dict[str, AggregateScore]:
 
 def test_a_full_stat_family_is_reassembled_into_one_range_score() -> None:
     scores = _by_name(
-        _aggregate_scores_from_gym(
+        aggregate_scores_from_gym(
             _gym(
                 {
                     "mean/total_tokens": 120.0,
@@ -48,7 +48,7 @@ def test_a_full_stat_family_is_reassembled_into_one_range_score() -> None:
 def test_a_partial_stat_family_is_left_as_standalone_scalars() -> None:
     # A resources-server may define a metric literally named `mean`; re-assembling on a partial match
     # would rename someone's real metric into a statistic of a distribution that never existed.
-    scores = _by_name(_aggregate_scores_from_gym(_gym({"mean/accuracy": 0.8, "max/accuracy": 1.0})))
+    scores = _by_name(aggregate_scores_from_gym(_gym({"mean/accuracy": 0.8, "max/accuracy": 1.0})))
 
     assert set(scores) == {"runner.gym.mean/accuracy", "runner.gym.max/accuracy"}
     assert all(isinstance(score, AggregateScalarScore) for score in scores.values())
@@ -58,7 +58,7 @@ def test_a_partial_stat_family_is_left_as_standalone_scalars() -> None:
 
 def test_environment_specific_metrics_survive_as_scalars() -> None:
     # 36 of Gym's ~97 resources-servers override compute_metrics, emitting keys in their own shapes.
-    scores = _by_name(_aggregate_scores_from_gym(_gym({"arena_elo/score": 1523.0, "easy/pass@1/accuracy": 0.42})))
+    scores = _by_name(aggregate_scores_from_gym(_gym({"arena_elo/score": 1523.0, "easy/pass@1/accuracy": 0.42})))
 
     assert set(scores) == {"runner.gym.arena_elo/score", "runner.gym.easy/pass@1/accuracy"}
     easy = scores["runner.gym.easy/pass@1/accuracy"]
@@ -67,7 +67,7 @@ def test_environment_specific_metrics_survive_as_scalars() -> None:
 
 def test_reward_is_skipped_because_the_sdk_scores_it_natively() -> None:
     scores = _by_name(
-        _aggregate_scores_from_gym(
+        aggregate_scores_from_gym(
             _gym(
                 {
                     "mean/reward": 0.6,
@@ -93,7 +93,7 @@ def test_an_incomplete_reward_family_is_skipped_rather_than_kept_as_scalars() ->
     # Redundancy is a property of the metric, not of how complete its family is. A resources-server
     # that emits only part of the reward family would otherwise leave `mean/reward` behind as a scalar
     # -- the very duplicate of the natively-computed `gym_reward.reward` that skipping reward prevents.
-    scores = _by_name(_aggregate_scores_from_gym(_gym({"mean/reward": 0.6, "max/reward": 1.0, "accuracy": 0.9})))
+    scores = _by_name(aggregate_scores_from_gym(_gym({"mean/reward": 0.6, "max/reward": 1.0, "accuracy": 0.9})))
 
     assert list(scores) == ["runner.gym.accuracy"]
 
@@ -118,7 +118,7 @@ def test_nothing_numeric_is_dropped_from_a_custom_environment_payload() -> None:
         "notes": "not a measurement",  # non-numeric: stays only in the opaque payload
         "converged": True,  # a bool is a flag, not a measurement
     }
-    scores = _aggregate_scores_from_gym(_gym(key_metrics))
+    scores = aggregate_scores_from_gym(_gym(key_metrics))
 
     numeric_keys = {key for key, value in key_metrics.items() if isinstance(value, (int, float)) and value is not True}
     represented = set()
@@ -134,26 +134,26 @@ def test_nothing_numeric_is_dropped_from_a_custom_environment_payload() -> None:
 
 def test_names_are_qualified_by_agent_only_when_a_run_produced_several() -> None:
     # One agent per run is the norm, so the agent name adds nothing; with two it prevents a collision.
-    one = _by_name(_aggregate_scores_from_gym(_gym({"score": 1.0})))
+    one = _by_name(aggregate_scores_from_gym(_gym({"score": 1.0})))
     assert list(one) == ["runner.gym.score"]
 
     two = _by_name(
-        _aggregate_scores_from_gym({"a": {"agent_metrics": {"score": 1.0}}, "b": {"agent_metrics": {"score": 2.0}}})
+        aggregate_scores_from_gym({"a": {"agent_metrics": {"score": 1.0}}, "b": {"agent_metrics": {"score": 2.0}}})
     )
     assert set(two) == {"runner.gym.a.score", "runner.gym.b.score"}
 
 
 def test_absent_or_malformed_aggregations_yield_nothing() -> None:
-    assert _aggregate_scores_from_gym(None) == []
-    assert _aggregate_scores_from_gym({}) == []
-    assert _aggregate_scores_from_gym({"agent": {"group_level_metrics": []}}) == []  # no agent_metrics
-    assert _aggregate_scores_from_gym({"agent": "not a mapping"}) == []
+    assert aggregate_scores_from_gym(None) == []
+    assert aggregate_scores_from_gym({}) == []
+    assert aggregate_scores_from_gym({"agent": {"group_level_metrics": []}}) == []  # no agent_metrics
+    assert aggregate_scores_from_gym({"agent": "not a mapping"}) == []
 
 
 def test_imported_scores_report_an_unknown_sample_size_rather_than_zero() -> None:
     # Gym reports statistics without the n behind them. count=0 would assert that nothing was
     # evaluated — false, and a landmine for anything that divides by it.
-    scores = _aggregate_scores_from_gym(
+    scores = aggregate_scores_from_gym(
         _gym(
             {
                 "mean/steps": 3.0,
@@ -191,7 +191,7 @@ def test_imports_read_agent_metrics_not_the_key_metrics_subset() -> None:
         }
     }
 
-    scores = _by_name(_aggregate_scores_from_gym(payload))
+    scores = _by_name(aggregate_scores_from_gym(payload))
 
     assert list(scores) == ["runner.gym.steps"]
     steps = scores["runner.gym.steps"]

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_gym_runtime.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_gym_runtime.py
@@ -25,21 +25,21 @@ from nemo_evaluator_sdk.agent_eval.runtimes.gym import (
     GymRuntimeConfig,
     discover_gym_tasks,
 )
-from nemo_evaluator_sdk.agent_eval.runtimes.gym.config import _flatten_overrides, _hydra_scalar, _selection_args
+from nemo_evaluator_sdk.agent_eval.runtimes.gym.config import _flatten_overrides, hydra_scalar, selection_args
 from nemo_evaluator_sdk.agent_eval.runtimes.gym.dataset import (
     _canonical_row_hash,
     _content_text,
-    _materialize_dataset,
     _render_instruction,
-    _source_datasets,
+    materialize_dataset,
+    source_datasets,
 )
 from nemo_evaluator_sdk.agent_eval.runtimes.gym.process import (
-    _LOG_TAIL_LINES,
-    _drain_pumps,
-    _gym_executable,
-    _gym_invocation_env,
-    _pending_servers,
-    _pump_stream,
+    LOG_TAIL_LINES,
+    drain_pumps,
+    gym_executable,
+    gym_invocation_env,
+    pending_servers,
+    pump_stream,
 )
 from nemo_evaluator_sdk.agent_eval.runtimes.gym.records import NG_ATTEMPT_INDEX, NG_ROLLOUT_INDEX, NG_TASK_INDEX
 from nemo_evaluator_sdk.agent_eval.runtimes.gym.results import (
@@ -47,10 +47,10 @@ from nemo_evaluator_sdk.agent_eval.runtimes.gym.results import (
     _TOKEN_USAGE_KEYS,
     _agent_never_ran,
     _aggregate_metrics_path_for,
-    _ensure_fresh_output,
-    _read_run_aggregations,
-    _require_full_coverage,
-    _trials_from_rollouts,
+    ensure_fresh_output,
+    read_run_aggregations,
+    require_full_coverage,
+    trials_from_rollouts,
 )
 from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrialStatus
 from nemo_evaluator_sdk.metrics.protocol import CandidateOutput, DatasetRow, MetricInput
@@ -66,7 +66,7 @@ def _rows(path: Path) -> list[dict]:
 
 def _index_map(tasks: list, tmp_path: Path) -> tuple[list[str], dict[int, str]]:
     """Materialize ``tasks`` the way the runner does, returning (task ids in order, index->id map)."""
-    index_map = _materialize_dataset(tasks, tmp_path / "gym_input.jsonl")
+    index_map = materialize_dataset(tasks, tmp_path / "gym_input.jsonl")
     return [task.id for task in tasks], index_map
 
 
@@ -143,7 +143,7 @@ def test_promptless_rows_still_hash_distinctly(tmp_path: Path) -> None:
     tasks = discover_gym_tasks(dataset)
     assert len({task.id for task in tasks}) == 5
     # and they re-materialize into the five rows Gym will read, each with its own index
-    index_map = _materialize_dataset(tasks, tmp_path / "gym_input.jsonl")
+    index_map = materialize_dataset(tasks, tmp_path / "gym_input.jsonl")
     rows = _rows(tmp_path / "gym_input.jsonl")
     assert [row["task_idx"] for row in rows] == [0, 1, 2, 3, 4]
     assert index_map == {index: task.id for index, task in enumerate(tasks)}
@@ -193,7 +193,7 @@ def test_materialize_dataset_stamps_task_index_and_returns_total_map(tmp_path: P
     # stamped with its own index, and the returned map covers all of them.
     tasks = discover_gym_tasks(EXAMPLE)
     dest = tmp_path / "gym_input.jsonl"
-    index_map = _materialize_dataset(tasks, dest)
+    index_map = materialize_dataset(tasks, dest)
     rows = _rows(dest)
     assert len(rows) == len(tasks)
     assert [row[NG_TASK_INDEX] for row in rows] == list(range(len(tasks)))
@@ -209,7 +209,7 @@ def test_materialize_dataset_subsets_to_requested_tasks(tmp_path: Path) -> None:
     # whose trials we would then discard.
     tasks = discover_gym_tasks(EXAMPLE)
     subset = [tasks[3], tasks[1]]
-    index_map = _materialize_dataset(subset, tmp_path / "gym_input.jsonl")
+    index_map = materialize_dataset(subset, tmp_path / "gym_input.jsonl")
     assert index_map == {0: tasks[3].id, 1: tasks[1].id}
     assert len(_rows(tmp_path / "gym_input.jsonl")) == 2
 
@@ -227,7 +227,7 @@ def test_materialize_dataset_overrides_preassigned_task_index(tmp_path: Path) ->
         encoding="utf-8",
     )
     tasks = discover_gym_tasks(dataset)
-    index_map = _materialize_dataset(tasks, tmp_path / "gym_input.jsonl")
+    index_map = materialize_dataset(tasks, tmp_path / "gym_input.jsonl")
     rows = _rows(tmp_path / "gym_input.jsonl")
     assert [row[NG_TASK_INDEX] for row in rows] == [0, 1]  # source values discarded
     # index 0 is the math row (first in file order), index 1 the capital row
@@ -243,7 +243,7 @@ def test_materialize_dataset_overrides_preassigned_task_index(tmp_path: Path) ->
         + "\n",
         encoding="utf-8",
     )
-    trials = _trials_from_rollouts(bundle, tasks, index_map)
+    trials = trials_from_rollouts(bundle, tasks, index_map)
     responses = {trial.task_id: (trial.output.response if trial.output else None) for trial in trials}
     rewards = {trial.task_id: trial.metadata["reward"] for trial in trials}
     assert responses[tasks[0].id] == "4"  # the math task got the math answer, not the capital task's
@@ -263,7 +263,7 @@ def test_serialization_variant_rows_collapse_without_index_drift(tmp_path: Path)
     )
     tasks = discover_gym_tasks(dataset)
     assert len(tasks) == 1  # same content -> same task
-    index_map = _materialize_dataset(tasks, tmp_path / "gym_input.jsonl")
+    index_map = materialize_dataset(tasks, tmp_path / "gym_input.jsonl")
     assert index_map == {0: tasks[0].id}
     assert len(_rows(tmp_path / "gym_input.jsonl")) == 1  # Gym is handed one row, so it emits one index
 
@@ -284,13 +284,13 @@ def test_discover_gym_tasks_warns_on_duplicate_rows(tmp_path: Path, caplog) -> N
 def test_materialize_dataset_reports_empty_task_list(tmp_path: Path) -> None:
     # The empty case used to surface as a confusing "needs a dataset path" from the provenance helper.
     with pytest.raises(ValueError, match="no tasks to run"):
-        _materialize_dataset([], tmp_path / "gym_input.jsonl")
+        materialize_dataset([], tmp_path / "gym_input.jsonl")
 
 
 def test_materialize_dataset_rejects_duplicate_tasks(tmp_path: Path) -> None:
     tasks = discover_gym_tasks(EXAMPLE)
     with pytest.raises(ValueError, match="more than once"):
-        _materialize_dataset([tasks[0], tasks[0]], tmp_path / "gym_input.jsonl")
+        materialize_dataset([tasks[0], tasks[0]], tmp_path / "gym_input.jsonl")
 
 
 def test_materialize_dataset_requires_source_rows(tmp_path: Path) -> None:
@@ -298,11 +298,11 @@ def test_materialize_dataset_requires_source_rows(tmp_path: Path) -> None:
     tasks = discover_gym_tasks(EXAMPLE)
     no_extras = tasks[0].model_copy(update={"metadata": {"gym_dataset_path": str(EXAMPLE)}})
     with pytest.raises(ValueError, match="gym_row_extras"):
-        _materialize_dataset([no_extras], tmp_path / "gym_input.jsonl")
+        materialize_dataset([no_extras], tmp_path / "gym_input.jsonl")
     # the other half of the split is equally required
     no_params = tasks[0].model_copy(update={"inputs": {k: v for k, v in tasks[0].inputs.items() if k != "gym_row"}})
     with pytest.raises(ValueError, match="gym_row"):
-        _materialize_dataset([no_params], tmp_path / "gym_input.jsonl")
+        materialize_dataset([no_params], tmp_path / "gym_input.jsonl")
 
 
 def test_content_text_warns_on_unsupported_shape(caplog) -> None:
@@ -329,7 +329,7 @@ def test_trials_fan_out_one_per_attempt(tmp_path: Path) -> None:
     bundle = tmp_path / "rollouts.jsonl"
     bundle.write_text("\n".join(json.dumps(record) for record in records) + "\n", encoding="utf-8")
 
-    trials = _trials_from_rollouts(bundle, tasks, index_map)
+    trials = trials_from_rollouts(bundle, tasks, index_map)
     assert len(trials) == 4  # 2 tasks x 2 attempts
     assert len({trial.id for trial in trials}) == 4  # distinct trial ids
     assert {trial.task_id for trial in trials} == {ordered[0], ordered[1]}  # attributed via _ng_task_index
@@ -345,7 +345,7 @@ def test_trials_raise_on_unstamped_task_index(tmp_path: Path) -> None:
     bundle = tmp_path / "rollouts.jsonl"
     bundle.write_text(json.dumps({NG_TASK_INDEX: 999, "reward": 1.0}) + "\n", encoding="utf-8")  # out of range
     with pytest.raises(ValueError):
-        _trials_from_rollouts(bundle, tasks, index_map)
+        trials_from_rollouts(bundle, tasks, index_map)
 
 
 def test_failures_sidecar_yields_failed_trials(tmp_path: Path) -> None:
@@ -357,7 +357,7 @@ def test_failures_sidecar_yields_failed_trials(tmp_path: Path) -> None:
     bundle.write_text(json.dumps({NG_TASK_INDEX: 0, NG_ROLLOUT_INDEX: 0, "reward": 1.0}) + "\n", encoding="utf-8")
     failures = tmp_path / "rollouts_failures.jsonl"
     failures.write_text(json.dumps({NG_TASK_INDEX: 1, NG_ROLLOUT_INDEX: 0, "error": "boom"}) + "\n", encoding="utf-8")
-    trials = _trials_from_rollouts(bundle, tasks, index_map)
+    trials = trials_from_rollouts(bundle, tasks, index_map)
     by_status = {trial.task_id: trial.status for trial in trials}
     assert by_status[ordered[0]] == AgentEvalTrialStatus.COMPLETED
     assert by_status[ordered[1]] == AgentEvalTrialStatus.FAILED
@@ -372,11 +372,11 @@ def test_ensure_fresh_output_rejects_reused_dir(tmp_path: Path) -> None:
     rollouts = tmp_path / "rollouts.jsonl"
     (tmp_path / "rollouts_failures.jsonl").write_text("{}\n", encoding="utf-8")
     with pytest.raises(FileExistsError):
-        _ensure_fresh_output(rollouts)
+        ensure_fresh_output(rollouts)
 
 
 def test_ensure_fresh_output_allows_clean_dir(tmp_path: Path) -> None:
-    _ensure_fresh_output(tmp_path / "rollouts.jsonl")  # no prior artifacts -> no raise
+    ensure_fresh_output(tmp_path / "rollouts.jsonl")  # no prior artifacts -> no raise
 
 
 def test_source_datasets_is_provenance_only_and_never_raises() -> None:
@@ -384,15 +384,15 @@ def test_source_datasets_is_provenance_only_and_never_raises() -> None:
     # tasks themselves. So mixing datasets in one run is now legitimate (the materialized dataset is
     # the union) and this summary must not gate the run; it only labels a log line.
     tasks = discover_gym_tasks(EXAMPLE)
-    assert "gym_mcqa_example.jsonl" in _source_datasets(tasks)
+    assert "gym_mcqa_example.jsonl" in source_datasets(tasks)
     other = tasks[0].model_copy(update={"metadata": {**tasks[0].metadata, "gym_dataset_path": "/other/ds.jsonl"}})
-    summary = _source_datasets([*tasks, other])  # must not raise
+    summary = source_datasets([*tasks, other])  # must not raise
     assert "gym_mcqa_example.jsonl" in summary and "/other/ds.jsonl" in summary
     # tasks with no stamped path at all are fine too — the run does not depend on it
     unstamped = tasks[0].model_copy(
         update={"metadata": {k: v for k, v in tasks[0].metadata.items() if k != "gym_dataset_path"}}
     )
-    assert _source_datasets([unstamped])
+    assert source_datasets([unstamped])
 
 
 def test_materialize_dataset_reassembles_row_without_storing_params_twice(tmp_path: Path) -> None:
@@ -402,7 +402,7 @@ def test_materialize_dataset_reassembles_row_without_storing_params_twice(tmp_pa
     extras = tasks[0].metadata["gym_row_extras"]
     assert "responses_create_params" not in extras  # not duplicated
     # ...yet materialization still reconstructs the complete source row Gym's verifier needs
-    _materialize_dataset(tasks, tmp_path / "gym_input.jsonl")
+    materialize_dataset(tasks, tmp_path / "gym_input.jsonl")
     row = _rows(tmp_path / "gym_input.jsonl")[0]
     source = _rows(EXAMPLE)[0]
     assert {k: v for k, v in row.items() if k != NG_TASK_INDEX} == source
@@ -418,7 +418,7 @@ async def test_a_rollout_carries_an_otlp_trace_the_sdk_can_read(tmp_path: Path) 
     dataset = tmp_path / "dataset.jsonl"
     dataset.write_text(json.dumps({"responses_create_params": {"input": "What is 2 + 2?"}}) + "\n", encoding="utf-8")
     tasks = discover_gym_tasks(dataset)
-    index_map = _materialize_dataset(tasks, tmp_path / "gym_input.jsonl")
+    index_map = materialize_dataset(tasks, tmp_path / "gym_input.jsonl")
     bundle = tmp_path / "rollouts.jsonl"
     bundle.write_text(
         json.dumps(
@@ -441,7 +441,7 @@ async def test_a_rollout_carries_an_otlp_trace_the_sdk_can_read(tmp_path: Path) 
         encoding="utf-8",
     )
 
-    trial = _trials_from_rollouts(bundle, tasks, index_map)[0]
+    trial = trials_from_rollouts(bundle, tasks, index_map)[0]
 
     assert trial.evidence is not None
     handle = await trial.evidence.trace(EVIDENCE_TRACE, format=EVIDENCE_FORMAT_OTLP)
@@ -469,7 +469,7 @@ def test_success_records_without_rollout_index_get_distinct_ids(tmp_path: Path) 
         json.dumps({NG_TASK_INDEX: 0, "reward": 1.0}) + "\n" + json.dumps({NG_TASK_INDEX: 0, "reward": 0.0}) + "\n",
         encoding="utf-8",
     )
-    trials = _trials_from_rollouts(bundle, tasks, index_map)
+    trials = trials_from_rollouts(bundle, tasks, index_map)
     assert len(trials) == 2
     assert len({trial.id for trial in trials}) == 2  # distinct ids despite missing rollout index
     assert all(trial.task_id == ordered[0] for trial in trials)
@@ -491,7 +491,7 @@ async def test_indexless_rollouts_of_one_task_get_distinct_trace_ids(tmp_path: P
         encoding="utf-8",
     )
 
-    trials = _trials_from_rollouts(bundle, tasks, index_map)
+    trials = trials_from_rollouts(bundle, tasks, index_map)
 
     roots = []
     for trial in trials:
@@ -520,7 +520,7 @@ async def test_retried_rollout_gets_ids_distinct_from_its_first_attempt(tmp_path
         encoding="utf-8",
     )
 
-    trials = _trials_from_rollouts(bundle, tasks, index_map)
+    trials = trials_from_rollouts(bundle, tasks, index_map)
 
     assert len(trials) == 2
     assert len({trial.id for trial in trials}) == 2
@@ -552,7 +552,7 @@ def test_retry_in_rollouts_does_not_collide_with_its_failed_attempt(tmp_path: Pa
         encoding="utf-8",
     )
 
-    trials = _trials_from_rollouts(bundle, tasks, index_map)
+    trials = trials_from_rollouts(bundle, tasks, index_map)
 
     assert len(trials) == 2
     assert len({trial.id for trial in trials}) == 2
@@ -573,7 +573,7 @@ def test_indexless_failures_get_distinct_trial_ids(tmp_path: Path) -> None:
         + "\n",
         encoding="utf-8",
     )
-    trials = _trials_from_rollouts(bundle, tasks, index_map)
+    trials = trials_from_rollouts(bundle, tasks, index_map)
     assert len(trials) == 2
     assert len({trial.id for trial in trials}) == 2  # distinct ids despite missing rollout index
     assert all(trial.status == AgentEvalTrialStatus.FAILED for trial in trials)
@@ -590,7 +590,7 @@ def test_malformed_line_in_failures_sidecar_is_skipped(tmp_path: Path) -> None:
     failures.write_text(
         json.dumps({NG_TASK_INDEX: 1, NG_ROLLOUT_INDEX: 0, "error": "boom"}) + "\n{ truncated\n", encoding="utf-8"
     )
-    trials = _trials_from_rollouts(bundle, tasks, index_map)  # must not raise
+    trials = trials_from_rollouts(bundle, tasks, index_map)  # must not raise
     statuses = Counter(trial.status for trial in trials)
     assert statuses[AgentEvalTrialStatus.COMPLETED] == 1
     assert statuses[AgentEvalTrialStatus.FAILED] == 1  # the valid failure survived; the bad line was skipped
@@ -604,7 +604,7 @@ def test_malformed_reward_is_recorded_unscored_not_crashing(tmp_path: Path) -> N
     bundle.write_text(
         json.dumps({NG_TASK_INDEX: 0, NG_ROLLOUT_INDEX: 0, "reward": "not-a-number"}) + "\n", encoding="utf-8"
     )
-    trials = _trials_from_rollouts(bundle, tasks, index_map)
+    trials = trials_from_rollouts(bundle, tasks, index_map)
     assert len(trials) == 1
     assert trials[0].status == AgentEvalTrialStatus.PARTIAL
     assert trials[0].metadata["reward"] is None
@@ -614,7 +614,7 @@ def test_trials_from_real_captured_bundle(tmp_path: Path) -> None:
     # End-to-end join against the real mcqa rollout bundle (--limit 2 --num-repeats 2 → 4 records).
     tasks = discover_gym_tasks(EXAMPLE)
     _ordered, index_map = _index_map(tasks, tmp_path)
-    trials = _trials_from_rollouts(ROLLOUTS, tasks, index_map)
+    trials = trials_from_rollouts(ROLLOUTS, tasks, index_map)
     records = _rows(ROLLOUTS)
     assert len(trials) == len(records)  # one trial per rollout record
     assert set(Counter(trial.task_id for trial in trials).values()) == {2}  # 2 attempts per task
@@ -634,7 +634,7 @@ async def test_pump_stream_writes_file_and_mirrors_to_logger(tmp_path: Path, cap
     log_path = tmp_path / "gym_eval.stdout.log"
     tails: dict[str, deque] = {}
     with caplog.at_level(logging.DEBUG, logger="nemo_evaluator_sdk.agent_eval.runtimes.gym.process"):
-        await _pump_stream(stream, log_path, label="gym eval", tails=tails, key="stdout")
+        await pump_stream(stream, log_path, label="gym eval", tails=tails, key="stdout")
     assert log_path.read_text(encoding="utf-8") == "first line\nsecond line\nno trailing newline"
     assert list(tails["stdout"]) == ["first line", "second line", "no trailing newline"]
     assert "second line" in caplog.text  # mirrored at DEBUG, not printed unconditionally
@@ -645,27 +645,27 @@ async def test_pump_stream_tail_is_bounded(tmp_path: Path) -> None:
     # The in-memory tail exists only to enrich a failure message; the file is the complete record, so
     # a long collection must not accumulate its whole transcript in memory.
     stream = asyncio.StreamReader()
-    stream.feed_data(b"".join(f"line {n}\n".encode() for n in range(_LOG_TAIL_LINES * 3)))
+    stream.feed_data(b"".join(f"line {n}\n".encode() for n in range(LOG_TAIL_LINES * 3)))
     stream.feed_eof()
     tails: dict[str, deque] = {}
-    await _pump_stream(stream, tmp_path / "out.log", label="gym eval", tails=tails, key="stdout")
-    assert len(tails["stdout"]) == _LOG_TAIL_LINES
-    assert tails["stdout"][-1] == f"line {_LOG_TAIL_LINES * 3 - 1}"  # kept the *last* lines
-    assert len((tmp_path / "out.log").read_text(encoding="utf-8").splitlines()) == _LOG_TAIL_LINES * 3
+    await pump_stream(stream, tmp_path / "out.log", label="gym eval", tails=tails, key="stdout")
+    assert len(tails["stdout"]) == LOG_TAIL_LINES
+    assert tails["stdout"][-1] == f"line {LOG_TAIL_LINES * 3 - 1}"  # kept the *last* lines
+    assert len((tmp_path / "out.log").read_text(encoding="utf-8").splitlines()) == LOG_TAIL_LINES * 3
 
 
 @pytest.mark.asyncio
 async def test_drain_pumps_returns_when_pipe_never_reaches_eof(tmp_path: Path, caplog) -> None:
     # A pump ends only at pipe EOF, which needs every inheritor of the write end to close it. Ray
-    # daemonizes gcs_server outside our process group (see _terminate), so a survivor can hold the fd
+    # daemonizes gcs_server outside our process group (see terminate), so a survivor can hold the fd
     # open forever. Draining must therefore be bounded: teardown cannot block on a leaked grandchild.
     stream = asyncio.StreamReader()
     stream.feed_data(b"partial output\n")  # data, but deliberately no feed_eof()
-    pump = asyncio.create_task(_pump_stream(stream, tmp_path / "stuck.log", label="gym env start"))
+    pump = asyncio.create_task(pump_stream(stream, tmp_path / "stuck.log", label="gym env start"))
     await asyncio.sleep(0)  # let the pump consume what's buffered and block on the next read
 
     with caplog.at_level(logging.WARNING):
-        await asyncio.wait_for(_drain_pumps([pump], grace_s=0.05, what="gym env start"), timeout=5)
+        await asyncio.wait_for(drain_pumps([pump], grace_s=0.05, what="gym env start"), timeout=5)
 
     assert pump.cancelled() or pump.done()  # abandoned, not awaited forever
     assert "did not finish" in caplog.text  # and the truncation is reported, not silent
@@ -681,9 +681,9 @@ async def test_drain_pumps_awaits_normal_completion(tmp_path: Path, caplog) -> N
     stream.feed_data(b"all of it\n")
     stream.feed_eof()
     tails: dict[str, deque] = {}
-    pump = asyncio.create_task(_pump_stream(stream, tmp_path / "done.log", label="gym eval", tails=tails))
+    pump = asyncio.create_task(pump_stream(stream, tmp_path / "done.log", label="gym eval", tails=tails))
     with caplog.at_level(logging.WARNING):
-        await _drain_pumps([pump], grace_s=5, what="gym eval")
+        await drain_pumps([pump], grace_s=5, what="gym eval")
     assert pump.done() and not pump.cancelled()
     assert list(tails["stdout"]) == ["all of it"]
     assert "did not finish" not in caplog.text
@@ -698,12 +698,12 @@ def test_trials_reject_index_map_disagreeing_with_tasks(tmp_path: Path) -> None:
     bundle = tmp_path / "rollouts.jsonl"
     bundle.write_text(json.dumps({NG_TASK_INDEX: 0, NG_ROLLOUT_INDEX: 0, "reward": 1.0}) + "\n", encoding="utf-8")
     with pytest.raises(ValueError, match="does not match"):
-        _trials_from_rollouts(bundle, tasks[1:], index_map)  # map covers a task not in the list
+        trials_from_rollouts(bundle, tasks[1:], index_map)  # map covers a task not in the list
 
 
 def test_success_record_without_usable_index_is_counted_not_silently_dropped(tmp_path: Path, caplog) -> None:
     # A success record with no usable _ng_task_index can't be attributed, but dropping it silently is
-    # the dangerous case: with num_repeats > 1 the task keeps its other trials, so _require_full_coverage
+    # the dangerous case: with num_repeats > 1 the task keeps its other trials, so require_full_coverage
     # won't fire and the task is simply scored on fewer attempts than were actually run. Count + warn,
     # matching what the failures loop already does.
     tasks = discover_gym_tasks(EXAMPLE)
@@ -717,7 +717,7 @@ def test_success_record_without_usable_index_is_counted_not_silently_dropped(tmp
         encoding="utf-8",
     )
     with caplog.at_level(logging.WARNING):
-        trials = _trials_from_rollouts(bundle, tasks, index_map)
+        trials = trials_from_rollouts(bundle, tasks, index_map)
     assert len(trials) == 1  # the unattributable record is still skipped
     assert "1 Gym rollout record(s)" in caplog.text  # ...but reported, with the count
     assert NG_TASK_INDEX in caplog.text
@@ -728,7 +728,7 @@ def test_odd_sidecar_index_is_counted_not_fatal(tmp_path: Path) -> None:
     # The failures sidecar is read tolerantly on purpose: it is written during abnormal termination,
     # so one odd record must not discard every already-parsed success. An unknown index there is
     # unattributable, not evidence of a bad join — and it cannot inflate a score, since failures carry
-    # no reward and any task left with no trial still trips _require_full_coverage.
+    # no reward and any task left with no trial still trips require_full_coverage.
     tasks = discover_gym_tasks(EXAMPLE)
     _ordered, index_map = _index_map(tasks, tmp_path)
     bundle = tmp_path / "rollouts.jsonl"
@@ -736,7 +736,7 @@ def test_odd_sidecar_index_is_counted_not_fatal(tmp_path: Path) -> None:
     failures = tmp_path / "rollouts_failures.jsonl"
     failures.write_text(json.dumps({NG_TASK_INDEX: 999, "error": "boom"}) + "\n", encoding="utf-8")
 
-    trials = _trials_from_rollouts(bundle, tasks, index_map)  # must not raise
+    trials = trials_from_rollouts(bundle, tasks, index_map)  # must not raise
     assert len(trials) == 1  # the good success survived
     assert trials[0].task_id == tasks[0].id
 
@@ -749,7 +749,7 @@ def test_odd_success_index_still_raises(tmp_path: Path) -> None:
     bundle = tmp_path / "rollouts.jsonl"
     bundle.write_text(json.dumps({NG_TASK_INDEX: 999, NG_ROLLOUT_INDEX: 0, "reward": 1.0}) + "\n", encoding="utf-8")
     with pytest.raises(ValueError, match="not one of"):
-        _trials_from_rollouts(bundle, tasks, index_map)
+        trials_from_rollouts(bundle, tasks, index_map)
 
 
 def test_incomplete_collection_raises_with_pointers_to_the_evidence(tmp_path: Path) -> None:
@@ -762,7 +762,7 @@ def test_incomplete_collection_raises_with_pointers_to_the_evidence(tmp_path: Pa
     rollouts = tmp_path / "rollouts.jsonl"
     covered = [trial_task_id for trial_task_id in [tasks[0].id]]
     with pytest.raises(RuntimeError) as excinfo:
-        _require_full_coverage(tasks, covered_task_ids=set(covered), rollouts_path=rollouts)
+        require_full_coverage(tasks, covered_task_ids=set(covered), rollouts_path=rollouts)
     message = str(excinfo.value)
     assert str(rollouts) in message  # points at the bundle
     assert "rollouts_failures.jsonl" in message  # ...and the sidecar
@@ -772,7 +772,7 @@ def test_incomplete_collection_raises_with_pointers_to_the_evidence(tmp_path: Pa
 
 def test_full_coverage_passes_silently(tmp_path: Path) -> None:
     tasks = discover_gym_tasks(EXAMPLE)
-    _require_full_coverage(tasks, covered_task_ids={t.id for t in tasks}, rollouts_path=tmp_path / "rollouts.jsonl")
+    require_full_coverage(tasks, covered_task_ids={t.id for t in tasks}, rollouts_path=tmp_path / "rollouts.jsonl")
 
 
 def test_reward_metric_shape() -> None:
@@ -808,7 +808,7 @@ def test_aggregate_metrics_sidecar_with_invalid_utf8_is_skipped_not_raised(tmp_p
     rollouts_path = tmp_path / "rollouts.jsonl"
     _aggregate_metrics_path_for(rollouts_path).write_bytes(b'[{"agent_ref": {"name": "a"}, "x": \xff}]')
 
-    assert _read_run_aggregations(rollouts_path) is None
+    assert read_run_aggregations(rollouts_path) is None
 
 
 # ---------------------------------------------------------------------------
@@ -819,47 +819,47 @@ def test_aggregate_metrics_sidecar_with_invalid_utf8_is_skipped_not_raised(tmp_p
 def test_hydra_scalars_use_hydra_spellings_not_python_ones() -> None:
     # `str(None)` is "None" and `str(True)` is "True" — both of which Hydra reads back as *strings*,
     # silently setting the literal text instead of a null or a boolean.
-    assert _hydra_scalar(None) == "null"
-    assert _hydra_scalar(True) == "true"
-    assert _hydra_scalar(False) == "false"
-    assert _hydra_scalar([1, None]) == "[1,null]"
-    assert _hydra_scalar(0.7) == "0.7"
+    assert hydra_scalar(None) == "null"
+    assert hydra_scalar(True) == "true"
+    assert hydra_scalar(False) == "false"
+    assert hydra_scalar([1, None]) == "[1,null]"
+    assert hydra_scalar(0.7) == "0.7"
 
 
 def test_hydra_strings_are_quoted_so_the_grammar_cannot_retype_them() -> None:
     # Hydra's grammar is typed: unquoted, "true" parses as a bool, "null" as None, "1.5" as a float,
     # and "a,b" as a *sweep* — so a string override would silently become something else.
-    assert _hydra_scalar("true") == "'true'"
-    assert _hydra_scalar("null") == "'null'"
-    assert _hydra_scalar("1.5") == "'1.5'"
-    assert _hydra_scalar("a,b") == "'a,b'"
-    assert _hydra_scalar("A[B") == "'A[B'"  # unquoted this does not parse at all
-    assert _hydra_scalar("") == "''"
+    assert hydra_scalar("true") == "'true'"
+    assert hydra_scalar("null") == "'null'"
+    assert hydra_scalar("1.5") == "'1.5'"
+    assert hydra_scalar("a,b") == "'a,b'"
+    assert hydra_scalar("A[B") == "'A[B'"  # unquoted this does not parse at all
+    assert hydra_scalar("") == "''"
     # Only the quote is escaped: Hydra does not decode `\\` inside a quoted value, so escaping
     # backslashes would double them.
-    assert _hydra_scalar("he'llo") == "'he\\'llo'"
-    assert _hydra_scalar("back\\slash") == "'back\\slash'"
+    assert hydra_scalar("he'llo") == "'he\\'llo'"
+    assert hydra_scalar("back\\slash") == "'back\\slash'"
     # Interpolation survives quoting — the override sets the text, OmegaConf resolves it on read.
-    assert _hydra_scalar("${policy_base_url}") == "'${policy_base_url}'"
+    assert hydra_scalar("${policy_base_url}") == "'${policy_base_url}'"
 
 
 def test_hydra_rejects_a_value_it_cannot_express() -> None:
     # A trailing backslash escapes the closing quote and leaves the value unterminated; there is no
     # spelling that avoids it, so say so rather than emit something unparseable.
     with pytest.raises(ValueError, match="ends with a backslash"):
-        _hydra_scalar("ends\\")
+        hydra_scalar("ends\\")
 
 
 def test_hydra_dicts_nested_in_a_list_use_the_grammars_bare_keys() -> None:
     # A mapping reached through a list has no dotted path to flatten onto, so it has to be spelled
     # inline. `str()` would emit Python's repr — `{'b': 1}` — whose quoted keys Hydra's `dictKey`
     # rule has no form for and rejects outright.
-    assert _hydra_scalar({"b": 1}) == "{b:1}"
-    assert _hydra_scalar([{"b": 1}, {"c": "true"}]) == "[{b:1},{c:'true'}]"
+    assert hydra_scalar({"b": 1}) == "{b:1}"
+    assert hydra_scalar([{"b": 1}, {"c": "true"}]) == "[{b:1},{c:'true'}]"
     # The typed spellings hold at depth: values recurse through the same function.
-    assert _hydra_scalar({"b": None, "c": True, "d": "a,b"}) == "{b:null,c:true,d:'a,b'}"
-    assert _hydra_scalar({"b": {"c": [1, "x"]}}) == "{b:{c:[1,'x']}}"
-    assert _hydra_scalar({}) == "{}"
+    assert hydra_scalar({"b": None, "c": True, "d": "a,b"}) == "{b:null,c:true,d:'a,b'}"
+    assert hydra_scalar({"b": {"c": [1, "x"]}}) == "{b:{c:[1,'x']}}"
+    assert hydra_scalar({}) == "{}"
 
 
 @pytest.mark.parametrize("key", ["true", "NULL", "1.5", "inf", "b:c", "b,c", "b}c", "b'c", "", 1])
@@ -868,7 +868,7 @@ def test_hydra_rejects_dict_keys_it_would_retype_or_fail_to_parse(key: object) -
     # of the lexer: `{true:1}` keys on the boolean True and `{b:c:1}` does not parse. Neither is what
     # the caller wrote, and the second is not even loud, so refuse both.
     with pytest.raises(ValueError, match="dict key"):
-        _hydra_scalar([{key: 1}])
+        hydra_scalar([{key: 1}])
 
 
 def test_flatten_overrides_produces_forcing_dotted_paths() -> None:
@@ -894,7 +894,7 @@ def _config(**kwargs: object) -> GymRuntimeConfig:
 
 
 def test_selection_binds_the_resources_server_by_default(tmp_path: Path) -> None:
-    selection = _selection_args(_config(), tmp_path)
+    selection = selection_args(_config(), tmp_path)
     assert "--resources-server" in selection and "mcqa" in selection
     assert "+simple_agent.responses_api_agents.simple_agent.resources_server.name=mcqa" in selection
 
@@ -902,7 +902,7 @@ def test_selection_binds_the_resources_server_by_default(tmp_path: Path) -> None
 def test_selection_omits_the_binding_when_the_caller_binds_it_themselves(tmp_path: Path) -> None:
     # gdpval registers its server as `gdpval_resources_server`, so the automatic binding is wrong for
     # it and the caller supplies their own. Emitting both would leave the config ambiguous.
-    selection = _selection_args(
+    selection = selection_args(
         _config(
             bind_resources_server=False,
             hydra_params={
@@ -927,19 +927,19 @@ def test_selection_quotes_a_work_dir_containing_hydra_grammar(tmp_path: Path, aw
     # Raised by review on #1295. `hydra.run.dir` is a path, and Hydra's grammar reads `,` as a sweep
     # separator and `[` as a list opener. Checked against Hydra's own parser: unquoted, `/tmp/a,b`
     # comes back as a ChoiceSweep and `/tmp/x[1]` raises OverrideParseException. Quoting round-trips
-    # all three, so the value has to go through _hydra_scalar like every other override.
+    # all three, so the value has to go through hydra_scalar like every other override.
     work_dir = tmp_path / awkward
-    arg = next(a for a in _selection_args(_config(), work_dir) if a.startswith("hydra.run.dir="))
+    arg = next(a for a in selection_args(_config(), work_dir) if a.startswith("hydra.run.dir="))
     value = arg.removeprefix("hydra.run.dir=")
-    assert value == _hydra_scalar(str(work_dir / "gym_hydra"))
+    assert value == hydra_scalar(str(work_dir / "gym_hydra"))
     assert value.startswith("'") and value.endswith("'")
 
 
 def test_selection_redirects_hydra_output_under_the_run_work_dir(tmp_path: Path) -> None:
     # Gym writes `outputs/<date>/<time>/` relative to cwd, and the subprocesses inherit ours so Gym
     # can find env.yaml — so without this every run litters the caller's directory.
-    selection = _selection_args(_config(), tmp_path)
-    assert f"hydra.run.dir={_hydra_scalar(str(tmp_path / 'gym_hydra'))}" in selection
+    selection = selection_args(_config(), tmp_path)
+    assert f"hydra.run.dir={hydra_scalar(str(tmp_path / 'gym_hydra'))}" in selection
 
 
 def _stub_gym(tmp_path: Path, *, exit_code: int, message: str) -> str:
@@ -988,34 +988,34 @@ def test_invocation_env_inherits_the_process_environment(monkeypatch: pytest.Mon
     # Gym honours ordinary variables a caller expects to carry over — proxies, HF_TOKEN — so the
     # parent environment is the base layer rather than being replaced.
     monkeypatch.setenv("A485_INHERITED", "from-parent")
-    assert _gym_invocation_env(_config())["A485_INHERITED"] == "from-parent"
+    assert gym_invocation_env(_config())["A485_INHERITED"] == "from-parent"
 
 
 def test_invocation_env_disables_rays_uv_hook_by_default() -> None:
     # Gym launches each server from its own subdir with its own .venv; Ray's uv-project replication
     # asserts the driver's cwd holds the pyproject and aborts startup.
-    assert _gym_invocation_env(_config())["RAY_ENABLE_UV_RUN_RUNTIME_ENV"] == "0"
+    assert gym_invocation_env(_config())["RAY_ENABLE_UV_RUN_RUNTIME_ENV"] == "0"
 
 
 def test_env_vars_win_over_the_inherited_environment(monkeypatch: pytest.MonkeyPatch) -> None:
     # The point of the field: naming a variable in the run config makes it a property of the
     # environment being run, not of whoever launched the runner.
     monkeypatch.setenv("WMT_TRANSLATION_COMET_PY_CACHE", "/whatever-the-launcher-had")
-    env = _gym_invocation_env(_config(env_vars={"WMT_TRANSLATION_COMET_PY_CACHE": "/from-the-run-config"}))
+    env = gym_invocation_env(_config(env_vars={"WMT_TRANSLATION_COMET_PY_CACHE": "/from-the-run-config"}))
     assert env["WMT_TRANSLATION_COMET_PY_CACHE"] == "/from-the-run-config"
 
 
 def test_env_vars_can_restore_rays_uv_hook() -> None:
     # The Ray default exists to make Gym work, not as an invariant — someone debugging that hook
     # needs a way to put it back, so an explicit value has to outrank it.
-    env = _gym_invocation_env(_config(env_vars={"RAY_ENABLE_UV_RUN_RUNTIME_ENV": "1"}))
+    env = gym_invocation_env(_config(env_vars={"RAY_ENABLE_UV_RUN_RUNTIME_ENV": "1"}))
     assert env["RAY_ENABLE_UV_RUN_RUNTIME_ENV"] == "1"
 
 
 def test_gym_executable_reports_how_to_install_when_absent(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(shutil, "which", lambda _: None)
     with pytest.raises(RuntimeError, match="own environment"):
-        _gym_executable()
+        gym_executable()
 
 
 #: Verbatim from a real `legal_agent_bench` startup timeout (AALGO-485 coverage sweep). Gym polls
@@ -1059,7 +1059,7 @@ def _two_tasks_and_map(tmp_path: Path):
         encoding="utf-8",
     )
     tasks = discover_gym_tasks(dataset)
-    return tasks, _materialize_dataset(tasks, tmp_path / "gym_input.jsonl")
+    return tasks, materialize_dataset(tasks, tmp_path / "gym_input.jsonl")
 
 
 def test_token_usage_keys_match_the_openai_schemas_they_mirror() -> None:
@@ -1153,7 +1153,7 @@ def test_agent_never_ran_is_false_without_usage_to_corroborate() -> None:
 
 
 def test_missing_results_file_names_the_logs_instead_of_raising_filenotfound(tmp_path: Path) -> None:
-    # Raised by review on #1295. `_ensure_fresh_output` deletes any stale file before the run and
+    # Raised by review on #1295. `ensure_fresh_output` deletes any stale file before the run and
     # `_collect_rollouts` already raised on a non-zero exit, so an absent file here means Gym
     # reported success and wrote nothing. Opening it regardless gives a bare FileNotFoundError
     # naming a path the reader has no reason to recognise.
@@ -1162,7 +1162,7 @@ def test_missing_results_file_names_the_logs_instead_of_raising_filenotfound(tmp
     assert not missing.exists()
 
     with pytest.raises(RuntimeError) as excinfo:
-        _trials_from_rollouts(missing, tasks, index_map)
+        trials_from_rollouts(missing, tasks, index_map)
 
     message = str(excinfo.value)
     assert "wrote no results" in message
@@ -1187,7 +1187,7 @@ def test_all_rollouts_empty_fails_the_run_instead_of_reporting_zeros(tmp_path: P
     )
 
     with pytest.raises(RuntimeError) as excinfo:
-        _trials_from_rollouts(bundle, tasks, index_map)
+        trials_from_rollouts(bundle, tasks, index_map)
 
     message = str(excinfo.value)
     assert "never called" in message
@@ -1220,7 +1220,7 @@ def test_an_unattributed_failure_prevents_the_all_empty_raise(tmp_path: Path) ->
         json.dumps({"error": "agent OOM-killed mid-episode"}) + "\n", encoding="utf-8"
     )
 
-    trials = _trials_from_rollouts(bundle, tasks, index_map)
+    trials = trials_from_rollouts(bundle, tasks, index_map)
 
     assert [trial.status for trial in trials] == [AgentEvalTrialStatus.FAILED]
 
@@ -1240,7 +1240,7 @@ def test_an_unattributed_rollout_prevents_the_all_empty_raise(tmp_path: Path) ->
         encoding="utf-8",
     )
 
-    trials = _trials_from_rollouts(bundle, tasks, index_map)
+    trials = trials_from_rollouts(bundle, tasks, index_map)
 
     assert [trial.status for trial in trials] == [AgentEvalTrialStatus.FAILED]
 
@@ -1271,7 +1271,7 @@ def test_empty_rollouts_alongside_a_sidecar_failure_do_not_raise(tmp_path: Path)
         encoding="utf-8",
     )
 
-    trials = _trials_from_rollouts(bundle, tasks, index_map)
+    trials = trials_from_rollouts(bundle, tasks, index_map)
 
     assert {trial.task_id for trial in trials} == {tasks[0].id, tasks[1].id}
     assert all(trial.status is AgentEvalTrialStatus.FAILED for trial in trials)
@@ -1292,7 +1292,7 @@ def test_some_rollouts_empty_fails_only_those_trials(tmp_path: Path) -> None:
         encoding="utf-8",
     )
 
-    trials = _trials_from_rollouts(bundle, tasks, index_map)
+    trials = trials_from_rollouts(bundle, tasks, index_map)
 
     by_task = {trial.task_id: trial for trial in trials}
     empty = by_task[tasks[0].id]
@@ -1307,13 +1307,13 @@ def test_some_rollouts_empty_fails_only_those_trials(tmp_path: Path) -> None:
 
 
 def test_pending_servers_reports_the_last_poll_not_the_first() -> None:
-    assert _pending_servers(_REAL_ENV_LOG) == (3, 4, ("legal_agent_bench",))
+    assert pending_servers(_REAL_ENV_LOG) == (3, 4, ("legal_agent_bench",))
 
 
 def test_pending_servers_is_none_when_gym_never_reported_readiness() -> None:
     # Gym died during composition or dependency install; there is no pending set to report, which
     # must not be confused with "nothing pending".
-    assert _pending_servers("NeMo Gym is starting a new Ray cluster...\nerror: No solution found\n") is None
+    assert pending_servers("NeMo Gym is starting a new Ray cluster...\nerror: No solution found\n") is None
 
 
 def test_startup_timeout_names_the_server_that_did_not_come_up(tmp_path: Path) -> None:
@@ -1364,7 +1364,7 @@ async def test_collection_failure_points_at_the_server_log_too(tmp_path: Path) -
 
 @pytest.mark.asyncio
 async def test_collection_redirects_hydra_output_under_the_run_work_dir(tmp_path: Path) -> None:
-    # `gym eval run` does not go through _selection_args, so it needs its own redirect — without it
+    # `gym eval run` does not go through selection_args, so it needs its own redirect — without it
     # every collection drops an `outputs/<date>/<time>/` into the caller's cwd.
     runner = GymAgentTaskRunner(config=_config())
     gym = _stub_gym(tmp_path, exit_code=0, message="done")
@@ -1372,4 +1372,4 @@ async def test_collection_redirects_hydra_output_under_the_run_work_dir(tmp_path
     await runner._collect_rollouts(gym, tmp_path / "in.jsonl", tmp_path / "out.jsonl", tmp_path, {})
 
     argv = (tmp_path / "argv.txt").read_text().splitlines()
-    assert f"hydra.run.dir={_hydra_scalar(str(tmp_path / 'gym_hydra'))}" in argv
+    assert f"hydra.run.dir={hydra_scalar(str(tmp_path / 'gym_hydra'))}" in argv


### PR DESCRIPTION
Part 2 of 2, stacked on #1814. **Review that one first** — this diff is only readable against it.

## Why

Twenty-two names in the gym runner carried a leading underscore while being imported by sibling modules. The marker said "module-private"; the imports said otherwise:

```python
from nemo_evaluator_sdk.agent_eval.runtimes.gym.results import (
    _aggregate_scores_from_gym,
    _ensure_fresh_output,
    _read_run_aggregations,
    _require_full_coverage,
    _trials_from_rollouts,
)
```

## What

Drop the underscore on every name a *production* sibling imports, across `config`, `dataset`, `process`, `records`, `results`. The convention is now readable off the name: no underscore means package-internal API, underscore means private to its module. The package itself is internal to the SDK and exports none of these.

An AST sweep confirms zero production modules still import a private name from a gym sibling.

## What is deliberately left alone

Seven names only tests reach for — `_agent_never_ran`, `_canonical_row_hash`, `_content_text`, `_render_instruction`, `_aggregate_metrics_path_for`, `_TOKEN_USAGE_KEYS`, `_INPUT_TOKEN_KEYS`. A test reaching into a module's privates is a different and milder thing than a sibling module doing it, and renaming them changes no production contract. Happy to make it uniform if reviewers prefer.

## Risk

Pure rename, no behaviour change. Scope was verified two ways:

- Every one of the 22 names already exists on `main`, so this touches nothing #1814 introduces — the two are separable in either order.
- The tree produced by #1814 plus this commit is byte-identical (same git tree object) to the state the full suite was run against before the work was split into commits.

An early draft of this rename was repo-wide and caught ten unrelated modules with their own private `_read_jsonl` / `_terminate` / `_LOG_TAIL_LINES`. Those were reverted; the scope here is the gym package and its two test files, nothing else.

**2803 passed, 38 skipped.** `ruff` and `ty` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Made Gym runtime configuration, dataset, process, record, and result utilities publicly accessible.
  - Expanded the public API for dataset handling, process management, configuration, logging, score aggregation, and rollout conversion.
- **Tests**
  - Updated Gym runtime tests to use the public APIs while preserving existing coverage and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->