### PR TITLE
fix(customizer): vendor nemo-gym in the RL image so native-v1 can install

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -128,7 +128,7 @@ variable "NEMO_RL_REPO" {
 # RL pins Gym as a git submodule (-> soluwalana/Gym over https), so Gym rides in with the RL git ADD
 # - no separate Gym pin needed.
 variable "NEMO_RL_REF" {
-  default = "07090a9875e8535a185e925e5f1ebd137e7f4d6b" # soluwalana/RL nmp/customizer
+  default = "9932dc8aa63a55fd431670d1b7c9d0bf3b2d2373" # soluwalana/RL nmp/customizer
 }
 variable "RL_BASE_CONTEXT" {
   default = ""

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -128,7 +128,7 @@ variable "NEMO_RL_REPO" {
 # RL pins Gym as a git submodule (-> soluwalana/Gym over https), so Gym rides in with the RL git ADD
 # - no separate Gym pin needed.
 variable "NEMO_RL_REF" {
-  default = "eab835b111b78d90c3629b26af9b3f12dc0d0d29" # soluwalana/RL nmp/customizer
+  default = "07090a9875e8535a185e925e5f1ebd137e7f4d6b" # soluwalana/RL nmp/customizer
 }
 variable "RL_BASE_CONTEXT" {
   default = ""

--- a/docker/rl/Dockerfile.nmp-rl-base
+++ b/docker/rl/Dockerfile.nmp-rl-base
@@ -133,10 +133,8 @@ ENV RAY_USAGE_STATS_ENABLED=0 \
     NEMO_GYM_VENV_DIR=/opt/gym_venvs
 
 # ---- gym-wheel: an installable nemo-gym for the Gym per-server venvs ----
-# Gym pins each staged server's venv to `nemo-gym==<the parent venv's version>` and resolves it
-# from a package index; this image runs a fork whose version is published nowhere, so every
-# native-v1 job died at spin-up (nvbug 6716627). Vendoring the wheel fixes that for every
-# environment. Rationale and the build-time guards live in the script.
+# Gym resolves `nemo-gym==<parent version>` from an index for every staged server, and this
+# image's fork version is published nowhere. See scripts/build-gym-wheel.sh for the why.
 FROM base AS gym-wheel
 COPY --from=nemo-rl 3rdparty/Gym-workspace/Gym /build/Gym
 RUN --mount=type=bind,source=docker/rl/scripts/build-gym-wheel.sh,target=/build/build-gym-wheel.sh \
@@ -552,20 +550,14 @@ RUN apt-get purge -y ccache vim vim-common less >/dev/null 2>&1 || true; \
         /opt/nvidia/nsight-systems-cli /opt/nvidia/nsight-compute \
         /usr/local/bin/nsys /usr/local/bin/nsys-ui /usr/local/bin/ncu /usr/local/bin/ncu-ui \
     || true
-# The vendored nemo-gym wheel (see the gym-wheel stage) and the env var that makes Gym's
-# per-server `uv pip install nemo-gym==<version>` resolve it. uv reads UV_FIND_LINKS natively, so
-# no Gym change is needed, and Gym's run_command copies os.environ into each server subprocess.
-#
-# Additive, not a redirect: everything else still resolves from the index, which native-v1 needs.
-# Safe for wheels-v1 too -- configure_environment_wheelhouse PREPENDS the package's own wheelhouse
-# and preserves what is already here, so an offline job still resolves from its own closure first.
-# Set in this stage, not in `base`: during the build the directory does not exist yet, and uv
-# errors on a find-links path it cannot open.
+# UV_FIND_LINKS below is additive: it adds nemo-gym as a local candidate, and everything else
+# still resolves from the index. Copied here rather than in `base` so the build's own uv steps
+# never see a find-links path that does not exist yet.
 COPY --from=gym-wheel /opt/gym-wheels /opt/gym-wheels
 
-# NO_VCS_VERSION=1: with no .git present, nemo_rl/package_info.py's `git rev-parse` would fail on
-# every `import nemo_rl` (harmlessly, but it forks a subprocess each time, and this image starts
-# many worker processes). The flag is package_info.py's own opt-out, so the lookup is skipped.
+# NO_VCS_VERSION=1: with no .git present, nemo_rl/package_info.py's `git rev-parse` would fail on every
+# `import nemo_rl` (harmlessly, but it forks a subprocess each time, and this image starts many
+# worker processes). The flag is package_info.py's own opt-out, so the lookup is skipped entirely.
 ENV VIRTUAL_ENV=/opt/nemo_rl_venv \
     HF_HUB_ENABLE_HF_TRANSFER=1 \
     PATH="/opt/nemo_rl_venv/bin:/usr/local/bin:${PATH}" \

--- a/docker/rl/Dockerfile.nmp-rl-base
+++ b/docker/rl/Dockerfile.nmp-rl-base
@@ -132,6 +132,16 @@ ENV RAY_USAGE_STATS_ENABLED=0 \
     NEMO_RL_VENV_DIR=/opt/ray_venvs \
     NEMO_GYM_VENV_DIR=/opt/gym_venvs
 
+# ---- gym-wheel: an installable nemo-gym for the Gym per-server venvs ----
+# Gym pins each staged server's venv to `nemo-gym==<the parent venv's version>` and resolves it
+# from a package index; this image runs a fork whose version is published nowhere, so every
+# native-v1 job died at spin-up (nvbug 6716627). Vendoring the wheel fixes that for every
+# environment. Rationale and the build-time guards live in the script.
+FROM base AS gym-wheel
+COPY --from=nemo-rl 3rdparty/Gym-workspace/Gym /build/Gym
+RUN --mount=type=bind,source=docker/rl/scripts/build-gym-wheel.sh,target=/build/build-gym-wheel.sh \
+    bash /build/build-gym-wheel.sh /build/Gym /opt/gym-wheels
+
 # ---- builder: uv sync RL + Gym with the extras we use ----
 # fsdp (DPO training), automodel (GRPO training on DTensor V2, the only LoRA-capable DTensor
 # backend), mcore (Megatron training + Megatron-native generation), vllm (generation), nemo_gym and
@@ -542,12 +552,24 @@ RUN apt-get purge -y ccache vim vim-common less >/dev/null 2>&1 || true; \
         /opt/nvidia/nsight-systems-cli /opt/nvidia/nsight-compute \
         /usr/local/bin/nsys /usr/local/bin/nsys-ui /usr/local/bin/ncu /usr/local/bin/ncu-ui \
     || true
-# NO_VCS_VERSION=1: with no .git present, nemo_rl/package_info.py's `git rev-parse` would fail on every
-# `import nemo_rl` (harmlessly, but it forks a subprocess each time, and this image starts many
-# worker processes). The flag is package_info.py's own opt-out, so the lookup is skipped entirely.
+# The vendored nemo-gym wheel (see the gym-wheel stage) and the env var that makes Gym's
+# per-server `uv pip install nemo-gym==<version>` resolve it. uv reads UV_FIND_LINKS natively, so
+# no Gym change is needed, and Gym's run_command copies os.environ into each server subprocess.
+#
+# Additive, not a redirect: everything else still resolves from the index, which native-v1 needs.
+# Safe for wheels-v1 too -- configure_environment_wheelhouse PREPENDS the package's own wheelhouse
+# and preserves what is already here, so an offline job still resolves from its own closure first.
+# Set in this stage, not in `base`: during the build the directory does not exist yet, and uv
+# errors on a find-links path it cannot open.
+COPY --from=gym-wheel /opt/gym-wheels /opt/gym-wheels
+
+# NO_VCS_VERSION=1: with no .git present, nemo_rl/package_info.py's `git rev-parse` would fail on
+# every `import nemo_rl` (harmlessly, but it forks a subprocess each time, and this image starts
+# many worker processes). The flag is package_info.py's own opt-out, so the lookup is skipped.
 ENV VIRTUAL_ENV=/opt/nemo_rl_venv \
     HF_HUB_ENABLE_HF_TRANSFER=1 \
     PATH="/opt/nemo_rl_venv/bin:/usr/local/bin:${PATH}" \
+    UV_FIND_LINKS=/opt/gym-wheels \
     NO_VCS_VERSION=1
 
 # The venv's python symlinks to CPython under /opt/cpython, nemo_rl is installed

--- a/docker/rl/scripts/build-gym-wheel.sh
+++ b/docker/rl/scripts/build-gym-wheel.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 # Build an installable nemo-gym wheel for the Gym per-server venvs.
 #
 # Gym rewrites the install line for any server directory that is NOT inside a Gym checkout --

--- a/docker/rl/scripts/build-gym-wheel.sh
+++ b/docker/rl/scripts/build-gym-wheel.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Build an installable nemo-gym wheel for the Gym per-server venvs.
+#
+# Gym rewrites the install line for any server directory that is NOT inside a Gym checkout --
+# which a platform environment FileSet staged at /job/environment never is. It strips the editable
+# line and substitutes `nemo-gym==<the parent venv's version>`, resolved from a package INDEX
+# (nemo_gym/cli/setup_command.py, _get_nemo_gym_version_spec). This image runs the soluwalana fork,
+# whose version is published nowhere, so that resolution has no candidate and every native-v1 job
+# dies at server spin-up with "No solution found when resolving: nemo-gym" (nvbug 6716627).
+#
+# The pin is exact, so a wheel built at any other version is invisible to it and the job fails
+# exactly as before -- hence the version check at the end.
+set -euo pipefail
+
+GYM_SRC=${1:?usage: build-gym-wheel.sh <gym-source-dir> <out-dir>}
+OUT_DIR=${2:?usage: build-gym-wheel.sh <gym-source-dir> <out-dir>}
+
+# Upstream declares almost no package-data, relying on setuptools-scm's VCS file-finder to sweep
+# the configs and READMEs into the wheel. That finder needs git, and there is none here: the RL
+# source arrives by `ADD <repo>#<ref>`, which keeps no submodule .git (a submodule's .git is a
+# gitdir pointer file, not a directory). Left alone the wheel builds and installs happily while
+# quietly missing every YAML, including the sandbox provider configs. Declare the data explicitly
+# rather than depend on VCS state this build cannot have.
+PKG_DATA_LINE='nemo_gym = ["resources/*.py"]'
+if ! grep -qxF "${PKG_DATA_LINE}" "${GYM_SRC}/pyproject.toml"; then
+    echo "build-gym-wheel: Gym's [tool.setuptools.package-data] entry moved;" \
+         "re-check this substitution against ${GYM_SRC}/pyproject.toml" >&2
+    exit 1
+fi
+# Fully single-quoted, and the brackets/dots/stars escaped: unescaped, `["resources/*.py"]` is a
+# BRE character class, which matches nothing here and would edit the file silently not at all.
+sed -i 's|^nemo_gym = \["resources/\*\.py"\]$|nemo_gym = ["resources/*.py", "**/*.yaml", "**/*.yml", "**/*.md"]\n"*" = ["**/*.yaml", "**/*.yml", "**/*.json", "**/*.md", "**/*.txt"]|' \
+    "${GYM_SRC}/pyproject.toml"
+
+# --no-config: uv would otherwise discover the platform workspace's `required-version` pin
+# (docker/rl/pyproject.workspace.toml, uv <0.10) and refuse to run as this image's uv 0.11.
+uv build --no-config --wheel --out-dir "${OUT_DIR}" "${GYM_SRC}"
+
+# Fail here rather than at spin-up on a GPU node: a wheel at the wrong version, or one missing the
+# package data above, installs cleanly and only misbehaves later.
+shopt -s nullglob
+wheels=("${OUT_DIR}"/nemo_gym-*.whl)
+if [[ ${#wheels[@]} -ne 1 ]]; then
+    echo "build-gym-wheel: expected exactly one wheel, got: ${wheels[*]:-none}" >&2
+    exit 1
+fi
+# package_info.py assembles __version__ from MAJOR/MINOR/PATCH/PRE_RELEASE and imports nothing,
+# so it can be read without installing the package it describes.
+expected="nemo_gym-$(python -c \
+    'import runpy, sys; print(runpy.run_path(sys.argv[1])["__version__"])' \
+    "${GYM_SRC}/nemo_gym/package_info.py")-py3-none-any.whl"
+if [[ "$(basename "${wheels[0]}")" != "${expected}" ]]; then
+    echo "build-gym-wheel: built $(basename "${wheels[0]}"), expected ${expected}" >&2
+    exit 1
+fi
+probe="nemo_gym/sandbox/providers/opensandbox/configs/opensandbox.yaml"
+# Listed into a variable rather than piped into grep: `grep -q` exits at the first match, unzip
+# takes SIGPIPE, and `set -o pipefail` then reports the pipeline as failed -- so a file that IS
+# present reads as missing.
+entries="$(unzip -Z1 "${wheels[0]}")"
+if ! grep -qxF "${probe}" <<<"${entries}"; then
+    echo "build-gym-wheel: ${probe} missing from the wheel; package-data did not take" >&2
+    exit 1
+fi
+echo "build-gym-wheel: built $(basename "${wheels[0]}")"


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
For every Gym server, Gym checks whether it is an editable install in the working directory. If it is not, it installs nemo-gym from a wheel pinned to the parent venv's version: https://github.com/soluwalana/Gym/blob/nmp/customizer/nemo_gym/cli/setup_command.py#L80

A staged environment FileSet is never an editable install, so every native-v1 server takes that path and asks an index for `nemo-gym==0.5.0rc0`. That is our fork's version and it is not published anywhere, PyPI has 0.5.0 and 0.5.1, no rc0. So the server venv never builds and the job fails at spin-up
```
    No solution found when resolving dependencies:
    Because there is no version of nemo-gym==0.5.0rc0 ...
```
This affects every native-v1 environment.

## Related Issue
<!-- Use Fixes #NNN or Closes #NNN for a related issue. Remove this section if there is none. -->

## Changes
- Build the wheel from the Gym submodule already in the image and set `UV_FIND_LINKS=/opt/gym-wheels`. Gym's install then finds it locally, and everything else still comes from the index as before.
- Letting it fall through to PyPI's `0.5.0` is not an option, the server venv would run upstream Gym while the actor runs our fork.
- `UV_FIND_LINKS` is additive and takes multiple paths, so it does not change how any other dependency resolves. It holds one wheel: nemo-gym.
- Gym relies on setuptools-scm's git file-finder to put configs in the wheel, and there is no git in this build. The build script declares that data explicitly and fails if it is missing, so we cannot ship a wheel that installs cleanly but has no YAML in it.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [ ] Pull request title follows the repository's Conventional Commit format
- [ ] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [ ] Targeted tests pass, or tests are marked not applicable above
- [ ] No secrets, API keys, or credentials are included

Targeted validation:

<!-- List each command and result. Explain skipped, blocked, or non-successful checks without marking them as passed. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * NeMo-Gym is now packaged and included in the RL base image, allowing installations to use the bundled wheel.
  * Required Gym configuration and documentation resources are included with the packaged component.

* **Bug Fixes**
  * Improved package validation helps ensure the bundled wheel is complete, correctly versioned, and contains required files.

* **Chores**
  * Updated the NeMo-RL base image to a newer pinned source revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->