### PR TITLE
fix(studio): set type=button on dataset retry button to stop form submit

### DIFF
--- a/web/packages/studio/src/components/customizer/CustomizationFilesetSelect/index.tsx
+++ b/web/packages/studio/src/components/customizer/CustomizationFilesetSelect/index.tsx
@@ -253,7 +253,11 @@ export const CustomizationFilesetSelect: FC<CustomizationFilesetSelectProps> = (
           <ErrorMessage
             header="Loading Error"
             message="This dataset was unable to load. Please try again."
-            slotFooter={<Button onClick={() => refetchFileset()}>Retry</Button>}
+            slotFooter={
+              <Button type="button" onClick={() => refetchFileset()}>
+                Retry
+              </Button>
+            }
           />
         </Block>
       )}


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
Submitting an error-state "Retry" click on the inline dataset select in the customization flow natively submitted the whole customization form instead of just refetching the dataset, refreshing the page. Filesets-page dataset creation was unaffected because it isn't nested in another form.

## Changes
- `CustomizationFilesetSelect`: add `type="button"` to the dataset "Retry" button so it no longer defaults to `type="submit"` inside the enclosing customization form.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: no existing test exercised this button's native submit type; the fix is a one-line HTML attribute with no new branching logic to unit test, verified via typecheck/lint and manual reasoning about form nesting.
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: internal bug fix, no user-facing docs.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `uv run pre-commit run -a` — passed
- `pnpm --filter nemo-studio-ui exec eslint src/components/customizer/CustomizationFilesetSelect/index.tsx` — passed, no output
- `pnpm --filter nemo-studio-ui typecheck` — passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the dataset-loading error retry button from unintentionally submitting its surrounding form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->