### PR TITLE
docs: align release notes setup guidance

### DIFF
--- a/docs/about/release-notes/current-release.mdx
+++ b/docs/about/release-notes/current-release.mdx
@@ -135,18 +135,9 @@ operations for the 0.5 release line.
 
 ## Install
 
-For a fresh local checkout:
-
-```bash
-git clone https://github.com/NVIDIA-NeMo/nemo-platform.git
-cd nemo-platform
-make bootstrap
-source .venv/bin/activate
-nemo setup
-```
-
-See [Setup](/documentation/get-started/setup) for prerequisites and provider
-configuration.
+For fresh local installs, see [Setup](/documentation/get-started/setup).
+It covers the recommended PyPI install, source-checkout prerequisites, Flox
+activation, the system-toolchain fallback, and provider configuration.
 
 For self-managed Kubernetes, start with
 [Install NeMo Platform Helm Chart](/documentation/kubernetes-deployment/setup/helm/install).
@@ -163,7 +154,16 @@ From an existing local checkout:
 git fetch
 git checkout main
 make bootstrap
-source .venv/bin/activate
+flox -q activate
+```
+
+Without Flox, install the system toolchain versions printed by
+`make toolchain-versions`, plus a C compiler, then run
+`make TOOLCHAIN=system bootstrap` followed by `source .venv/bin/activate`.
+
+Run setup after updating the checkout:
+
+```bash
 nemo setup
 ```
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
Aligns the v0.5.0 current release notes install and upgrade guidance with the canonical Setup page. The release note now defers fresh local installs to Setup and uses the Flox-first source checkout activation guidance for v0.4.x upgrades.

## Changes
- Replace the fresh local checkout command block with a link to Setup, which documents PyPI, source checkout prerequisites, Flox activation, and the system-toolchain fallback.
- Update the v0.4.x source-checkout upgrade block to use `flox -q activate` after `make bootstrap`.
- Move `nemo setup` into a separate post-update command block and keep the existing restart and ethos migration guidance.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [x] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: Documentation-only release note wording update.
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `make docs-check` — passed.
- `make docs-broken-links` — completed and reported 80 existing broken links outside `docs/about/release-notes/current-release.mdx` on the release docs tree.
- `flox activate -- uv run pre-commit run -a` — passed.
- DCO audit for `origin/release/0.5..HEAD` — passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to direct new local users to the setup guide.
  * Expanded upgrade guidance with Flox activation, a system-toolchain fallback, and explicit setup steps after updating.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->