### PR TITLE
docs(studio): add Custom Models page for the Studio customization UI

### DIFF
--- a/docs/fern/versions/latest.yml
+++ b/docs/fern/versions/latest.yml
@@ -350,6 +350,8 @@ navigation:
         contents:
           - page: Agents
             path: ../../studio/agents.mdx
+          - page: Custom Models
+            path: ../../studio/customization.mdx
           - page: Data Designer
             path: ../../studio/data-designer-build.mdx
           - page: Monitor

--- a/docs/studio/customization.mdx
+++ b/docs/studio/customization.mdx
@@ -24,7 +24,7 @@ Select **Customize a Model** from the Custom Models list, or open a base model's
 | ------- | ------------------- |
 | Training Backend | **Automodel** (multi-GPU), **Unsloth** (single-GPU, 4-bit quantized), or **RL**. |
 | Model | Base model, output model name, and description. |
-| Training Method | Backend-specific method, for example SFT, distillation, DPO, or GRPO. |
+| Training Method | For Automodel and Unsloth: fine-tuning type (**LoRA**, **LoRA (Merged)**, or **Full Weights**), plus, for Automodel, training type (**SFT** or **Distillation**, with a teacher model field for distillation). For RL: **DPO** or **GRPO**. |
 | Reward Environment | Shown for GRPO jobs. Selects the reward environment used during training. |
 | Dataset | The training fileset, selected from filesets available in the workspace. |
 | Parameters | General hyperparameters, or GRPO-specific parameters when the training method is GRPO. |
@@ -52,9 +52,19 @@ Select a job to open its detail page, which shows the job name, status badge, an
 
 | Tab | Shows |
 | --- | ----- |
-| Overview | Job configuration, training progress, and the source dataset's fileset details. |
+| Overview | Training progress, run configuration, and the source dataset's fileset details. |
 | Logs | Job execution logs. |
 | Chat with your Model | A chat playground against the resulting model, shown once the job completes. |
+
+The Overview tab's training progress panel differs by training method:
+
+| Training method | Panel | Shows |
+| ---------------- | ----- | ----- |
+| SFT, distillation, DPO | Training Loss | Train and validation loss per step, plus loss and progress stat tiles. |
+| GRPO | Reward | Training and validation reward per step (loss isn't meaningful for GRPO's policy-gradient objective), plus reward and progress stat tiles. |
+| GRPO | Training Health | Collapsed by default. Diagnostic charts from NeMo RL, such as KL divergence and clip fraction, that can flag a run diverging before reward does. |
+
+Below the training panel, **Run Configuration** summarizes the customization ID, output model, base model, and other run metadata, with a **View Job Configuration** action that opens the full job spec.
 
 From the detail page header, select **Evaluate** to start an evaluation against the resulting model once the job is launchable, or open the actions menu (**⋯**) for **Clone** and, while the job is active or pending, **Cancel Job**.
 

