### PR TITLE
fix(models): make Docker LoRA sidecar command a valid executable

### DIFF
--- a/packages/nmp_platform/config/local.yaml
+++ b/packages/nmp_platform/config/local.yaml
@@ -176,12 +176,15 @@ models:
         enabled: true
         docker_executor: local-docker
         default_executor: local-docker
-        # LoRA adapter-download sidecar for deployments with lora_enabled. The
-        # docker backend has no separate args field (unlike k8s) and keeps the
-        # image ENTRYPOINT — nmp-customizer-tasks is `/opt/venv/bin/python`, so
-        # the module goes in lora_sidecar_command (runs `python -m <module>`).
+        # LoRA adapter-download sidecar for deployments with lora_enabled. Both
+        # backends override the image ENTRYPOINT with lora_sidecar_command: k8s
+        # maps it to the pod container `command`, and the docker backend maps it
+        # to docker's `entrypoint` (with lora_sidecar_args -> docker `command`).
+        # So the command must be a complete executable list, not a bare `-m`
+        # fragment — `python` resolves on the nmp-customizer-tasks PATH
+        # (/opt/venv/bin).
         lora_sidecar_image_name: nmp-customizer-tasks
-        lora_sidecar_command: ["-m", "nmp.core.models.sidecars.adapters.main"]
+        lora_sidecar_command: ["python", "-m", "nmp.core.models.sidecars.adapters.main"]
 
 # Inference gateway configuration - uses default values
 inference_gateway: {}

--- a/packages/nmp_platform_runner/src/nmp/platform_runner/config/local.yaml
+++ b/packages/nmp_platform_runner/src/nmp/platform_runner/config/local.yaml
@@ -68,12 +68,15 @@ models:
         enabled: true
         docker_executor: local-docker
         default_executor: local-docker
-        # LoRA adapter-download sidecar for deployments with lora_enabled. The
-        # docker backend has no separate args field (unlike k8s) and keeps the
-        # image ENTRYPOINT — nmp-customizer-tasks is `/opt/venv/bin/python`, so
-        # the module goes in lora_sidecar_command (runs `python -m <module>`).
+        # LoRA adapter-download sidecar for deployments with lora_enabled. Both
+        # backends override the image ENTRYPOINT with lora_sidecar_command: k8s
+        # maps it to the pod container `command`, and the docker backend maps it
+        # to docker's `entrypoint` (with lora_sidecar_args -> docker `command`).
+        # So the command must be a complete executable list, not a bare `-m`
+        # fragment — `python` resolves on the nmp-customizer-tasks PATH
+        # (/opt/venv/bin).
         lora_sidecar_image_name: nmp-customizer-tasks
-        lora_sidecar_command: ["-m", "nmp.core.models.sidecars.adapters.main"]
+        lora_sidecar_command: ["python", "-m", "nmp.core.models.sidecars.adapters.main"]
 
 deployments:
   executors:

