### PR TITLE
fix(sandboxed-gym): stop blaming the sandbox for a body it may never have sent

### DIFF
--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/sandboxed.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/sandboxed.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import json
 import logging
 import tempfile
+import time
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
@@ -47,6 +48,7 @@ from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalRunConfig, AgentEvalTas
 from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial, RunnerInfo
 from nemo_evaluator_sdk.values.results import AggregateScore
 from pydantic import BaseModel, ConfigDict, Field
+from sandboxed_gym.host.models import MIN_PROXY_CUTOFF_S
 
 logger = logging.getLogger(__name__)
 
@@ -128,7 +130,7 @@ class SandboxedGymAgentTaskRunner:
             headers[PROXY_AUTH_HEADER] = self._config.auth_token
         return headers
 
-    def _decode_body(self, response: httpx.Response) -> Any:
+    def _decode_body(self, response: httpx.Response, elapsed: float | None = None) -> Any:
         """Decode a 2xx rollout body, naming the host when there is nothing decodable in it.
 
         The host commits its 200 before the batch finishes and pads the open connection with
@@ -147,12 +149,28 @@ class SandboxedGymAgentTaskRunner:
             raise RuntimeError(
                 f"sandboxed Gym host returned a body that is not UTF-8 from {self._config.rollout_url}: {exc}"
             ) from exc
+        if not text:
+            if elapsed is not None and elapsed < MIN_PROXY_CUTOFF_S:
+                raise RuntimeError(
+                    f"sandboxed Gym host at {self._config.rollout_url} answered and then sent "
+                    f"nothing in {elapsed:.1f}s -- too fast to have been cut in transit, so it "
+                    f"died before it could write; check whether the sandbox was OOMKilled or "
+                    f"evicted"
+                )
+            raise RuntimeError(
+                f"sandboxed Gym host at {self._config.rollout_url} sent no body at all"
+                + (f" in {elapsed:.1f}s" if elapsed is not None else "")
+                + " -- nothing was ever written. Either it died before writing anything (check the "
+                "sandbox for an OOMKill or an eviction), or its image predates the rollout "
+                "heartbeat and the proxy cut the silent request at its own cap. Without a "
+                "Content-Length the body ends at the close, so this client cannot tell them apart"
+            )
         if not text.strip():
             raise RuntimeError(
                 f"sandboxed Gym host at {self._config.rollout_url} answered and then stopped "
-                f"without sending a `results` envelope ({len(response.content)} byte(s) of heartbeat "
-                f"only); it most likely died mid-batch -- check whether the sandbox was OOMKilled "
-                f"or evicted"
+                f"without sending a `results` envelope ({len(response.content)} byte(s) of "
+                f"heartbeat, then silence); it most likely died mid-batch -- check whether the "
+                f"sandbox was OOMKilled or evicted"
             )
         try:
             # The host heartbeats leading whitespace while a batch runs; json tolerates it.
@@ -168,12 +186,14 @@ class SandboxedGymAgentTaskRunner:
 
     async def _collect(self, examples: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """POST the examples and return the host's rollout records."""
+        started = time.monotonic()
         async with httpx.AsyncClient(timeout=self._config.timeout_s) as client:
             response = await client.post(
                 self._config.rollout_url,
                 json={"examples": examples},
                 headers=self._request_headers(),
             )
+        elapsed = time.monotonic() - started
         if response.status_code >= 400:
             # The body is the host's own error envelope; it names which example or server failed,
             # which the status code alone does not.
@@ -181,7 +201,7 @@ class SandboxedGymAgentTaskRunner:
                 f"sandboxed Gym host returned {response.status_code} from {self._config.rollout_url}: "
                 f"{response.text[:2000]}"
             )
