### PR TITLE
chore: merge release/0.5 into main

### DIFF
--- a/docs/fern/versions/latest.yml
+++ b/docs/fern/versions/latest.yml
@@ -354,12 +354,20 @@ navigation:
             path: ../../studio/customization.mdx
           - page: Data Designer
             path: ../../studio/data-designer-build.mdx
+          - page: Experiments
+            path: ../../studio/experiments.mdx
+          - page: Insights
+            path: ../../studio/insights.mdx
+          - page: Model Evaluations
+            path: ../../studio/model-evaluations.mdx
           - page: Monitor
             path: ../../studio/monitor.mdx
           - page: Plugin UIs
             path: ../../studio/plugins.mdx
           - page: Guardrail Configs
             path: ../../studio/guardrails.mdx
+          - page: Traces
+            path: ../../studio/traces.mdx
           - page: Virtual Models
             path: ../../studio/virtual-models.mdx
       - section: Kubernetes Deployment

--- a/docs/studio/experiments.mdx
+++ b/docs/studio/experiments.mdx
@@ -1,0 +1,49 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+title: "NeMo Studio Experiments"
+description: "Group evaluations into experiments, drill into results, and compare runs side by side."
+---
+
+Use **Evaluations > Experiments** in the NeMo Studio workspace sidebar to group evaluations for comparison, and to drill into evaluation results and individual runs.
+
+<Note>
+
+Experiments is enabled by default. An administrator can disable it by setting `studio.feature_flags.experiment: false` in the platform configuration and restarting Studio.
+
+</Note>
+
+## Create an Experiment
+
+Select **New experiment** from the Experiments list. In the **Create experiment** tab, provide a name, an optional description, and a default sort order for the experiment's evaluations, then select **Create**.
+
+<Note>
+
+The modal also has **NeMo Assistant** and **CLI command** tabs. **CLI command** shows an equivalent `nemo agents experimentalist run` invocation, with `--train-dataset` and `--validation-dataset` selecting the training and validation data; **NeMo Assistant** is a placeholder for a future guided flow.
+
+</Note>
+
+## Experiment Detail
+
+Select an experiment to open its detail page, which shows aggregate metrics across its evaluations and a table of the evaluations in the group. Toggle **Pareto view** to plot evaluations on a chart instead of the table, by default cost against latency. Change either axis to cost, latency, or any evaluator's score (`cost_usd`, `latency_ms`, or `evaluators.<name>`); the selection is saved per experiment.
+
+Select **Edit** to update the experiment's name, description, or default sort order.
+
+If the experiment was created from an Optimizer insight, an **Insight description** card appears with a link back to that insight. See [NeMo Studio Insights](/documentation/studio/insights).
+
+## Evaluation Drill-Down
+
+Select an evaluation from an experiment's table to open its detail page, which shows aggregate metrics for that evaluation and a table of its test-case runs (sessions).
+
+Select a session to open its detail page — the same trace and span view used by **Traces**, scoped to that test case. See [NeMo Studio Traces](/documentation/studio/traces).
+
+## Compare Runs Side by Side
+
+From a session's detail page, select **Compare against…** and choose another run of the same test case. Studio splits the view into two columns — the current run on the left, the selected run on the right — so you can compare trace output side by side. Select **Clear** to return to the single-run view.
+
+## Related Topics
+
+- [Experiments](/documentation/evaluate-models/experiments)
+- [NeMo Studio Insights](/documentation/studio/insights)
+- [NeMo Studio Traces](/documentation/studio/traces)

--- a/docs/studio/index.mdx
+++ b/docs/studio/index.mdx
@@ -32,11 +32,11 @@ The current sidebar groups related pages under expandable parents. Selecting a p
 
 | Sidebar group | Current entry point | Purpose and availability |
 | --- | --- | --- |
-| **Observability** | **Insights** | Review recurring agent failure patterns and optimization insights. Shown when optimization is enabled. |
-| **Observability** | **Traces** | Inspect ingested traces, spans, and session details. |
+| **Observability** | **Insights** | Review optimization insights generated from observed agent sessions. Shown when optimization is enabled; see [NeMo Studio Insights](/documentation/studio/insights). |
+| **Observability** | **Traces** | Inspect ingested traces, spans, and session details; see [NeMo Studio Traces](/documentation/studio/traces). |
 | **Components** | **Agents** | Opens the agent list. Select an agent to access Deployments, Logs, Chat, Evaluations, and Details. |
