### PR TITLE
chore: Improve logging in run_task, execute agent, analyst agent

### DIFF
--- a/packages/nemo_platform/pyproject.toml
+++ b/packages/nemo_platform/pyproject.toml
@@ -741,6 +741,10 @@ nemo-switchyard = "nemo_switchyard.middleware:SwitchyardMiddleware"
 "data-designer.retrieval-run" = "nemo_data_designer_plugin.jobs.retrieval_run:RetrievalRunJob"
 
 # Generated from [tool.bundle-package]; do not edit this table by hand.
+[project.entry-points."nemo.logging_provider"]
+platform = "nmp.common.observability.task_logging:PlatformTaskLoggingProvider"
+
+# Generated from [tool.bundle-package]; do not edit this table by hand.
 [project.entry-points."nemo.optimization.backends"]
 optuna = "nemo_optimization.backends.optuna.backend:OptunaBackend"
 ga = "nemo_optimization.backends.ga.backend:GaBackend"

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/tasks/dispatcher.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/tasks/dispatcher.py
@@ -57,6 +57,7 @@ from nemo_platform_plugin.jobs.constants import (
     PERSISTENT_JOB_STORAGE_PATH_ENVVAR,
 )
 from nemo_platform_plugin.run_dependencies import LocalRunError, resolve_run_kwargs
+from nemo_platform_plugin.tasks.logging_setup import configure_task_logging
 
 logger = logging.getLogger(__name__)
 
