### PR TITLE
chore: make helm app and chart versions clearer placeholders

### DIFF
--- a/contrib/auth/authentik/helm/Chart.yaml
+++ b/contrib/auth/authentik/helm/Chart.yaml
@@ -12,5 +12,5 @@ dependencies:
     version: 2026.5.4
     repository: https://charts.goauthentik.io
   - name: nemo-platform
-    version: 0.1.0
+    version: 0.0.0
     repository: file://../../../../k8s/helm

--- a/k8s/helm/Chart.yaml
+++ b/k8s/helm/Chart.yaml
@@ -9,7 +9,9 @@ maintainers:
 description: NeMo Platform Helm Chart
 type: application
 # version is the version of the Helm chart, and can be different from the appVersion.
-version: 0.1.0
+version: 0.0.0
 # appVersion is the version of the application deployed in the chart.
-appVersion: "0.3.0"
+# This is overwritten on release, for regular releases
+# See https://catalog.ngc.nvidia.com/orgs/nvidia/nemo-platform/helm-charts/nemo-platform/-
+appVersion: "0.0.0"
 home: https://nvidia.com

--- a/tests/auth_idp/static/test_authentik_kubernetes_demo.py
+++ b/tests/auth_idp/static/test_authentik_kubernetes_demo.py
@@ -313,7 +313,7 @@ def test_authentik_umbrella_chart_declares_expected_dependencies() -> None:
     assert "postgresql" not in dependencies
     assert dependencies["nemo-platform"] == {
         "name": "nemo-platform",
-        "version": "0.1.0",
+        "version": "0.0.0",
         "repository": "file://../../../../k8s/helm",
     }
 


### PR DESCRIPTION
* Use 0.0.0 as the placeholder, so it's clearer when using source installations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Helm chart and application version metadata to `0.0.0`.
  * Aligned the Authentik deployment chart’s platform dependency version with `0.0.0`.
  * Updated validation expectations to reflect the revised chart dependency version.
  * Added release metadata references to the chart information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->