### PR TITLE
fix(studio): only offer deployable models in the deployment wizard (ASTD-558)

### DIFF
--- a/web/packages/studio/src/routes/DeploymentsListRoute/CreateDeploymentSidePanel/WorkspaceSourceFields.test.tsx
+++ b/web/packages/studio/src/routes/DeploymentsListRoute/CreateDeploymentSidePanel/WorkspaceSourceFields.test.tsx
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  useModelSearch,
+  type UseModelSearchOptions,
+  type UseModelSearchResult,
+} from '@nemo/common/src/api/models/useModelSearch';
+import type { ModelEntity } from '@nemo/sdk/generated/platform/schema';
+import {
+  defaultWizardValues,
+  type WizardFormValues,
+} from '@studio/routes/DeploymentsListRoute/CreateDeploymentSidePanel/schema';
+import { WorkspaceSourceFields } from '@studio/routes/DeploymentsListRoute/CreateDeploymentSidePanel/WorkspaceSourceFields';
+import { renderRoute } from '@studio/tests/util/render';
+import type { FC } from 'react';
+import { useForm } from 'react-hook-form';
+
+vi.mock('@nemo/common/src/api/models/useModelSearch', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@nemo/common/src/api/models/useModelSearch')>();
+  return { ...actual, useModelSearch: vi.fn() };
+});
+
+const mockUseModelSearch = vi.mocked(useModelSearch);
+
+const emptyResult: UseModelSearchResult = {
+  models: [],
+  groups: [],
+  search: '',
+  error: null,
+  loading: false,
+  onSearchChange: vi.fn(),
+  onLoadMore: vi.fn(),
+  hasMore: false,
+  isLoadingMore: false,
+};
+
+const buildModel = (overrides: Partial<ModelEntity> = {}) =>
+  ({ id: 'model-1', name: 'my-model', workspace: 'default', ...overrides }) as ModelEntity;
+
+/** Renders the workspace source fields against a real form control. */
+const Harness: FC = () => {
+  const { control, formState } = useForm<WizardFormValues>({
+    defaultValues: defaultWizardValues(),
+  });
+  return (
+    <WorkspaceSourceFields
+      workspace="default"
+      queryEnabled
+      control={control}
+      errors={formState.errors}
+      onPickerTypeChange={() => {}}
+    />
+  );
+};
+
+const capturedOptions = (): UseModelSearchOptions => {
+  const call = mockUseModelSearch.mock.calls.at(-1);
+  if (!call) throw new Error('useModelSearch was never called');
+  return call[0];
+};
+
+describe('WorkspaceSourceFields model picker', () => {
+  beforeEach(() => {
+    mockUseModelSearch.mockReturnValue(emptyResult);
+  });
+
+  it('passes an include predicate to the model search', () => {
+    renderRoute(<Harness />);
+    expect(capturedOptions().include).toBeDefined();
+  });
+
+  it('admits models that have a fileset of weights', () => {
+    renderRoute(<Harness />);
+    const include = capturedOptions().include!;
+    expect(include(buildModel({ fileset: 'default/qwen3-0.6b-weights' }))).toBe(true);
+  });
+
+  it('excludes remote provider models, which have no weights to pull', () => {
+    renderRoute(<Harness />);
+    const include = capturedOptions().include!;
+    // Shape of a NVIDIA Build catalog entry: served remotely, no fileset.
+    expect(include(buildModel({ model_providers: ['default/build'] }))).toBe(false);
+  });
+});

--- a/web/packages/studio/src/routes/DeploymentsListRoute/CreateDeploymentSidePanel/WorkspaceSourceFields.tsx
+++ b/web/packages/studio/src/routes/DeploymentsListRoute/CreateDeploymentSidePanel/WorkspaceSourceFields.tsx
@@ -8,6 +8,7 @@ import { FilesetSearchableSelect } from '@nemo/common/src/components/FilesetSear
 import { type ModelSelection, ModelSelectV2 } from '@nemo/common/src/components/ModelSelectV2';
 import { RadioCard } from '@nemo/common/src/components/RadioCard';
 import { Flex, FormField, RadioGroupRoot, Stack } from '@nvidia/foundations-react-core';
