### PR TITLE
ci: tag on-call group in forward-merge alerts

### DIFF
--- a/.github/scripts/forward-merge-alert.cjs
+++ b/.github/scripts/forward-merge-alert.cjs
@@ -14,6 +14,14 @@ function escapeSlackText(value) {
     .replaceAll("\n", "\\n");
 }
 
+function slackUserGroupMention(value) {
+  const userGroupId = String(value || "").trim();
+  if (!/^S[A-Z0-9]{8,}$/.test(userGroupId)) {
+    return "";
+  }
+  return `<!subteam^${userGroupId}>`;
+}
+
 function selectSourcePullRequest({
   pulls,
   forwardPullNumber,
@@ -167,9 +175,11 @@ function buildSlackMessage({
   source,
   conflicts,
   runUrl,
+  userGroupId,
 }) {
+  const mention = slackUserGroupMention(userGroupId);
   const lines = [
-    ":warning: *Forward merge needs attention*",
+    `${mention ? `${mention} ` : ""}:warning: *Forward merge needs attention*`,
     `Repository: ${escapeSlackText(repository)}`,
     `PR: <${pullUrl}|${escapeSlackText(pullTitle)}>`,
     sourceLine(source),
@@ -301,6 +311,7 @@ async function sendForwardMergeAlert({
     source,
     conflicts,
     runUrl: env.RUN_URL,
+    userGroupId: env.SLACK_ALERT_USERGROUP_ID,
   });
   await postSlack({
     fetchImpl,
@@ -321,4 +332,5 @@ module.exports = {
   resolveSource,
   selectSourcePullRequest,
   sendForwardMergeAlert,
+  slackUserGroupMention,
 };

--- a/.github/scripts/tests/forward-merge-alert.test.cjs
+++ b/.github/scripts/tests/forward-merge-alert.test.cjs
@@ -14,6 +14,7 @@ const {
   resolveSource,
   selectSourcePullRequest,
   sendForwardMergeAlert,
+  slackUserGroupMention,
 } = require("../forward-merge-alert.cjs");
 
 function git(workspace, ...args) {
@@ -169,6 +170,26 @@ test("shows only ten conflict files and links the remainder", () => {
   assert.match(message, /\+2 more/);
 });
 
+test("tags the configured Slack user group", () => {
+  const message = buildSlackMessage(
+    messageFixture({ userGroupId: "S0123456789" }),
+  );
+
+  assert.match(
+    message,
+    /^<!subteam\^S0123456789> :warning: \*Forward merge needs attention\*/,
+  );
+});
+
+test("omits a missing or invalid Slack user group", () => {
+  assert.equal(slackUserGroupMention(), "");
+  assert.equal(slackUserGroupMention("not-a-slack-group"), "");
+  assert.match(
+    buildSlackMessage(messageFixture()),
+    /^:warning: \*Forward merge needs attention\*/,
+  );
+});
+
 test("escapes untrusted Slack labels", () => {
   const message = buildSlackMessage(
     messageFixture({
@@ -229,6 +250,7 @@ test("falls back to the basic alert when PR metadata fails", async () => {
     env: {
       RUN_URL: "https://github.com/NVIDIA-NeMo/nemo-platform/actions/runs/1234",
       SLACK_ALERTS_WEBHOOK: "https://hooks.slack.test/example",
+      SLACK_ALERT_USERGROUP_ID: "S0123456789",
     },
     fetchImpl: async (url, options) => {
       requests.push({ url, options });
@@ -239,6 +261,10 @@ test("falls back to the basic alert when PR metadata fails", async () => {
 
   assert.equal(requests.length, 1);
   assert.equal(requests[0].options.redirect, "error");
+  assert.match(
+    JSON.parse(requests[0].options.body).text,
+    /^<!subteam\^S0123456789>/,
+  );
   assert.match(result.text, /Source: unavailable/);
   assert.match(result.text, /Conflict metadata unavailable/);
   assert.match(warnings[0], /Unable to read forward-merge PR/);

--- a/.github/workflows/forward-merge-alert.yaml
+++ b/.github/workflows/forward-merge-alert.yaml
@@ -32,6 +32,7 @@ jobs:
         env:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           SLACK_ALERTS_WEBHOOK: ${{ secrets.SLACK_RELEASE_WEBHOOK }}
+          SLACK_ALERT_USERGROUP_ID: ${{ secrets.SLACK_ALERT_USERGROUP_ID }}
         with:
           script: |
             const { sendForwardMergeAlert } = require("./.github/scripts/forward-merge-alert.cjs");


### PR DESCRIPTION
Adds an optional on-call mention to failed forward-merge alerts.

The group ID stays in a GitHub secret, and alerts still work before the secret is added.

Tested locally:
- `make check-github-scripts`
- `flox activate --dir tools/actionlint -- actionlint .github/workflows/forward-merge-alert.yaml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Forward-merge alerts can now notify a configured Slack user group using a validated group mention.
  - Slack alerts include the configured group mention when available.

- **Tests**
  - Added coverage for valid, missing, and invalid Slack user-group identifiers.
  - Updated alert verification to confirm group mentions are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->