--- a/docs/studio/customization.mdx
+++ b/docs/studio/customization.mdx
@@ -1,0 +1,66 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+title: "NeMo Studio Custom Models"
+description: "Fine-tune models from NeMo Studio, and track customization jobs."
+---
+
+Use **Models > Fine-tune** in the NeMo Studio workspace sidebar to open the Custom Models list, start Customizer jobs, and track their progress for the selected workspace.
+
+<Note>
+
+Custom Models is enabled by default. An administrator can disable it by setting `studio.feature_flags.customizer_enabled: false` in the platform configuration and restarting Studio, which removes the **Custom Models** navigation entry and hides Customizer jobs from the general **Jobs** list.
+
+</Note>
+
+For customization concepts, supported models, and the underlying CLI and API workflow, see [Customization Concepts](/documentation/customizer-reference/customization-concepts).
+
+## Start a Customization Job
+
+Select **Customize a Model** from the Custom Models list, or open a base model's details panel and select **Customize this Model**. Both open **Fine-tune a Model**, a single form with the following sections, shown as they apply to your selections:
+
+| Section | What you configure |
+| ------- | ------------------- |
+| Training Backend | **Automodel** (multi-GPU), **Unsloth** (single-GPU, 4-bit quantized), or **RL**. |
+| Model | Base model, output model name, and description. |
+| Training Method | Backend-specific method, for example SFT, distillation, DPO, or GRPO. |
+| Reward Environment | Shown for GRPO jobs. Selects the reward environment used during training. |
+| Dataset | The training fileset, selected from filesets available in the workspace. |
+| Parameters | General hyperparameters, or GRPO-specific parameters when the training method is GRPO. |
+| LoRA Parameters | Shown when the training method uses a LoRA or LoRA-merged finetuning type. |
+| DPO Parameters | Shown for RL jobs using DPO. |
+| Compute Resources | GPU and node allocation for the job. |
+
+Several sections include an advanced JSON field for power-user overrides — for example raw parallelism or backend-specific keyword arguments — alongside the structured form fields. Use these only when a setting isn't exposed elsewhere in the form.
+
+Select **Start Fine-Tuning** to create the job. Studio confirms with a toast and navigates to the new job's detail page.
+
+Model eligibility for fine-tuning depends on the selected base model; **Customize this Model** is disabled for models that have no fileset to fine-tune from.
+
+### Clone an Existing Job
+
+From a job's detail page, open the actions menu (**⋯**) and select **Clone** to open **Fine-tune a Model** pre-filled with that job's settings. Adjust any fields before submitting to start a new job.
+
+## Custom Models List
+
+The Custom Models list shows fine-tuned models created in the current workspace. Select a row to open the model details side panel, which includes **Model Details** and **Chat Playground** tabs, a **Customize this Model** action, an **Evaluate this Model** action, and a **View Intake Traces** link when intake is enabled.
+
+## Customization Job Details
+
+Select a job to open its detail page, which shows the job name, status badge, and metadata such as training type, base model, and creation date.
+
+| Tab | Shows |
+| --- | ----- |
+| Overview | Job configuration, training progress, and the source dataset's fileset details. |
+| Logs | Job execution logs. |
+| Chat with your Model | A chat playground against the resulting model, shown once the job completes. |
+
+From the detail page header, select **Evaluate** to start an evaluation against the resulting model once the job is launchable, or open the actions menu (**⋯**) for **Clone** and, while the job is active or pending, **Cancel Job**.
+
+## Related Topics
+
+- [Customization Concepts](/documentation/customizer-reference/customization-concepts)
+- [Create a Customization Job](/documentation/customizer-reference/manage-customization-jobs/create-a-customization-job)
+- [Customization Job Reference](/documentation/customizer-reference/manage-customization-jobs/customization-job-reference)
+- [Experiments](/documentation/evaluate-models/experiments)

--- a/docs/studio/index.mdx
+++ b/docs/studio/index.mdx
@@ -35,7 +35,7 @@ The current sidebar groups related pages under expandable parents. Selecting a p
 | **Observability** | **Insights** | Review recurring agent failure patterns and optimization insights. Shown when optimization is enabled. |
 | **Observability** | **Traces** | Inspect ingested traces, spans, and session details. |
 | **Components** | **Agents** | Opens the agent list. Select an agent to access Deployments, Logs, Chat, Evaluations, and Details. |
-| **Components** | **Models** | Opens the base-model list directly. Expand **Models** for **Fine-tune**, **Model Evaluations**, **Playground**, and **Virtual Models**, when those capabilities are enabled. |
+| **Components** | **Models** | Opens the base-model list directly. Expand **Models** for **Fine-tune**, **Model Evaluations**, **Playground**, and **Virtual Models**, when those capabilities are enabled. **Fine-tune** opens the Custom Models list; see [NeMo Studio Custom Models](/documentation/studio/customization). |
 | **Evaluations** | **Experiments** | Review experiments, evaluations, sessions, and published results across the workspace. |
 | **Data** | **Datasets > Data Designer** | Build and monitor synthetic-data jobs. Other installed data plugins can appear below **Datasets**. |
 | **Governance** | **Guardrails** | Manage guardrail configurations. Disabled by default; see [Studio Guardrail Configs](/documentation/studio/guardrail-configs). |
@@ -80,6 +80,10 @@ Select **Models** to browse base-model entities available in the current workspa
 The Base Models page supports searching by model name, filtering by creation or update date, sorting alphabetically or by creation time, and showing only customizable models. Select a model card to open the model details side panel.
 
 The model details side panel shows model metadata, parameters, and available actions. From the side panel you can open the chat playground for chat-capable models or navigate to model evaluation results.
+
+### Custom Models
+
+Select **Models > Fine-tune** to open the Custom Models list, start a fine-tuning job against an eligible base model, and track job progress. Enabled by default; see [NeMo Studio Custom Models](/documentation/studio/customization).
 
 ### Workspaces
 


### PR DESCRIPTION
Docs update for https://nvbugspro.nvidia.com/bug/6721055

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a Custom Models section to the Studio documentation navigation.
  - Documented creating and cloning customization jobs, selecting training options, datasets, resources, and eligible models.
  - Added guidance for tracking job progress, evaluation, and cancellation.
  - Updated Models documentation to explain how to start and monitor fine-tuning jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->