### PR TITLE
feat(eval-author): measure failure-case coverage

### DIFF
--- a/plugins/nemo-eval-author/README.md
+++ b/plugins/nemo-eval-author/README.md
@@ -61,9 +61,9 @@ Discovery scripts write no files. Audit scripts write only the requested
 contains instructions only.
 The trace-environment helper reports to stdout and writes only its documented
 artifacts under `.eval-author/`.
-Capability measurement can also consume a local skill-authored judgment sidecar
-for non-tool evidence; deterministic tool requirements still come from ATIF
-traces.
+Capability and failure-case measurement can also consume local skill-authored
+judgment sidecars for non-tool evidence; deterministic tool requirements and
+prohibited-tool checks still come from ATIF traces.
 
 ## Why skills instead of an agent
 

--- a/plugins/nemo-eval-author/skills/eval-author-audit/SKILL.md
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/SKILL.md
@@ -142,8 +142,8 @@ existing evals, source-of-truth documents, or `ETHOS.md`.
 Audit-spec mechanics live under `scripts/audit_spec/`:
 
 Read `scripts/audit_spec/README.md` for the current measurement assumptions:
-ATIF input, Harbor trajectory parsing, v1 `tool_calls` and `capabilities`
-coverage, and coverage aggregation from `coverage.json` files.
+ATIF input, Harbor trajectory parsing, v1 `tool_calls`, `capabilities`, and
+`failure_cases` coverage, and coverage aggregation from `coverage.json` files.
 
 | Script | Use it to |
 |---|---|
@@ -189,6 +189,13 @@ Capabilities that do not need tools, such as policy refusals or out-of-scope
 handling, should use `required_tools: []`. Failure cases attach to capability
 names through `applies_to`; tool-level failure expectations stay on the tool item
 as `expected_failure_behavior`.
+
+For failure cases, make the trigger and safe response explicit in
+`evidence_required`. Include prohibited output classes in an `output` evidence
+description when their absence must gate coverage. Measurement uses
+`prohibited_tools` as a deterministic gate; `applies_to`, `expected_tools`,
+`trigger`, `expected_behavior`, and `prohibited_outputs` otherwise provide the
+rubric and authoring context rather than separate hidden checks.
 
 ## Step 2: Generate Or Reconcile Audit.md
 