+import { canFineTuneModel } from '@studio/hooks/useModelCustomizationEligibility';
 import { EngineFields } from '@studio/routes/DeploymentsListRoute/CreateDeploymentSidePanel/EngineFields';
 import { GPULoraFields } from '@studio/routes/DeploymentsListRoute/CreateDeploymentSidePanel/GPULoraFields';
 import {
@@ -105,14 +106,21 @@ const WorkspaceModelPicker: FC<WorkspaceModelPickerProps> = ({
   const { field } = useController({ control, name: 'modelRef' });
   const [open, setOpen] = useState(false);
 
-  const modelSearch = useModelSearch({ workspace, enabled: queryEnabled && open });
+  // Deployment needs local weights: the puller resolves `model.fileset` and fails
+  // if it is absent, which is what remote provider catalog entries look like.
+  // Same condition as fine-tuning, so the predicate is shared.
+  const modelSearch = useModelSearch({
+    workspace,
+    enabled: queryEnabled && open,
+    include: canFineTuneModel,
+  });
 
   const value: ModelSelection | null = field.value ? { model: field.value as string } : null;
 
   return (
     <FormField
       slotLabel="Model"
-      slotInfo="Existing model entity to deploy from this workspace."
+      slotInfo="Registered model with weights in this workspace. Models served by a remote provider cannot be deployed."
       slotError={errorMessage}
     >
       <ModelSelectV2


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary

The deployment wizard's "Existing model" picker listed every model entity in the workspace, including remote inference-provider catalog entries that have no local weights. Selecting one was always a failure: the platform allocated a GPU volume, started a puller with nothing to pull, and marked the deployment `ERROR` seconds later with `Prerequisite '<name>-puller' failed` — and the puller container holding the real reason is reaped by orphan cleanup shortly after, so the reason is unrecoverable.

Deployment needs the same thing fine-tuning does: a fileset holding the weights. This passes the existing `canFineTuneModel` predicate to the picker so only models that have one are offered. Every other model picker in Studio already passes a predicate; this was the only one that did not.

Before: on a workspace with the NVIDIA Build catalog registered, 83 models offered, 2 deployable. After: 2 offered.

| Before | After |
| --- | --- |
| <img width="588" height="428" alt="image" src="https://github.com/user-attachments/assets/43b6bf1e-fde7-4b80-88f7-253cf52e6ee2" /> | <img width="594" height="409" alt="image" src="https://github.com/user-attachments/assets/470df3ef-5437-41cd-93e5-35db3ad203d4" /> |

## Changes

- `WorkspaceSourceFields.tsx`: pass `include: canFineTuneModel` to the picker's `useModelSearch` call, and update the field's helper text so the narrowed list reads as intentional.
- `WorkspaceSourceFields.test.tsx`: new test file (the component had none), asserting the predicate's behavior rather than its identity so it survives a later rename or inline.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: narrows an existing picker to valid options and adjusts one helper string; no documented behavior or API changes.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

```
# New test
npx vitest --run src/routes/DeploymentsListRoute/CreateDeploymentSidePanel/WorkspaceSourceFields.test.tsx
  -> Test Files 1 passed (1) | Tests 3 passed (3)

# Negative check: with `include: canFineTuneModel` removed, all 3 fail; restored, all 3 pass.

# Full Studio suite
vitest --run   -> Tests 3304 passed

# Types and lint
pnpm typecheck                                  -> clean
eslint <both changed files> --max-warnings 0    -> clean
```

`uv run pre-commit run -a` was not run across the whole repo. The pre-commit hooks did run on commit against the staged files — `Fix copyright headers`, `Run UI lint-staged`, `Check commit is signed off (DCO)`, and `check for merge conflicts` all passed; every Python/Helm/uv hook reported "no files to check", as this change is TypeScript-only.

Not verified: the change has not been exercised against a running platform in a browser.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model selection for deployments now shows only models with local weight files.
  * Remote-provider models without local files are excluded from deployment options.
  * Updated field guidance clarifies that remote-provider models cannot be deployed.

* **Tests**
  * Added coverage for model eligibility filtering in the deployment workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->