### PR TITLE
docs: align current-release Install and Upgrade with Setup

### DIFF
--- a/docs/about/release-notes/current-release.mdx
+++ b/docs/about/release-notes/current-release.mdx
@@ -135,18 +135,27 @@ operations for the 0.5 release line.
 
 ## Install
 
-For a fresh local checkout:
+The quickest local install is from PyPI:
+
+```bash
+uv tool install "nemo-platform[all]"
+nemo setup
+```
+
+For a source checkout (contributing, local plugins, or Studio from source),
+install [Flox](https://flox.dev/docs/install-flox/install) first, then:
 
 ```bash
 git clone https://github.com/NVIDIA-NeMo/nemo-platform.git
 cd nemo-platform
 make bootstrap
-source .venv/bin/activate
+flox -q activate
 nemo setup
 ```
 
-See [Setup](/documentation/get-started/setup) for prerequisites and provider
-configuration.
+Without Flox, run `make TOOLCHAIN=system bootstrap` followed by
+`source .venv/bin/activate`. See [Setup](/documentation/get-started/setup)
+for prerequisites, provider configuration, and the full wizard.
 
 For self-managed Kubernetes, start with
 [Install NeMo Platform Helm Chart](/documentation/kubernetes-deployment/setup/helm/install).
@@ -157,15 +166,26 @@ and [OpenSandbox](/documentation/kubernetes-deployment/setup/helm/opensandbox).
 
 ## Upgrade from v0.4.x
 
-From an existing local checkout:
+If you installed from PyPI:
+
+```bash
+uv tool install "nemo-platform[all]"
+nemo setup
+```
+
+From an existing local source checkout, install
+[Flox](https://flox.dev/docs/install-flox/install) first, then:
 
 ```bash
 git fetch
 git checkout main
 make bootstrap
-source .venv/bin/activate
+flox -q activate
 nemo setup
 ```
+
+Without Flox, run `make TOOLCHAIN=system bootstrap` followed by
+`source .venv/bin/activate`.
 
 After setup, restart local services before using CLI, SDK, Studio, or plugin
 workflows against the upgraded checkout.


### PR DESCRIPTION
## Summary

The published v0.5.0 current-release Install and Upgrade snippets still used `source .venv/bin/activate` after `make bootstrap` and only documented a source checkout. Setup now recommends PyPI first and `flox -q activate` for source installs. This change makes the release notes match Setup so first-time and upgrading users do not follow a stale activation path.

## Related Issue

NVBug [6734000](https://nvbugspro.nvidia.com/bug/6734000)

## Changes

- Document the PyPI install path (`uv tool install "nemo-platform[all]"`) on Install and Upgrade.
- Switch source-checkout activation from `source .venv/bin/activate` to `flox -q activate`.
- Keep the no-Flox `make TOOLCHAIN=system bootstrap` fallback.
- Keep Upgrade-only steps: `git fetch` / `git checkout main`, restart local services, and `nemo agents ethos migrate`.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [x] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: documentation-only change to release-note command snippets
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- Compared published Setup (`docs/get-started/setup.mdx`) with `docs/about/release-notes/current-release.mdx` Install and Upgrade blocks.
- `uv run pre-commit run -a` and `make docs-check` were not run locally; Fern docs CI on this PR should cover MDX/nav checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated local installation and upgrade instructions to include PyPI installation.
  * Added Flox-based setup guidance, with system-toolchain instructions retained as a fallback.
  * Updated source checkout and upgrade steps to activate Flox when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->