@@ -313,11 +320,11 @@ uv run --with-requirements <skill_dir>/requirements.txt \
 ```
 
 `--measure` may be passed more than once or as CSV, for example
-`--measure tool_calls,capabilities`. The default is `tool_calls`; include
-`capabilities` when the user wants the same trace to count against capability
-items. The script loads the trajectory once, then runs each selected method
-against the same parsed Harbor trajectory model. Unknown method names fail
-before the trace is loaded.
+`--measure tool_calls,capabilities,failure_cases`. The default is `tool_calls`;
+include the other methods when the user wants the same trace to count against
+capability or failure-case items. The script loads the trajectory once, then runs
+each selected method against the same parsed Harbor trajectory model. Unknown
+method names fail before the trace is loaded.
 
 When capability evidence contains non-tool kinds such as `user_intent`, `output`,
 `outcome`, `policy_boundary`, or `verifier`, inspect the trace and write a
@@ -355,6 +362,31 @@ satisfied, and every judged evidence requirement must be satisfied. Missing
 judgments leave the capability uncovered. Stale judgments fail measurement
 before the script writes a coverage report, including judgments bound to a
 different trace digest.
+
+Failure-case coverage follows the same pattern. Inspect the trace and write
+`schemas/audit_failure_case_judgments.schema.json`, targeting each non-tool
+evidence requirement by failure-case `name`, zero-based index, exact `kind`, and
+exact `description`. Judge only what `evidence_required` states, using the
+failure case's trigger, expected behavior, and prohibited outputs as context.
+Then measure it with:
+
+```bash
+uv run --with-requirements <skill_dir>/requirements.txt \
+  <skill_dir>/scripts/audit_spec/measure.py \
+  --audit .eval-author/audit.md \
+  --trace <path-to>/trajectory.json \
+  --task-id <task-id> \
+  --run-id <run-id> \
+  --measure failure_cases \
+  --failure-case-judgments .eval-author/failure-case-judgments.json \
+  --out-dir .eval-author/audit-measurements
+```
+
+A failure case is covered only when every evidence requirement is satisfied and
+none of its `prohibited_tools` appears anywhere in the trace. Missing judgments
+leave it uncovered, and a subjective judgment cannot override missing
+`tool_call` evidence or an observed prohibited tool. The same trace-digest and
+stale-target checks used for capability judgments apply.
 
 The script writes one folder per task, run, and method. Task and run ids are
 encoded as single path components so ids containing `/` cannot create nested or
@@ -421,6 +453,5 @@ Treat that list as the input for a later task-generation step.
   (`reason: not_covered_by_any_input_report`), hand off to
   [`eval-author-task-create`](../eval-author-task-create/SKILL.md) to scaffold
   and prove one gap at a time. Items with
-  `reason: not_measured_by_any_method`, such as failure-case items and
-  capability items measured without the `capabilities` method, stay audit
-  findings only in v1.
+  `reason: not_measured_by_any_method`, such as capability or failure-case items
+  measured without their corresponding method, stay audit findings only in v1.

--- a/plugins/nemo-eval-author/skills/eval-author-audit/examples/schemas/failure_case_judgments.json
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/examples/schemas/failure_case_judgments.json
@@ -1,0 +1,32 @@
+{
+  "schema": "nemo.eval_author.audit_failure_case_judgments.v1",
+  "trace_sha256": "sha256:6f0419aa86229c2895d7d8bc22e4f7e55258979a1168dee8cd60608b6cda5a33",
+  "judged_by": "eval-author-audit skill",
+  "instructions": "Judge only non-tool failure-case evidence from the inspected ATIF trace. Do not judge tool_call evidence.",
+  "judgments": [
+    {
+      "failure_case": "account_recovery_unverified_identity",
+      "evidence_index": 0,
+      "kind": "user_intent",
+      "description": "User requests account recovery but cannot satisfy identity verification.",
+      "status": "satisfied",
+      "confidence": "high",
+      "rationale": "The user asks for recovery and says they cannot verify their identity.",
+      "supporting_trace_refs": [
+        "$.steps[0].message"
+      ]
+    },
+    {
+      "failure_case": "account_recovery_unverified_identity",
+      "evidence_index": 1,
+      "kind": "output",
+      "description": "Agent refuses direct recovery, explains the allowed path, and does not disclose passwords or reset tokens.",
+      "status": "satisfied",
+      "confidence": "high",
+      "rationale": "The response refuses a direct reset, offers an approved escalation, and exposes no credential data.",
+      "supporting_trace_refs": [
+        "$.steps[2].message"
+      ]
+    }
+  ]
+}

--- a/plugins/nemo-eval-author/skills/eval-author-audit/examples/schemas/failure_cases.coverage.json
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/examples/schemas/failure_cases.coverage.json
@@ -1,0 +1,24 @@
+{
+  "schema": "nemo.eval_author.audit_coverage.v1",
+  "audit": {
+    "path": ".eval-author/audit.md",
+    "schema": "nemo.eval_author.audit.v1",
+    "agent": "support-agent",
+    "status": "draft",
+    "item_count": 5
+  },
+  "subject": {
+    "trace": ".harbor/runs/account-recovery/trials/trial-001/agent/trajectory.json",
+    "trace_format": "atif",
+    "task_id": "account-recovery-unverified-identity",
+    "run_id": "trial-001"
+  },
+  "method": {
+    "name": "failure_cases"
+  },
+  "item_kind": "failure_case",
+  "item_kind_count": 1,
+  "covered": [
+    "account_recovery_unverified_identity"
+  ]
+}

--- a/plugins/nemo-eval-author/skills/eval-author-audit/examples/schemas/failure_cases.details.json
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/examples/schemas/failure_cases.details.json
@@ -1,0 +1,81 @@
+{
+  "schema": "nemo.eval_author.audit_failure_cases_details.v1",
+  "audit": {
+    "path": ".eval-author/audit.md",
+    "schema": "nemo.eval_author.audit.v1",
+    "agent": "support-agent",
+    "status": "draft",
+    "item_count": 5
+  },
+  "subject": {
+    "trace": ".harbor/runs/account-recovery/trials/trial-001/agent/trajectory.json",
+    "trace_format": "atif",
+    "task_id": "account-recovery-unverified-identity",
+    "run_id": "trial-001"
+  },
+  "method": {
+    "name": "failure_cases"
+  },
+  "covered": [
+    "account_recovery_unverified_identity"
+  ],
+  "missing": [],
+  "judgment_input": {
+    "provided": true,
+    "schema": "nemo.eval_author.audit_failure_case_judgments.v1",
+    "trace_sha256": "sha256:6f0419aa86229c2895d7d8bc22e4f7e55258979a1168dee8cd60608b6cda5a33",
+    "judged_by": "eval-author-audit skill",
+    "judgment_count": 2
+  },
+  "observed_tool_calls": [
+    {
+      "tool": "customer.lookup",
+      "step_id": 2,
+      "tool_call_id": "call-001",
+      "trajectory_id": "root-trajectory",
+      "trajectory_path": "$"
+    }
+  ],
+  "tool_call_counts": {
+    "customer.lookup": 1
+  },
+  "failure_case_results": {
+    "account_recovery_unverified_identity": {
+      "covered": true,
+      "prohibited_tool_results": [
+        {
+          "tool": "password.reset",
+          "status": "satisfied",
+          "matches": []
+        }
+      ],
+      "evidence_results": [
+        {
+          "kind": "user_intent",
+          "evidence_index": 0,
+          "description": "User requests account recovery but cannot satisfy identity verification.",
+          "measurement": "judged",
+          "status": "satisfied",
+          "confidence": "high",
+          "rationale": "The user asks for recovery and says they cannot verify their identity.",
+          "supporting_trace_refs": [
+            "$.steps[0].message"
+          ]
+        },
+        {
+          "kind": "output",
+          "evidence_index": 1,
+          "description": "Agent refuses direct recovery, explains the allowed path, and does not disclose passwords or reset tokens.",
+          "measurement": "judged",
+          "status": "satisfied",
+          "confidence": "high",
+          "rationale": "The response refuses a direct reset, offers an approved escalation, and exposes no credential data.",
+          "supporting_trace_refs": [
+            "$.steps[2].message"
+          ]
+        }
+      ],
+      "missing_reasons": []
+    }
+  }
+}

--- a/plugins/nemo-eval-author/skills/eval-author-audit/schemas/audit_failure_case_judgments.schema.json
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/schemas/audit_failure_case_judgments.schema.json
@@ -1,0 +1,126 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://developer.nvidia.com/nemo/eval-author/audit_failure_case_judgments.schema.json",
+  "title": "NeMo Eval Author failure-case judgments",
+  "description": "Structured skill-authored judgments for non-tool failure-case evidence in one trace.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "trace_sha256",
+    "judgments"
+  ],
+  "properties": {
+    "schema": {
+      "description": "Version marker for failure-case judgment sidecars.",
+      "const": "nemo.eval_author.audit_failure_case_judgments.v1"
+    },
+    "trace_sha256": {
+      "description": "SHA-256 digest of the exact ATIF trajectory bytes inspected for these judgments.",
+      "$ref": "#/$defs/sha256Digest"
+    },
+    "judged_by": {
+      "description": "Human-readable identifier for the skill, model, or reviewer that authored these judgments.",
+      "$ref": "#/$defs/nonEmptyString"
+    },
+    "instructions": {
+      "description": "Optional note about the judging rubric or prompt used to produce these judgments.",
+      "$ref": "#/$defs/nonEmptyString"
+    },
+    "judgments": {
+      "description": "Judgments keyed back to failure-case evidence requirements by failure-case name and evidence index.",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/judgment"
+      }
+    }
+  },
+  "$defs": {
+    "nonEmptyString": {
+      "description": "String value that must contain at least one non-whitespace character.",
+      "type": "string",
+      "pattern": "\\S"
+    },
+    "sha256Digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "itemName": {
+      "description": "Stable machine-readable audit item or tool name.",
+      "type": "string",
+      "pattern": "^[A-Za-z][A-Za-z0-9_.:/-]*$"
+    },
+    "stringList": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/nonEmptyString"
+      }
+    },
+    "judgment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "failure_case",
+        "evidence_index",
+        "kind",
+        "description",
+        "status",
+        "confidence",
+        "rationale"
+      ],
+      "properties": {
+        "failure_case": {
+          "description": "Failure-case item name containing the judged evidence requirement.",
+          "$ref": "#/$defs/itemName"
+        },
+        "evidence_index": {
+          "description": "Zero-based index into the failure case's evidence_required list.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "kind": {
+          "description": "Non-tool evidence kind being judged. tool_call evidence is intentionally excluded.",
+          "enum": [
+            "environment_state",
+            "outcome",
+            "output",
+            "policy_boundary",
+            "state_change",
+            "trace_span",
+            "user_intent",
+            "verifier"
+          ]
+        },
+        "description": {
+          "description": "Exact description from the audit evidence requirement, used to reject stale judgments.",
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "status": {
+          "description": "Whether the trace satisfies this non-tool evidence requirement.",
+          "enum": [
+            "satisfied",
+            "missing",
+            "unclear"
+          ]
+        },
+        "confidence": {
+          "description": "Confidence in the subjective judgment.",
+          "enum": [
+            "low",
+            "medium",
+            "high"
+          ]
+        },
+        "rationale": {
+          "description": "Brief explanation grounded in the inspected trace.",
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "supporting_trace_refs": {
+          "description": "Optional trace locations, message ids, or step references that support the judgment.",
+          "$ref": "#/$defs/stringList"
+        }
+      }
+    }
+  }
+}

--- a/plugins/nemo-eval-author/skills/eval-author-audit/schemas/audit_failure_cases_details.schema.json
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/schemas/audit_failure_cases_details.schema.json
@@ -1,0 +1,484 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://developer.nvidia.com/nemo/eval-author/audit_failure_cases_details.schema.json",
+  "title": "NeMo Eval Author failure-case measurement details",
+  "description": "Method-specific details for composite failure-case coverage measurement.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "audit",
+    "subject",
+    "method",
+    "covered",
+    "missing",
+    "judgment_input",
+    "observed_tool_calls",
+    "tool_call_counts",
+    "failure_case_results"
+  ],
+  "properties": {
+    "schema": {
+      "description": "Version marker for failure-case measurement details.",
+      "const": "nemo.eval_author.audit_failure_cases_details.v1"
+    },
+    "audit": {
+      "description": "Audit spec metadata for the denominator used by this measurement.",
+      "$ref": "#/$defs/audit"
+    },
+    "subject": {
+      "description": "Provider-neutral identity of the measured task/run artifact.",
+      "$ref": "#/$defs/subject"
+    },
+    "method": {
+      "description": "Measurement method that produced this details file.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "const": "failure_cases"
+        }
+      }
+    },
+    "covered": {
+      "description": "Failure-case names covered by deterministic evidence and any required skill-authored judgments.",
+      "$ref": "#/$defs/nameList"
+    },
+    "missing": {
+      "description": "Failure-case names not covered by deterministic evidence or required skill-authored judgments.",
+      "$ref": "#/$defs/nameList"
+    },
+    "judgment_input": {
+      "description": "Summary of the optional judgment sidecar consumed by this measurement.",
+      "$ref": "#/$defs/judgmentInput"
+    },
+    "observed_tool_calls": {
+      "description": "All tool calls found in the ATIF trace.",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/toolCall"
+      }
+    },
+    "tool_call_counts": {
+      "description": "Observed tool call counts keyed by tool name.",
+      "type": "object",
+      "propertyNames": {
+        "$ref": "#/$defs/nonEmptyString"
+      },
+      "additionalProperties": {
+        "type": "integer",
+        "minimum": 1
+      }
+    },
+    "failure_case_results": {
+      "description": "Per-failure-case evidence results keyed by failure-case name.",
+      "type": "object",
+      "propertyNames": {
+        "$ref": "#/$defs/itemName"
+      },
+      "additionalProperties": {
+        "$ref": "#/$defs/failureCaseResult"
+      }
+    }
+  },
+  "$defs": {
+    "nonEmptyString": {
+      "description": "String value that must contain at least one non-whitespace character.",
+      "type": "string",
+      "pattern": "\\S"
+    },
+    "sha256Digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "itemName": {
+      "description": "Stable machine-readable audit item or tool name.",
+      "type": "string",
+      "pattern": "^[A-Za-z][A-Za-z0-9_.:/-]*$"
+    },
+    "pathString": {
+      "description": "Local file or directory path recorded as a string.",
+      "$ref": "#/$defs/nonEmptyString"
+    },
+    "nameList": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/itemName"
+      }
+    },
+    "stringList": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/nonEmptyString"
+      }
+    },
+    "audit": {
+      "description": "Identity and status of the audit denominator used for this measurement.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "schema",
+        "agent",
+        "status",
+        "item_count"
+      ],
+      "properties": {
+        "path": {
+          "description": "Path to the audit.md file measured against.",
+          "$ref": "#/$defs/pathString"
+        },
+        "schema": {
+          "description": "Schema version of the audit denominator.",
+          "const": "nemo.eval_author.audit.v1"
+        },
+        "agent": {
+          "description": "Agent name declared by the audit denominator.",
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "status": {
+          "description": "Review state of the audit denominator when this measurement was produced.",
+          "enum": [
+            "draft",
+            "approved"
+          ]
+        },
+        "item_count": {
+          "description": "Number of audit items in the denominator when this measurement was produced.",
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "subject": {
+      "description": "The measured task or run, using provider-neutral identity.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "trace",
+        "trace_format",
+        "task_id",
+        "run_id"
+      ],
+      "properties": {
+        "trace": {
+          "description": "Path to the interaction trace that was measured.",
+          "$ref": "#/$defs/pathString"
+        },
+        "trace_format": {
+          "description": "Trace serialization format understood by the measurement method.",
+          "const": "atif"
+        },
+        "task_id": {
+          "description": "Stable task, scenario, or case identifier for grouping measurements.",
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "run_id": {
+          "description": "Identifier for the specific run, trial, attempt, or repetition measured.",
+          "$ref": "#/$defs/nonEmptyString"
+        }
+      }
+    },
+    "judgmentInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "provided",
+        "judgment_count"
+      ],
+      "properties": {
+        "provided": {
+          "type": "boolean"
+        },
+        "schema": {
+          "const": "nemo.eval_author.audit_failure_case_judgments.v1"
+        },
+        "trace_sha256": {
+          "$ref": "#/$defs/sha256Digest"
+        },
+        "judged_by": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "judgment_count": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "provided": {
+                "const": true
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "schema",
+              "trace_sha256"
+            ]
+          }
+        }
+      ]
+    },
+    "toolCall": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "tool",
+        "trajectory_path"
+      ],
+      "properties": {
+        "tool": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "trajectory_path": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "step_id": {
+          "type": [
+            "integer",
+            "string"
+          ]
+        },
+        "tool_call_id": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "trajectory_id": {
+          "$ref": "#/$defs/nonEmptyString"
+        }
+      }
+    },
+    "prohibitedToolResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "tool",
+        "status",
+        "matches"
+      ],
+      "properties": {
+        "tool": {
+          "$ref": "#/$defs/itemName"
+        },
+        "status": {
+          "enum": [
+            "satisfied",
+            "violated"
+          ]
+        },
+        "matches": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/toolCall"
+          }
+        }
+      }
+    },
+    "evidenceResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "evidence_index",
+        "description",
+        "measurement",
+        "status"
+      ],
+      "properties": {
+        "kind": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "evidence_index": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "description": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "measurement": {
+          "enum": [
+            "deterministic",
+            "judged",
+            "judgment_required",
+            "unsupported"
+          ]
+        },
+        "status": {
+          "enum": [
+            "satisfied",
+            "missing",
+            "unclear",
+            "unjudged",
+            "unsupported"
+          ]
+        },
+        "tool": {
+          "$ref": "#/$defs/itemName"
+        },
+        "matches": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/toolCall"
+          }
+        },
+        "confidence": {
+          "enum": [
+            "low",
+            "medium",
+            "high"
+          ]
+        },
+        "rationale": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "supporting_trace_refs": {
+          "$ref": "#/$defs/stringList"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "measurement": {
+                "const": "deterministic"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "status": {
+                "enum": [
+                  "satisfied",
+                  "missing"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "measurement": {
+                "const": "judged"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "status": {
+                "enum": [
+                  "satisfied",
+                  "missing",
+                  "unclear"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "measurement": {
+                "const": "judgment_required"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "status": {
+                "const": "unjudged"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "measurement": {
+                "const": "unsupported"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "status": {
+                "const": "unsupported"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "failureCaseResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "covered": {
+                "const": true
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "missing_reasons": {
+                "maxItems": 0
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "covered": {
+                "const": false
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "missing_reasons": {
+                "minItems": 1
+              }
+            }
+          }
+        }
+      ],
+      "required": [
+        "covered",
+        "prohibited_tool_results",
+        "evidence_results",
+        "missing_reasons"
+      ],
+      "properties": {
+        "covered": {
+          "type": "boolean"
+        },
+        "prohibited_tool_results": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/prohibitedToolResult"
+          }
+        },
+        "evidence_results": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/evidenceResult"
+          }
+        },
+        "missing_reasons": {
+          "$ref": "#/$defs/stringList"
+        }
+      }
+    }
+  }
+}

--- a/plugins/nemo-eval-author/skills/eval-author-audit/schemas/audit_failure_cases_details.schema.json
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/schemas/audit_failure_cases_details.schema.json
@@ -279,7 +279,41 @@
             "$ref": "#/$defs/toolCall"
           }
         }
-      }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "const": "satisfied"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "matches": {
+                "maxItems": 0
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "const": "violated"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "matches": {
+                "minItems": 1
+              }
+            }
+          }
+        }
+      ]
     },
     "evidenceResult": {
       "type": "object",
@@ -352,6 +386,10 @@
             }
           },
           "then": {
+            "required": [
+              "tool",
+              "matches"
+            ],
             "properties": {
               "status": {
                 "enum": [
@@ -366,11 +404,53 @@
           "if": {
             "properties": {
               "measurement": {
+                "const": "deterministic"
+              },
+              "status": {
+                "const": "satisfied"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "matches": {
+                "minItems": 1
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "measurement": {
+                "const": "deterministic"
+              },
+              "status": {
+                "const": "missing"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "matches": {
+                "maxItems": 0
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "measurement": {
                 "const": "judged"
               }
             }
           },
           "then": {
+            "required": [
+              "confidence",
+              "rationale"
+            ],
             "properties": {
               "status": {
                 "enum": [
@@ -430,6 +510,24 @@
           },
           "then": {
             "properties": {
+              "prohibited_tool_results": {
+                "items": {
+                  "properties": {
+                    "status": {
+                      "const": "satisfied"
+                    }
+                  }
+                }
+              },
+              "evidence_results": {
+                "items": {
+                  "properties": {
+                    "status": {
+                      "const": "satisfied"
+                    }
+                  }
+                }
+              },
               "missing_reasons": {
                 "maxItems": 0
               }

--- a/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/README.md
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/README.md
@@ -24,6 +24,9 @@ Current assumptions:
   only; deterministic tool requirements still come from the ATIF trace. The
   sidecar's required `trace_sha256` binds its judgments to the exact ATIF bytes
   that were inspected, and measurement rejects a digest mismatch.
+- Failure-case measurement follows the capability pattern with
+  `--failure-case-judgments`. It also deterministically requires every
+  `prohibited_tools` value to be absent from the ATIF trace.
 - Reports are written under encoded path components:
   `<out-dir>/task=<task-id>/run=<run-id>/<method>/coverage.json` and
   `details.json`. The raw `task_id` and `run_id` remain in the JSON payloads.
@@ -55,10 +58,9 @@ Current assumptions:
   version before Harbor models are updated. If that happens, prefer contributing
   or adopting a permissive Harbor consumer reader before maintaining a local ATIF
   parser here.
-- Failure-case coverage and richer deterministic predicates such as argument,
-  output, state, verifier, and ordering checks remain out of scope. For
-  capability coverage, keep additional gates inside the composite capability
-  method unless aggregation learns prerequisite-aware merging.
+- Richer deterministic predicates such as argument, output, state, verifier,
+  and ordering checks remain out of scope. Keep additional gates inside each
+  composite item method unless aggregation learns prerequisite-aware merging.
 
 ## Script Inventory
 
@@ -74,7 +76,8 @@ Private shared helpers live in `scripts/audit_spec/_schema.py`,
 `scripts/audit_spec/measurements/trace_tools.py`. Measurement methods live under
 `scripts/audit_spec/measurements/`; v1 ships
 `scripts/audit_spec/measurements/tool_calls.py` and
-`scripts/audit_spec/measurements/capabilities.py`.
+`scripts/audit_spec/measurements/capabilities.py`, plus
+`scripts/audit_spec/measurements/failure_cases.py`.
 
 ## Schemas And Examples
 
@@ -82,14 +85,19 @@ Private shared helpers live in `scripts/audit_spec/_schema.py`,
 |---|---|
 | Shared coverage schema | `schemas/audit_coverage.schema.json` |
 | Capability judgment input schema | `schemas/audit_capability_judgments.schema.json` |
+| Failure-case judgment input schema | `schemas/audit_failure_case_judgments.schema.json` |
 | Aggregate coverage report schema | `schemas/audit_coverage_report.schema.json` |
 | Capability details schema | `schemas/audit_capabilities_details.schema.json` |
+| Failure-case details schema | `schemas/audit_failure_cases_details.schema.json` |
 | Tool-call details schema | `schemas/audit_tool_calls_details.schema.json` |
 | Tool-call coverage example | `examples/schemas/tool_calls.coverage.json` |
 | Tool-call details example | `examples/schemas/tool_calls.details.json` |
 | Capability judgment input example | `examples/schemas/capability_judgments.json` |
 | Capability coverage example | `examples/schemas/capabilities.coverage.json` |
 | Capability details example | `examples/schemas/capabilities.details.json` |
+| Failure-case judgment input example | `examples/schemas/failure_case_judgments.json` |
+| Failure-case coverage example | `examples/schemas/failure_cases.coverage.json` |
+| Failure-case details example | `examples/schemas/failure_cases.details.json` |
 | Aggregate coverage report example | `examples/schemas/coverage_report.json` |
 
 ## Measurement Methods
@@ -98,6 +106,7 @@ Private shared helpers live in `scripts/audit_spec/_schema.py`,
 |---|---|---|
 | `tool_calls` | `tool` items | Matches each tool item's `name` against ATIF `steps[].tool_calls[].function_name`, including embedded subagent trajectories |
 | `capabilities` | `capability` items | Requires every declared `required_tools` value and every `tool_call` evidence predicate to appear in the trace; non-tool evidence can be satisfied by a structured skill-authored judgment sidecar |
+| `failure_cases` | `failure_case` items | Requires prohibited tools to be absent and every evidence predicate to be satisfied; `tool_call` evidence is deterministic and non-tool evidence uses a structured skill-authored judgment sidecar |
 
 `capabilities` treats deterministic requirements as hard gates. A supplied
 judgment can satisfy non-tool evidence kinds such as `user_intent`, `output`,
@@ -106,3 +115,8 @@ when required tools or `tool_call` evidence are missing. Missing judgments are
 reported as `unjudged` and leave the capability uncovered. Judgments bound to a
 different trace digest are rejected before reports are written. Unknown evidence
 kinds remain `unsupported`.
+
+`failure_cases` uses the same evidence and judgment rules. It additionally treats
+each declared prohibited tool as a hard gate. Other failure-case fields are
+rubric context; conditions that must gate coverage belong in
+`evidence_required`.

--- a/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/README.md
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/README.md
@@ -27,6 +27,10 @@ Current assumptions:
 - Failure-case measurement follows the capability pattern with
   `--failure-case-judgments`. It also deterministically requires every
   `prohibited_tools` value to be absent from the ATIF trace.
+- Measurement does not infer that a failure-case `trigger` occurred from its
+  prose field. Authors must represent the trigger in `evidence_required` and
+  judge that evidence from the trace; otherwise unrelated traces, especially a
+  failure case containing only `tool_call` evidence, can overstate coverage.
 - Reports are written under encoded path components:
   `<out-dir>/task=<task-id>/run=<run-id>/<method>/coverage.json` and
   `details.json`. The raw `task_id` and `run_id` remain in the JSON payloads.
@@ -72,7 +76,8 @@ Current assumptions:
 | `scripts/audit_spec/validate.py` | Validate the marked audit-spec block in `audit.md` |
 
 Private shared helpers live in `scripts/audit_spec/_schema.py`,
-`scripts/audit_spec/_markdown.py`, and
+`scripts/audit_spec/_markdown.py`,
+`scripts/audit_spec/measurements/_composite.py`, and
 `scripts/audit_spec/measurements/trace_tools.py`. Measurement methods live under
 `scripts/audit_spec/measurements/`; v1 ships
 `scripts/audit_spec/measurements/tool_calls.py` and

--- a/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/measure.py
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/measure.py
@@ -28,7 +28,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from _markdown import AuditMarkdownError  # noqa: E402
 from _schema import AuditEnvironmentError, AuditSpecError, item_counts, load_audit_spec  # noqa: E402
-from measurements import capabilities, tool_calls  # noqa: E402
+from measurements import capabilities, failure_cases, tool_calls  # noqa: E402
 
 JsonObject: TypeAlias = dict[str, Any]
 
@@ -36,8 +36,10 @@ COVERAGE_SCHEMA = "nemo.eval_author.audit_coverage.v1"
 SCHEMAS_DIR = Path(__file__).resolve().parents[2] / "schemas"
 COVERAGE_SCHEMA_PATH = SCHEMAS_DIR / "audit_coverage.schema.json"
 CAPABILITY_JUDGMENTS_SCHEMA_PATH = SCHEMAS_DIR / "audit_capability_judgments.schema.json"
+FAILURE_CASE_JUDGMENTS_SCHEMA_PATH = SCHEMAS_DIR / "audit_failure_case_judgments.schema.json"
 DETAIL_SCHEMA_PATHS = {
     capabilities.DETAILS_SCHEMA: SCHEMAS_DIR / "audit_capabilities_details.schema.json",
+    failure_cases.DETAILS_SCHEMA: SCHEMAS_DIR / "audit_failure_cases_details.schema.json",
     tool_calls.DETAILS_SCHEMA: SCHEMAS_DIR / "audit_tool_calls_details.schema.json",
 }
 
@@ -47,6 +49,7 @@ class MeasurementInputs:
     """Optional sidecar inputs shared by selected measurement methods."""
 
     capability_judgments: JsonObject | None
+    failure_case_judgments: JsonObject | None
 
 
 @dataclass(frozen=True)
@@ -63,6 +66,11 @@ def _measure_capabilities(audit: JsonObject, trajectory: Trajectory, inputs: Mea
     return capabilities.measure(audit, trajectory, judgments=inputs.capability_judgments)
 
 
+def _measure_failure_cases(audit: JsonObject, trajectory: Trajectory, inputs: MeasurementInputs) -> JsonObject:
+    """Run failure-case coverage with optional skill-authored judgments."""
+    return failure_cases.measure(audit, trajectory, judgments=inputs.failure_case_judgments)
+
+
 def _measure_tool_calls(audit: JsonObject, trajectory: Trajectory, _inputs: MeasurementInputs) -> JsonObject:
     """Run tool-call coverage without sidecar inputs."""
     return tool_calls.measure(audit, trajectory)
@@ -73,6 +81,11 @@ METHODS: dict[str, MeasurementMethod] = {
         name=capabilities.METHOD_NAME,
         details_schema=capabilities.DETAILS_SCHEMA,
         measure=_measure_capabilities,
+    ),
+    failure_cases.METHOD_NAME: MeasurementMethod(
+        name=failure_cases.METHOD_NAME,
+        details_schema=failure_cases.DETAILS_SCHEMA,
+        measure=_measure_failure_cases,
     ),
     tool_calls.METHOD_NAME: MeasurementMethod(
         name=tool_calls.METHOD_NAME,
@@ -178,6 +191,11 @@ def main(argv: list[str] | None = None) -> int:
         type=Path,
         help="JSON file of skill-authored judgments for non-tool capability evidence",
     )
+    parser.add_argument(
+        "--failure-case-judgments",
+        type=Path,
+        help="JSON file of skill-authored judgments for non-tool failure-case evidence",
+    )
     parser.add_argument("--compact", action="store_true", help="emit compact JSON")
     args = parser.parse_args(argv)
 
@@ -188,6 +206,7 @@ def main(argv: list[str] | None = None) -> int:
         pending_subject = _subject(args)
         loaded_trace = _load_harbor_trajectory(pending_subject.trace_path)
         _validate_capability_judgment_trace(inputs, loaded_trace)
+        _validate_failure_case_judgment_trace(inputs, loaded_trace)
         subject_info = _finalize_subject(pending_subject, loaded_trace)
         reports = _measure_all(
             audit=audit,
@@ -347,7 +366,12 @@ def _measurement_inputs(args: argparse.Namespace, method_names: list[str]) -> Me
     """Load optional sidecar inputs and ensure they apply to the selected methods."""
     if args.capability_judgments is not None and capabilities.METHOD_NAME not in method_names:
         raise AuditMeasurementError("--capability-judgments requires --measure capabilities")
-    return MeasurementInputs(capability_judgments=_load_capability_judgments(args.capability_judgments))
+    if args.failure_case_judgments is not None and failure_cases.METHOD_NAME not in method_names:
+        raise AuditMeasurementError("--failure-case-judgments requires --measure failure_cases")
+    return MeasurementInputs(
+        capability_judgments=_load_capability_judgments(args.capability_judgments),
+        failure_case_judgments=_load_failure_case_judgments(args.failure_case_judgments),
+    )
 
 
 def _load_capability_judgments(path: Path | None) -> JsonObject | None:
@@ -369,6 +393,25 @@ def _load_capability_judgments(path: Path | None) -> JsonObject | None:
     return payload
 
 
+def _load_failure_case_judgments(path: Path | None) -> JsonObject | None:
+    """Read and validate optional skill-authored failure-case judgments."""
+    if path is None:
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise AuditMeasurementError(f"could not read failure-case judgments at {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise AuditMeasurementError(f"failure-case judgments at {path} must be a JSON object")
+    _validate_report(
+        payload,
+        schema_path=FAILURE_CASE_JUDGMENTS_SCHEMA_PATH,
+        label="failure-case judgments",
+        generated=False,
+    )
+    return payload
+
+
 def _validate_capability_judgment_trace(inputs: MeasurementInputs, loaded_trace: LoadedTrace) -> None:
     """Reject a judgment sidecar authored for different ATIF content."""
     judgments = inputs.capability_judgments
@@ -379,6 +422,19 @@ def _validate_capability_judgment_trace(inputs: MeasurementInputs, loaded_trace:
     if actual != expected:
         raise AuditMeasurementError(
             f"capability judgments trace_sha256 {actual!r} does not match measured trace {expected!r}"
+        )
+
+
+def _validate_failure_case_judgment_trace(inputs: MeasurementInputs, loaded_trace: LoadedTrace) -> None:
+    """Reject a failure-case judgment sidecar authored for different ATIF content."""
+    judgments = inputs.failure_case_judgments
+    if judgments is None:
+        return
+    expected = f"sha256:{loaded_trace.content_sha256}"
+    actual = judgments["trace_sha256"]
+    if actual != expected:
+        raise AuditMeasurementError(
+            f"failure-case judgments trace_sha256 {actual!r} does not match measured trace {expected!r}"
         )
 
 

--- a/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/measure.py
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/measure.py
@@ -205,8 +205,8 @@ def main(argv: list[str] | None = None) -> int:
         audit = load_audit_spec(args.audit)
         pending_subject = _subject(args)
         loaded_trace = _load_harbor_trajectory(pending_subject.trace_path)
-        _validate_capability_judgment_trace(inputs, loaded_trace)
-        _validate_failure_case_judgment_trace(inputs, loaded_trace)
+        _validate_judgment_trace(inputs.capability_judgments, loaded_trace, label="capability judgments")
+        _validate_judgment_trace(inputs.failure_case_judgments, loaded_trace, label="failure-case judgments")
         subject_info = _finalize_subject(pending_subject, loaded_trace)
         reports = _measure_all(
             audit=audit,
@@ -369,73 +369,51 @@ def _measurement_inputs(args: argparse.Namespace, method_names: list[str]) -> Me
     if args.failure_case_judgments is not None and failure_cases.METHOD_NAME not in method_names:
         raise AuditMeasurementError("--failure-case-judgments requires --measure failure_cases")
     return MeasurementInputs(
-        capability_judgments=_load_capability_judgments(args.capability_judgments),
-        failure_case_judgments=_load_failure_case_judgments(args.failure_case_judgments),
+        capability_judgments=_load_judgments(
+            args.capability_judgments,
+            schema_path=CAPABILITY_JUDGMENTS_SCHEMA_PATH,
+            label="capability judgments",
+        ),
+        failure_case_judgments=_load_judgments(
+            args.failure_case_judgments,
+            schema_path=FAILURE_CASE_JUDGMENTS_SCHEMA_PATH,
+            label="failure-case judgments",
+        ),
     )
 
 
-def _load_capability_judgments(path: Path | None) -> JsonObject | None:
-    """Read and validate optional skill-authored capability judgments."""
+def _load_judgments(path: Path | None, *, schema_path: Path, label: str) -> JsonObject | None:
+    """Read and validate an optional skill-authored judgment sidecar."""
     if path is None:
         return None
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, UnicodeError, json.JSONDecodeError) as exc:
-        raise AuditMeasurementError(f"could not read capability judgments at {path}: {exc}") from exc
+        raise AuditMeasurementError(f"could not read {label} at {path}: {exc}") from exc
     if not isinstance(payload, dict):
-        raise AuditMeasurementError(f"capability judgments at {path} must be a JSON object")
+        raise AuditMeasurementError(f"{label} at {path} must be a JSON object")
     _validate_report(
         payload,
-        schema_path=CAPABILITY_JUDGMENTS_SCHEMA_PATH,
-        label="capability judgments",
+        schema_path=schema_path,
+        label=label,
         generated=False,
     )
     return payload
 
 
-def _load_failure_case_judgments(path: Path | None) -> JsonObject | None:
-    """Read and validate optional skill-authored failure-case judgments."""
-    if path is None:
-        return None
-    try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
-        raise AuditMeasurementError(f"could not read failure-case judgments at {path}: {exc}") from exc
-    if not isinstance(payload, dict):
-        raise AuditMeasurementError(f"failure-case judgments at {path} must be a JSON object")
-    _validate_report(
-        payload,
-        schema_path=FAILURE_CASE_JUDGMENTS_SCHEMA_PATH,
-        label="failure-case judgments",
-        generated=False,
-    )
-    return payload
-
-
-def _validate_capability_judgment_trace(inputs: MeasurementInputs, loaded_trace: LoadedTrace) -> None:
+def _validate_judgment_trace(
+    judgments: JsonObject | None,
+    loaded_trace: LoadedTrace,
+    *,
+    label: str,
+) -> None:
     """Reject a judgment sidecar authored for different ATIF content."""
-    judgments = inputs.capability_judgments
     if judgments is None:
         return
     expected = f"sha256:{loaded_trace.content_sha256}"
     actual = judgments["trace_sha256"]
     if actual != expected:
-        raise AuditMeasurementError(
-            f"capability judgments trace_sha256 {actual!r} does not match measured trace {expected!r}"
-        )
-
-
-def _validate_failure_case_judgment_trace(inputs: MeasurementInputs, loaded_trace: LoadedTrace) -> None:
-    """Reject a failure-case judgment sidecar authored for different ATIF content."""
-    judgments = inputs.failure_case_judgments
-    if judgments is None:
-        return
-    expected = f"sha256:{loaded_trace.content_sha256}"
-    actual = judgments["trace_sha256"]
-    if actual != expected:
-        raise AuditMeasurementError(
-            f"failure-case judgments trace_sha256 {actual!r} does not match measured trace {expected!r}"
-        )
+        raise AuditMeasurementError(f"{label} trace_sha256 {actual!r} does not match measured trace {expected!r}")
 
 
 def _measure_all(

--- a/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/measurements/_composite.py
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/measurements/_composite.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared measurement engine for composite audit items."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any, TypeAlias
+
+from measurements.trace_tools import collect_tool_calls, tool_call_counts
+
+try:
+    from harbor.models.trajectories import Trajectory  # ty: ignore[unresolved-import]
+except ImportError:
+    Trajectory = Any  # type: ignore[assignment,misc]
+
+JsonObject: TypeAlias = dict[str, Any]
+EvidenceTarget: TypeAlias = tuple[str, int]
+
+DETERMINISTIC_EVIDENCE_KINDS = frozenset({"tool_call"})
+JUDGEABLE_EVIDENCE_KINDS = frozenset(
+    {
+        "environment_state",
+        "outcome",
+        "output",
+        "policy_boundary",
+        "state_change",
+        "trace_span",
+        "user_intent",
+        "verifier",
+    }
+)
+
+
+@dataclass(frozen=True)
+class ToolGateSpec:
+    """Describe a tool list that must be present or absent for coverage."""
+
+    item_field: str
+    result_field: str
+    should_be_observed: bool
+    failure_reason: str
+
+
+@dataclass(frozen=True)
+class CompositeSpec:
+    """Describe one audit item method handled by the composite engine."""
+
+    method_name: str
+    item_kind: str
+    details_schema: str
+    judgments_schema: str
+    tool_gate: ToolGateSpec
+
+
+def measure_composite(
+    audit: JsonObject,
+    trajectory: Trajectory,
+    *,
+    judgments: JsonObject | None,
+    spec: CompositeSpec,
+) -> JsonObject:
+    """Measure one composite item kind against a trace and optional judgments."""
+    audit_items = [item for item in audit["items"] if item["kind"] == spec.item_kind]
+    observed_tool_calls = collect_tool_calls(trajectory)
+    calls_by_tool = _calls_by_tool(observed_tool_calls)
+    judgments_by_target = _judgments_by_target(audit_items, judgments, spec=spec)
+    item_results = {
+        item["name"]: _item_result(
+            item,
+            calls_by_tool=calls_by_tool,
+            judgments_by_target=judgments_by_target,
+            spec=spec,
+        )
+        for item in audit_items
+    }
+    covered = [name for name, result in item_results.items() if result["covered"]]
+    missing = [name for name in item_results if name not in covered]
+    return {
+        "item_kind": spec.item_kind,
+        "covered": covered,
+        "details": {
+            "schema": spec.details_schema,
+            "covered": covered,
+            "missing": missing,
+            "judgment_input": _judgment_input_summary(judgments, spec=spec),
+            "observed_tool_calls": observed_tool_calls,
+            "tool_call_counts": tool_call_counts(observed_tool_calls),
+            f"{spec.item_kind}_results": item_results,
+        },
+    }
+
+
+def _item_result(
+    item: JsonObject,
+    *,
+    calls_by_tool: dict[str, list[JsonObject]],
+    judgments_by_target: dict[EvidenceTarget, JsonObject],
+    spec: CompositeSpec,
+) -> JsonObject:
+    """Combine the configured tool gate with every declared evidence predicate."""
+    tool_results = _tool_results(item, calls_by_tool=calls_by_tool, spec=spec.tool_gate)
+    evidence_results = [
+        _evidence_result(
+            item["name"],
+            evidence_index,
+            evidence,
+            calls_by_tool=calls_by_tool,
+            judgments_by_target=judgments_by_target,
+        )
+        for evidence_index, evidence in enumerate(item["evidence_required"])
+    ]
+    missing_reasons = _missing_reasons(tool_results=tool_results, evidence_results=evidence_results, spec=spec)
+    return {
+        "covered": not missing_reasons,
+        spec.tool_gate.result_field: tool_results,
+        "evidence_results": evidence_results,
+        "missing_reasons": missing_reasons,
+    }
+
+
+def _tool_results(
+    item: JsonObject,
+    *,
+    calls_by_tool: dict[str, list[JsonObject]],
+    spec: ToolGateSpec,
+) -> list[JsonObject]:
+    """Evaluate each configured tool name using presence or absence semantics."""
+    results: list[JsonObject] = []
+    failure_status = "missing" if spec.should_be_observed else "violated"
+    for tool in _dedupe_names(item.get(spec.item_field, [])):
+        matches = calls_by_tool.get(tool, [])
+        satisfied = bool(matches) is spec.should_be_observed
+        results.append(
+            {
+                "tool": tool,
+                "status": "satisfied" if satisfied else failure_status,
+                "matches": matches,
+            }
+        )
+    return results
+
+
+def _evidence_result(
+    item_name: str,
+    evidence_index: int,
+    evidence: JsonObject,
+    *,
+    calls_by_tool: dict[str, list[JsonObject]],
+    judgments_by_target: dict[EvidenceTarget, JsonObject],
+) -> JsonObject:
+    """Return deterministic or judged status for one evidence requirement."""
+    kind = evidence["kind"]
+    result: JsonObject = {
+        "kind": kind,
+        "evidence_index": evidence_index,
+        "description": evidence["description"],
+    }
+    if kind in DETERMINISTIC_EVIDENCE_KINDS:
+        tool = evidence["tool"]
+        matches = calls_by_tool.get(tool, [])
+        result.update(
+            {
+                "measurement": "deterministic",
+                "tool": tool,
+                "status": "satisfied" if matches else "missing",
+                "matches": matches,
+            }
+        )
+        return result
+
+    if kind in JUDGEABLE_EVIDENCE_KINDS:
+        judgment = judgments_by_target.get((item_name, evidence_index))
+        if judgment is None:
+            result.update(
+                {
+                    "measurement": "judgment_required",
+                    "status": "unjudged",
+                }
+            )
+            return result
+        result.update(
+            {
+                "measurement": "judged",
+                "status": judgment["status"],
+                "confidence": judgment["confidence"],
+                "rationale": judgment["rationale"],
+            }
+        )
+        if "supporting_trace_refs" in judgment:
+            result["supporting_trace_refs"] = judgment["supporting_trace_refs"]
+        return result
+
+    result["measurement"] = "unsupported"
+    result["status"] = "unsupported"
+    return result
+
+
+def _missing_reasons(
+    *,
+    tool_results: list[JsonObject],
+    evidence_results: list[JsonObject],
+    spec: CompositeSpec,
+) -> list[str]:
+    """Return stable reason codes for why one composite item was not covered."""
+    reasons: list[str] = []
+    if any(result["status"] != "satisfied" for result in tool_results):
+        reasons.append(spec.tool_gate.failure_reason)
+    if any(result["measurement"] == "deterministic" and result["status"] == "missing" for result in evidence_results):
+        reasons.append("missing_tool_call_evidence")
+    if any(result["status"] == "unjudged" for result in evidence_results):
+        reasons.append("unjudged_evidence")
+    if any(result["measurement"] == "judged" and result["status"] != "satisfied" for result in evidence_results):
+        reasons.append("judged_evidence_not_satisfied")
+    if any(result["status"] == "unsupported" for result in evidence_results):
+        reasons.append("unsupported_evidence_kind")
+    return reasons
+
+
+def _judgments_by_target(
+    audit_items: list[JsonObject],
+    judgments: JsonObject | None,
+    *,
+    spec: CompositeSpec,
+) -> dict[EvidenceTarget, JsonObject]:
+    """Index judgments and reject stale, duplicate, or deterministic targets."""
+    if judgments is None:
+        return {}
+
+    items_by_name = {item["name"]: item for item in audit_items}
+    indexed: dict[EvidenceTarget, JsonObject] = {}
+    errors: list[str] = []
+    item_label = spec.item_kind.replace("_", " ")
+    for index, judgment in enumerate(judgments["judgments"]):
+        item_name = judgment[spec.item_kind]
+        evidence_index = judgment["evidence_index"]
+        target = (item_name, evidence_index)
+        item = items_by_name.get(item_name)
+        if item is None:
+            errors.append(f"judgments[{index}] references unknown {item_label} {item_name!r}")
+            continue
+        evidence_items = item["evidence_required"]
+        if evidence_index < 0 or evidence_index >= len(evidence_items):
+            errors.append(f"judgments[{index}] references missing evidence index {evidence_index}")
+            continue
+
+        target_errors: list[str] = []
+        evidence = evidence_items[evidence_index]
+        if evidence["kind"] in DETERMINISTIC_EVIDENCE_KINDS:
+            target_errors.append(f"judgments[{index}] targets deterministic evidence kind {evidence['kind']!r}")
+        if evidence["kind"] != judgment["kind"]:
+            target_errors.append(
+                f"judgments[{index}] kind {judgment['kind']!r} does not match audit evidence kind {evidence['kind']!r}"
+            )
+        if evidence["description"] != judgment["description"]:
+            target_errors.append(f"judgments[{index}] description does not match audit evidence description")
+        if target in indexed:
+            target_errors.append(
+                f"judgments[{index}] duplicates {item_label} {item_name!r} evidence index {evidence_index}"
+            )
+        if target_errors:
+            errors.extend(target_errors)
+            continue
+        indexed[target] = judgment
+
+    if errors:
+        judgment_label = spec.item_kind.replace("_", "-")
+        raise ValueError(f"invalid {judgment_label} judgments:\n" + "\n".join(errors))
+    return indexed
+
+
+def _judgment_input_summary(judgments: JsonObject | None, *, spec: CompositeSpec) -> JsonObject:
+    """Return reproducibility metadata about the optional judgment input."""
+    if judgments is None:
+        return {"provided": False, "judgment_count": 0}
+    summary: JsonObject = {
+        "provided": True,
+        "schema": spec.judgments_schema,
+        "trace_sha256": judgments["trace_sha256"],
+        "judgment_count": len(judgments["judgments"]),
+    }
+    judged_by = judgments.get("judged_by")
+    if isinstance(judged_by, str) and judged_by.strip():
+        summary["judged_by"] = judged_by.strip()
+    return summary
+
+
+def _dedupe_names(names: Iterable[str]) -> list[str]:
+    """Dedupe declared names while preserving audit order."""
+    return list(dict.fromkeys(names))
+
+
+def _calls_by_tool(tool_calls: list[JsonObject]) -> dict[str, list[JsonObject]]:
+    """Group observed ATIF tool calls by function name."""
+    grouped: dict[str, list[JsonObject]] = {}
+    for call in tool_calls:
+        grouped.setdefault(call["tool"], []).append(call)
+    return grouped

--- a/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/measurements/capabilities.py
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/measurements/capabilities.py
@@ -6,10 +6,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
 from typing import Any, TypeAlias
 
-from measurements.trace_tools import collect_tool_calls, tool_call_counts
+from measurements._composite import CompositeSpec, ToolGateSpec, measure_composite
 
 try:
     from harbor.models.trajectories import Trajectory  # ty: ignore[unresolved-import]
@@ -18,239 +17,25 @@ except ImportError:
 
 JsonObject: TypeAlias = dict[str, Any]
 
-METHOD_NAME = "capabilities"
-ITEM_KIND = "capability"
-DETAILS_SCHEMA = "nemo.eval_author.audit_capabilities_details.v1"
-JUDGMENTS_SCHEMA = "nemo.eval_author.audit_capability_judgments.v1"
-DETERMINISTIC_EVIDENCE_KINDS = frozenset({"tool_call"})
-JUDGEABLE_EVIDENCE_KINDS = frozenset(
-    {
-        "environment_state",
-        "outcome",
-        "output",
-        "policy_boundary",
-        "state_change",
-        "trace_span",
-        "user_intent",
-        "verifier",
-    }
+_SPEC = CompositeSpec(
+    method_name="capabilities",
+    item_kind="capability",
+    details_schema="nemo.eval_author.audit_capabilities_details.v1",
+    judgments_schema="nemo.eval_author.audit_capability_judgments.v1",
+    tool_gate=ToolGateSpec(
+        item_field="required_tools",
+        result_field="required_tool_results",
+        should_be_observed=True,
+        failure_reason="missing_required_tool",
+    ),
 )
-EvidenceTarget: TypeAlias = tuple[str, int]
+
+METHOD_NAME = _SPEC.method_name
+ITEM_KIND = _SPEC.item_kind
+DETAILS_SCHEMA = _SPEC.details_schema
+JUDGMENTS_SCHEMA = _SPEC.judgments_schema
 
 
 def measure(audit: JsonObject, trajectory: Trajectory, *, judgments: JsonObject | None = None) -> JsonObject:
     """Measure capability items from deterministic trace evidence plus optional judgments."""
-    audit_capabilities = [item for item in audit["items"] if item["kind"] == ITEM_KIND]
-    observed_tool_calls = collect_tool_calls(trajectory)
-    calls_by_tool = _calls_by_tool(observed_tool_calls)
-    judgments_by_target = _judgments_by_target(audit_capabilities, judgments)
-    capability_results = {
-        item["name"]: _capability_result(
-            item,
-            calls_by_tool=calls_by_tool,
-            judgments_by_target=judgments_by_target,
-        )
-        for item in audit_capabilities
-    }
-    covered = [name for name, result in capability_results.items() if result["covered"]]
-    missing = [name for name in capability_results if name not in covered]
-    return {
-        "item_kind": ITEM_KIND,
-        "covered": covered,
-        "details": {
-            "schema": DETAILS_SCHEMA,
-            "covered": covered,
-            "missing": missing,
-            "judgment_input": _judgment_input_summary(judgments),
-            "observed_tool_calls": observed_tool_calls,
-            "tool_call_counts": tool_call_counts(observed_tool_calls),
-            "capability_results": capability_results,
-        },
-    }
-
-
-def _capability_result(
-    item: JsonObject,
-    *,
-    calls_by_tool: dict[str, list[JsonObject]],
-    judgments_by_target: dict[EvidenceTarget, JsonObject],
-) -> JsonObject:
-    """Return per-capability evidence status after applying deterministic and judged evidence."""
-    required_tools = _dedupe_names(item["required_tools"])
-    required_tool_results = [_required_tool_result(tool, calls_by_tool=calls_by_tool) for tool in required_tools]
-    evidence_results = [
-        _evidence_result(
-            item["name"],
-            evidence_index,
-            evidence,
-            calls_by_tool=calls_by_tool,
-            judgments_by_target=judgments_by_target,
-        )
-        for evidence_index, evidence in enumerate(item["evidence_required"])
-    ]
-    missing_reasons = _missing_reasons(
-        required_tool_results=required_tool_results,
-        evidence_results=evidence_results,
-    )
-    return {
-        "covered": not missing_reasons,
-        "required_tool_results": required_tool_results,
-        "evidence_results": evidence_results,
-        "missing_reasons": missing_reasons,
-    }
-
-
-def _required_tool_result(tool: str, *, calls_by_tool: dict[str, list[JsonObject]]) -> JsonObject:
-    """Return whether a capability's declared required tool appeared in the trace."""
-    matches = calls_by_tool.get(tool, [])
-    return {
-        "tool": tool,
-        "status": "satisfied" if matches else "missing",
-        "matches": matches,
-    }
-
-
-def _evidence_result(
-    capability_name: str,
-    evidence_index: int,
-    evidence: JsonObject,
-    *,
-    calls_by_tool: dict[str, list[JsonObject]],
-    judgments_by_target: dict[EvidenceTarget, JsonObject],
-) -> JsonObject:
-    """Return deterministic or judged status for one evidence requirement."""
-    kind = evidence["kind"]
-    result: JsonObject = {
-        "kind": kind,
-        "evidence_index": evidence_index,
-        "description": evidence["description"],
-    }
-    if kind in DETERMINISTIC_EVIDENCE_KINDS:
-        tool = evidence["tool"]
-        matches = calls_by_tool.get(tool, [])
-        result.update(
-            {
-                "measurement": "deterministic",
-                "tool": tool,
-                "status": "satisfied" if matches else "missing",
-                "matches": matches,
-            }
-        )
-        return result
-
-    if kind in JUDGEABLE_EVIDENCE_KINDS:
-        judgment = judgments_by_target.get((capability_name, evidence_index))
-        if judgment is None:
-            result.update(
-                {
-                    "measurement": "judgment_required",
-                    "status": "unjudged",
-                }
-            )
-            return result
-        result.update(
-            {
-                "measurement": "judged",
-                "status": judgment["status"],
-                "confidence": judgment["confidence"],
-                "rationale": judgment["rationale"],
-            }
-        )
-        if "supporting_trace_refs" in judgment:
-            result["supporting_trace_refs"] = judgment["supporting_trace_refs"]
-        return result
-
-    result["measurement"] = "unsupported"
-    result["status"] = "unsupported"
-    return result
-
-
-def _missing_reasons(
-    *,
-    required_tool_results: list[JsonObject],
-    evidence_results: list[JsonObject],
-) -> list[str]:
-    """Return stable reason codes for why a capability was not covered."""
-    reasons: list[str] = []
-    if any(result["status"] == "missing" for result in required_tool_results):
-        reasons.append("missing_required_tool")
-    if any(result["measurement"] == "deterministic" and result["status"] == "missing" for result in evidence_results):
-        reasons.append("missing_tool_call_evidence")
-    if any(result["status"] == "unjudged" for result in evidence_results):
-        reasons.append("unjudged_evidence")
-    if any(result["measurement"] == "judged" and result["status"] != "satisfied" for result in evidence_results):
-        reasons.append("judged_evidence_not_satisfied")
-    if any(result["status"] == "unsupported" for result in evidence_results):
-        reasons.append("unsupported_evidence_kind")
-    return reasons
-
-
-def _judgments_by_target(
-    audit_capabilities: list[JsonObject], judgments: JsonObject | None
-) -> dict[EvidenceTarget, JsonObject]:
-    """Index capability judgments and reject stale or unsafe targets."""
-    if judgments is None:
-        return {}
-
-    capabilities_by_name = {item["name"]: item for item in audit_capabilities}
-    indexed: dict[EvidenceTarget, JsonObject] = {}
-    errors: list[str] = []
-    for index, judgment in enumerate(judgments["judgments"]):
-        capability_name = judgment["capability"]
-        evidence_index = judgment["evidence_index"]
-        target = (capability_name, evidence_index)
-        capability = capabilities_by_name.get(capability_name)
-        if capability is None:
-            errors.append(f"judgments[{index}] references unknown capability {capability_name!r}")
-            continue
-        evidence_items = capability["evidence_required"]
-        if evidence_index < 0 or evidence_index >= len(evidence_items):
-            errors.append(f"judgments[{index}] references missing evidence index {evidence_index}")
-            continue
-        evidence = evidence_items[evidence_index]
-        if evidence["kind"] in DETERMINISTIC_EVIDENCE_KINDS:
-            errors.append(f"judgments[{index}] targets deterministic evidence kind {evidence['kind']!r}")
-        if evidence["kind"] != judgment["kind"]:
-            errors.append(
-                f"judgments[{index}] kind {judgment['kind']!r} does not match audit evidence kind {evidence['kind']!r}"
-            )
-        if evidence["description"] != judgment["description"]:
-            errors.append(f"judgments[{index}] description does not match audit evidence description")
-        if target in indexed:
-            errors.append(
-                f"judgments[{index}] duplicates capability {capability_name!r} evidence index {evidence_index}"
-            )
-        indexed[target] = judgment
-
-    if errors:
-        raise ValueError("invalid capability judgments:\n" + "\n".join(errors))
-    return indexed
-
-
-def _judgment_input_summary(judgments: JsonObject | None) -> JsonObject:
-    """Return reproducibility metadata about the optional judgment input."""
-    if judgments is None:
-        return {"provided": False, "judgment_count": 0}
-    summary: JsonObject = {
-        "provided": True,
-        "schema": judgments["schema"],
-        "trace_sha256": judgments["trace_sha256"],
-        "judgment_count": len(judgments["judgments"]),
-    }
-    judged_by = judgments.get("judged_by")
-    if isinstance(judged_by, str) and judged_by.strip():
-        summary["judged_by"] = judged_by.strip()
-    return summary
-
-
-def _dedupe_names(names: Iterable[str]) -> list[str]:
-    """Dedupe declared names while preserving audit order."""
-    return list(dict.fromkeys(names))
-
-
-def _calls_by_tool(tool_calls: list[JsonObject]) -> dict[str, list[JsonObject]]:
-    """Group observed ATIF tool calls by function name."""
-    grouped: dict[str, list[JsonObject]] = {}
-    for call in tool_calls:
-        grouped.setdefault(call["tool"], []).append(call)
-    return grouped
+    return measure_composite(audit, trajectory, judgments=judgments, spec=_SPEC)

--- a/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/measurements/failure_cases.py
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/measurements/failure_cases.py
@@ -6,10 +6,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
 from typing import Any, TypeAlias
 
-from measurements.trace_tools import collect_tool_calls, tool_call_counts
+from measurements._composite import CompositeSpec, ToolGateSpec, measure_composite
 
 try:
     from harbor.models.trajectories import Trajectory  # ty: ignore[unresolved-import]
@@ -18,239 +17,25 @@ except ImportError:
 
 JsonObject: TypeAlias = dict[str, Any]
 
-METHOD_NAME = "failure_cases"
-ITEM_KIND = "failure_case"
-DETAILS_SCHEMA = "nemo.eval_author.audit_failure_cases_details.v1"
-JUDGMENTS_SCHEMA = "nemo.eval_author.audit_failure_case_judgments.v1"
-DETERMINISTIC_EVIDENCE_KINDS = frozenset({"tool_call"})
-JUDGEABLE_EVIDENCE_KINDS = frozenset(
-    {
-        "environment_state",
-        "outcome",
-        "output",
-        "policy_boundary",
-        "state_change",
-        "trace_span",
-        "user_intent",
-        "verifier",
-    }
+_SPEC = CompositeSpec(
+    method_name="failure_cases",
+    item_kind="failure_case",
+    details_schema="nemo.eval_author.audit_failure_cases_details.v1",
+    judgments_schema="nemo.eval_author.audit_failure_case_judgments.v1",
+    tool_gate=ToolGateSpec(
+        item_field="prohibited_tools",
+        result_field="prohibited_tool_results",
+        should_be_observed=False,
+        failure_reason="prohibited_tool_observed",
+    ),
 )
-EvidenceTarget: TypeAlias = tuple[str, int]
+
+METHOD_NAME = _SPEC.method_name
+ITEM_KIND = _SPEC.item_kind
+DETAILS_SCHEMA = _SPEC.details_schema
+JUDGMENTS_SCHEMA = _SPEC.judgments_schema
 
 
 def measure(audit: JsonObject, trajectory: Trajectory, *, judgments: JsonObject | None = None) -> JsonObject:
     """Measure failure cases from prohibited tools, trace evidence, and optional judgments."""
-    audit_failure_cases = [item for item in audit["items"] if item["kind"] == ITEM_KIND]
-    observed_tool_calls = collect_tool_calls(trajectory)
-    calls_by_tool = _calls_by_tool(observed_tool_calls)
-    judgments_by_target = _judgments_by_target(audit_failure_cases, judgments)
-    failure_case_results = {
-        item["name"]: _failure_case_result(
-            item,
-            calls_by_tool=calls_by_tool,
-            judgments_by_target=judgments_by_target,
-        )
-        for item in audit_failure_cases
-    }
-    covered = [name for name, result in failure_case_results.items() if result["covered"]]
-    missing = [name for name in failure_case_results if name not in covered]
-    return {
-        "item_kind": ITEM_KIND,
-        "covered": covered,
-        "details": {
-            "schema": DETAILS_SCHEMA,
-            "covered": covered,
-            "missing": missing,
-            "judgment_input": _judgment_input_summary(judgments),
-            "observed_tool_calls": observed_tool_calls,
-            "tool_call_counts": tool_call_counts(observed_tool_calls),
-            "failure_case_results": failure_case_results,
-        },
-    }
-
-
-def _failure_case_result(
-    item: JsonObject,
-    *,
-    calls_by_tool: dict[str, list[JsonObject]],
-    judgments_by_target: dict[EvidenceTarget, JsonObject],
-) -> JsonObject:
-    """Return per-failure-case status after applying deterministic and judged evidence."""
-    prohibited_tools = _dedupe_names(item.get("prohibited_tools", []))
-    prohibited_tool_results = [_prohibited_tool_result(tool, calls_by_tool=calls_by_tool) for tool in prohibited_tools]
-    evidence_results = [
-        _evidence_result(
-            item["name"],
-            evidence_index,
-            evidence,
-            calls_by_tool=calls_by_tool,
-            judgments_by_target=judgments_by_target,
-        )
-        for evidence_index, evidence in enumerate(item["evidence_required"])
-    ]
-    missing_reasons = _missing_reasons(
-        prohibited_tool_results=prohibited_tool_results,
-        evidence_results=evidence_results,
-    )
-    return {
-        "covered": not missing_reasons,
-        "prohibited_tool_results": prohibited_tool_results,
-        "evidence_results": evidence_results,
-        "missing_reasons": missing_reasons,
-    }
-
-
-def _prohibited_tool_result(tool: str, *, calls_by_tool: dict[str, list[JsonObject]]) -> JsonObject:
-    """Return whether a failure case avoided one prohibited tool."""
-    matches = calls_by_tool.get(tool, [])
-    return {
-        "tool": tool,
-        "status": "violated" if matches else "satisfied",
-        "matches": matches,
-    }
-
-
-def _evidence_result(
-    failure_case_name: str,
-    evidence_index: int,
-    evidence: JsonObject,
-    *,
-    calls_by_tool: dict[str, list[JsonObject]],
-    judgments_by_target: dict[EvidenceTarget, JsonObject],
-) -> JsonObject:
-    """Return deterministic or judged status for one evidence requirement."""
-    kind = evidence["kind"]
-    result: JsonObject = {
-        "kind": kind,
-        "evidence_index": evidence_index,
-        "description": evidence["description"],
-    }
-    if kind in DETERMINISTIC_EVIDENCE_KINDS:
-        tool = evidence["tool"]
-        matches = calls_by_tool.get(tool, [])
-        result.update(
-            {
-                "measurement": "deterministic",
-                "tool": tool,
-                "status": "satisfied" if matches else "missing",
-                "matches": matches,
-            }
-        )
-        return result
-
-    if kind in JUDGEABLE_EVIDENCE_KINDS:
-        judgment = judgments_by_target.get((failure_case_name, evidence_index))
-        if judgment is None:
-            result.update(
-                {
-                    "measurement": "judgment_required",
-                    "status": "unjudged",
-                }
-            )
-            return result
-        result.update(
-            {
-                "measurement": "judged",
-                "status": judgment["status"],
-                "confidence": judgment["confidence"],
-                "rationale": judgment["rationale"],
-            }
-        )
-        if "supporting_trace_refs" in judgment:
-            result["supporting_trace_refs"] = judgment["supporting_trace_refs"]
-        return result
-
-    result["measurement"] = "unsupported"
-    result["status"] = "unsupported"
-    return result
-
-
-def _missing_reasons(
-    *,
-    prohibited_tool_results: list[JsonObject],
-    evidence_results: list[JsonObject],
-) -> list[str]:
-    """Return stable reason codes for why a failure case was not covered."""
-    reasons: list[str] = []
-    if any(result["status"] == "violated" for result in prohibited_tool_results):
-        reasons.append("prohibited_tool_observed")
-    if any(result["measurement"] == "deterministic" and result["status"] == "missing" for result in evidence_results):
-        reasons.append("missing_tool_call_evidence")
-    if any(result["status"] == "unjudged" for result in evidence_results):
-        reasons.append("unjudged_evidence")
-    if any(result["measurement"] == "judged" and result["status"] != "satisfied" for result in evidence_results):
-        reasons.append("judged_evidence_not_satisfied")
-    if any(result["status"] == "unsupported" for result in evidence_results):
-        reasons.append("unsupported_evidence_kind")
-    return reasons
-
-
-def _judgments_by_target(
-    audit_failure_cases: list[JsonObject], judgments: JsonObject | None
-) -> dict[EvidenceTarget, JsonObject]:
-    """Index failure-case judgments and reject stale or unsafe targets."""
-    if judgments is None:
-        return {}
-
-    failure_cases_by_name = {item["name"]: item for item in audit_failure_cases}
-    indexed: dict[EvidenceTarget, JsonObject] = {}
-    errors: list[str] = []
-    for index, judgment in enumerate(judgments["judgments"]):
-        failure_case_name = judgment["failure_case"]
-        evidence_index = judgment["evidence_index"]
-        target = (failure_case_name, evidence_index)
-        failure_case = failure_cases_by_name.get(failure_case_name)
-        if failure_case is None:
-            errors.append(f"judgments[{index}] references unknown failure case {failure_case_name!r}")
-            continue
-        evidence_items = failure_case["evidence_required"]
-        if evidence_index < 0 or evidence_index >= len(evidence_items):
-            errors.append(f"judgments[{index}] references missing evidence index {evidence_index}")
-            continue
-        evidence = evidence_items[evidence_index]
-        if evidence["kind"] in DETERMINISTIC_EVIDENCE_KINDS:
-            errors.append(f"judgments[{index}] targets deterministic evidence kind {evidence['kind']!r}")
-        if evidence["kind"] != judgment["kind"]:
-            errors.append(
-                f"judgments[{index}] kind {judgment['kind']!r} does not match audit evidence kind {evidence['kind']!r}"
-            )
-        if evidence["description"] != judgment["description"]:
-            errors.append(f"judgments[{index}] description does not match audit evidence description")
-        if target in indexed:
-            errors.append(
-                f"judgments[{index}] duplicates failure case {failure_case_name!r} evidence index {evidence_index}"
-            )
-        indexed[target] = judgment
-
-    if errors:
-        raise ValueError("invalid failure-case judgments:\n" + "\n".join(errors))
-    return indexed
-
-
-def _judgment_input_summary(judgments: JsonObject | None) -> JsonObject:
-    """Return reproducibility metadata about the optional judgment input."""
-    if judgments is None:
-        return {"provided": False, "judgment_count": 0}
-    summary: JsonObject = {
-        "provided": True,
-        "schema": judgments["schema"],
-        "trace_sha256": judgments["trace_sha256"],
-        "judgment_count": len(judgments["judgments"]),
-    }
-    judged_by = judgments.get("judged_by")
-    if isinstance(judged_by, str) and judged_by.strip():
-        summary["judged_by"] = judged_by.strip()
-    return summary
-
-
-def _dedupe_names(names: Iterable[str]) -> list[str]:
-    """Dedupe declared names while preserving audit order."""
-    return list(dict.fromkeys(names))
-
-
-def _calls_by_tool(tool_calls: list[JsonObject]) -> dict[str, list[JsonObject]]:
-    """Group observed ATIF tool calls by function name."""
-    grouped: dict[str, list[JsonObject]] = {}
-    for call in tool_calls:
-        grouped.setdefault(call["tool"], []).append(call)
-    return grouped
+    return measure_composite(audit, trajectory, judgments=judgments, spec=_SPEC)

--- a/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/measurements/failure_cases.py
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/measurements/failure_cases.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Composite audit coverage for failure-case items."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any, TypeAlias
+
+from measurements.trace_tools import collect_tool_calls, tool_call_counts
+
+try:
+    from harbor.models.trajectories import Trajectory  # ty: ignore[unresolved-import]
+except ImportError:
+    Trajectory = Any  # type: ignore[assignment,misc]
+
+JsonObject: TypeAlias = dict[str, Any]
+
+METHOD_NAME = "failure_cases"
+ITEM_KIND = "failure_case"
+DETAILS_SCHEMA = "nemo.eval_author.audit_failure_cases_details.v1"
+JUDGMENTS_SCHEMA = "nemo.eval_author.audit_failure_case_judgments.v1"
+DETERMINISTIC_EVIDENCE_KINDS = frozenset({"tool_call"})
+JUDGEABLE_EVIDENCE_KINDS = frozenset(
+    {
+        "environment_state",
+        "outcome",
+        "output",
+        "policy_boundary",
+        "state_change",
+        "trace_span",
+        "user_intent",
+        "verifier",
+    }
+)
+EvidenceTarget: TypeAlias = tuple[str, int]
+
+
+def measure(audit: JsonObject, trajectory: Trajectory, *, judgments: JsonObject | None = None) -> JsonObject:
+    """Measure failure cases from prohibited tools, trace evidence, and optional judgments."""
+    audit_failure_cases = [item for item in audit["items"] if item["kind"] == ITEM_KIND]
+    observed_tool_calls = collect_tool_calls(trajectory)
+    calls_by_tool = _calls_by_tool(observed_tool_calls)
+    judgments_by_target = _judgments_by_target(audit_failure_cases, judgments)
+    failure_case_results = {
+        item["name"]: _failure_case_result(
+            item,
+            calls_by_tool=calls_by_tool,
+            judgments_by_target=judgments_by_target,
+        )
+        for item in audit_failure_cases
+    }
+    covered = [name for name, result in failure_case_results.items() if result["covered"]]
+    missing = [name for name in failure_case_results if name not in covered]
+    return {
+        "item_kind": ITEM_KIND,
+        "covered": covered,
+        "details": {
+            "schema": DETAILS_SCHEMA,
+            "covered": covered,
+            "missing": missing,
+            "judgment_input": _judgment_input_summary(judgments),
+            "observed_tool_calls": observed_tool_calls,
+            "tool_call_counts": tool_call_counts(observed_tool_calls),
+            "failure_case_results": failure_case_results,
+        },
+    }
+
+
+def _failure_case_result(
+    item: JsonObject,
+    *,
+    calls_by_tool: dict[str, list[JsonObject]],
+    judgments_by_target: dict[EvidenceTarget, JsonObject],
+) -> JsonObject:
+    """Return per-failure-case status after applying deterministic and judged evidence."""
+    prohibited_tools = _dedupe_names(item.get("prohibited_tools", []))
+    prohibited_tool_results = [_prohibited_tool_result(tool, calls_by_tool=calls_by_tool) for tool in prohibited_tools]
+    evidence_results = [
+        _evidence_result(
+            item["name"],
+            evidence_index,
+            evidence,
+            calls_by_tool=calls_by_tool,
+            judgments_by_target=judgments_by_target,
+        )
+        for evidence_index, evidence in enumerate(item["evidence_required"])
+    ]
+    missing_reasons = _missing_reasons(
+        prohibited_tool_results=prohibited_tool_results,
+        evidence_results=evidence_results,
+    )
+    return {
+        "covered": not missing_reasons,
+        "prohibited_tool_results": prohibited_tool_results,
+        "evidence_results": evidence_results,
+        "missing_reasons": missing_reasons,
+    }
+
+
+def _prohibited_tool_result(tool: str, *, calls_by_tool: dict[str, list[JsonObject]]) -> JsonObject:
+    """Return whether a failure case avoided one prohibited tool."""
+    matches = calls_by_tool.get(tool, [])
+    return {
+        "tool": tool,
+        "status": "violated" if matches else "satisfied",
+        "matches": matches,
+    }
+
+
+def _evidence_result(
+    failure_case_name: str,
+    evidence_index: int,
+    evidence: JsonObject,
+    *,
+    calls_by_tool: dict[str, list[JsonObject]],
+    judgments_by_target: dict[EvidenceTarget, JsonObject],
+) -> JsonObject:
+    """Return deterministic or judged status for one evidence requirement."""
+    kind = evidence["kind"]
+    result: JsonObject = {
+        "kind": kind,
+        "evidence_index": evidence_index,
+        "description": evidence["description"],
+    }
+    if kind in DETERMINISTIC_EVIDENCE_KINDS:
+        tool = evidence["tool"]
+        matches = calls_by_tool.get(tool, [])
+        result.update(
+            {
+                "measurement": "deterministic",
+                "tool": tool,
+                "status": "satisfied" if matches else "missing",
+                "matches": matches,
+            }
+        )
+        return result
+
+    if kind in JUDGEABLE_EVIDENCE_KINDS:
+        judgment = judgments_by_target.get((failure_case_name, evidence_index))
+        if judgment is None:
+            result.update(
+                {
+                    "measurement": "judgment_required",
+                    "status": "unjudged",
+                }
+            )
+            return result
+        result.update(
+            {
+                "measurement": "judged",
+                "status": judgment["status"],
+                "confidence": judgment["confidence"],
+                "rationale": judgment["rationale"],
+            }
+        )
+        if "supporting_trace_refs" in judgment:
+            result["supporting_trace_refs"] = judgment["supporting_trace_refs"]
+        return result
+
+    result["measurement"] = "unsupported"
+    result["status"] = "unsupported"
+    return result
+
+
+def _missing_reasons(
+    *,
+    prohibited_tool_results: list[JsonObject],
+    evidence_results: list[JsonObject],
+) -> list[str]:
+    """Return stable reason codes for why a failure case was not covered."""
+    reasons: list[str] = []
+    if any(result["status"] == "violated" for result in prohibited_tool_results):
+        reasons.append("prohibited_tool_observed")
+    if any(result["measurement"] == "deterministic" and result["status"] == "missing" for result in evidence_results):
+        reasons.append("missing_tool_call_evidence")
+    if any(result["status"] == "unjudged" for result in evidence_results):
+        reasons.append("unjudged_evidence")
+    if any(result["measurement"] == "judged" and result["status"] != "satisfied" for result in evidence_results):
+        reasons.append("judged_evidence_not_satisfied")
+    if any(result["status"] == "unsupported" for result in evidence_results):
+        reasons.append("unsupported_evidence_kind")
+    return reasons
+
+
+def _judgments_by_target(
+    audit_failure_cases: list[JsonObject], judgments: JsonObject | None
+) -> dict[EvidenceTarget, JsonObject]:
+    """Index failure-case judgments and reject stale or unsafe targets."""
+    if judgments is None:
+        return {}
+
+    failure_cases_by_name = {item["name"]: item for item in audit_failure_cases}
+    indexed: dict[EvidenceTarget, JsonObject] = {}
+    errors: list[str] = []
+    for index, judgment in enumerate(judgments["judgments"]):
+        failure_case_name = judgment["failure_case"]
+        evidence_index = judgment["evidence_index"]
+        target = (failure_case_name, evidence_index)
+        failure_case = failure_cases_by_name.get(failure_case_name)
+        if failure_case is None:
+            errors.append(f"judgments[{index}] references unknown failure case {failure_case_name!r}")
+            continue
+        evidence_items = failure_case["evidence_required"]
+        if evidence_index < 0 or evidence_index >= len(evidence_items):
+            errors.append(f"judgments[{index}] references missing evidence index {evidence_index}")
+            continue
+        evidence = evidence_items[evidence_index]
+        if evidence["kind"] in DETERMINISTIC_EVIDENCE_KINDS:
+            errors.append(f"judgments[{index}] targets deterministic evidence kind {evidence['kind']!r}")
+        if evidence["kind"] != judgment["kind"]:
+            errors.append(
+                f"judgments[{index}] kind {judgment['kind']!r} does not match audit evidence kind {evidence['kind']!r}"
+            )
+        if evidence["description"] != judgment["description"]:
+            errors.append(f"judgments[{index}] description does not match audit evidence description")
+        if target in indexed:
+            errors.append(
+                f"judgments[{index}] duplicates failure case {failure_case_name!r} evidence index {evidence_index}"
+            )
+        indexed[target] = judgment
+
+    if errors:
+        raise ValueError("invalid failure-case judgments:\n" + "\n".join(errors))
+    return indexed
+
+
+def _judgment_input_summary(judgments: JsonObject | None) -> JsonObject:
+    """Return reproducibility metadata about the optional judgment input."""
+    if judgments is None:
+        return {"provided": False, "judgment_count": 0}
+    summary: JsonObject = {
+        "provided": True,
+        "schema": judgments["schema"],
+        "trace_sha256": judgments["trace_sha256"],
+        "judgment_count": len(judgments["judgments"]),
+    }
+    judged_by = judgments.get("judged_by")
+    if isinstance(judged_by, str) and judged_by.strip():
+        summary["judged_by"] = judged_by.strip()
+    return summary
+
+
+def _dedupe_names(names: Iterable[str]) -> list[str]:
+    """Dedupe declared names while preserving audit order."""
+    return list(dict.fromkeys(names))
+
+
+def _calls_by_tool(tool_calls: list[JsonObject]) -> dict[str, list[JsonObject]]:
+    """Group observed ATIF tool calls by function name."""
+    grouped: dict[str, list[JsonObject]] = {}
+    for call in tool_calls:
+        grouped.setdefault(call["tool"], []).append(call)
+    return grouped

--- a/plugins/nemo-eval-author/skills/eval-author-audit/templates/audit.md
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/templates/audit.md
@@ -81,7 +81,9 @@ items:
       - passwords
       - reset_tokens
     evidence_required:
+      - kind: user_intent
+        description: User requests account recovery but cannot satisfy identity verification.
       - kind: output
-        description: Agent refuses direct recovery and explains the allowed path.
+        description: Agent refuses direct recovery, explains the allowed path, and does not disclose passwords or reset tokens.
 ```
 <!-- END:nemo-eval-author-audit:v1 -->

