### PR TITLE
docs: drop issue-number prefix from branch-naming guidance

### DIFF
--- a/.agents/skills/contributor-create-pr/SKILL.md
+++ b/.agents/skills/contributor-create-pr/SKILL.md
@@ -104,7 +104,7 @@ git diff --stat "$NMP_BASE_REF...HEAD"
 Require all of the following:
 
 - Use a named feature branch, not detached `HEAD` and not the default branch.
-- Follow `[git-issue-number]-<descriptive-branch-name>/<username>` from `AGENTS.md`. Omit the issue prefix only when no issue is known; keep kebab case and the username suffix.
+- Follow `<descriptive-branch-name>/<username>` from `AGENTS.md`. Keep kebab case and the username suffix. Do NOT embed an issue/ticket number in the branch name — branch names are public and trackers may be private.
 - Keep only the intended PR changes in the worktree. Do not stash, discard, or absorb unrelated changes without the user's direction.
 - Confirm that the branch has commits ahead of the trusted base or intended uncommitted changes that the user asked to include.
 - Confirm that another worktree or active PR branch is not being repurposed.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,9 +5,6 @@
 ## Summary
 <!-- In 1-3 plain sentences, explain what changes and why. Describe before-and-after behavior when it applies. -->
 
-## Related Issue
-<!-- Use Fixes #NNN or Closes #NNN for a related issue. Remove this section if there is none. -->
-
 ## Changes
 <!-- List the concrete changes included in this pull request. -->
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ This project loads local developer preferences from @AGENTS.local.md. You MUST r
 
 ## Git Workflow
 
-- Git branches should follow the pattern `[git-issue-number]-<descriptive-branch-name>/<username>` where the GitLab issue number is inserted as a prefix if known, the branch name follows, the `/<username>` suffix is included (not email address, just username), and kebab case is used.
+- Git branches should follow the pattern `<descriptive-branch-name>/<username>` where the branch name comes first, the `/<username>` suffix is included (not email address, just username), and kebab case is used. Do NOT embed an issue/ticket number in the branch name — branch names are public and issue trackers may be private, so a tracker ID in a branch name leaks private references.
 - Always pass `-s` to `git commit` (DCO sign-off). This includes amends, fixups, and any commit variant.
 
 ### Squashing Commits


### PR DESCRIPTION
## Summary

The repo's branch-naming guidance told contributors to embed an issue/ticket
number as a branch-name prefix. Branch names are public, but issue trackers may
be private, so a tracker ID in a branch name leaks private references. This drops
the issue-number prefix and explicitly forbids tracker IDs in branch names.

## Changes

- `AGENTS.md` (Git Workflow): change the branch pattern to
  `<descriptive-branch-name>/<username>` and add a note forbidding issue/ticket
  numbers in branch names.
- `.agents/skills/contributor-create-pr/SKILL.md` (branch verification): update
  the cited pattern to match `AGENTS.md` and drop the "omit the issue prefix"
  wording, keeping the two consistent.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [x] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: documentation-only guidance change; no code or behavior affected.
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- Two exact one-line edits only; `git diff` confirms no markdown reflow (2 files changed, 2 insertions(+), 2 deletions(-)).
- `uv run pre-commit run -a` not run locally; will rely on CI hooks for markdown/lint validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated contributor guidance to require feature branches to follow the `<descriptive-branch-name>/<username>` format.
  - Clarified that issue and ticket numbers must not be included in branch names.
  - Removed the optional related-issue prompt from pull request templates, leaving the changes prompt as the next section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->