### PR TITLE
docs(auditor): update examples with correct attr access (#1634)

### DIFF
--- a/docs/auditor/targets/index.mdx
+++ b/docs/auditor/targets/index.mdx
@@ -29,8 +29,8 @@ Audit a NIM (or any OpenAI-compatible chat endpoint) routed through a NeMo Platf
 ```python
 # List providers registered in your deployment and pick one.
 providers = client.inference.providers.list(workspace="default")
-for provider in providers["data"]:
-    print(provider["name"], provider.get("host_url"))
+for provider in providers.data:
+    print(provider.name, provider.host_url)
 ```
 
 Use a `provider` name from this output in the target below. The model identifier format depends on the provider — check the provider's API documentation or served-model list if unsure.

--- a/docs/auditor/tutorials/run-audit-locally.mdx
+++ b/docs/auditor/tutorials/run-audit-locally.mdx
@@ -95,8 +95,8 @@ First, list the providers registered in your deployment so you can pick one that
 
 ```python
 providers = client.inference.providers.list(workspace="default")
-for provider in providers["data"]:
-    print(provider["name"], provider.get("host_url"))
+for provider in providers.data:
+    print(provider.name, provider.host_url)
 ```
 
 Use a `provider` name from this output in the target below. The model identifier format depends on the provider — check the provider's API documentation or served-model list if unsure.


### PR DESCRIPTION
Cherry pick from main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated provider-listing examples to access provider details through typed object attributes.
  - Revised examples to use `provider.name` and `provider.host_url` for clearer, current usage guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->