--- a/services/core/models/src/nmp/core/models/controllers/backends/deployments_plugin/compiler.py
+++ b/services/core/models/src/nmp/core/models/controllers/backends/deployments_plugin/compiler.py
@@ -371,11 +371,11 @@ def compile_model_deployment(
         if engine == ENGINE_NIM:
             apply_k8s_nim_operator_container_overrides(server, readiness_probe, resolved.view)
         if resolved.runtime == Runtime.DOCKER:
-            # Docker v1 is single-container today; emit a second container so the
-            # shape matches the locked design for when the plugin docker backend
-            # accepts multi-container DeploymentConfigs. In practice the backend
-            # fails fast on docker + LoRA before reaching create (see
-            # DeploymentsPluginServiceBackend.create_model_deployment).
+            # Docker emits the sidecar as a second container in the server
+            # DeploymentConfig (rather than a k8s-style native/init sidecar).
+            # The docker backend starts it sharing the server's network
+            # namespace and volumes; its command/args must be a valid
+            # executable (see lora_sidecar_command in config).
             server_config_containers = [server, lora]
         else:
             server_config_containers = [server]

--- a/services/core/models/tests/unit/controllers/backends/deployments_plugin/test_compiler.py
+++ b/services/core/models/tests/unit/controllers/backends/deployments_plugin/test_compiler.py
@@ -505,6 +505,9 @@ def test_shipped_local_yaml_lora_sidecar_command_is_a_valid_executable(config_re
     assert not command[0].startswith("-"), (
         f"{config_rel_path}: lora_sidecar_command[0] '{command[0]}' looks like a flag, not an executable"
     )
+
+
+def test_lora_sidecar_rewrites_loopback_nmp_base_url_for_docker() -> None:
     """Docker LoRA sidecars must not keep host loopback as NMP_BASE_URL (jobs/auth-proxy pattern)."""
     config = DeploymentsPluginConfig()
     platform = MagicMock()

--- a/services/core/models/tests/unit/controllers/backends/deployments_plugin/test_compiler.py
+++ b/services/core/models/tests/unit/controllers/backends/deployments_plugin/test_compiler.py
@@ -1,10 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+import yaml
 from nemo_deployments_plugin.entities import SecretRef
 from nemo_platform.types.inference.k8s_nim_operator_config import K8sNIMOperatorConfig
 from nmp.common.config import Runtime
@@ -421,9 +423,88 @@ def test_lora_uses_native_sidecar_on_k8s_and_container_on_docker() -> None:
     assert env["NMP_BASE_URL"] == "http://platform.example:8080"
     assert env["VLLM_ENDPOINT"] == "http://127.0.0.1:8000"
     assert len(docker.server_config.containers) == 2
+    # The docker sidecar's command becomes docker's entrypoint (replacing the
+    # image ENTRYPOINT), so it must be a complete executable list, never a bare
+    # `-m` fragment (which runc would look up as the executable -> `exec: "-m"`).
+    docker_sidecar = docker.server_config.containers[1]
+    assert docker_sidecar.name == "lora-adapters"
+    assert docker_sidecar.command == ["python", "-m", "nmp.core.models.sidecars.adapters.main"]
+    assert docker_sidecar.command[0] != "-m"
 
 
-def test_lora_sidecar_rewrites_loopback_nmp_base_url_for_docker() -> None:
+def test_docker_lora_sidecar_command_is_a_valid_executable_under_override() -> None:
+    """A LoRA sidecar command overridden in config must still be a valid executable.
+
+    The docker backend maps ``Container.command`` onto docker's ``entrypoint``,
+    replacing the image ENTRYPOINT, so a bare ``["-m", "<module>"]`` fragment
+    makes runc treat ``-m`` as the executable and fail with ``exec: "-m":
+    executable file not found in $PATH``. This guards the config override shape
+    (mirroring the local.yaml deployments-plugin section) so that regression is
+    caught in unit tests rather than only on a live docker deployment.
+    """
+    config = DeploymentsPluginConfig(
+        lora_sidecar_image_name="nmp-customizer-tasks",
+        lora_sidecar_command=["python", "-m", "nmp.core.models.sidecars.adapters.main"],
+    )
+    platform = MagicMock()
+    platform.base_url = "http://platform.example:8080"
+    with (
+        patch(
+            "nmp.core.models.controllers.backends.deployments_plugin.compiler.get_qualified_image",
+            return_value="registry/nmp-customizer-tasks:tag",
+        ),
+        patch(
+            "nmp.core.models.controllers.backends.deployments_plugin.compiler.get_platform_config",
+            return_value=platform,
+        ),
+    ):
+        docker = compile_model_deployment(_resolved("vllm", lora=True, runtime=Runtime.DOCKER), config)
+
+    sidecar = docker.server_config.containers[1]
+    assert sidecar.name == "lora-adapters"
+    # command[0] is what the docker backend uses as the entrypoint executable; it
+    # must be a real program, not an interpreter flag.
+    assert sidecar.command
+    assert sidecar.command[0] != "-m"
+    assert sidecar.command == ["python", "-m", "nmp.core.models.sidecars.adapters.main"]
+
+
+def _repo_root() -> Path:
+    """Walk up from this test file to the repo root (the dir holding ``packages/``)."""
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "packages" / "nmp_platform" / "config" / "local.yaml").is_file():
+            return parent
+    raise AssertionError("could not locate repo root from test file")
+
+
+@pytest.mark.parametrize(
+    "config_rel_path",
+    [
+        "packages/nmp_platform/config/local.yaml",
+        "packages/nmp_platform_runner/src/nmp/platform_runner/config/local.yaml",
+    ],
+)
+def test_shipped_local_yaml_lora_sidecar_command_is_a_valid_executable(config_rel_path: str) -> None:
+    """The shipped local.yaml overrides must not reintroduce the bare ``-m`` bug.
+
+    The docker backend maps ``lora_sidecar_command`` onto docker's ``entrypoint``
+    (replacing the image ENTRYPOINT), so ``command[0]`` is the executable. A bare
+    ``["-m", "<module>"]`` fragment makes runc fail with ``exec: "-m"``. This test
+    reads the ACTUAL shipped config files (not a hardcoded config object), so a
+    future revert of either ``local.yaml`` back to a relative ``-m`` fragment fails
+    here rather than only on a live docker deployment.
+    """
+    doc = yaml.safe_load((_repo_root() / config_rel_path).read_text())
+    plugin = doc["models"]["controller"]["backends"]["deployments_plugin"]
+    command = plugin["lora_sidecar_command"]
+    assert command, f"{config_rel_path}: lora_sidecar_command must not be empty"
+    assert command[0] != "-m", (
+        f"{config_rel_path}: lora_sidecar_command[0] is '-m'; the docker backend maps command -> "
+        "entrypoint, so command[0] must be a real executable (e.g. 'python'), not an interpreter flag"
+    )
+    assert not command[0].startswith("-"), (
+        f"{config_rel_path}: lora_sidecar_command[0] '{command[0]}' looks like a flag, not an executable"
+    )
     """Docker LoRA sidecars must not keep host loopback as NMP_BASE_URL (jobs/auth-proxy pattern)."""
     config = DeploymentsPluginConfig()
     platform = MagicMock()


### PR DESCRIPTION
## Summary

Enabling LoRA on a Docker-backed vLLM/NIM model deployment left it stuck in ERROR: the LoRA adapter sidecar failed to start with `exec: "-m": executable file not found in $PATH`. The Docker deployments-plugin backend maps a container spec's `command` onto docker's `entrypoint` (replacing the image ENTRYPOINT), mirroring how Kubernetes treats `command`/`args`. The deployments-plugin `local.yaml` override set the sidecar command to a bare `["-m", "<module>"]` fragment — valid only under the older behavior where `command` was appended to the image ENTRYPOINT (`/opt/venv/bin/python`). Under the current entrypoint-replacing mapping, runc looks up `-m` as the executable and the sidecar dies. After this change the sidecar command is a complete `["python", "-m", "<module>"]` argv, so Docker LoRA deployments start correctly.

## Changes

- Set `lora_sidecar_command` to `["python", "-m", "nmp.core.models.sidecars.adapters.main"]` in both `packages/nmp_platform/config/local.yaml` and `packages/nmp_platform_runner/src/nmp/platform_runner/config/local.yaml` (matches the compiler default and the k8s path; `python` resolves on the `nmp-customizer-tasks` image PATH `/opt/venv/bin`).
- Corrected the misleading comments in both `local.yaml` copies: the Docker backend replaces the image ENTRYPOINT with `command` and does map `args` onto docker's `command`, so the command must be a complete executable list.
- Rewrote the stale compiler comment that claimed Docker + LoRA fails fast before reaching create; the backend now emits and starts both the server and sidecar containers.
- Extended `test_lora_uses_native_sidecar_on_k8s_and_container_on_docker` to assert the compiled Docker sidecar argv is a valid executable (not a bare `-m`).
- Added `test_docker_lora_sidecar_command_is_a_valid_executable_under_override` (compiler-path guard) and `test_shipped_local_yaml_lora_sidecar_command_is_a_valid_executable` (reads the actual shipped `local.yaml` files, parametrized over both) so a future relative-fragment regression in either config fails in unit tests rather than only on a live Docker deployment.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: internal config/comment fix with no user-facing docs surface; behavior is covered by unit tests.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `uv run --frozen pytest services/core/models/tests/unit/controllers/backends/deployments_plugin/test_compiler.py -q` → 22 passed (includes the new config-file + override regression guards)
- `uv run pre-commit run --files <the 4 changed files>` → ruff, ruff format, ty typechecks, copyright headers, merge-conflict check all Passed
- `uv run ruff check <changed files>` / `uv run ruff format --check <changed files>` → clean
- `uv run --frozen ty check` on the changed compiler/test files → no new diagnostics (the only 3 reported are pre-existing `SimpleNamespace` test-helper patterns identical on the base branch)

## Manual testing (live Docker deployment)

Verified the fix end-to-end on a live Docker-backed platform (docker-in-docker, A100-80GB GPU) running this branch with the docker deployments-plugin backend (`local-docker`, `runtime: docker`), reproducing the reported failure scenario: a vLLM deployment with `lora_enabled=true`, base model `Qwen/Qwen3-1.7B` plus a Hugging Face-hosted LoRA adapter (`premjatin/qwen-linear-algebra-coder`).

1. **Mechanism proof.** Reproduced the docker backend's `command → docker entrypoint` mapping directly against a real image that has `python` and the adapters module: the pre-fix argv `["-m", "…adapters.main"]` fails with `exec: "-m": executable file not found in $PATH` (exit 127 — the exact bug), while the fixed argv `["python", "-m", "…adapters.main"]` launches the interpreter and runs the sidecar module.
2. **Full deployment reached `READY`.** After the fix, creating the deployment produced: the weight-puller container `Exited (0)`; the vLLM server container up and serving `/v1/models` + `/health` 200; and the `lora-adapters` sidecar container **running (exit code 0)**, cleanly polling the platform API for adapters. Final deployment status: **`READY` — "Container running and ready (http probe 200)"**, with **zero** occurrences of `exec: "-m"` in the sidecar logs.

Acceptance criteria for the reported issue (deployment reaches READY, sidecar starts without `exec: "-m"`, existing non-LoRA behavior unaffected, and a unit test that fails if the sidecar argv would regress to `-m`) are satisfied. (The vLLM server requires a GPU; making GPU containers run under the pod's docker-in-docker needed the nvidia-container-toolkit — an environment prerequisite unrelated to this change. The LoRA sidecar itself needs no GPU and is what this fix concerns.) Test resources were torn down afterward.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed LoRA adapter downloads in local and Docker-based deployments by ensuring the sidecar uses a complete, valid Python command.
  - Improved reliability for deployments using shipped local configurations and custom sidecar command overrides.
  - Clarified Docker sidecar behavior, including shared networking and volumes, to support more predictable deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->