-| **Components** | **Models** | Opens the base-model list directly. Expand **Models** for **Fine-tune**, **Model Evaluations**, **Playground**, and **Virtual Models**, when those capabilities are enabled. **Fine-tune** opens the Custom Models list; see [NeMo Studio Custom Models](/documentation/studio/customization). |
-| **Evaluations** | **Experiments** | Review experiments, evaluations, sessions, and published results across the workspace. |
+| **Components** | **Models** | Opens the base-model list directly. Expand **Models** for **Fine-tune**, **Model Evaluations**, **Playground**, and **Virtual Models**, when those capabilities are enabled. **Fine-tune** opens the Custom Models list; see [NeMo Studio Custom Models](/documentation/studio/customization). **Model Evaluations** opens evaluation job results; see [NeMo Studio Model Evaluations](/documentation/studio/model-evaluations). |
+| **Evaluations** | **Experiments** | Group evaluations for comparison, drill into results, and compare runs side by side; see [NeMo Studio Experiments](/documentation/studio/experiments). |
 | **Data** | **Datasets > Data Designer** | Build and monitor synthetic-data jobs. Other installed data plugins can appear below **Datasets**. |
 | **Governance** | **Guardrails** | Manage guardrail configurations. Disabled by default; see [Studio Guardrail Configs](/documentation/studio/guardrail-configs). |
 | **Governance** | **Iron Swarm** | Plugin-provided agent hardening UI. Appears only when the Iron Swarm plugin is installed; see [Studio Plugin UIs](/documentation/studio/plugins). |
@@ -50,6 +50,18 @@ Additional entries, including Dashboard, Safe Synthesizer, Anonymizer, deploymen
 Use the Studio Agents area to review Platform-managed agents, including the current Fabric-first `nemo-agents-spec-v1` experience, inspect agent details, deploy agents, open a chat session against a running deployment, and clean up deployments that are no longer needed.
 
 For the full workflow, see [Studio Agents](/documentation/studio/agents).
+
+### Insights
+
+Use **Observability > Insights** to review optimization insights the analyst agent generates from observed agent sessions and traces, and drill into an insight's linked experiments and source traces. For a resolved or deleted insight, **Run experiment** shows the CLI command to start experiments for it.
+
+For the full workflow, see [Studio Insights](/documentation/studio/insights).
+
+### Traces
+
+Use **Observability > Traces** to inspect ingested telemetry in the Traces and Spans tables, and drill into a session's trace and span detail, with specialized views for LLM, tool, agent, chain, embedding, reranker, retriever, guardrail, and evaluator spans.
+
+For the full workflow, see [Studio Traces](/documentation/studio/traces).
 
 ### Monitor
 
@@ -120,8 +132,8 @@ Studio provides separate agent, model, and workspace evaluation views:
 | Location | What it shows |
 | -------- | ------------- |
 | **Agents > select an agent > Evaluations** | Active evaluation jobs, completed evaluations, and experiments scoped to the selected agent. |
-| **Models > Model Evaluations** | Model evaluation results. |
-| **Evaluations > Experiments** | Experiments and their evaluations across the workspace. |
+| **Models > Model Evaluations** | Model evaluation job results and per-row scores. See [Studio Model Evaluations](/documentation/studio/model-evaluations). |
+| **Evaluations > Experiments** | Experiments and their evaluations across the workspace, evaluation drill-down, and side-by-side run comparison. See [Studio Experiments](/documentation/studio/experiments). |
 
 Use the agent's **Evaluations** tab when reviewing how a specific agent performed. Use **Experiments** for the broader workspace history.
 

--- a/docs/studio/insights.mdx
+++ b/docs/studio/insights.mdx
@@ -1,0 +1,42 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+title: "NeMo Studio Insights"
+description: "Review optimization insights generated from observed agent sessions."
+---
+
+Use **Observability > Insights** in the NeMo Studio workspace sidebar to review insights the analyst agent generates from observed agent sessions and traces.
+
+<Note>
+
+Insights is enabled by default. An administrator can disable it by setting `studio.feature_flags.optimizer_enabled: false` in the platform configuration and restarting Studio.
+
+</Note>
+
+## Insight List
+
+The Insights table shows each insight's status, title, source agent, number of observed traces, number of linked experiments, and creation and last-seen times. Select a row to open the insight's detail page.
+
+## Insight Detail
+
+The detail page shows the insight's status, source agent, description, and:
+
+| Section | Shows |
+| ------- | ----- |
+| Experiments | Experiments linked to this insight, with evaluation counts and last-updated times. Select a row to open that experiment. |
+| Traces | The observed sessions and traces that produced this insight. |
+
+Available actions depend on the insight's status:
+
+| Status | Available actions |
+| ------ | ------------------ |
+| Open | **Delete**, or **Resolve**. |
+| Resolved or Deleted | **Run experiment** — reopens the insight and shows a modal with the `nemo exp run` CLI command to start experiments for it. Studio doesn't launch the experiment for you; run the command yourself. |
+
+If the insight originated an experiment, that experiment's detail page links back here. See [NeMo Studio Experiments](/documentation/studio/experiments).
+
+## Related Topics
+
+- [NeMo Studio Experiments](/documentation/studio/experiments)
+- [Optimize Agents](/documentation/agents/optimize-agents)