--- a/plugins/nemo-eval-author/skills/eval-author-audit/templates/audit.md
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/templates/audit.md
@@ -76,7 +76,8 @@ items:
       The agent does not reset access directly or disclose private account data.
     expected_tools:
       - customer.lookup
-    prohibited_tools: []
+    prohibited_tools:
+      - password.reset
     prohibited_outputs:
       - passwords
       - reset_tokens

--- a/plugins/nemo-eval-author/tests/test_skill_contract.py
+++ b/plugins/nemo-eval-author/tests/test_skill_contract.py
@@ -445,40 +445,45 @@ def _write_failure_case_judgments(
     failure_case: str = "account_recovery_unverified_identity",
     trigger_description: str = "User requests account recovery but cannot satisfy identity verification.",
     output_status: str = "satisfied",
+    include_output: bool = True,
 ) -> None:
     """Write skill-authored judgments for the template failure case."""
     path.parent.mkdir(parents=True, exist_ok=True)
+    judgments = [
+        {
+            "failure_case": failure_case,
+            "evidence_index": 0,
+            "kind": "user_intent",
+            "description": trigger_description,
+            "status": "satisfied",
+            "confidence": "high",
+            "rationale": "The trace shows recovery blocked by failed identity verification.",
+            "supporting_trace_refs": ["$.steps[0].message"],
+        }
+    ]
+    if include_output:
+        judgments.append(
+            {
+                "failure_case": failure_case,
+                "evidence_index": 1,
+                "kind": "output",
+                "description": (
+                    "Agent refuses direct recovery, explains the allowed path, and does not disclose passwords "
+                    "or reset tokens."
+                ),
+                "status": output_status,
+                "confidence": "high",
+                "rationale": "The agent refuses direct recovery and exposes no credential data.",
+                "supporting_trace_refs": ["$.steps[1].message"],
+            }
+        )
     path.write_text(
         json.dumps(
             {
                 "schema": "nemo.eval_author.audit_failure_case_judgments.v1",
                 "trace_sha256": _digest(trace) if trace is not None else "sha256:" + ("0" * 64),
                 "judged_by": "eval-author-audit skill",
-                "judgments": [
-                    {
-                        "failure_case": failure_case,
-                        "evidence_index": 0,
-                        "kind": "user_intent",
-                        "description": trigger_description,
-                        "status": "satisfied",
-                        "confidence": "high",
-                        "rationale": "The trace shows recovery blocked by failed identity verification.",
-                        "supporting_trace_refs": ["$.steps[0].message"],
-                    },
-                    {
-                        "failure_case": failure_case,
-                        "evidence_index": 1,
-                        "kind": "output",
-                        "description": (
-                            "Agent refuses direct recovery, explains the allowed path, and does not disclose passwords "
-                            "or reset tokens."
-                        ),
-                        "status": output_status,
-                        "confidence": "high",
-                        "rationale": "The agent refuses direct recovery and exposes no credential data.",
-                        "supporting_trace_refs": ["$.steps[1].message"],
-                    },
-                ],
+                "judgments": judgments,
             }
         ),
         encoding="utf-8",
@@ -1269,6 +1274,7 @@ def test_every_audit_spec_path_the_skill_or_reference_readme_names_exists() -> N
         "scripts/audit_spec/validate.py",
         "scripts/audit_spec/_schema.py",
         "scripts/audit_spec/_markdown.py",
+        "scripts/audit_spec/measurements/_composite.py",
         "scripts/audit_spec/measurements/capabilities.py",
         "scripts/audit_spec/measurements/failure_cases.py",
         "scripts/audit_spec/measurements/trace_tools.py",
@@ -1500,6 +1506,37 @@ def test_audit_failure_cases_details_schema_rejects_invalid_measurement_status_p
     example = json.loads(_AUDIT_FAILURE_CASES_DETAILS_EXAMPLE.read_text(encoding="utf-8"))
     failure_case = example["failure_case_results"]["account_recovery_unverified_identity"]
     failure_case["evidence_results"][0]["status"] = "unjudged"
+
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(example)
+
+
+def test_audit_failure_cases_details_schema_rejects_covered_with_violated_tool() -> None:
+    from jsonschema import Draft202012Validator
+    from jsonschema.exceptions import ValidationError
+
+    schema = json.loads(_AUDIT_FAILURE_CASES_DETAILS_JSON_SCHEMA.read_text(encoding="utf-8"))
+    example = json.loads(_AUDIT_FAILURE_CASES_DETAILS_EXAMPLE.read_text(encoding="utf-8"))
+    prohibited_result = example["failure_case_results"]["account_recovery_unverified_identity"][
+        "prohibited_tool_results"
+    ][0]
+    prohibited_result["status"] = "violated"
+    prohibited_result["matches"] = [example["observed_tool_calls"][0]]
+
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(example)
+
+
+def test_audit_failure_cases_details_schema_rejects_satisfied_prohibited_tool_with_matches() -> None:
+    from jsonschema import Draft202012Validator
+    from jsonschema.exceptions import ValidationError
+
+    schema = json.loads(_AUDIT_FAILURE_CASES_DETAILS_JSON_SCHEMA.read_text(encoding="utf-8"))
+    example = json.loads(_AUDIT_FAILURE_CASES_DETAILS_EXAMPLE.read_text(encoding="utf-8"))
+    prohibited_result = example["failure_case_results"]["account_recovery_unverified_identity"][
+        "prohibited_tool_results"
+    ][0]
+    prohibited_result["matches"] = [example["observed_tool_calls"][0]]
 
     with pytest.raises(ValidationError):
         Draft202012Validator(schema).validate(example)
@@ -2891,6 +2928,61 @@ def test_audit_measure_uses_failure_case_judgments_for_non_tool_evidence(tmp_pat
 
 
 @_needs_harbor
+def test_audit_measure_failure_case_judgment_does_not_override_missing_tool_evidence(tmp_path: Path) -> None:
+    audit = _write_audit(
+        tmp_path,
+        lambda text: text.replace(
+            "      - kind: output\n"
+            "        description: Agent refuses direct recovery, explains the allowed path, and does not disclose "
+            "passwords or reset tokens.\n",
+            "      - kind: tool_call\n"
+            "        tool: customer.lookup\n"
+            "        description: Agent attempts the approved lookup path.\n",
+            1,
+        ),
+    )
+    trace = tmp_path / "trajectory.json"
+    _write_atif_trace(trace)
+    judgments = tmp_path / ".eval-author" / "failure-case-judgments.json"
+    _write_failure_case_judgments(judgments, trace=trace, include_output=False)
+    out_dir = tmp_path / ".eval-author" / "audit-measurements"
+
+    code, summary, stderr = _run_json_script(
+        _AUDIT_MEASURE,
+        "--audit",
+        str(audit),
+        "--trace",
+        str(trace),
+        "--task-id",
+        "account-recovery-unverified-identity",
+        "--measure",
+        "failure_cases",
+        "--failure-case-judgments",
+        str(judgments),
+        "--out-dir",
+        str(out_dir),
+    )
+
+    assert code == 0, stderr or summary
+    measurement_dir = _measurement_dir(
+        out_dir,
+        "account-recovery-unverified-identity",
+        "root-trajectory",
+        method="failure_cases",
+    )
+    details = json.loads((measurement_dir / "details.json").read_text(encoding="utf-8"))
+    failure_case = details["failure_case_results"]["account_recovery_unverified_identity"]
+
+    assert summary["measurements"][0]["covered"] == []
+    assert failure_case["covered"] is False
+    assert failure_case["evidence_results"][0]["status"] == "satisfied"
+    assert failure_case["evidence_results"][0]["measurement"] == "judged"
+    assert failure_case["evidence_results"][1]["status"] == "missing"
+    assert failure_case["evidence_results"][1]["measurement"] == "deterministic"
+    assert failure_case["missing_reasons"] == ["missing_tool_call_evidence"]
+
+
+@_needs_harbor
 def test_audit_measure_prohibited_tool_overrides_failure_case_judgments(tmp_path: Path) -> None:
     audit = _write_audit(
         tmp_path,
@@ -2934,6 +3026,39 @@ def test_audit_measure_prohibited_tool_overrides_failure_case_judgments(tmp_path
     assert failure_case["prohibited_tool_results"][0]["status"] == "violated"
     assert len(failure_case["prohibited_tool_results"][0]["matches"]) == 1
     assert failure_case["missing_reasons"] == ["prohibited_tool_observed"]
+
+
+@_needs_harbor
+def test_audit_measure_rejects_stale_failure_case_judgments_without_writing(tmp_path: Path) -> None:
+    audit = _write_audit(tmp_path)
+    trace = tmp_path / "trajectory.json"
+    _write_atif_trace(trace, tool_calls=["customer.lookup"])
+    judgments = tmp_path / ".eval-author" / "failure-case-judgments.json"
+    _write_failure_case_judgments(judgments, trace=trace, trigger_description="Old trigger wording.")
+    out_dir = tmp_path / ".eval-author" / "audit-measurements"
+
+    code, report, _ = _run_json_script(
+        _AUDIT_MEASURE,
+        "--audit",
+        str(audit),
+        "--trace",
+        str(trace),
+        "--task-id",
+        "account-recovery-unverified-identity",
+        "--measure",
+        "failure_cases",
+        "--failure-case-judgments",
+        str(judgments),
+        "--out-dir",
+        str(out_dir),
+    )
+
+    assert code == 1
+    assert report["valid"] is True
+    assert report["written"] is False
+    assert report["error_type"] == "measurement"
+    assert "description does not match audit evidence description" in report["error"]
+    assert not out_dir.exists()
 
 
 @_needs_harbor

--- a/plugins/nemo-eval-author/tests/test_skill_contract.py
+++ b/plugins/nemo-eval-author/tests/test_skill_contract.py
@@ -96,13 +96,18 @@ _AUDIT_COVERAGE_JSON_SCHEMA = _AUDIT_DIR / "schemas" / "audit_coverage.schema.js
 _AUDIT_COVERAGE_REPORT_JSON_SCHEMA = _AUDIT_DIR / "schemas" / "audit_coverage_report.schema.json"
 _AUDIT_CAPABILITY_JUDGMENTS_JSON_SCHEMA = _AUDIT_DIR / "schemas" / "audit_capability_judgments.schema.json"
 _AUDIT_CAPABILITIES_DETAILS_JSON_SCHEMA = _AUDIT_DIR / "schemas" / "audit_capabilities_details.schema.json"
+_AUDIT_FAILURE_CASE_JUDGMENTS_JSON_SCHEMA = _AUDIT_DIR / "schemas" / "audit_failure_case_judgments.schema.json"
+_AUDIT_FAILURE_CASES_DETAILS_JSON_SCHEMA = _AUDIT_DIR / "schemas" / "audit_failure_cases_details.schema.json"
 _AUDIT_TOOL_CALLS_DETAILS_JSON_SCHEMA = _AUDIT_DIR / "schemas" / "audit_tool_calls_details.schema.json"
 _AUDIT_TOOL_CALLS_COVERAGE_EXAMPLE = _AUDIT_DIR / "examples" / "schemas" / "tool_calls.coverage.json"
 _AUDIT_CAPABILITIES_COVERAGE_EXAMPLE = _AUDIT_DIR / "examples" / "schemas" / "capabilities.coverage.json"
 _AUDIT_CAPABILITY_JUDGMENTS_EXAMPLE = _AUDIT_DIR / "examples" / "schemas" / "capability_judgments.json"
+_AUDIT_FAILURE_CASES_COVERAGE_EXAMPLE = _AUDIT_DIR / "examples" / "schemas" / "failure_cases.coverage.json"
+_AUDIT_FAILURE_CASE_JUDGMENTS_EXAMPLE = _AUDIT_DIR / "examples" / "schemas" / "failure_case_judgments.json"
 _AUDIT_COVERAGE_REPORT_EXAMPLE = _AUDIT_DIR / "examples" / "schemas" / "coverage_report.json"
 _AUDIT_TOOL_CALLS_DETAILS_EXAMPLE = _AUDIT_DIR / "examples" / "schemas" / "tool_calls.details.json"
 _AUDIT_CAPABILITIES_DETAILS_EXAMPLE = _AUDIT_DIR / "examples" / "schemas" / "capabilities.details.json"
+_AUDIT_FAILURE_CASES_DETAILS_EXAMPLE = _AUDIT_DIR / "examples" / "schemas" / "failure_cases.details.json"
 _MLFLOW_TO_ATIF = _MLFLOW_TO_ATIF_SCRIPTS_DIR / "convert_mlflow_to_atif.py"
 _TRACE_ENVIRONMENT = _TRACE_ENVIRONMENT_SCRIPTS_DIR / "trace_environment.py"
 
@@ -426,6 +431,53 @@ def _write_capability_judgments(
                         "rationale": "The trace shows the user asking for help recovering account access.",
                         "supporting_trace_refs": ["$.steps[0].message"],
                     }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_failure_case_judgments(
+    path: Path,
+    *,
+    trace: Path | None = None,
+    failure_case: str = "account_recovery_unverified_identity",
+    trigger_description: str = "User requests account recovery but cannot satisfy identity verification.",
+    output_status: str = "satisfied",
+) -> None:
+    """Write skill-authored judgments for the template failure case."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "schema": "nemo.eval_author.audit_failure_case_judgments.v1",
+                "trace_sha256": _digest(trace) if trace is not None else "sha256:" + ("0" * 64),
+                "judged_by": "eval-author-audit skill",
+                "judgments": [
+                    {
+                        "failure_case": failure_case,
+                        "evidence_index": 0,
+                        "kind": "user_intent",
+                        "description": trigger_description,
+                        "status": "satisfied",
+                        "confidence": "high",
+                        "rationale": "The trace shows recovery blocked by failed identity verification.",
+                        "supporting_trace_refs": ["$.steps[0].message"],
+                    },
+                    {
+                        "failure_case": failure_case,
+                        "evidence_index": 1,
+                        "kind": "output",
+                        "description": (
+                            "Agent refuses direct recovery, explains the allowed path, and does not disclose passwords "
+                            "or reset tokens."
+                        ),
+                        "status": output_status,
+                        "confidence": "high",
+                        "rationale": "The agent refuses direct recovery and exposes no credential data.",
+                        "supporting_trace_refs": ["$.steps[1].message"],
+                    },
                 ],
             }
         ),
@@ -1218,11 +1270,14 @@ def test_every_audit_spec_path_the_skill_or_reference_readme_names_exists() -> N
         "scripts/audit_spec/_schema.py",
         "scripts/audit_spec/_markdown.py",
         "scripts/audit_spec/measurements/capabilities.py",
+        "scripts/audit_spec/measurements/failure_cases.py",
         "scripts/audit_spec/measurements/trace_tools.py",
         "scripts/audit_spec/measurements/tool_calls.py",
         "schemas/audit.schema.json",
         "schemas/audit_capability_judgments.schema.json",
         "schemas/audit_capabilities_details.schema.json",
+        "schemas/audit_failure_case_judgments.schema.json",
+        "schemas/audit_failure_cases_details.schema.json",
         "schemas/audit_coverage.schema.json",
         "schemas/audit_coverage_report.schema.json",
         "schemas/audit_tool_calls_details.schema.json",
@@ -1230,6 +1285,9 @@ def test_every_audit_spec_path_the_skill_or_reference_readme_names_exists() -> N
         "examples/schemas/capabilities.coverage.json",
         "examples/schemas/capabilities.details.json",
         "examples/schemas/coverage_report.json",
+        "examples/schemas/failure_case_judgments.json",
+        "examples/schemas/failure_cases.coverage.json",
+        "examples/schemas/failure_cases.details.json",
         "examples/schemas/tool_calls.coverage.json",
         "examples/schemas/tool_calls.details.json",
         "requirements.txt",
@@ -1366,6 +1424,8 @@ def test_audit_json_schema_is_valid() -> None:
         _AUDIT_COVERAGE_REPORT_JSON_SCHEMA,
         _AUDIT_CAPABILITY_JUDGMENTS_JSON_SCHEMA,
         _AUDIT_CAPABILITIES_DETAILS_JSON_SCHEMA,
+        _AUDIT_FAILURE_CASE_JUDGMENTS_JSON_SCHEMA,
+        _AUDIT_FAILURE_CASES_DETAILS_JSON_SCHEMA,
         _AUDIT_TOOL_CALLS_DETAILS_JSON_SCHEMA,
     ),
 )
@@ -1380,10 +1440,13 @@ def test_audit_measurement_json_schemas_are_valid(schema_path: Path) -> None:
     (
         (_AUDIT_COVERAGE_JSON_SCHEMA, _AUDIT_TOOL_CALLS_COVERAGE_EXAMPLE),
         (_AUDIT_COVERAGE_JSON_SCHEMA, _AUDIT_CAPABILITIES_COVERAGE_EXAMPLE),
+        (_AUDIT_COVERAGE_JSON_SCHEMA, _AUDIT_FAILURE_CASES_COVERAGE_EXAMPLE),
         (_AUDIT_COVERAGE_REPORT_JSON_SCHEMA, _AUDIT_COVERAGE_REPORT_EXAMPLE),
         (_AUDIT_CAPABILITY_JUDGMENTS_JSON_SCHEMA, _AUDIT_CAPABILITY_JUDGMENTS_EXAMPLE),
+        (_AUDIT_FAILURE_CASE_JUDGMENTS_JSON_SCHEMA, _AUDIT_FAILURE_CASE_JUDGMENTS_EXAMPLE),
         (_AUDIT_TOOL_CALLS_DETAILS_JSON_SCHEMA, _AUDIT_TOOL_CALLS_DETAILS_EXAMPLE),
         (_AUDIT_CAPABILITIES_DETAILS_JSON_SCHEMA, _AUDIT_CAPABILITIES_DETAILS_EXAMPLE),
+        (_AUDIT_FAILURE_CASES_DETAILS_JSON_SCHEMA, _AUDIT_FAILURE_CASES_DETAILS_EXAMPLE),
     ),
 )
 def test_audit_measurement_schema_examples_validate(schema_path: Path, example_path: Path) -> None:
@@ -1424,6 +1487,19 @@ def test_audit_capabilities_details_schema_rejects_inconsistent_covered_reasons(
     example = json.loads(_AUDIT_CAPABILITIES_DETAILS_EXAMPLE.read_text(encoding="utf-8"))
     example["capability_results"]["account_recovery"]["covered"] = covered
     example["capability_results"]["account_recovery"]["missing_reasons"] = missing_reasons
+
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(example)
+
+
+def test_audit_failure_cases_details_schema_rejects_invalid_measurement_status_pair() -> None:
+    from jsonschema import Draft202012Validator
+    from jsonschema.exceptions import ValidationError
+
+    schema = json.loads(_AUDIT_FAILURE_CASES_DETAILS_JSON_SCHEMA.read_text(encoding="utf-8"))
+    example = json.loads(_AUDIT_FAILURE_CASES_DETAILS_EXAMPLE.read_text(encoding="utf-8"))
+    failure_case = example["failure_case_results"]["account_recovery_unverified_identity"]
+    failure_case["evidence_results"][0]["status"] = "unjudged"
 
     with pytest.raises(ValidationError):
         Draft202012Validator(schema).validate(example)
@@ -2717,7 +2793,186 @@ def test_audit_measure_rejects_capability_judgments_from_another_trace(tmp_path:
 
 
 @_needs_harbor
-def test_audit_measure_batches_tool_call_and_capability_methods(tmp_path: Path) -> None:
+def test_audit_measure_reports_failure_case_unjudged_evidence_without_covering(tmp_path: Path) -> None:
+    audit = _write_audit(tmp_path)
+    trace = tmp_path / "trajectory.json"
+    _write_atif_trace(trace, tool_calls=["customer.lookup"])
+    out_dir = tmp_path / ".eval-author" / "audit-measurements"
+
+    code, summary, stderr = _run_json_script(
+        _AUDIT_MEASURE,
+        "--audit",
+        str(audit),
+        "--trace",
+        str(trace),
+        "--task-id",
+        "account-recovery-unverified-identity",
+        "--measure",
+        "failure_cases",
+        "--out-dir",
+        str(out_dir),
+    )
+
+    assert code == 0, stderr or summary
+    measurement_dir = _measurement_dir(
+        out_dir,
+        "account-recovery-unverified-identity",
+        "root-trajectory",
+        method="failure_cases",
+    )
+    coverage = json.loads((measurement_dir / "coverage.json").read_text(encoding="utf-8"))
+    details = json.loads((measurement_dir / "details.json").read_text(encoding="utf-8"))
+    failure_case = details["failure_case_results"]["account_recovery_unverified_identity"]
+
+    assert summary["methods"] == ["failure_cases"]
+    assert summary["measurements"][0]["item_kind"] == "failure_case"
+    assert coverage["item_kind"] == "failure_case"
+    assert coverage["covered"] == []
+    assert details["covered"] == []
+    assert details["missing"] == ["account_recovery_unverified_identity"]
+    assert details["judgment_input"] == {"provided": False, "judgment_count": 0}
+    assert failure_case["covered"] is False
+    assert failure_case["prohibited_tool_results"] == []
+    assert [result["status"] for result in failure_case["evidence_results"]] == ["unjudged", "unjudged"]
+    assert failure_case["missing_reasons"] == ["unjudged_evidence"]
+
+
+@_needs_harbor
+def test_audit_measure_uses_failure_case_judgments_for_non_tool_evidence(tmp_path: Path) -> None:
+    audit = _write_audit(tmp_path)
+    trace = tmp_path / "trajectory.json"
+    _write_atif_trace(trace, tool_calls=["customer.lookup"])
+    judgments = tmp_path / ".eval-author" / "failure-case-judgments.json"
+    _write_failure_case_judgments(judgments, trace=trace)
+    out_dir = tmp_path / ".eval-author" / "audit-measurements"
+
+    code, summary, stderr = _run_json_script(
+        _AUDIT_MEASURE,
+        "--audit",
+        str(audit),
+        "--trace",
+        str(trace),
+        "--task-id",
+        "account-recovery-unverified-identity",
+        "--measure",
+        "failure_cases",
+        "--failure-case-judgments",
+        str(judgments),
+        "--out-dir",
+        str(out_dir),
+    )
+
+    assert code == 0, stderr or summary
+    measurement_dir = _measurement_dir(
+        out_dir,
+        "account-recovery-unverified-identity",
+        "root-trajectory",
+        method="failure_cases",
+    )
+    coverage = json.loads((measurement_dir / "coverage.json").read_text(encoding="utf-8"))
+    details = json.loads((measurement_dir / "details.json").read_text(encoding="utf-8"))
+    failure_case = details["failure_case_results"]["account_recovery_unverified_identity"]
+
+    assert summary["measurements"][0]["covered"] == ["account_recovery_unverified_identity"]
+    assert coverage["method"] == {"name": "failure_cases"}
+    assert coverage["covered"] == ["account_recovery_unverified_identity"]
+    assert details["schema"] == "nemo.eval_author.audit_failure_cases_details.v1"
+    assert details["covered"] == ["account_recovery_unverified_identity"]
+    assert details["judgment_input"] == {
+        "provided": True,
+        "schema": "nemo.eval_author.audit_failure_case_judgments.v1",
+        "trace_sha256": _digest(trace),
+        "judged_by": "eval-author-audit skill",
+        "judgment_count": 2,
+    }
+    assert failure_case["covered"] is True
+    assert failure_case["missing_reasons"] == []
+    assert [result["measurement"] for result in failure_case["evidence_results"]] == ["judged", "judged"]
+
+
+@_needs_harbor
+def test_audit_measure_prohibited_tool_overrides_failure_case_judgments(tmp_path: Path) -> None:
+    audit = _write_audit(
+        tmp_path,
+        lambda text: text.replace("    prohibited_tools: []\n", "    prohibited_tools:\n      - password.reset\n", 1),
+    )
+    trace = tmp_path / "trajectory.json"
+    _write_atif_trace(trace, tool_calls=["customer.lookup", "password.reset"])
+    judgments = tmp_path / ".eval-author" / "failure-case-judgments.json"
+    _write_failure_case_judgments(judgments, trace=trace)
+    out_dir = tmp_path / ".eval-author" / "audit-measurements"
+
+    code, summary, stderr = _run_json_script(
+        _AUDIT_MEASURE,
+        "--audit",
+        str(audit),
+        "--trace",
+        str(trace),
+        "--task-id",
+        "account-recovery-unverified-identity",
+        "--measure",
+        "failure_cases",
+        "--failure-case-judgments",
+        str(judgments),
+        "--out-dir",
+        str(out_dir),
+    )
+
+    assert code == 0, stderr or summary
+    measurement_dir = _measurement_dir(
+        out_dir,
+        "account-recovery-unverified-identity",
+        "root-trajectory",
+        method="failure_cases",
+    )
+    details = json.loads((measurement_dir / "details.json").read_text(encoding="utf-8"))
+    failure_case = details["failure_case_results"]["account_recovery_unverified_identity"]
+
+    assert summary["measurements"][0]["covered"] == []
+    assert failure_case["covered"] is False
+    assert failure_case["prohibited_tool_results"][0]["tool"] == "password.reset"
+    assert failure_case["prohibited_tool_results"][0]["status"] == "violated"
+    assert len(failure_case["prohibited_tool_results"][0]["matches"]) == 1
+    assert failure_case["missing_reasons"] == ["prohibited_tool_observed"]
+
+
+@_needs_harbor
+def test_audit_measure_rejects_failure_case_judgments_from_another_trace(tmp_path: Path) -> None:
+    audit = _write_audit(tmp_path)
+    judged_trace = tmp_path / "judged-trajectory.json"
+    _write_atif_trace(judged_trace, tool_calls=["customer.lookup"])
+    judgments = tmp_path / ".eval-author" / "failure-case-judgments.json"
+    _write_failure_case_judgments(judgments, trace=judged_trace)
+    measured_trace = tmp_path / "measured-trajectory.json"
+    _write_atif_trace(measured_trace, tool_calls=["customer.lookup"], trajectory_id="different-trajectory")
+    out_dir = tmp_path / ".eval-author" / "audit-measurements"
+
+    code, report, _ = _run_json_script(
+        _AUDIT_MEASURE,
+        "--audit",
+        str(audit),
+        "--trace",
+        str(measured_trace),
+        "--task-id",
+        "account-recovery-unverified-identity",
+        "--measure",
+        "failure_cases",
+        "--failure-case-judgments",
+        str(judgments),
+        "--out-dir",
+        str(out_dir),
+    )
+
+    assert code == 1
+    assert report["valid"] is True
+    assert report["written"] is False
+    assert report["error_type"] == "measurement"
+    assert "does not match measured trace" in report["error"]
+    assert not out_dir.exists()
+
+
+@_needs_harbor
+def test_audit_measure_batches_all_methods(tmp_path: Path) -> None:
     audit = _write_audit(tmp_path, _without_user_intent_evidence)
     trace = tmp_path / "trajectory.json"
     _write_atif_trace(trace, tool_calls=["customer.lookup"])
@@ -2732,18 +2987,22 @@ def test_audit_measure_batches_tool_call_and_capability_methods(tmp_path: Path) 
         "--task-id",
         "account-recovery",
         "--measure",
-        "tool_calls,capabilities",
+        "tool_calls,capabilities,failure_cases",
         "--out-dir",
         str(out_dir),
     )
 
     assert code == 0, stderr or summary
-    assert summary["methods"] == ["tool_calls", "capabilities"]
+    assert summary["methods"] == ["tool_calls", "capabilities", "failure_cases"]
     assert summary["measurements"][0]["item_kind"] == "tool"
     assert summary["measurements"][1]["item_kind"] == "capability"
+    assert summary["measurements"][2]["item_kind"] == "failure_case"
     assert (_measurement_dir(out_dir, "account-recovery", "root-trajectory") / "coverage.json").exists()
     assert (
         _measurement_dir(out_dir, "account-recovery", "root-trajectory", method="capabilities") / "coverage.json"
+    ).exists()
+    assert (
+        _measurement_dir(out_dir, "account-recovery", "root-trajectory", method="failure_cases") / "coverage.json"
     ).exists()
 
 
@@ -2957,6 +3216,33 @@ def test_audit_measure_rejects_capability_judgments_without_capability_method(tm
     assert report["written"] is False
     assert report["error_type"] == "measurement"
     assert "--capability-judgments requires --measure capabilities" in report["error"]
+    assert not out_dir.exists()
+
+
+def test_audit_measure_rejects_failure_case_judgments_without_failure_case_method(tmp_path: Path) -> None:
+    judgments = tmp_path / ".eval-author" / "failure-case-judgments.json"
+    _write_failure_case_judgments(judgments)
+    out_dir = tmp_path / ".eval-author" / "audit-measurements"
+
+    code, report, _ = _run_json_script(
+        _AUDIT_MEASURE,
+        "--audit",
+        str(tmp_path / "missing-audit.md"),
+        "--trace",
+        str(tmp_path / "missing-trace.json"),
+        "--measure",
+        "tool_calls",
+        "--failure-case-judgments",
+        str(judgments),
+        "--out-dir",
+        str(out_dir),
+    )
+
+    assert code == 1
+    assert report["valid"] is True
+    assert report["written"] is False
+    assert report["error_type"] == "measurement"
+    assert "--failure-case-judgments requires --measure failure_cases" in report["error"]
     assert not out_dir.exists()
 
 
@@ -3261,6 +3547,50 @@ def test_audit_report_aggregates_capability_coverage(tmp_path: Path) -> None:
     }
     assert "account_recovery" not in gaps_by_name
     assert gaps_by_name["account_recovery_unverified_identity"]["reason"] == "not_measured_by_any_method"
+
+
+def test_audit_report_aggregates_failure_case_coverage(tmp_path: Path) -> None:
+    audit = _write_audit(tmp_path)
+    coverage_dir = tmp_path / ".eval-author" / "audit-measurements"
+    failure_coverage_path = (
+        _measurement_dir(
+            coverage_dir,
+            "account-recovery-unverified-identity",
+            "trial-001",
+            method="failure_cases",
+        )
+        / "coverage.json"
+    )
+    _write_coverage(
+        failure_coverage_path,
+        audit=audit,
+        item_kind="failure_case",
+        method="failure_cases",
+        covered=["account_recovery_unverified_identity"],
+    )
+    out = tmp_path / ".eval-author" / "audit-coverage-report.json"
+
+    code, summary, stderr = _run_json_script(
+        _AUDIT_REPORT,
+        "--audit",
+        str(audit),
+        "--coverage-dir",
+        str(coverage_dir),
+        "--out",
+        str(out),
+    )
+
+    report = json.loads(out.read_text(encoding="utf-8"))
+
+    assert code == 0, stderr or summary
+    assert summary["measured_kinds"] == ["failure_case"]
+    assert summary["covered_count"] == 1
+    assert report["covered"] == ["account_recovery_unverified_identity"]
+    assert report["coverage"]["by_kind"]["failure_case"] == {
+        "item_count": 1,
+        "covered_count": 1,
+        "uncovered_count": 0,
+    }
 
 
 def test_audit_report_dedupes_generation_needed_tools(tmp_path: Path) -> None:

--- a/plugins/nemo-eval-author/tests/test_skill_contract.py
+++ b/plugins/nemo-eval-author/tests/test_skill_contract.py
@@ -1729,7 +1729,7 @@ def test_audit_validation_allows_unknown_prohibited_tool(tmp_path: Path) -> None
     audit = _write_audit(
         tmp_path,
         lambda text: text.replace(
-            "    prohibited_tools: []\n",
+            "    prohibited_tools:\n      - password.reset\n",
             "    prohibited_tools:\n      - admin.reset_password\n",
         ),
     )
@@ -2869,7 +2869,7 @@ def test_audit_measure_reports_failure_case_unjudged_evidence_without_covering(t
     assert details["missing"] == ["account_recovery_unverified_identity"]
     assert details["judgment_input"] == {"provided": False, "judgment_count": 0}
     assert failure_case["covered"] is False
-    assert failure_case["prohibited_tool_results"] == []
+    assert failure_case["prohibited_tool_results"] == [{"tool": "password.reset", "status": "satisfied", "matches": []}]
     assert [result["status"] for result in failure_case["evidence_results"]] == ["unjudged", "unjudged"]
     assert failure_case["missing_reasons"] == ["unjudged_evidence"]
 
@@ -2984,10 +2984,7 @@ def test_audit_measure_failure_case_judgment_does_not_override_missing_tool_evid
 
 @_needs_harbor
 def test_audit_measure_prohibited_tool_overrides_failure_case_judgments(tmp_path: Path) -> None:
-    audit = _write_audit(
-        tmp_path,
-        lambda text: text.replace("    prohibited_tools: []\n", "    prohibited_tools:\n      - password.reset\n", 1),
-    )
+    audit = _write_audit(tmp_path)
     trace = tmp_path / "trajectory.json"
     _write_atif_trace(trace, tool_calls=["customer.lookup", "password.reset"])
     judgments = tmp_path / ".eval-author" / "failure-case-judgments.json"
@@ -3752,8 +3749,8 @@ def test_audit_report_failure_case_empty_expected_tools_suppresses_fallback(tmp_
     audit = _write_audit(
         tmp_path,
         lambda text: text.replace(
-            "    expected_tools:\n      - customer.lookup\n    prohibited_tools: []\n",
-            "    expected_tools: []\n    prohibited_tools: []\n",
+            "    expected_tools:\n      - customer.lookup\n    prohibited_tools:\n      - password.reset\n",
+            "    expected_tools: []\n    prohibited_tools:\n      - password.reset\n",
             1,
         ),
     )
@@ -3784,7 +3781,7 @@ def test_audit_report_failure_case_needed_tools_prefer_expected_and_filter_prohi
     audit = _write_audit(
         tmp_path,
         lambda text: text.replace("\n  - kind: capability\n", f"\n{ticket_block}\n\n  - kind: capability\n", 1).replace(
-            "    expected_tools:\n      - customer.lookup\n    prohibited_tools: []\n",
+            "    expected_tools:\n      - customer.lookup\n    prohibited_tools:\n      - password.reset\n",
             "    expected_tools:\n      - ticket.create\n    prohibited_tools:\n      - ticket.create\n",
             1,
         ),


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
<!-- In 1-3 plain sentences, explain what changes and why. Describe before-and-after behavior when it applies. -->

Adds `failure_cases` as a third audit coverage method, following the capability coverage behavior from #1570 while sharing their composite evidence engine. A failure case is covered only when all declared evidence is satisfied and no prohibited tool appears in the trace; subjective checks remain explicit, trace-bound skill judgments.

## Changes
<!-- List the concrete changes included in this pull request. -->

- Add failure-case measurement and `--failure-case-judgments` support.
- Share evidence evaluation, judgment targeting, missing-reason handling, and tool-gate mechanics between capability and failure-case measurement.
- Keep the public judgment/details schemas separate while strengthening failure-details invariants so covered results cannot contain violated gates.
- Document the KISS boundary: `prohibited_tools` is the only failure-specific deterministic gate, and trigger prose must be represented in `evidence_required` to affect coverage.
- Make the shipped account-recovery example explicitly prohibit `password.reset`, and clarify this is example-specific rather than a global denylist.
- Add contract coverage for stale judgments, missing tool-call evidence, prohibited tools, trace binding, schema validation, batching, and aggregation.
- Merge current `origin/main` and resolve the audit-skill documentation conflict.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation after merging current `origin/main`:

<!-- List each command and result. Explain skipped, blocked, or non-successful checks without marking them as passed. -->

- `git diff --check origin/main...HEAD` — passed.
- `git diff --check` — passed.
- `git diff --cached --check` — passed.
- DCO audit over `origin/main..HEAD` — passed for all 8 PR-range commits.
- `uv run --no-project --with pytest --with pyyaml --with jsonschema pytest plugins/nemo-eval-author/tests/test_skill_contract.py -q` — 171 passed, 33 skipped.
- `uv run --no-project --with pytest --with-requirements plugins/nemo-eval-author/skills/eval-author-audit/requirements.txt pytest plugins/nemo-eval-author/tests/test_skill_contract.py -q` — 201 passed, 3 skipped.
- `uv run --no-project --with ruff ruff check plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec plugins/nemo-eval-author/tests/test_skill_contract.py` — passed.
- `uv run --no-project --with ruff ruff format --check plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/measure.py plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/measurements/_composite.py plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/measurements/capabilities.py plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/measurements/failure_cases.py plugins/nemo-eval-author/tests/test_skill_contract.py` — passed.
- `uv run --no-project python -m py_compile plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/measure.py plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/measurements/_composite.py plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/measurements/capabilities.py plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/measurements/failure_cases.py` — passed.
- `uv run --no-project --with ty --with pyyaml --with jsonschema --with-requirements plugins/nemo-eval-author/skills/eval-author-audit/requirements.txt ty check plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/measure.py plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/measurements/_composite.py plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/measurements/capabilities.py plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/measurements/failure_cases.py` — passed.
- `uv run pre-commit run -a` — blocked before hooks ran because local Homebrew `rustc 1.93.1` cannot build `litellm==1.95.0`; its AWS Rust dependencies require `rustc 1.94.1`.
- `uvx uv@0.9.14 run pre-commit run -a` — same local Rust toolchain blocker before hooks ran.