@@ -80,6 +81,11 @@ def run_task(
     :class:`~nemo_platform_plugin.job_results.PlatformJobResults` as ``ctx.results``,
     so *sdk* is required when *ctx* is not supplied.
 
+    Root logging is bootstrapped via
+    :func:`~nemo_platform_plugin.tasks.logging_setup.configure_task_logging`
+    before anything else, since a task container configures none of its own.
+    A caller that already configured logging keeps it.
+
     Args:
         job_cls: The :class:`~nemo_platform_plugin.job.NemoJob` subclass to run.
         sdk: :class:`~nemo_platform.NeMoPlatform` handle, typically built via
@@ -93,6 +99,11 @@ def run_task(
     Returns:
         Process exit code suitable for :func:`sys.exit`.
     """
+    # First thing in the process: a task container configures nothing itself,
+    # so without this every message below INFO+lastResort is lost - including
+    # the failure reporting further down. Must precede the first log call.
+    configure_task_logging()
+
     try:
         config = _read_step_config()
     except Exception:
@@ -155,6 +166,9 @@ def _exit_code_for(result: Any) -> int:
     if not isinstance(result, dict):
         return 0
     if result.get("status") == "failed":
+        # A job that reports failure through its return value never raises, so
+        # nothing else in this process says why the exit code is non-zero.
+        logger.error("Job reported status=failed; result: %s", result)
         return 1
     exit_code = result.get("exit_code")
     if isinstance(exit_code, int) and exit_code != 0:

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/tasks/dispatcher.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/tasks/dispatcher.py
@@ -172,6 +172,7 @@ def _exit_code_for(result: Any) -> int:
         return 1
     exit_code = result.get("exit_code")
     if isinstance(exit_code, int) and exit_code != 0:
+        logger.error("Job reported non-zero exit_code=%s; result: %s", exit_code, result)
         return 1
     return 0
 

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/tasks/logging_setup.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/tasks/logging_setup.py
@@ -1,0 +1,194 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Logging bootstrap for platform-spawned task processes.
+
+A task container runs its entrypoint directly (``python -m <task module>``),
+so nothing configures the root logger the way a service's startup does. With
+no root handler Python falls back to :data:`logging.lastResort`: WARNING and
+above reach stderr as bare messages with no timestamp, level or logger name,
+and INFO/DEBUG are dropped outright. A job that fails without raising can
+therefore produce completely empty logs.
+
+:func:`configure_task_logging` closes that gap for every task dispatched
+through :func:`~nemo_platform_plugin.tasks.dispatcher.run_task`.
+
+Lookup order for the provider
+-----------------------------
+
+Mirrors :mod:`nemo_platform_plugin.client_provider` and
+:mod:`nemo_platform_plugin.sdk_provider`, for the same reason: it lets the
+platform supply a richer implementation without ``nemo-platform-plugin`` ever
+depending on ``nmp-common``.
+
+1. **Explicit override** - set via :func:`set_task_logging_provider` (tests).
+2. **Entry-point discovery** - scans the ``nemo.logging_provider`` group.
+   When ``nmp-common`` is installed (every platform image), its provider is
+   picked up and task output becomes the same structured stream the services
+   emit, so log aggregation treats the two alike.
+3. **Built-in default** - :class:`DefaultTaskLoggingProvider`, a plain stderr
+   handler. Covers local development and any image without ``nmp-common``.
+
+Unlike the client and SDK providers, a provider that fails to load here is
+downgraded to the default rather than raised: logging is diagnostic
+scaffolding, and failing a task because its logging setup broke would destroy
+the very evidence needed to debug it.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Literal, Protocol, runtime_checkable
+
+from nemo_platform_plugin.discovery import discover_entry_points
+
+#: The platform's configured logging vocabulary, mirroring
+#: ``CommonServiceConfig`` so a value read from settings can be handed
+#: straight to a provider without a cast.
+LogLevel = Literal["DEBUG", "INFO", "WARN", "ERROR"]
+LogFormat = Literal["json", "plain"]
+
+#: Entry-point group a platform-side logging provider registers under.
+TASK_LOGGING_PROVIDER_GROUP = "nemo.logging_provider"
+
+#: Formatter used by the built-in default. Deliberately carries the fields
+#: ``lastResort`` drops - timestamp, level and logger name - since that is what
+#: makes a task log readable at all.
+FALLBACK_LOG_FORMAT = "%(asctime)s %(levelname)s %(name)s: %(message)s"
+
+#: Transport libraries that log a line per request at INFO. Clamped so their
+#: output cannot drown the job's own messages.
+_NOISY_LOGGERS = ("httpx", "httpcore", "asyncio")
+
+logger = logging.getLogger(__name__)
+
+_provider_override: TaskLoggingProvider | None = None
+
+
+@runtime_checkable
+class TaskLoggingProvider(Protocol):
+    """Configures root logging for a task process."""
+
+    def configure_logging(self, *, level: LogLevel, log_format: LogFormat) -> None: ...
+
+
+class DefaultTaskLoggingProvider:
+    """Built-in provider: a plain stderr handler on the root logger."""
+
+    def configure_logging(self, *, level: LogLevel, log_format: LogFormat) -> None:
+        # ``log_format`` is part of the provider contract but the default has
+        # only one rendering; a platform provider is what honours "json".
+        del log_format
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter(FALLBACK_LOG_FORMAT))
+        root = logging.getLogger()
+        root.addHandler(handler)
+        try:
+            root.setLevel(level)
+        except ValueError:
+            root.setLevel(logging.INFO)
+        for name in _NOISY_LOGGERS:
+            logging.getLogger(name).setLevel(logging.WARNING)
+
+
+def set_task_logging_provider(provider: TaskLoggingProvider | None) -> None:
+    """Override the provider, or restore discovery by passing ``None``."""
+    global _provider_override
+    _provider_override = provider
+
+
+def configure_task_logging() -> None:
+    """Configure root logging for a task process, if nothing else has.
+
+    A no-op when the root logger already has handlers, so a caller that
+    configured logging itself keeps ownership of it: a service that dispatches
+    in-process, the ``nemo-platform run task`` entrypoint, or a test harness.
+    Safe to call more than once.
+    """
+    if logging.getLogger().handlers:
+        return
+
+    level, log_format = _resolve_log_config()
+    provider = _resolve_provider()
+    try:
+        provider.configure_logging(level=level, log_format=log_format)
+    except Exception:
+        logger.warning("Task logging provider failed; falling back to the default.", exc_info=True)
+        if not logging.getLogger().handlers:
+            DefaultTaskLoggingProvider().configure_logging(level=level, log_format=log_format)
+
+
+def _resolve_log_config() -> tuple[LogLevel, LogFormat]:
+    """Read the level/format the platform is configured with.
+
+    ``CommonServiceConfig`` is owned by this package and reads the same
+    ``LOG_LEVEL`` / ``LOG_FORMAT`` environment the services use, so a task
+    honours whatever the deployment sets. Falls back to the field defaults
+    rather than failing: a task with misconfigured settings should still log.
+    """
+    try:
+        from nemo_platform_plugin.config import CommonServiceConfig
+
+        service_config = CommonServiceConfig()
+    except Exception:
+        return "INFO", "plain"
+    return service_config.log_level, service_config.log_format
+
+
+def _resolve_provider() -> TaskLoggingProvider:
+    """Resolve the provider: explicit override -> entry-point -> default."""
+    if _provider_override is not None:
+        return _provider_override
+
+    try:
+        entry_points = discover_entry_points(TASK_LOGGING_PROVIDER_GROUP)
+    except Exception:
+        logger.warning("Failed to scan for task logging providers.", exc_info=True)
+        return DefaultTaskLoggingProvider()
+
+    # The nemo-platform bundle inherits nmp-common's entry points, so the same
+    # provider legitimately appears under one name from two distributions; a
+    # dict keyed by name already collapses that. More than one *name* means a
+    # second package registered its own, which is not something to guess at.
+    if len(entry_points) > 1:
+        logger.warning(
+            "Multiple task logging providers registered under %r: %s. Using the default.",
+            TASK_LOGGING_PROVIDER_GROUP,
+            ", ".join(sorted(entry_points)),
+        )
+        return DefaultTaskLoggingProvider()
+
+    for entry_point in entry_points.values():
+        try:
+            provider = entry_point.load()
+            if isinstance(provider, type):
+                provider = provider()
+        except Exception:
+            logger.warning(
+                "Failed to load task logging provider %r from %r; using the default.",
+                entry_point.name,
+                entry_point.value,
+                exc_info=True,
+            )
+            break
+        if not isinstance(provider, TaskLoggingProvider):
+            logger.warning(
+                "Task logging provider %r does not implement configure_logging; using the default.",
+                entry_point.name,
+            )
+            break
+        return provider
+
+    return DefaultTaskLoggingProvider()
+
+
+__all__ = [
+    "FALLBACK_LOG_FORMAT",
+    "TASK_LOGGING_PROVIDER_GROUP",
+    "DefaultTaskLoggingProvider",
+    "LogFormat",
+    "LogLevel",
+    "TaskLoggingProvider",
+    "configure_task_logging",
+    "set_task_logging_provider",
+]

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/tasks/logging_setup.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/tasks/logging_setup.py
@@ -113,9 +113,19 @@ def configure_task_logging() -> None:
     try:
         provider.configure_logging(level=level, log_format=log_format)
     except Exception:
-        logger.warning("Task logging provider failed; falling back to the default.", exc_info=True)
-        if not logging.getLogger().handlers:
-            DefaultTaskLoggingProvider().configure_logging(level=level, log_format=log_format)
+        # A provider that raised part-way through can leave a configuration that
+        # looks present but does not work - a handler attached before it got to
+        # setting the root level, say, which would strand the task at WARNING.
+        # The early return above guarantees the root logger was bare when we
+        # called it, so anything here now came from the failed call: discard it
+        # rather than trust half of it.
+        root = logging.getLogger()
+        for handler in root.handlers[:]:
+            root.removeHandler(handler)
+        DefaultTaskLoggingProvider().configure_logging(level=level, log_format=log_format)
+        # Logged only once the fallback is in place. Reporting the failure
+        # first would emit it into the broken configuration we are replacing.
+        logger.warning("Task logging provider failed; using the default.", exc_info=True)
 
 
 def _resolve_log_config() -> tuple[LogLevel, LogFormat]:

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/tasks/logging_setup.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/tasks/logging_setup.py
@@ -131,15 +131,20 @@ def configure_task_logging() -> None:
 def _resolve_log_config() -> tuple[LogLevel, LogFormat]:
     """Read the level/format the platform is configured with.
 
-    ``CommonServiceConfig`` is owned by this package and reads the same
-    ``LOG_LEVEL`` / ``LOG_FORMAT`` environment the services use, so a task
-    honours whatever the deployment sets. Falls back to the field defaults
-    rather than failing: a task with misconfigured settings should still log.
+    Going through ``Configuration`` merges the platform config file when one
+    is reachable (local and subprocess runs, and any container where it is mounted),
+    and ``EnvironmentFirstSettings`` still lets the environment win - which is what
+    carries the setting into containers that have no config file, since the
+    jobs backends inject the platform's resolved ``LOG_LEVEL``/``LOG_FORMAT``
+    into every task.
+
+    Falls back to the field defaults rather than failing: a task with misconfigured
+    settings should still log.
     """
     try:
-        from nemo_platform_plugin.config import CommonServiceConfig
+        from nemo_platform_plugin.config import CommonServiceConfig, Configuration
 
-        service_config = CommonServiceConfig()
+        service_config = Configuration.get_service_config(CommonServiceConfig)
     except Exception:
         return "INFO", "plain"
     return service_config.log_level, service_config.log_format

--- a/packages/nemo_platform_plugin/tests/test_task_logging_setup.py
+++ b/packages/nemo_platform_plugin/tests/test_task_logging_setup.py
@@ -57,6 +57,18 @@ class _ExplodingProvider:
         raise RuntimeError("provider is broken")
 
 
+class _PartiallyApplyingProvider:
+    """Attaches a handler, then fails before setting a usable level.
+
+    The shape that makes a naive "did it leave any handler?" check wrong: the
+    root logger looks configured but drops every record the task emits.
+    """
+
+    def configure_logging(self, *, level: str, log_format: str) -> None:
+        logging.getLogger().addHandler(logging.NullHandler())
+        raise RuntimeError("failed after attaching a handler")
+
+
 def test_configure_task_logging_makes_info_records_reachable() -> None:
     """The regression this exists for: INFO must survive in a task container.
 
@@ -208,3 +220,32 @@ def test_resolve_log_config_falls_back_when_settings_cannot_be_read(
     monkeypatch.setattr(plugin_config, "CommonServiceConfig", _explode)
 
     assert logging_setup._resolve_log_config() == ("INFO", "plain")
+
+
+def test_a_partially_applied_provider_is_discarded_not_trusted(caplog: pytest.LogCaptureFixture) -> None:
+    """A handler left behind by a failed call is not a working configuration."""
+    set_task_logging_provider(_PartiallyApplyingProvider())
+    _strip_root_handlers()
+
+    configure_task_logging()
+
+    root = logging.getLogger()
+    assert not any(isinstance(handler, logging.NullHandler) for handler in root.handlers), (
+        "the failed provider's handler survived"
+    )
+    assert any(getattr(h.formatter, "_fmt", None) == FALLBACK_LOG_FORMAT for h in root.handlers)
+    # The point of the cleanup: task INFO records must reach the fallback.
+    assert logging.getLogger("some.task.module").isEnabledFor(logging.INFO)
+
+
+def test_provider_failure_is_reported_through_the_fallback(capsys: pytest.CaptureFixture[str]) -> None:
+    """Reporting the failure before the fallback exists would emit it into the
+    broken configuration being replaced."""
+    set_task_logging_provider(_PartiallyApplyingProvider())
+    _strip_root_handlers()
+
+    configure_task_logging()
+
+    stderr = capsys.readouterr().err
+    assert "Task logging provider failed" in stderr
+    assert "failed after attaching a handler" in stderr

--- a/packages/nemo_platform_plugin/tests/test_task_logging_setup.py
+++ b/packages/nemo_platform_plugin/tests/test_task_logging_setup.py
@@ -1,0 +1,210 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Root-logging bootstrap for platform-spawned task processes."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from typing import Any, cast
+
+import pytest
+from nemo_platform_plugin.tasks import logging_setup
+from nemo_platform_plugin.tasks.logging_setup import (
+    FALLBACK_LOG_FORMAT,
+    DefaultTaskLoggingProvider,
+    configure_task_logging,
+    set_task_logging_provider,
+)
+
+
+@pytest.fixture(autouse=True)
+def _restore_global_state() -> Iterator[None]:
+    """Undo the global logging and provider state these tests mutate by design."""
+    root = logging.getLogger()
+    saved_handlers = root.handlers[:]
+    saved_level = root.level
+    try:
+        yield
+    finally:
+        root.handlers = saved_handlers
+        root.setLevel(saved_level)
+        set_task_logging_provider(None)
+
+
+def _strip_root_handlers() -> None:
+    """Reproduce a task container's bare root logger.
+
+    Has to run inside the test body rather than a fixture: pytest's own log
+    capture attaches a handler to the root logger for each test phase, so a
+    fixture that cleared it would be undone before the test ran.
+    """
+    logging.getLogger().handlers = []
+
+
+class _RecordingProvider:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def configure_logging(self, *, level: str, log_format: str) -> None:
+        self.calls.append({"level": level, "log_format": log_format})
+        logging.getLogger().addHandler(logging.NullHandler())
+
+
+class _ExplodingProvider:
+    def configure_logging(self, *, level: str, log_format: str) -> None:
+        raise RuntimeError("provider is broken")
+
+
+def test_configure_task_logging_makes_info_records_reachable() -> None:
+    """The regression this exists for: INFO must survive in a task container.
+
+    With no root handler Python falls back to ``logging.lastResort``, which
+    drops everything below WARNING - which is how a failing job produced
+    completely empty logs.
+    """
+    _strip_root_handlers()
+
+    configure_task_logging()
+
+    root = logging.getLogger()
+    assert root.handlers, "no handler installed; INFO records would still be dropped"
+    assert logging.getLogger("some.task.module").isEnabledFor(logging.INFO)
+
+
+def test_configure_task_logging_leaves_an_existing_configuration_alone() -> None:
+    """A caller that configured logging keeps ownership of it."""
+    _strip_root_handlers()
+    existing = logging.StreamHandler()
+    logging.getLogger().addHandler(existing)
+
+    configure_task_logging()
+
+    assert logging.getLogger().handlers == [existing]
+
+
+def test_configure_task_logging_is_idempotent() -> None:
+    """Calling twice must not double every log line."""
+    _strip_root_handlers()
+    configure_task_logging()
+    handlers_after_first = logging.getLogger().handlers[:]
+
+    configure_task_logging()
+
+    assert logging.getLogger().handlers == handlers_after_first
+
+
+def test_a_registered_provider_is_used_and_given_the_configured_settings() -> None:
+    """The seam exists so the platform can supply structured logging."""
+    provider = _RecordingProvider()
+    set_task_logging_provider(provider)
+    _strip_root_handlers()
+
+    configure_task_logging()
+
+    assert provider.calls == [{"level": "INFO", "log_format": "plain"}]
+
+
+def test_a_failing_provider_falls_back_to_the_default(caplog: pytest.LogCaptureFixture) -> None:
+    """Logging is diagnostic scaffolding: a broken provider must not take the
+    task down with it, or it destroys the evidence needed to debug it."""
+    set_task_logging_provider(_ExplodingProvider())
+    _strip_root_handlers()
+
+    configure_task_logging()
+
+    handlers = logging.getLogger().handlers
+    assert handlers, "the task was left silent"
+    assert any(getattr(h.formatter, "_fmt", None) == FALLBACK_LOG_FORMAT for h in handlers)
+
+
+def test_default_provider_is_used_when_nothing_is_registered(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``nmp_common`` is optional, so its absence must not leave a silent task."""
+    monkeypatch.setattr(logging_setup, "discover_entry_points", lambda group: {})
+    _strip_root_handlers()
+
+    configure_task_logging()
+
+    handlers = logging.getLogger().handlers
+    assert len(handlers) == 1
+    assert handlers[0].formatter is not None
+    assert handlers[0].formatter._fmt == FALLBACK_LOG_FORMAT
+
+
+def test_competing_providers_fall_back_to_the_default(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Two packages registering their own provider is not something to guess at."""
+    monkeypatch.setattr(
+        logging_setup,
+        "discover_entry_points",
+        lambda group: {"platform": object(), "someone-else": object()},
+    )
+    _strip_root_handlers()
+
+    with caplog.at_level(logging.WARNING, logger="nemo_platform_plugin.tasks.logging_setup"):
+        configure_task_logging()
+
+    handlers = logging.getLogger().handlers
+    assert any(getattr(h.formatter, "_fmt", None) == FALLBACK_LOG_FORMAT for h in handlers)
+
+
+def test_a_provider_that_does_not_implement_the_protocol_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A wrong target must degrade, not raise mid-bootstrap."""
+
+    class _Entry:
+        name = "platform"
+        value = "some.module:NotAProvider"
+
+        def load(self) -> Any:
+            return object()
+
+    monkeypatch.setattr(logging_setup, "discover_entry_points", lambda group: {"platform": _Entry()})
+    _strip_root_handlers()
+
+    configure_task_logging()
+
+    handlers = logging.getLogger().handlers
+    assert any(getattr(h.formatter, "_fmt", None) == FALLBACK_LOG_FORMAT for h in handlers)
+
+
+def test_default_provider_emits_the_fields_last_resort_drops(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Level and logger name are what make a task log readable at all."""
+    _strip_root_handlers()
+
+    DefaultTaskLoggingProvider().configure_logging(level="INFO", log_format="plain")
+    logging.getLogger("nemo_agents_plugin.jobs.execute").info("agent finished")
+
+    stderr = capsys.readouterr().err
+    assert "INFO" in stderr
+    assert "nemo_agents_plugin.jobs.execute" in stderr
+    assert "agent finished" in stderr
+
+
+def test_default_provider_tolerates_an_unparseable_level() -> None:
+    """A bad LOG_LEVEL should degrade to INFO, not crash the task before it runs."""
+    _strip_root_handlers()
+
+    # Deliberately off-contract: the guard exists for a misconfigured deployment.
+    DefaultTaskLoggingProvider().configure_logging(level=cast(Any, "NOT_A_LEVEL"), log_format="plain")
+
+    assert logging.getLogger().level == logging.INFO
+
+
+def test_resolve_log_config_falls_back_when_settings_cannot_be_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Misconfigured settings must not be the reason a task cannot log."""
+    import nemo_platform_plugin.config as plugin_config
+
+    def _explode() -> None:
+        raise RuntimeError("bad settings")
+
+    monkeypatch.setattr(plugin_config, "CommonServiceConfig", _explode)
+
+    assert logging_setup._resolve_log_config() == ("INFO", "plain")

--- a/packages/nemo_platform_plugin/tests/test_task_logging_setup.py
+++ b/packages/nemo_platform_plugin/tests/test_task_logging_setup.py
@@ -7,9 +7,11 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Iterator
+from pathlib import Path
 from typing import Any, cast
 
 import pytest
+from nemo_platform_plugin.config import NMP_CONFIG_FILE_PATH_ENV_VAR, Configuration
 from nemo_platform_plugin.tasks import logging_setup
 from nemo_platform_plugin.tasks.logging_setup import (
     FALLBACK_LOG_FORMAT,
@@ -249,3 +251,55 @@ def test_provider_failure_is_reported_through_the_fallback(capsys: pytest.Captur
     stderr = capsys.readouterr().err
     assert "Task logging provider failed" in stderr
     assert "failed after attaching a handler" in stderr
+
+
+def test_resolve_log_config_reads_the_yaml_backed_platform_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A deployment configures logging in the platform config file, not the
+    environment. Instantiating the settings class directly would read only the
+    environment and silently leave such a deployment on the defaults."""
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("service:\n  LOG_FORMAT: json\n  LOG_LEVEL: DEBUG\n")
+    monkeypatch.setenv(NMP_CONFIG_FILE_PATH_ENV_VAR, str(config_file))
+    monkeypatch.delenv("LOG_FORMAT", raising=False)
+    monkeypatch.delenv("LOG_LEVEL", raising=False)
+    Configuration.clear_cache()
+
+    try:
+        assert logging_setup._resolve_log_config() == ("DEBUG", "json")
+    finally:
+        Configuration.clear_cache()
+
+
+def test_environment_still_wins_over_the_config_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Containers with no config file get their settings from the environment
+    the jobs backends inject, so that source has to take precedence."""
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("service:\n  LOG_FORMAT: plain\n  LOG_LEVEL: ERROR\n")
+    monkeypatch.setenv(NMP_CONFIG_FILE_PATH_ENV_VAR, str(config_file))
+    monkeypatch.setenv("LOG_FORMAT", "json")
+    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+    Configuration.clear_cache()
+
+    try:
+        assert logging_setup._resolve_log_config() == ("DEBUG", "json")
+    finally:
+        Configuration.clear_cache()
+
+
+def test_resolve_log_config_falls_back_when_the_config_file_is_unreadable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A malformed config file must not be the reason a task cannot log."""
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("this: is: not: valid: yaml:\n")
+    monkeypatch.setenv(NMP_CONFIG_FILE_PATH_ENV_VAR, str(config_file))
+    monkeypatch.delenv("LOG_FORMAT", raising=False)
+    monkeypatch.delenv("LOG_LEVEL", raising=False)
+    Configuration.clear_cache()
+
+    try:
+        assert logging_setup._resolve_log_config() == ("INFO", "plain")
+    finally:
+        Configuration.clear_cache()

--- a/packages/nmp_common/pyproject.toml
+++ b/packages/nmp_common/pyproject.toml
@@ -75,5 +75,8 @@ platform = "nmp.common.sdk_factory:PlatformSDKProvider"
 [project.entry-points."nemo.client_provider"]
 platform = "nmp.common.client_factory:PlatformNemoClientProvider"
 
+[project.entry-points."nemo.logging_provider"]
+platform = "nmp.common.observability.task_logging:PlatformTaskLoggingProvider"
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/nmp_common", "src/nmp"]

--- a/packages/nmp_common/src/nmp/common/observability/task_logging.py
+++ b/packages/nmp_common/src/nmp/common/observability/task_logging.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Platform task-logging provider.
+
+Registered under the ``nemo.logging_provider`` entry-point group so
+:func:`nemo_platform_plugin.tasks.logging_setup.configure_task_logging` picks
+it up in any image where ``nmp-common`` is installed. This is the
+:mod:`nmp.common.client_factory` pattern applied to logging: the plugin
+package declares the seam and keeps no dependency on ``nmp-common``, while the
+platform supplies the real implementation.
+
+The effect is that a task container's output is the same structured stream a
+service emits - same renderer, same level handling, same sensitive-data
+filters - so log aggregation does not have to treat task logs as a special
+case. Without this provider the plugin's built-in default gives a task plain
+stderr lines, which is readable but unstructured.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from nmp.common.observability.otel import settings
+from nmp.common.observability.structured_logging import initialize_logging
+
+
+class PlatformTaskLoggingProvider:
+    """Configure a task process with the platform's structured logging."""
+
+    def configure_logging(
+        self,
+        *,
+        level: Literal["DEBUG", "INFO", "WARN", "ERROR"],
+        log_format: Literal["json", "plain"],
+    ) -> None:
+        # Sync the OTEL settings before initializing, mirroring what the
+        # ``nemo-platform run task`` entrypoint does, so a task honours the
+        # deployment's configured level and format.
+        settings.log_level = level
+        settings.log_format = log_format
+        # Only the logging half of observability. Tracing and metrics export
+        # are a separate concern and are not something a logging bootstrap
+        # should switch on behind the caller's back.
+        initialize_logging()

--- a/plugins/nemo-agents/src/nemo_agents_plugin/jobs/execute.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/jobs/execute.py
@@ -94,6 +94,11 @@ SUCCESSFUL_FABRIC_STATUSES = {"succeeded"}
 DEFAULT_AGENT_EXECUTION_TIMEOUT_SECONDS = 60 * 60
 DEFAULT_AGENT_EXECUTION_IMAGE_NAME = "nmp-api"
 
+# Name Fabric gives the agent process's captured stderr. It lives under a
+# runtime/invocation directory Fabric names itself, so it is found by search
+# rather than opened by path.
+_AGENT_STDERR_FILENAME = "stderr.txt"
+
 # k8s resource key carrying the GPU count. The agents ``ComputeResources`` maps
 # express GPUs the Kubernetes way (a ``nvidia.com/gpu`` entry in ``limits``);
 # the jobs executor's ``ResourcesSpec`` instead carries a top-level integer
@@ -399,6 +404,12 @@ class ExecuteAgentJob(NemoJob):
                 )
             )
         except Exception as error:
+            # Fabric never produced a result, so the agent's own stderr is the
+            # only account of how far it got, if anywhere.
+            logger.exception(
+                "Fabric invocation failed for agent %s/%s.", step_config.agent.workspace, step_config.agent.name
+            )
+            _log_agent_stderr(fabric_dirs.artifacts)
             self._save_fabric_error_results(
                 ctx, workspace_dir=fabric_dirs.workspace, artifacts_dir=fabric_dirs.artifacts, error=error
             )
@@ -427,6 +438,24 @@ class ExecuteAgentJob(NemoJob):
             except Exception:
                 logger.exception("Execute-agent extension failed.")
                 raise
+        else:
+            # A Fabric result that *reports* failure is not an exception here,
+            # so this is the only place the reason is stated. Without it the
+            # step exits non-zero having logged nothing at all, and the cause
+            # is only reachable by downloading the saved artifacts.
+            logger.error(
+                "Agent %s/%s failed: fabric_status=%s error=%s (runtime_id=%s invocation_id=%s). "
+                "Fabric run result: %s. Agent stdout/stderr: %s",
+                step_config.agent.workspace,
+                step_config.agent.name,
+                result.status,
+                result.error,
+                result.runtime_id,
+                result.invocation_id,
+                fabric_run_result_ref.artifact_url,
+                output_artifacts_ref.artifact_url,
+            )
+            _log_agent_stderr(fabric_dirs.artifacts)
 
         output = {
             "status": status,
@@ -471,6 +500,43 @@ class ExecuteAgentJob(NemoJob):
             _save_json_result(ctx, FABRIC_ERROR_RESULT_NAME, ctx.storage.ephemeral / FABRIC_ERROR_FILENAME, payload)
         except Exception:
             logger.warning("Failed to save Fabric error result.", exc_info=True)
+
+
+def _log_agent_stderr(artifacts_dir: Path) -> None:
+    """Log the agent process's captured stderr after a run that failed.
+
+    Fabric runs the agent as its own process and redirects its streams to files
+    under the artifacts directory, so nothing it logs reaches the task
+    container's stdout. Only stderr is worth reading: the stdout file is the
+    adapter's protocol channel - a single JSON response, already saved as
+    ``fabric_run_result`` - and the lifecycle harness redirects the agent's own
+    stdout into stderr anyway, so nothing is lost by ignoring it.
+
+    Read on failure only. A healthy run's execution record belongs in telemetry,
+    which carries it live and structured; this exists for what telemetry cannot
+    see - a failure before the agent started and produced any spans, an export
+    that never landed, a process that died.
+
+    Best-effort: it runs on an already-failing path and must never replace the
+    error that got us here.
+    """
+    try:
+        paths = sorted(artifacts_dir.rglob(_AGENT_STDERR_FILENAME))
+    except OSError as error:
+        logger.warning("Could not search %s for agent stderr: %s", artifacts_dir, error)
+        return
+    for path in paths:
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError as error:
+            logger.warning("Could not read agent stderr at %s: %s", path, error)
+            continue
+        if not text.strip():
+            logger.warning("Agent stderr at %s was empty.", path)
+            continue
+        # Logged whole: it is only read on failure, and the tail of a truncated
+        # traceback is rarely the half that explains anything.
+        logger.error("Agent stderr (%s):\n%s", path, text)
 
 
 class _AgentSource(BaseModel):

--- a/plugins/nemo-agents/src/nemo_agents_plugin/jobs/execute.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/jobs/execute.py
@@ -9,6 +9,7 @@ import asyncio
 import json
 import logging
 import re
+import time
 from dataclasses import asdict
 from pathlib import Path
 from typing import Any, ClassVar, cast
@@ -374,6 +375,10 @@ class ExecuteAgentJob(NemoJob):
 
     def run(self, config: dict, *, ctx: JobContext, sdk: NeMoPlatform | None = None) -> dict:
         step_config = ExecuteAgentStepConfig.model_validate(config)
+        agent_ref = f"{step_config.agent.workspace}/{step_config.agent.name}"
+        # Logged before validation so a config that fails to parse still names the agent it belonged to.
+        logger.info("Executing agent %s (timeout %gs).", agent_ref, step_config.request.timeout_seconds)
+
         _validate_agent_config_format(step_config.agent.config_format)
         agent_config = _validate_agent_config(step_config.agent.config)
 
@@ -382,10 +387,13 @@ class ExecuteAgentJob(NemoJob):
         if step_config.workdir is not None and _has_workdir_inputs(step_config.workdir):
             if sdk is None:
                 raise RuntimeError("sdk is required to stage workdir inputs.")
+            logger.info("Staging workdir inputs for agent %s.", agent_ref)
             materialize_agent_workdir(step_config.workdir, sdk.files, fabric_dirs.workspace)
 
         input_workdir_ref = ctx.results.save(INPUT_WORKDIR_RESULT_NAME, fabric_dirs.workspace)
 
+        logger.info("Invoking agent %s.", agent_ref)
+        started_at = time.monotonic()
         try:
             result = asyncio.run(
                 invoke_agent_config_request_once(
@@ -397,7 +405,7 @@ class ExecuteAgentJob(NemoJob):
                         caller_context={
                             "job_id": ctx.job_id,
                             "job_workspace": ctx.workspace,
-                            "agent": f"{step_config.agent.workspace}/{step_config.agent.name}",
+                            "agent": agent_ref,
                         },
                         timeout_seconds=step_config.request.timeout_seconds,
                     )
@@ -407,13 +415,15 @@ class ExecuteAgentJob(NemoJob):
             # Fabric never produced a result, so the agent's own stderr is the
             # only account of how far it got, if anywhere.
             logger.exception(
-                "Fabric invocation failed for agent %s/%s.", step_config.agent.workspace, step_config.agent.name
+                "Fabric invocation failed for agent %s after %.1fs.", agent_ref, time.monotonic() - started_at
             )
             _log_agent_stderr(fabric_dirs.artifacts)
             self._save_fabric_error_results(
                 ctx, workspace_dir=fabric_dirs.workspace, artifacts_dir=fabric_dirs.artifacts, error=error
             )
             raise
+
+        logger.info("Agent %s returned status=%s after %.1fs.", agent_ref, result.status, time.monotonic() - started_at)
 
         fabric_run_result_ref = _save_json_result(
             ctx,
@@ -444,10 +454,9 @@ class ExecuteAgentJob(NemoJob):
             # step exits non-zero having logged nothing at all, and the cause
             # is only reachable by downloading the saved artifacts.
             logger.error(
-                "Agent %s/%s failed: fabric_status=%s error=%s (runtime_id=%s invocation_id=%s). "
+                "Agent %s failed: fabric_status=%s error=%s (runtime_id=%s invocation_id=%s). "
                 "Fabric run result: %s. Agent stdout/stderr: %s",
-                step_config.agent.workspace,
-                step_config.agent.name,
+                agent_ref,
                 result.status,
                 result.error,
                 result.runtime_id,
@@ -459,7 +468,7 @@ class ExecuteAgentJob(NemoJob):
 
         output = {
             "status": status,
-            "agent": f"{step_config.agent.workspace}/{step_config.agent.name}",
+            "agent": agent_ref,
             "fabric_status": result.status,
             "runtime_id": result.runtime_id,
             "invocation_id": result.invocation_id,
@@ -534,8 +543,6 @@ def _log_agent_stderr(artifacts_dir: Path) -> None:
         if not text.strip():
             logger.warning("Agent stderr at %s was empty.", path)
             continue
-        # Logged whole: it is only read on failure, and the tail of a truncated
-        # traceback is rarely the half that explains anything.
         logger.error("Agent stderr (%s):\n%s", path, text)
 
 

--- a/plugins/nemo-agents/src/nemo_agents_plugin/jobs/execute.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/jobs/execute.py
@@ -99,6 +99,15 @@ DEFAULT_AGENT_EXECUTION_IMAGE_NAME = "nmp-api"
 # runtime/invocation directory Fabric names itself, so it is found by search
 # rather than opened by path.
 _AGENT_STDERR_FILENAME = "stderr.txt"
+# Bounds on what a failing agent can make this task read into memory. The
+# artifacts directory is agent-writable, so neither the size nor the number of
+# these files is ours to trust, and a runaway agent could otherwise exhaust the
+# task's memory while it reports the failure - destroying the diagnostics this
+# exists to produce. Sized never to fire on real output (a genuine failed run's
+# stderr measured ~2 KiB), so it bounds the pathological case without
+# truncating the ordinary one.
+_MAX_LOGGED_STDERR_BYTES = 4 * 1024 * 1024
+_MAX_LOGGED_STDERR_FILES = 5
 
 # k8s resource key carrying the GPU count. The agents ``ComputeResources`` maps
 # express GPUs the Kubernetes way (a ``nvidia.com/gpu`` entry in ``limits``);
@@ -530,20 +539,57 @@ def _log_agent_stderr(artifacts_dir: Path) -> None:
     error that got us here.
     """
     try:
+        # Safe to run over an agent-writable tree: pathlib's ``**`` does not
+        # follow symlinks, so a symlink loop cannot make this hang.
         paths = sorted(artifacts_dir.rglob(_AGENT_STDERR_FILENAME))
     except OSError as error:
         logger.warning("Could not search %s for agent stderr: %s", artifacts_dir, error)
         return
+    if len(paths) > _MAX_LOGGED_STDERR_FILES:
+        logger.warning(
+            "Found %d agent stderr files under %s; logging the first %d.",
+            len(paths),
+            artifacts_dir,
+            _MAX_LOGGED_STDERR_FILES,
+        )
+        paths = paths[:_MAX_LOGGED_STDERR_FILES]
     for path in paths:
         try:
-            text = path.read_text(encoding="utf-8", errors="replace")
+            text, omitted = _read_stderr_tail(path)
         except OSError as error:
             logger.warning("Could not read agent stderr at %s: %s", path, error)
             continue
         if not text.strip():
             logger.warning("Agent stderr at %s was empty.", path)
             continue
-        logger.error("Agent stderr (%s):\n%s", path, text)
+        if omitted:
+            logger.error(
+                "Agent stderr (%s, last %d bytes; %d earlier bytes omitted - the saved artifact has "
+                "the whole stream):\n%s",
+                path,
+                len(text),
+                omitted,
+                text,
+            )
+        else:
+            logger.error("Agent stderr (%s):\n%s", path, text)
+
+
+def _read_stderr_tail(path: Path) -> tuple[str, int]:
+    """Return *path*'s contents and how many leading bytes were dropped.
+
+    Takes the tail rather than the head when a stream exceeds the cap: a file
+    that large means the agent ran a long while before failing, so the failure
+    is at the end. A run that fails early writes little and is never truncated,
+    which is where the beginning would have mattered.
+    """
+    size = path.stat().st_size
+    if size <= _MAX_LOGGED_STDERR_BYTES:
+        return path.read_text(encoding="utf-8", errors="replace"), 0
+    with path.open("rb") as handle:
+        handle.seek(size - _MAX_LOGGED_STDERR_BYTES)
+        chunk = handle.read()
+    return chunk.decode("utf-8", errors="replace"), size - len(chunk)
 
 
 class _AgentSource(BaseModel):

--- a/plugins/nemo-agents/src/nemo_agents_plugin/jobs/execute.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/jobs/execute.py
@@ -8,11 +8,13 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import re
+import stat
 import time
 from dataclasses import asdict
 from pathlib import Path
-from typing import Any, ClassVar, cast
+from typing import Any, ClassVar, NamedTuple, cast
 
 from nemo_agents_plugin.agent_config import AgentConfig
 from nemo_agents_plugin.agent_config_formats import resolve_agent_config_for_deployment
@@ -555,41 +557,67 @@ def _log_agent_stderr(artifacts_dir: Path) -> None:
         paths = paths[:_MAX_LOGGED_STDERR_FILES]
     for path in paths:
         try:
-            text, omitted = _read_stderr_tail(path)
+            tail = _read_stderr_tail(path)
         except OSError as error:
             logger.warning("Could not read agent stderr at %s: %s", path, error)
             continue
-        if not text.strip():
+        if not tail.text.strip():
             logger.warning("Agent stderr at %s was empty.", path)
             continue
-        if omitted:
+        if tail.omitted_bytes:
             logger.error(
                 "Agent stderr (%s, last %d bytes; %d earlier bytes omitted - the saved artifact has "
                 "the whole stream):\n%s",
                 path,
-                len(text),
-                omitted,
-                text,
+                tail.read_bytes,
+                tail.omitted_bytes,
+                tail.text,
             )
         else:
-            logger.error("Agent stderr (%s):\n%s", path, text)
+            logger.error("Agent stderr (%s):\n%s", path, tail.text)
 
 
-def _read_stderr_tail(path: Path) -> tuple[str, int]:
+class _StderrTail(NamedTuple):
+    """What was read from an agent stderr file, in bytes rather than characters."""
+
+    text: str
+    read_bytes: int
+    omitted_bytes: int
+
+
+def _read_stderr_tail(path: Path) -> _StderrTail:
     """Return *path*'s contents and how many leading bytes were dropped.
 
     Takes the tail rather than the head when a stream exceeds the cap: a file
     that large means the agent ran a long while before failing, so the failure
     is at the end. A run that fails early writes little and is never truncated,
     which is where the beginning would have mattered.
+
+    The file type is not taken on trust, because the artifacts directory is
+    agent-writable and a size check alone is not a bound: a ``stderr.txt``
+    symlinked to ``/dev/zero`` reports ``st_size`` 0, passes any cap, and then
+    reads forever, and a FIFO of that name would block this task indefinitely
+    while it is trying to report a failure. ``O_NOFOLLOW`` refuses a symlinked
+    final component, ``O_NONBLOCK`` keeps a FIFO from blocking the open, and
+    the ``fstat`` below rejects anything that is not a regular file - checked
+    on the open descriptor so the answer cannot change underneath us.
     """
-    size = path.stat().st_size
-    if size <= _MAX_LOGGED_STDERR_BYTES:
-        return path.read_text(encoding="utf-8", errors="replace"), 0
-    with path.open("rb") as handle:
-        handle.seek(size - _MAX_LOGGED_STDERR_BYTES)
-        chunk = handle.read()
-    return chunk.decode("utf-8", errors="replace"), size - len(chunk)
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+    with os.fdopen(os.open(path, flags), "rb") as handle:
+        info = os.fstat(handle.fileno())
+        if not stat.S_ISREG(info.st_mode):
+            raise OSError(f"{path} is not a regular file")
+        size = info.st_size
+        if size > _MAX_LOGGED_STDERR_BYTES:
+            handle.seek(size - _MAX_LOGGED_STDERR_BYTES)
+        # Bounded by the cap regardless of what ``st_size`` claimed, so a file
+        # that lied about its size or grew mid-read still cannot run away.
+        chunk = handle.read(_MAX_LOGGED_STDERR_BYTES)
+    return _StderrTail(
+        text=chunk.decode("utf-8", errors="replace"),
+        read_bytes=len(chunk),
+        omitted_bytes=max(0, size - len(chunk)),
+    )
 
 
 class _AgentSource(BaseModel):

--- a/plugins/nemo-agents/tests/unit/test_execute_job.py
+++ b/plugins/nemo-agents/tests/unit/test_execute_job.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
@@ -1745,3 +1746,46 @@ def test_log_agent_stderr_does_not_flag_truncation_when_it_fits(
 
     assert "short and complete" in caplog.text
     assert "omitted" not in caplog.text
+
+
+def test_log_agent_stderr_reports_byte_counts_not_character_counts(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The cap is a byte budget, so the notice has to be in bytes: multibyte
+    UTF-8 would otherwise under-report by up to 4x."""
+    monkeypatch.setattr("nemo_agents_plugin.jobs.execute._MAX_LOGGED_STDERR_BYTES", 400)
+    # 2 bytes per character, so a character count would read as half of this.
+    (tmp_path / "stderr.txt").write_text("é" * 1000, encoding="utf-8")
+
+    with caplog.at_level(logging.ERROR, logger="nemo_agents_plugin.jobs.execute"):
+        _log_agent_stderr(tmp_path)
+
+    assert "last 400 bytes" in caplog.text
+    assert "1600 earlier bytes omitted" in caplog.text
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="mkfifo is not available on this platform")
+def test_log_agent_stderr_rejects_a_fifo_without_blocking(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """A FIFO with no writer would block this task forever - while it is trying
+    to report a failure. The artifacts dir is agent-writable, so the file type
+    is not ours to trust."""
+    os.mkfifo(tmp_path / "stderr.txt")
+
+    with caplog.at_level(logging.WARNING, logger="nemo_agents_plugin.jobs.execute"):
+        _log_agent_stderr(tmp_path)
+
+    assert "is not a regular file" in caplog.text
+
+
+def test_log_agent_stderr_refuses_to_follow_a_symlink(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """``st_size`` on a symlinked character device reads as 0, so it would pass
+    any size cap and then read without bound (``/dev/zero`` being the obvious
+    case). Refusing the symlink outright is what closes that."""
+    (tmp_path / "real.txt").write_text("some diagnostics\n")
+    (tmp_path / "stderr.txt").symlink_to(tmp_path / "real.txt")
+
+    with caplog.at_level(logging.WARNING, logger="nemo_agents_plugin.jobs.execute"):
+        _log_agent_stderr(tmp_path)
+
+    assert "Could not read agent stderr" in caplog.text
+    assert "some diagnostics" not in caplog.text

--- a/plugins/nemo-agents/tests/unit/test_execute_job.py
+++ b/plugins/nemo-agents/tests/unit/test_execute_job.py
@@ -38,6 +38,7 @@ from nemo_agents_plugin.jobs.execute import (
     ExecuteAgentJobConfig,
     ExecuteAgentStepConfig,
     ResolvedAgentConfig,
+    _log_agent_stderr,
 )
 from nemo_agents_plugin.tasks.execute.workdir import (
     AgentWorkdir,
@@ -1423,3 +1424,188 @@ def test_agent_entity_may_still_hold_a_nat_workflow_config() -> None:
     entity = Agent(name="legacy", workspace="default", config={"workflow": {}})
 
     assert entity.config_format == "nat-workflow-v1"
+
+
+def test_run_failed_fabric_result_reports_the_reason_in_the_log(
+    ctx: JobContext, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A Fabric result that reports failure never raises, so this is the only
+    place the reason is stated. Without it the step exits non-zero having
+    logged nothing at all."""
+    spec = ExecuteAgentStepConfig(
+        request=ExecuteAgentJobConfig(agent="calc", input="hello"),
+        agent=_resolved_agent(),
+    )
+
+    async def _invoke(request: Any) -> FabricRuntimeResult:
+        return FabricRuntimeResult(
+            status="failed",
+            error={"stage": "invoke", "code": "insights_analyst_failed", "message": "LLM API error"},
+            runtime_id="runtime-1",
+            invocation_id="invocation-1",
+        )
+
+    with (
+        caplog.at_level(logging.ERROR, logger="nemo_agents_plugin.jobs.execute"),
+        patch("nemo_agents_plugin.jobs.execute.invoke_agent_config_request_once", _invoke),
+    ):
+        ExecuteAgentJob().run(spec.model_dump(mode="json"), ctx=ctx)
+
+    logged = caplog.text
+    assert "LLM API error" in logged
+    assert "insights_analyst_failed" in logged
+    assert "runtime-1" in logged
+    assert "invocation-1" in logged
+
+
+def test_run_logs_the_agent_stderr_when_the_run_fails(ctx: JobContext, caplog: pytest.LogCaptureFixture) -> None:
+    """Fabric captures the agent process's stderr to a file, so on failure the
+    real traceback reaches the container's own logs nowhere else."""
+    spec = ExecuteAgentStepConfig(
+        request=ExecuteAgentJobConfig(agent="calc", input="hello"),
+        agent=_resolved_agent(),
+    )
+
+    async def _invoke(request: Any) -> FabricRuntimeResult:
+        # Mirrors the layout Fabric creates: a runtime/invocation directory it
+        # names itself, under the artifacts dir.
+        invocation_dir = request.base_dir / "artifacts" / ".fabric" / "runtime-1" / "invocation-1"
+        invocation_dir.mkdir(parents=True, exist_ok=True)
+        (invocation_dir / "stderr.txt").write_text("Traceback (most recent call last):\nValueError: the actual cause\n")
+        return FabricRuntimeResult(status="failed", error={"message": "agent failed"})
+
+    with (
+        caplog.at_level(logging.ERROR, logger="nemo_agents_plugin.jobs.execute"),
+        patch("nemo_agents_plugin.jobs.execute.invoke_agent_config_request_once", _invoke),
+    ):
+        ExecuteAgentJob().run(spec.model_dump(mode="json"), ctx=ctx)
+
+    assert "ValueError: the actual cause" in caplog.text
+
+
+def test_run_logs_the_agent_stderr_when_fabric_raises(ctx: JobContext, caplog: pytest.LogCaptureFixture) -> None:
+    """Fabric produced no result, so the agent's stderr is the only account of
+    how far it got - which is the case telemetry cannot cover."""
+    spec = ExecuteAgentStepConfig(
+        request=ExecuteAgentJobConfig(agent="calc", input="hello"),
+        agent=_resolved_agent(),
+    )
+
+    async def _invoke(request: Any) -> FabricRuntimeResult:
+        invocation_dir = request.base_dir / "artifacts" / ".fabric" / "runtime-1" / "invocation-1"
+        invocation_dir.mkdir(parents=True, exist_ok=True)
+        (invocation_dir / "stderr.txt").write_text("got as far as loading traces\n")
+        raise TimeoutError("fabric timed out")
+
+    with (
+        caplog.at_level(logging.ERROR, logger="nemo_agents_plugin.jobs.execute"),
+        patch("nemo_agents_plugin.jobs.execute.invoke_agent_config_request_once", _invoke),
+        pytest.raises(TimeoutError),
+    ):
+        ExecuteAgentJob().run(spec.model_dump(mode="json"), ctx=ctx)
+
+    assert "got as far as loading traces" in caplog.text
+
+
+def test_run_does_not_log_agent_stderr_on_success(ctx: JobContext, caplog: pytest.LogCaptureFixture) -> None:
+    """A healthy run's execution record belongs in telemetry, which carries it
+    live and structured; duplicating it into the job log is noise."""
+    spec = ExecuteAgentStepConfig(
+        request=ExecuteAgentJobConfig(agent="calc", input="hello"),
+        agent=_resolved_agent(),
+    )
+
+    async def _invoke(request: Any) -> FabricRuntimeResult:
+        invocation_dir = request.base_dir / "artifacts" / ".fabric" / "runtime-1" / "invocation-1"
+        invocation_dir.mkdir(parents=True, exist_ok=True)
+        (invocation_dir / "stderr.txt").write_text("routine chatter nobody needs\n")
+        return FabricRuntimeResult(status="succeeded", response="done")
+
+    with (
+        caplog.at_level(logging.INFO, logger="nemo_agents_plugin.jobs.execute"),
+        patch("nemo_agents_plugin.jobs.execute.invoke_agent_config_request_once", _invoke),
+    ):
+        result = ExecuteAgentJob().run(spec.model_dump(mode="json"), ctx=ctx)
+
+    assert result["status"] == "completed"
+    assert "routine chatter nobody needs" not in caplog.text
+
+
+def test_run_ignores_the_agent_stdout_file(ctx: JobContext, caplog: pytest.LogCaptureFixture) -> None:
+    """``stdout.txt`` is the adapter's protocol channel - a single JSON response
+    already saved as ``fabric_run_result`` - not a log stream."""
+    spec = ExecuteAgentStepConfig(
+        request=ExecuteAgentJobConfig(agent="calc", input="hello"),
+        agent=_resolved_agent(),
+    )
+
+    async def _invoke(request: Any) -> FabricRuntimeResult:
+        invocation_dir = request.base_dir / "artifacts" / ".fabric" / "runtime-1" / "invocation-1"
+        invocation_dir.mkdir(parents=True, exist_ok=True)
+        (invocation_dir / "stdout.txt").write_text('{"response":"the protocol payload"}\n')
+        (invocation_dir / "stderr.txt").write_text("the real diagnostics\n")
+        return FabricRuntimeResult(status="failed", error={"message": "agent failed"})
+
+    with (
+        caplog.at_level(logging.ERROR, logger="nemo_agents_plugin.jobs.execute"),
+        patch("nemo_agents_plugin.jobs.execute.invoke_agent_config_request_once", _invoke),
+    ):
+        ExecuteAgentJob().run(spec.model_dump(mode="json"), ctx=ctx)
+
+    assert "the real diagnostics" in caplog.text
+    assert "the protocol payload" not in caplog.text
+
+
+def test_run_logs_the_whole_agent_stderr_without_truncating(ctx: JobContext, caplog: pytest.LogCaptureFixture) -> None:
+    """Read only on failure, so there is no reason to cut it short."""
+    spec = ExecuteAgentStepConfig(
+        request=ExecuteAgentJobConfig(agent="calc", input="hello"),
+        agent=_resolved_agent(),
+    )
+    long_stderr = "\n".join(f"line {n}" for n in range(5000))
+
+    async def _invoke(request: Any) -> FabricRuntimeResult:
+        invocation_dir = request.base_dir / "artifacts" / ".fabric" / "runtime-1" / "invocation-1"
+        invocation_dir.mkdir(parents=True, exist_ok=True)
+        (invocation_dir / "stderr.txt").write_text(long_stderr)
+        return FabricRuntimeResult(status="failed", error={"message": "agent failed"})
+
+    with (
+        caplog.at_level(logging.ERROR, logger="nemo_agents_plugin.jobs.execute"),
+        patch("nemo_agents_plugin.jobs.execute.invoke_agent_config_request_once", _invoke),
+    ):
+        ExecuteAgentJob().run(spec.model_dump(mode="json"), ctx=ctx)
+
+    assert "line 0" in caplog.text
+    assert "line 4999" in caplog.text
+
+
+def test_run_tolerates_a_failure_with_no_agent_stderr(ctx: JobContext) -> None:
+    """The dump runs on an already-failing path; it must not replace the error."""
+    spec = ExecuteAgentStepConfig(
+        request=ExecuteAgentJobConfig(agent="calc", input="hello"),
+        agent=_resolved_agent(),
+    )
+
+    async def _invoke(request: Any) -> FabricRuntimeResult:
+        return FabricRuntimeResult(status="failed", error={"message": "agent failed"})
+
+    with patch("nemo_agents_plugin.jobs.execute.invoke_agent_config_request_once", _invoke):
+        result = ExecuteAgentJob().run(spec.model_dump(mode="json"), ctx=ctx)
+
+    assert result["status"] == "failed"
+
+
+def test_log_agent_stderr_reports_an_empty_stream(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """An empty stderr is itself a finding: the agent logged nothing at all."""
+    (tmp_path / "stderr.txt").write_text("   \n")
+
+    with caplog.at_level(logging.WARNING, logger="nemo_agents_plugin.jobs.execute"):
+        _log_agent_stderr(tmp_path)
+
+    assert "was empty" in caplog.text
+
+
+def test_log_agent_stderr_survives_a_missing_artifacts_directory() -> None:
+    """Never the reason a failing run fails differently."""
+    _log_agent_stderr(Path("/nonexistent/artifacts"))

--- a/plugins/nemo-agents/tests/unit/test_execute_job.py
+++ b/plugins/nemo-agents/tests/unit/test_execute_job.py
@@ -1556,8 +1556,11 @@ def test_run_ignores_the_agent_stdout_file(ctx: JobContext, caplog: pytest.LogCa
     assert "the protocol payload" not in caplog.text
 
 
-def test_run_logs_the_whole_agent_stderr_without_truncating(ctx: JobContext, caplog: pytest.LogCaptureFixture) -> None:
-    """Read only on failure, so there is no reason to cut it short."""
+def test_run_logs_the_whole_agent_stderr_for_realistic_output(
+    ctx: JobContext, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The byte cap exists for the pathological case only; ordinary output,
+    however long, must arrive complete."""
     spec = ExecuteAgentStepConfig(
         request=ExecuteAgentJobConfig(agent="calc", input="hello"),
         agent=_resolved_agent(),
@@ -1693,3 +1696,52 @@ def test_run_logs_elapsed_time_when_fabric_raises(ctx: JobContext, caplog: pytes
         ExecuteAgentJob().run(spec.model_dump(mode="json"), ctx=ctx)
 
     assert "Fabric invocation failed for agent default/calc after" in caplog.text
+
+
+def test_log_agent_stderr_tails_a_stream_over_the_cap(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The artifacts dir is agent-writable, so an unbounded read here could
+    exhaust the task's memory while it reports a failure - destroying the very
+    diagnostics this produces."""
+    monkeypatch.setattr("nemo_agents_plugin.jobs.execute._MAX_LOGGED_STDERR_BYTES", 200)
+    (tmp_path / "stderr.txt").write_text("A" * 5000 + "\nthe failure is at the end\n")
+
+    with caplog.at_level(logging.ERROR, logger="nemo_agents_plugin.jobs.execute"):
+        _log_agent_stderr(tmp_path)
+
+    assert "the failure is at the end" in caplog.text, "the tail is what matters for a long run"
+    assert "earlier bytes omitted" in caplog.text
+    assert "A" * 1000 not in caplog.text, "the whole file was read despite the cap"
+
+
+def test_log_agent_stderr_caps_the_number_of_files(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An agent can write as many of these as it likes into its artifacts dir."""
+    monkeypatch.setattr("nemo_agents_plugin.jobs.execute._MAX_LOGGED_STDERR_FILES", 2)
+    for n in range(5):
+        run_dir = tmp_path / f"run-{n}"
+        run_dir.mkdir()
+        (run_dir / "stderr.txt").write_text(f"stream {n}\n")
+
+    with caplog.at_level(logging.WARNING, logger="nemo_agents_plugin.jobs.execute"):
+        _log_agent_stderr(tmp_path)
+
+    assert "Found 5 agent stderr files" in caplog.text
+    assert "stream 0" in caplog.text
+    assert "stream 1" in caplog.text
+    assert "stream 4" not in caplog.text
+
+
+def test_log_agent_stderr_does_not_flag_truncation_when_it_fits(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A run under the cap must read as complete, with no misleading notice."""
+    (tmp_path / "stderr.txt").write_text("short and complete\n")
+
+    with caplog.at_level(logging.ERROR, logger="nemo_agents_plugin.jobs.execute"):
+        _log_agent_stderr(tmp_path)
+
+    assert "short and complete" in caplog.text
+    assert "omitted" not in caplog.text

--- a/plugins/nemo-agents/tests/unit/test_execute_job.py
+++ b/plugins/nemo-agents/tests/unit/test_execute_job.py
@@ -1609,3 +1609,87 @@ def test_log_agent_stderr_reports_an_empty_stream(tmp_path: Path, caplog: pytest
 def test_log_agent_stderr_survives_a_missing_artifacts_directory() -> None:
     """Never the reason a failing run fails differently."""
     _log_agent_stderr(Path("/nonexistent/artifacts"))
+
+
+def test_run_logs_progress_through_a_successful_run(ctx: JobContext, caplog: pytest.LogCaptureFixture) -> None:
+    """A healthy run should account for itself: which agent, that it was
+    invoked, and what came back."""
+    spec = ExecuteAgentStepConfig(
+        request=ExecuteAgentJobConfig(agent="calc", input="hello", timeout_seconds=300),
+        agent=_resolved_agent(),
+    )
+
+    async def _invoke(request: Any) -> FabricRuntimeResult:
+        return FabricRuntimeResult(status="succeeded", response="done")
+
+    with (
+        caplog.at_level(logging.INFO, logger="nemo_agents_plugin.jobs.execute"),
+        patch("nemo_agents_plugin.jobs.execute.invoke_agent_config_request_once", _invoke),
+    ):
+        ExecuteAgentJob().run(spec.model_dump(mode="json"), ctx=ctx)
+
+    assert "Executing agent default/calc (timeout 300s)." in caplog.text
+    assert "Invoking agent default/calc." in caplog.text
+    assert "returned status=succeeded after" in caplog.text
+
+
+def test_run_names_the_agent_before_validating_its_config(ctx: JobContext, caplog: pytest.LogCaptureFixture) -> None:
+    """A config that fails to parse must still say which agent it belonged to."""
+    spec = ExecuteAgentStepConfig(
+        request=ExecuteAgentJobConfig(agent="calc", input="hello"),
+        agent=ResolvedAgentConfig(
+            name="calc",
+            workspace="default",
+            config={"not": "a valid agent config"},
+            config_format="nemo-agents-spec-v1",
+        ),
+    )
+
+    with (
+        caplog.at_level(logging.INFO, logger="nemo_agents_plugin.jobs.execute"),
+        pytest.raises(Exception),
+    ):
+        ExecuteAgentJob().run(spec.model_dump(mode="json"), ctx=ctx)
+
+    assert "Executing agent default/calc" in caplog.text
+
+
+def test_run_does_not_announce_workdir_staging_when_there_is_none(
+    ctx: JobContext, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Most runs stage nothing; the line would be noise."""
+    spec = ExecuteAgentStepConfig(
+        request=ExecuteAgentJobConfig(agent="calc", input="hello"),
+        agent=_resolved_agent(),
+    )
+
+    async def _invoke(request: Any) -> FabricRuntimeResult:
+        return FabricRuntimeResult(status="succeeded", response="done")
+
+    with (
+        caplog.at_level(logging.INFO, logger="nemo_agents_plugin.jobs.execute"),
+        patch("nemo_agents_plugin.jobs.execute.invoke_agent_config_request_once", _invoke),
+    ):
+        ExecuteAgentJob().run(spec.model_dump(mode="json"), ctx=ctx)
+
+    assert "Staging workdir" not in caplog.text
+
+
+def test_run_logs_elapsed_time_when_fabric_raises(ctx: JobContext, caplog: pytest.LogCaptureFixture) -> None:
+    """How long a run got before dying is part of diagnosing a timeout."""
+    spec = ExecuteAgentStepConfig(
+        request=ExecuteAgentJobConfig(agent="calc", input="hello"),
+        agent=_resolved_agent(),
+    )
+
+    async def _invoke(request: Any) -> FabricRuntimeResult:
+        raise TimeoutError("fabric timed out")
+
+    with (
+        caplog.at_level(logging.INFO, logger="nemo_agents_plugin.jobs.execute"),
+        patch("nemo_agents_plugin.jobs.execute.invoke_agent_config_request_once", _invoke),
+        pytest.raises(TimeoutError),
+    ):
+        ExecuteAgentJob().run(spec.model_dump(mode="json"), ctx=ctx)
+
+    assert "Fabric invocation failed for agent default/calc after" in caplog.text

--- a/plugins/nemo-insights/src/nemo_insights_plugin/fabric_adapter.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/fabric_adapter.py
@@ -5,7 +5,9 @@
 
 from __future__ import annotations
 
+import logging
 import os
+import traceback
 from datetime import datetime
 from typing import Any
 
@@ -14,6 +16,9 @@ from nemo_fabric_adapters.common import lifecycle
 from nemo_insights_plugin.analyst.run import run_analyst_change_set
 from nemo_platform_plugin.nooa_model_client import ConfiguredModelRefs
 from nemo_platform_plugin.sdk_provider import get_async_task_sdk
+from nemo_platform_plugin.tasks.logging_setup import configure_task_logging
+
+logger = logging.getLogger(__name__)
 
 
 class AnalystAdapterConfigError(ValueError):
@@ -41,9 +46,22 @@ class InsightsAnalystRuntime:
         try:
             result = await self._run_analysis(request)
         except Exception as error:
+            # Log the full exception so it reaches this process's stderr, which
+            # is where the job reads a failed run's diagnostics from.
+            logger.exception("Insights analyst run failed.")
             return contract.AgentRunResult(
                 status=contract.AgentRunStatus.FAILED,
-                output={"response": str(error)},
+                # ``AgentRunError`` carries only code/message/retryable, so the
+                # diagnostic detail rides on ``output``, which the adapter owns.
+                # This is what puts it in ``fabric_run_result`` - the artifact
+                # someone debugging a failed run reaches for first, and which
+                # otherwise holds only ``str(error)``. The extension that reads
+                # ``output`` runs on success only, so these keys cannot confuse it.
+                output={
+                    "response": str(error),
+                    "error_type": type(error).__name__,
+                    "traceback": _format_traceback(error),
+                },
                 error=contract.AgentRunError(
                     code="insights_analyst_failed",
                     message=str(error),
@@ -103,6 +121,19 @@ class InsightsAnalystRuntime:
         self.__init__()
 
 
+def _format_traceback(error: BaseException) -> str:
+    """Render *error* with its whole cause chain.
+
+    Rendered in full: it lands in a saved artifact rather than on a job record,
+    and both ends of a chain carry the diagnosis. ``format_exception`` renders
+    oldest-first, so the *originating* exception is at the head while the one
+    actually raised is at the tail - an LLM error raised after retries reads
+    identically at the tail whatever provoked it, and only the head names the
+    endpoint that 404'd.
+    """
+    return "".join(traceback.format_exception(type(error), error, error.__traceback__))
+
+
 def _string_setting(settings: dict[str, Any], key: str) -> str | None:
     value = settings.get(key)
     if value is None:
@@ -154,6 +185,11 @@ def _fast_model_ref(
 
 def main() -> None:
     """Serve the persistent local-host lifecycle protocol."""
+    # Fabric spawns this as its own process and redirects its streams to the
+    # run's stdout/stderr artifacts. Nothing configures logging here, so
+    # without this the analyst's and Nooa's INFO output is dropped and those
+    # artifacts hold only bare WARNING+ lines from ``logging.lastResort``.
+    configure_task_logging()
     lifecycle.serve(InsightsAnalystRuntime, config_loader=contract.AgentConfig.from_mapping)
 
 

--- a/plugins/nemo-insights/src/nemo_insights_plugin/fabric_adapter.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/fabric_adapter.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import logging
 import os
-import traceback
 from datetime import datetime
 from typing import Any
 
@@ -51,17 +50,7 @@ class InsightsAnalystRuntime:
             logger.exception("Insights analyst run failed.")
             return contract.AgentRunResult(
                 status=contract.AgentRunStatus.FAILED,
-                # ``AgentRunError`` carries only code/message/retryable, so the
-                # diagnostic detail rides on ``output``, which the adapter owns.
-                # This is what puts it in ``fabric_run_result`` - the artifact
-                # someone debugging a failed run reaches for first, and which
-                # otherwise holds only ``str(error)``. The extension that reads
-                # ``output`` runs on success only, so these keys cannot confuse it.
-                output={
-                    "response": str(error),
-                    "error_type": type(error).__name__,
-                    "traceback": _format_traceback(error),
-                },
+                output={"response": str(error)},
                 error=contract.AgentRunError(
                     code="insights_analyst_failed",
                     message=str(error),
@@ -119,19 +108,6 @@ class InsightsAnalystRuntime:
 
     async def stop(self) -> None:
         self.__init__()
-
-
-def _format_traceback(error: BaseException) -> str:
-    """Render *error* with its whole cause chain.
-
-    Rendered in full: it lands in a saved artifact rather than on a job record,
-    and both ends of a chain carry the diagnosis. ``format_exception`` renders
-    oldest-first, so the *originating* exception is at the head while the one
-    actually raised is at the tail - an LLM error raised after retries reads
-    identically at the tail whatever provoked it, and only the head names the
-    endpoint that 404'd.
-    """
-    return "".join(traceback.format_exception(type(error), error, error.__traceback__))
 
 
 def _string_setting(settings: dict[str, Any], key: str) -> str | None:

--- a/plugins/nemo-insights/tests/test_fabric_adapter.py
+++ b/plugins/nemo-insights/tests/test_fabric_adapter.py
@@ -141,3 +141,73 @@ async def test_fabric_adapter_reports_configuration_failure() -> None:
     assert result.error is not None
     assert result.error.code == "insights_analyst_failed"
     assert "harness.settings.agent is required" in result.error.message
+
+
+async def test_fabric_adapter_failure_output_carries_the_traceback(monkeypatch) -> None:
+    """``str(error)`` alone loses the cause chain, which is what actually
+    identifies the failure - an LLM error raised after retries reads
+    identically whatever provoked it."""
+    clients: list[_StubClient] = []
+
+    async def fail(**kwargs: Any) -> tuple[AnalystResult, object]:
+        raise RuntimeError("LLM API error after 3 retries")
+
+    monkeypatch.setattr(fabric_adapter, "run_analyst_change_set", fail)
+    monkeypatch.setattr(fabric_adapter, "get_async_task_sdk", _stub_sdk_factory(clients))
+
+    runtime = fabric_adapter.InsightsAnalystRuntime()
+    await runtime.start({"config": _agent_config({"agent": "research-agent"})})
+
+    result = await runtime.invoke(_request({"job_workspace": "workspace"}), cast(contract.RuntimeContext, None))
+
+    assert result.status is contract.AgentRunStatus.FAILED
+    assert result.output["error_type"] == "RuntimeError"
+    assert "LLM API error after 3 retries" in result.output["traceback"]
+    assert "Traceback (most recent call last)" in result.output["traceback"]
+    assert result.error is not None
+    assert result.error.code == "insights_analyst_failed"
+
+
+async def test_fabric_adapter_logs_the_failure_with_its_traceback(monkeypatch, caplog) -> None:
+    """The adapter's stderr is captured to a run artifact, so logging here is
+    what puts the traceback somewhere retrievable."""
+    clients: list[_StubClient] = []
+
+    async def fail(**kwargs: Any) -> tuple[AnalystResult, object]:
+        raise RuntimeError("gateway returned 502")
+
+    monkeypatch.setattr(fabric_adapter, "run_analyst_change_set", fail)
+    monkeypatch.setattr(fabric_adapter, "get_async_task_sdk", _stub_sdk_factory(clients))
+
+    runtime = fabric_adapter.InsightsAnalystRuntime()
+    await runtime.start({"config": _agent_config({"agent": "research-agent"})})
+
+    with caplog.at_level("ERROR", logger="nemo_insights_plugin.fabric_adapter"):
+        await runtime.invoke(_request({"job_workspace": "workspace"}), cast(contract.RuntimeContext, None))
+
+    assert "Insights analyst run failed." in caplog.text
+    assert "gateway returned 502" in caplog.text
+
+
+async def test_fabric_adapter_preserves_the_cause_chain_in_the_traceback(monkeypatch) -> None:
+    clients: list[_StubClient] = []
+
+    first_message = "Function 'abc-123': Not found for account"
+    second_message = "LLM API error after 3 retries"
+
+    async def fail(**kwargs: Any) -> tuple[AnalystResult, object]:
+        try:
+            raise ValueError(first_message)
+        except ValueError as cause:
+            raise RuntimeError(second_message) from cause
+
+    monkeypatch.setattr(fabric_adapter, "run_analyst_change_set", fail)
+    monkeypatch.setattr(fabric_adapter, "get_async_task_sdk", _stub_sdk_factory(clients))
+
+    runtime = fabric_adapter.InsightsAnalystRuntime()
+    await runtime.start({"config": _agent_config({"agent": "research-agent"})})
+
+    result = await runtime.invoke(_request({"job_workspace": "workspace"}), cast(contract.RuntimeContext, None))
+
+    assert first_message in result.output["traceback"]
+    assert second_message in result.output["traceback"]

--- a/plugins/nemo-insights/tests/test_fabric_adapter.py
+++ b/plugins/nemo-insights/tests/test_fabric_adapter.py
@@ -143,34 +143,10 @@ async def test_fabric_adapter_reports_configuration_failure() -> None:
     assert "harness.settings.agent is required" in result.error.message
 
 
-async def test_fabric_adapter_failure_output_carries_the_traceback(monkeypatch) -> None:
-    """``str(error)`` alone loses the cause chain, which is what actually
-    identifies the failure - an LLM error raised after retries reads
-    identically whatever provoked it."""
-    clients: list[_StubClient] = []
-
-    async def fail(**kwargs: Any) -> tuple[AnalystResult, object]:
-        raise RuntimeError("LLM API error after 3 retries")
-
-    monkeypatch.setattr(fabric_adapter, "run_analyst_change_set", fail)
-    monkeypatch.setattr(fabric_adapter, "get_async_task_sdk", _stub_sdk_factory(clients))
-
-    runtime = fabric_adapter.InsightsAnalystRuntime()
-    await runtime.start({"config": _agent_config({"agent": "research-agent"})})
-
-    result = await runtime.invoke(_request({"job_workspace": "workspace"}), cast(contract.RuntimeContext, None))
-
-    assert result.status is contract.AgentRunStatus.FAILED
-    assert result.output["error_type"] == "RuntimeError"
-    assert "LLM API error after 3 retries" in result.output["traceback"]
-    assert "Traceback (most recent call last)" in result.output["traceback"]
-    assert result.error is not None
-    assert result.error.code == "insights_analyst_failed"
-
-
 async def test_fabric_adapter_logs_the_failure_with_its_traceback(monkeypatch, caplog) -> None:
-    """The adapter's stderr is captured to a run artifact, so logging here is
-    what puts the traceback somewhere retrievable."""
+    """``str(error)`` alone loses the traceback, and the adapter's stderr is
+    captured to a run artifact the job dumps on failure - so logging here is
+    what puts the traceback somewhere anyone will actually read."""
     clients: list[_StubClient] = []
 
     async def fail(**kwargs: Any) -> tuple[AnalystResult, object]:
@@ -183,23 +159,29 @@ async def test_fabric_adapter_logs_the_failure_with_its_traceback(monkeypatch, c
     await runtime.start({"config": _agent_config({"agent": "research-agent"})})
 
     with caplog.at_level("ERROR", logger="nemo_insights_plugin.fabric_adapter"):
-        await runtime.invoke(_request({"job_workspace": "workspace"}), cast(contract.RuntimeContext, None))
+        result = await runtime.invoke(_request({"job_workspace": "workspace"}), cast(contract.RuntimeContext, None))
 
+    assert result.status is contract.AgentRunStatus.FAILED
+    assert result.error is not None
+    assert result.error.code == "insights_analyst_failed"
     assert "Insights analyst run failed." in caplog.text
     assert "gateway returned 502" in caplog.text
+    assert "Traceback (most recent call last)" in caplog.text
 
 
-async def test_fabric_adapter_preserves_the_cause_chain_in_the_traceback(monkeypatch) -> None:
+async def test_fabric_adapter_logs_the_whole_cause_chain(monkeypatch, caplog) -> None:
+    """The originating error is what distinguishes one failure from another:
+    an LLM error raised after retries reads identically whatever provoked it."""
     clients: list[_StubClient] = []
 
-    first_message = "Function 'abc-123': Not found for account"
-    second_message = "LLM API error after 3 retries"
+    originating = "Function 'abc-123': Not found for account"
+    raised = "LLM API error after 3 retries"
 
     async def fail(**kwargs: Any) -> tuple[AnalystResult, object]:
         try:
-            raise ValueError(first_message)
+            raise ValueError(originating)
         except ValueError as cause:
-            raise RuntimeError(second_message) from cause
+            raise RuntimeError(raised) from cause
 
     monkeypatch.setattr(fabric_adapter, "run_analyst_change_set", fail)
     monkeypatch.setattr(fabric_adapter, "get_async_task_sdk", _stub_sdk_factory(clients))
@@ -207,7 +189,8 @@ async def test_fabric_adapter_preserves_the_cause_chain_in_the_traceback(monkeyp
     runtime = fabric_adapter.InsightsAnalystRuntime()
     await runtime.start({"config": _agent_config({"agent": "research-agent"})})
 
-    result = await runtime.invoke(_request({"job_workspace": "workspace"}), cast(contract.RuntimeContext, None))
+    with caplog.at_level("ERROR", logger="nemo_insights_plugin.fabric_adapter"):
+        await runtime.invoke(_request({"job_workspace": "workspace"}), cast(contract.RuntimeContext, None))
 
-    assert first_message in result.output["traceback"]
-    assert second_message in result.output["traceback"]
+    assert originating in caplog.text, "root cause was dropped"
+    assert raised in caplog.text

--- a/services/core/jobs/src/nmp/core/jobs/controllers/backends/base.py
+++ b/services/core/jobs/src/nmp/core/jobs/controllers/backends/base.py
@@ -26,6 +26,7 @@ from nmp.common.config.base import (
     NMP_CONFIG_WARNINGS_DISABLED_ENV_VAR,
     PlatformConfig,
     determine_loopback_override,
+    get_common_service_config,
 )
 from nmp.common.jobs.constants import (
     CONFIG_TASK_STORAGE_PATH_ENVVAR,
@@ -321,6 +322,20 @@ def get_job_runtime_shared_envvars(
 
     if disable_warnings:
         envvars[NMP_CONFIG_WARNINGS_DISABLED_ENV_VAR] = "1"
+
+    # A task container does not get the platform config file, so the deployment's
+    # logging settings would otherwise not reach it: a chart configured with
+    # ``service.log_format: json`` would still start its tasks on ``plain``.
+    # Resolve them here, where the file *is* readable, and pass the answer down.
+    # Best-effort - logging configuration is not worth failing a schedule over,
+    # and the task falls back to its own defaults.
+    try:
+        service_config = get_common_service_config()
+    except Exception:
+        logger.warning("Could not resolve logging settings for job runtime env.", exc_info=True)
+    else:
+        envvars["LOG_LEVEL"] = service_config.log_level
+        envvars["LOG_FORMAT"] = service_config.log_format
 
     return envvars
 

--- a/services/core/jobs/tests/controllers/test_base.py
+++ b/services/core/jobs/tests/controllers/test_base.py
@@ -379,6 +379,44 @@ class TestGetLogsEndpointFromFileset:
 
 
 class TestGetJobRuntimeSharedEnvvars:
+    def test_propagates_the_deployments_logging_settings_to_task_containers(self, monkeypatch, tmp_path):
+        """A task container gets no platform config file, so a chart set to
+        ``service.log_format: json`` would otherwise start its tasks on
+        ``plain``. Resolve here, where the file is readable, and pass it down."""
+        from nemo_platform_plugin.config import NMP_CONFIG_FILE_PATH_ENV_VAR, Configuration
+
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("service:\n  LOG_FORMAT: json\n  LOG_LEVEL: DEBUG\n")
+        monkeypatch.setenv(NMP_CONFIG_FILE_PATH_ENV_VAR, str(config_file))
+        monkeypatch.delenv("LOG_FORMAT", raising=False)
+        monkeypatch.delenv("LOG_LEVEL", raising=False)
+        Configuration.clear_cache()
+
+        try:
+            envvars = get_job_runtime_shared_envvars(PlatformConfig())
+        finally:
+            Configuration.clear_cache()
+
+        assert envvars["LOG_FORMAT"] == "json"
+        assert envvars["LOG_LEVEL"] == "DEBUG"
+
+    def test_unreadable_logging_settings_do_not_fail_scheduling(self, monkeypatch, tmp_path):
+        """Logging configuration is not worth failing a schedule over; the task
+        falls back to its own defaults."""
+        from nemo_platform_plugin.config import NMP_CONFIG_FILE_PATH_ENV_VAR, Configuration
+
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("this: is: not: valid: yaml:\n")
+        monkeypatch.setenv(NMP_CONFIG_FILE_PATH_ENV_VAR, str(config_file))
+        Configuration.clear_cache()
+
+        try:
+            envvars = get_job_runtime_shared_envvars(PlatformConfig())
+        finally:
+            Configuration.clear_cache()
+
+        assert "NMP_BASE_URL" in envvars, "scheduling env was lost over a logging setting"
+
     def test_uses_service_discovery_gateway_urls_for_job_runtimes(self):
         config = PlatformConfig(  # type: ignore[abstract]
             base_url="http://127.0.0.1:8080",
@@ -403,6 +441,10 @@ class TestGetJobRuntimeSharedEnvvars:
             "NMP_MODELS_URL": "https://nemo-gateway:8080",
             "NMP_SECRETS_URL": "https://nemo-gateway:8080",
             "NMP_CONFIG_WARNINGS_DISABLED": "1",
+            # Propagated so a task container, which has no platform config
+            # file, still logs the way the deployment configured it.
+            "LOG_LEVEL": "INFO",
+            "LOG_FORMAT": "plain",
         }
 
     def test_gateway_base_url_is_used_for_job_runtimes_without_service_discovery(self):
@@ -427,6 +469,10 @@ class TestGetJobRuntimeSharedEnvvars:
             "NMP_MODELS_URL": "https://nemo-gateway:8080",
             "NMP_SECRETS_URL": "https://nemo-gateway:8080",
             "NMP_CONFIG_WARNINGS_DISABLED": "1",
+            # Propagated so a task container, which has no platform config
+            # file, still logs the way the deployment configured it.
+            "LOG_LEVEL": "INFO",
+            "LOG_FORMAT": "plain",
         }
 
     def test_resolved_base_url_is_used_for_job_runtimes_without_service_discovery(self):
@@ -451,6 +497,10 @@ class TestGetJobRuntimeSharedEnvvars:
             "NMP_MODELS_URL": "http://127.0.0.1:59007",
             "NMP_SECRETS_URL": "http://127.0.0.1:59007",
             "NMP_CONFIG_WARNINGS_DISABLED": "1",
+            # Propagated so a task container, which has no platform config
+            # file, still logs the way the deployment configured it.
+            "LOG_LEVEL": "INFO",
+            "LOG_FORMAT": "plain",
         }
 
     def test_auth_service_url_is_exported_for_job_runtime(self):


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
Improves job logging at three layers.

### run_task

This is a generic function that several (but not all) plugins use in/as their job task entrypoints. We now configure a standardized logging setup here for consistent formatting, and make sure we at least log an error message right before exit-1'ing a failed job.

This is configured to pick up nmp.common observability settings **without** carrying a direct dependency on nmp.common, following the existing pattern used for SDK clients.

### ExecuteAgentJob

Add several log statements so that these jobs aren't silent as the grave

### Analyst agent (fabric adapter)

Configure logging inside the fabric subprocess, and include an exception log when `_run_analysis` raises


## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Task processes now initialize logging with platform-configured levels and formats.
  - Structured logging providers are supported, with a fallback format when configuration is unavailable.
  - Task and agent logs now include progress, timing, identifiers, and captured error output.
  - Error output is safely bounded to prevent excessive log volume.
  - Logging settings are propagated to job runtimes.

- **Bug Fixes**
  - Failed jobs and analyst runs now record detailed failure information, including tracebacks and result details.
  - Existing logging configuration is preserved, and repeated initialization is handled safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->