--- a/docs/studio/model-evaluations.mdx
+++ b/docs/studio/model-evaluations.mdx
@@ -1,0 +1,31 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+title: "NeMo Studio Model Evaluations"
+description: "Review model evaluation job results and per-row scores."
+---
+
+Use **Models > Model Evaluations** in the NeMo Studio workspace sidebar to review evaluation jobs run against models in the workspace.
+
+<Note>
+
+Model Evaluations is enabled by default. An administrator can disable it by setting `studio.feature_flags.evaluator_enabled: false` in the platform configuration and restarting Studio, which also removes agent- and customization-scoped evaluation entry points.
+
+</Note>
+
+This page is read-only: it lists evaluation jobs and their results. Start an evaluation from an agent's **Evaluations** tab, a Custom Model's **Evaluate this Model** action, or the `nemo evaluation` CLI or API.
+
+## Evaluation Results List
+
+The list shows each evaluation job's name, status, and creation time. Search by name or filter by status. Select a row to open the job's detail page.
+
+## Evaluation Result Detail
+
+The detail page shows the job's details, a **Scores** panel with aggregate metrics, per-row results for the evaluated dataset, and a collapsible **Logs** panel. Scores and row results are computed once the job reaches a terminal state; if the job failed, results aren't available.
+
+## Related Topics
+
+- [Model Configuration](/documentation/evaluate-models/metrics/model-configuration)
+- [NeMo Studio Custom Models](/documentation/studio/customization)
+- [NeMo Studio Agents](/documentation/studio/agents)

--- a/docs/studio/traces.mdx
+++ b/docs/studio/traces.mdx
@@ -1,0 +1,39 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+title: "NeMo Studio Traces"
+description: "Inspect ingested traces, spans, and session detail from agent telemetry."
+---
+
+Use **Observability > Traces** in the NeMo Studio workspace sidebar to inspect telemetry ingested from agent runs.
+
+<Note>
+
+Traces is enabled by default. An administrator can disable it by setting `studio.feature_flags.intake_enabled: false` in the platform configuration and restarting Studio.
+
+</Note>
+
+## Traces and Spans Tables
+
+The **Traces** and **Spans** tabs list ingested telemetry at different granularity:
+
+| Tab | Columns |
+| --- | ------- |
+| Traces | Trace, input, output, duration, span count, errors, tokens, cost, started. |
+| Spans | Status, kind, span, input, output, subject, trace, duration, tokens, cost, started. |
+
+Select a row in either table to open the session it belongs to.
+
+## Session Detail
+
+The session detail page shows a summary header, then the selected trace's spans. Use the **Tree** / **List** toggle to switch between a nested span tree and a flat list, and **Collapse all** / **Expand all** to manage the tree view.
+
+Selecting a span opens its detail body. Studio renders a specialized view for known span kinds — LLM, tool, agent, chain, embedding, reranker, retriever, guardrail, and evaluator — and falls back to a generic view for unrecognized kinds. Each span body includes metadata, an annotations panel, and a raw JSON view for debugging.
+
+Evaluation test-case runs reuse this same session detail view; see [Compare Runs Side by Side](/documentation/studio/experiments#compare-runs-side-by-side) in NeMo Studio Experiments.
+
+## Related Topics
+
+- [NeMo Studio Experiments](/documentation/studio/experiments)
+- [NeMo Studio Insights](/documentation/studio/insights)


### PR DESCRIPTION
## Summary

- Recover failed ForwardMerger PR #1835.
- Resolve the Studio docs conflicts while preserving current `main` changes.
- Keep the release history intact with a merge commit.

## Validation

- Fern check passed.
- 224 MDX files parsed cleanly.
- NotebookViewer and gated-link checks passed.
- Parents match current `main` (`392786febf99365f82825d8b25b1a334ab884966`) and `release/0.5` (`c1936d5ab091988b04463a9a04e12e9c5fa1f870`).

The full `make docs-check` also checks Git LFS assets; that step could not run in the partial local clone because those existing images are LFS pointers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive NeMo Studio guidance for Insights, Traces, Model Evaluations, Models, and Experiments.
  - Documented Insight navigation, detail views, available actions, experiment links, and administrator configuration.
  - Added Model Evaluations coverage, including filtering, scores, results, logs, and failure behavior.
  - Added Traces guidance covering trace and span views, session navigation, specialized rendering, and raw JSON access.
  - Expanded Experiments documentation with creation, configuration, evaluation drill-down, and run comparison workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->