-        body = self._decode_body(response)
+        body = self._decode_body(response, elapsed)
         error = body.get("error") if isinstance(body, Mapping) else None
         if error is not None:
             # The host commits its 200 before the batch finishes, so that it can hold the

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_gym_sandboxed_runtime.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_gym_sandboxed_runtime.py
@@ -197,6 +197,56 @@ async def test_a_heartbeat_only_200_names_the_host_as_the_failure(tasks, tmp_pat
     assert "error" in message.lower() or "results" in message.lower()
 
 
+async def test_a_body_free_200_names_both_causes(tasks, tmp_path, monkeypatch) -> None:
+    """Zero bytes, not even heartbeat padding.
+
+    A host that died before writing and a silent host whose request the proxy truncated arrive
+    identically, because without a Content-Length the body ends at the close. The runner must
+    offer both and the check for each, not pick one.
+    """
+    host = _FakeHost(content=b"")
+    runner = runner_against(host, monkeypatch)
+    # The runner times its own POST; a MockTransport answers instantly, so stand in for the wait.
+    monkeypatch.setattr(
+        "nemo_evaluator_sdk.agent_eval.runtimes.gym.sandboxed.time.monotonic",
+        _clock_advancing_by(180.0),
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await runner.run_tasks(tasks, AgentEvalRunConfig(work_dir=tmp_path))
+
+    message = str(excinfo.value)
+    assert ROLLOUT_URL in message
+    assert "OOMKill" in message
+    assert "predates the rollout heartbeat" in message
+
+
+async def test_a_body_free_200_that_arrived_fast_blames_the_sandbox_alone(tasks, tmp_path, monkeypatch) -> None:
+    host = _FakeHost(content=b"")
+    runner = runner_against(host, monkeypatch)
+    monkeypatch.setattr(
+        "nemo_evaluator_sdk.agent_eval.runtimes.gym.sandboxed.time.monotonic",
+        _clock_advancing_by(2.0),
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await runner.run_tasks(tasks, AgentEvalRunConfig(work_dir=tmp_path))
+
+    message = str(excinfo.value)
+    assert "OOMKilled" in message
+    assert "heartbeat" not in message
+
+
+def _clock_advancing_by(delta: float):
+    """A monotonic clock whose second reading is ``delta`` later than its first."""
+    readings = iter((0.0, delta))
+
+    def _clock() -> float:
+        return next(readings, delta)
+
+    return _clock
+
+
 async def test_a_non_json_200_names_the_host_rather_than_the_decoder(tasks, tmp_path, monkeypatch) -> None:
     """A non-empty body that is not JSON is a broken response contract, not an evaluator bug.
 

--- a/packages/sandboxed_gym/src/sandboxed_gym/host/models.py
+++ b/packages/sandboxed_gym/src/sandboxed_gym/host/models.py
@@ -26,6 +26,8 @@ DEFAULT_HOST_READY_TIMEOUT_S = 15 * 60
 DEFAULT_ROLLOUT_TIMEOUT_S = 30 * 60
 # A batch is split into bounded POSTs so request duration and response size track the chunk rather
 # than the batch. Tune the two together: concurrency offsets the split.
+#: A request that failed faster than this cannot have been cut for staying open too long.
+MIN_PROXY_CUTOFF_S = 30.0
 DEFAULT_ROLLOUT_CHUNK_SIZE = 8
 DEFAULT_ROLLOUT_MAX_IN_FLIGHT = 8
 # Applied to transport failures only. An error the host itself reported is deterministic, so

--- a/packages/sandboxed_gym/src/sandboxed_gym/orchestrator.py
+++ b/packages/sandboxed_gym/src/sandboxed_gym/orchestrator.py
@@ -25,6 +25,7 @@ from urllib.parse import urlparse
 from sandboxed_gym.broker import EpisodeBrokerServer
 from sandboxed_gym.config import BrokerEndpoint
 from sandboxed_gym.host.models import (
+    MIN_PROXY_CUTOFF_S,
     GymHostEgressRule,
     GymHostHandle,
     GymHostSpec,
@@ -44,10 +45,6 @@ from sandboxed_gym.serve_config import (
 LOGGER = logging.getLogger(__name__)
 
 T = TypeVar("T")
-
-#: Below this a request cannot have been cut for staying open too long, so the host went away
-#: instead. Only used to choose which hint an error carries.
-MIN_PROXY_CUTOFF_S = 30.0
 
 
 class RolloutTransportError(RuntimeError):
@@ -509,7 +506,7 @@ class SandboxedGymSession:
                 retryable=False,
                 origin="client",
             )
-        return self._decode_results(payload)
+        return self._decode_results(payload, time.monotonic() - started)
 
     def _in_transit_error(
         self, detail: str, chunk: list[dict[str, Any]], started: float, *, retryable: bool
@@ -555,7 +552,7 @@ class SandboxedGymSession:
             origin="proxy",
         )
 
-    def _decode_results(self, payload: bytes) -> list[Any]:
+    def _decode_results(self, payload: bytes, elapsed: float | None = None) -> list[Any]:
         try:
             # Strict, and caught rather than avoided: errors="replace" would let a body with one
             # corrupt byte still parse, handing the caller U+FFFD where the host wrote data.
@@ -566,15 +563,31 @@ class SandboxedGymSession:
                 retryable=False,
                 origin="sandbox",
             ) from exc
+        if not body:
+            if elapsed is not None and elapsed < MIN_PROXY_CUTOFF_S:
+                raise RolloutTransportError(
+                    f"the sandboxed Gym host answered and then sent nothing in {elapsed:.1f}s -- "
+                    f"too fast to have been cut in transit, so it died before it could write; "
+                    f"check whether the sandbox was OOMKilled or evicted",
+                    retryable=False,
+                    origin="sandbox",
+                )
+            raise RolloutTransportError(
+                "the sandboxed Gym host sent no body at all"
+                + (f" in {elapsed:.1f}s" if elapsed is not None else "")
+                + " -- nothing was ever written. Either it died before writing anything (check the "
+                "sandbox for an OOMKill or an eviction), or its image predates the rollout "
+                "heartbeat and the proxy cut the silent request at its own cap (check "
+                "sandbox.image). A dropped connection and a truncated one are indistinguishable "
+                "to this client",
+                retryable=False,
+                origin="sandbox",
+            )
         if not body.strip():
-            # Heartbeats and nothing else: the host committed its 200, padded the connection while
-            # it worked, and then went away without ever writing the envelope -- an OOMKill or an
-            # evicted pod mid-batch. Reported as the sandbox failing rather than as malformed JSON,
-            # which is what `json.loads` alone would have called it.
             raise RolloutTransportError(
                 f"the sandboxed Gym host answered and then stopped without sending a result "
-                f"envelope ({len(payload)} byte(s) of heartbeat only); it most likely died "
-                f"mid-batch -- check whether the sandbox was OOMKilled or evicted",
+                f"envelope ({len(payload)} byte(s) of heartbeat, then silence); it most likely "
+                f"died mid-batch -- check whether the sandbox was OOMKilled or evicted",
                 retryable=False,
                 origin="sandbox",
             )

--- a/packages/sandboxed_gym/src/sandboxed_gym/runtime/gym_host_runtime.py
+++ b/packages/sandboxed_gym/src/sandboxed_gym/runtime/gym_host_runtime.py
@@ -509,7 +509,9 @@ class Handler(BaseHTTPRequestHandler):
             self.send_response(404)
             self.end_headers()
             return
-        if not _READY:
+        # Must match do_POST: a host that passes /health and then 503s every rollout is
+        # invisible to wait_ready.
+        if not _READY or _HEAD_SERVER_CONFIG is None or _ROLLOUT_HELPER is None:
             body = json.dumps({"status": "starting"}).encode("utf-8")
             self.send_response(503)
         else:

--- a/packages/sandboxed_gym/tests/test_gym_host_runtime.py
+++ b/packages/sandboxed_gym/tests/test_gym_host_runtime.py
@@ -68,6 +68,26 @@ def test_health_not_ready():
         server.server_close()
 
 
+def test_health_is_not_ready_until_the_rollout_helpers_are(ready_server):
+    """/health must gate on what do_POST gates on.
+
+    Reporting ready off ``_READY`` alone lets a host pass ``wait_ready`` and then refuse every
+    rollout with 503 bootstrap_failed -- a state the caller has no way to observe until it has
+    already committed a batch.
+    """
+    import urllib.error
+    import urllib.request
+
+    runtime._ROLLOUT_HELPER = None
+    try:
+        with pytest.raises(urllib.error.HTTPError) as excinfo:
+            urllib.request.urlopen(f"{ready_server}/health", timeout=5)
+        assert excinfo.value.code == 503
+        assert json.loads(excinfo.value.read())["status"] == "starting"
+    finally:
+        runtime._ROLLOUT_HELPER = _FakeRolloutHelper()
+
+
 def test_health_ready(ready_server):
     import urllib.request
 

--- a/packages/sandboxed_gym/tests/test_rollout_transport.py
+++ b/packages/sandboxed_gym/tests/test_rollout_transport.py
@@ -390,11 +390,49 @@ def test_a_heartbeat_only_body_names_the_host_as_the_failure() -> None:
     session = _session()
 
     with pytest.raises(RolloutTransportError) as excinfo:
-        session._decode_results(b"    ")
+        session._decode_results(b"    ", 42.0)
 
     assert excinfo.value.origin == "sandbox"
     assert not excinfo.value.retryable
     assert "OOMKilled" in str(excinfo.value)
+
+
+def test_an_empty_body_names_both_causes_rather_than_picking_one() -> None:
+    """Zero bytes is produced by a dead host *and* by a request the proxy truncated.
+
+    A heartbeatless image cut at the proxy's cap and a host OOMKilled mid-batch both land here.
+    Without a Content-Length the body ends at the close either way, so the client cannot tell them
+    apart and must not claim to.
+    """
+    session = _session()
+
+    with pytest.raises(RolloutTransportError) as excinfo:
+        session._decode_results(b"", 180.0)
+
+    message = str(excinfo.value)
+    assert "OOMKill" in message
+    assert "sandbox.image" in message
+
+
+def test_an_empty_body_mid_range_does_not_blame_the_image_alone() -> None:
+    session = _session()
+
+    with pytest.raises(RolloutTransportError) as excinfo:
+        session._decode_results(b"", 60.0)
+
+    assert "OOMKill" in str(excinfo.value)
+
+
+def test_an_empty_body_that_arrived_fast_blames_the_sandbox_alone() -> None:
+    session = _session()
+
+    with pytest.raises(RolloutTransportError) as excinfo:
+        session._decode_results(b"", 2.0)
+
+    message = str(excinfo.value)
+    assert excinfo.value.origin == "sandbox"
+    assert "OOMKilled" in message
+    assert "sandbox.image" not in message
 
 
 def test_a_malformed_non_empty_body_is_a_contract_failure() -> None:


### PR DESCRIPTION
## Summary

Both rollout decoders read a 200 with nothing in it as the sandbox having died mid-batch, advising the reader to "check whether the sandbox was OOMKilled or evicted". Two different failures produce that body, and the message asserts one of them.

The host commits its `200` before the batch finishes and sends no `Content-Length` — the body is delimited by the close that `Connection: close` promises. When the proxy's read timeout fires on a silent host it cannot retract the status line, so it ends the body and the caller gets a well-formed 200 carrying zero bytes. **A host that is OOMKilled mid-batch produces exactly the same bytes**, because a dropped connection and a truncated one are indistinguishable without a length. Elapsed time does not separate them either — the two causes span the same range.

So this stops asserting a cause it cannot prove, and instead names both plus the check that settles each.

## Related Issue

Part of AALGO-584.

## Changes

- `_decode_results` and the evaluator-SDK `_decode_body` no longer claim one cause for a zero-byte body. Below `MIN_PROXY_CUTOFF_S` nothing had time to cut a request in transit, so the host did die and the message says only that. Above it, both causes are named with their discriminating checks: the sandbox's exit status, or whether `sandbox.image` carries the heartbeat.
- `origin` stays `"sandbox"` throughout rather than moving to `"proxy"` on a guess.
- Padding-then-silence is untouched and stays the sandbox's failure — there the heartbeats are evidence the host was alive after its 200, which the zero-byte case lacks.
- `_collect` times its own POST so the SDK runner can make the same distinction.
- Wording: "N byte(s) of heartbeat only" becomes "N byte(s) of heartbeat, then silence", which claimed heartbeats in the case that has none.
- `/health` now gates on the same three conditions `do_POST` requires, so a host cannot pass `wait_ready` and then 503 every rollout.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [x] Documentation not applicable — justification: operator-facing error text only; no documented interface changes.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `uv run --frozen pytest packages/sandboxed_gym/tests` — 298 passed, 5 skipped
- `uv run --frozen pytest packages/nemo_evaluator_sdk/tests/agent_eval` — 815 passed, 10 skipped
- `uv run pre-commit run -a` — no failures
- Mutation-tested: forcing each branch the wrong way turns exactly one test red, so the tests constrain behaviour rather than merely executing it.

**Live validation.** A local kind cluster running the upstream OpenSandbox server (shared-kernel, Docker Hub images), with a stub Gym host that can outlast the 180s cap or hard-exit `137` mid-batch. Real sandbox pods, real PVC remounts, real proxy route resolution.

| Live case | elapsed | Result |
|---|---|---|
| Silent host cut at the proxy cap | 180.0s | both causes named, `sandbox.image` check included |
| Silent host OOMKilled mid-batch | 57.4s | both causes named, OOMKill check first |
| Heartbeating host over the cap | 200.1s | succeeds, 13 heartbeat bytes, results intact |

The first two producing the same message is the point: the client cannot tell them apart, so claiming otherwise in either direction is the defect.

An earlier revision of this branch did claim otherwise — it moved `origin` to `"proxy"` above a 30s threshold, which told the operator of an OOMKilled sandbox to check their image version. That was caught by independent review and reproduced live before being reworked.

Not covered: Kata isolation, real NeMo-Gym with a policy model and environment FileSet, and the evaluator plugin's own live test — all of which need a managed cluster.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandboxed Gym rollout error messages by distinguishing fast host failures from proxy cutoffs and silent termination.
  * Added timing and heartbeat details to empty-response diagnostics while preserving existing heartbeat-only and JSON decoding errors.
  * Updated the health endpoint to return `503 starting` until all required Gym runtime components are initialized.

* **Tests**
  * Added coverage for readiness checks and time-dependent rollout failure diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->