### PR TITLE
fix(studio): show loading state while Base Model dropdown skips filtered pages

### DIFF
--- a/web/packages/common/src/components/ModelSelectV2/ModelDropdown.test.tsx
+++ b/web/packages/common/src/components/ModelSelectV2/ModelDropdown.test.tsx
@@ -140,6 +140,22 @@ describe('ModelDropdown', () => {
       expect(onLoadMore).not.toHaveBeenCalled();
     });
 
+    // Regression: an `include` filter can empty every loaded page (e.g. no fine-tunable models on
+    // this page), so the visible row count stays zero across several silent background fetches.
+    // The empty-state copy used to show up during those fetches, reading as "no models" when more
+    // pages were still on the way.
+    it('shows the loading message instead of the empty state while paging past filtered-out pages', () => {
+      renderOpen({
+        groups: [],
+        hasMore: true,
+        isLoadingMore: true,
+        emptyMessage: 'No models found',
+      });
+
+      expect(screen.getByText('Loading models...')).toBeInTheDocument();
+      expect(screen.queryByText('No models found')).not.toBeInTheDocument();
+    });
+
     it('shows the done message only after the last page', async () => {
       const { rerender } = renderOpen({
         onLoadMore: vi.fn(),

--- a/web/packages/common/src/components/ModelSelectV2/ModelDropdown.test.tsx
+++ b/web/packages/common/src/components/ModelSelectV2/ModelDropdown.test.tsx
@@ -140,10 +140,6 @@ describe('ModelDropdown', () => {
       expect(onLoadMore).not.toHaveBeenCalled();
     });
 
-    // Regression: an `include` filter can empty every loaded page (e.g. no fine-tunable models on
-    // this page), so the visible row count stays zero across several silent background fetches.
-    // The empty-state copy used to show up during those fetches, reading as "no models" when more
-    // pages were still on the way.
     it('shows the loading message instead of the empty state while paging past filtered-out pages', () => {
       renderOpen({
         groups: [],

--- a/web/packages/common/src/components/ModelSelectV2/ModelDropdownList.tsx
+++ b/web/packages/common/src/components/ModelSelectV2/ModelDropdownList.tsx
@@ -144,7 +144,9 @@ export const ModelDropdownList: FC<ModelDropdownListProps> = ({
   if (rows.length === 0) {
     return (
       <Flex align="center" justify="center" className="w-full px-density-md py-density-lg">
-        <Text className="text-secondary">{loading ? 'Loading models...' : emptyMessage}</Text>
+        <Text className="text-secondary">
+          {loading || loadingMore ? 'Loading models...' : emptyMessage}
+        </Text>
       </Flex>
     );
   }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
The Base Model dropdown could sit on the "No models found" empty state while it was still silently paging in the background — `useModelSearch`'s `include` filter can empty out several consecutive server pages before landing on one with an eligible model, and the dropdown's empty-state check only looked at the first-page loading flag, not the ongoing background fetches. On a slow connection that background paging takes longer, so the dropdown looked broken/empty until the user typed a search term that happened to land on a non-empty page first.

## Changes
- `ModelDropdownList`: the empty-state branch now shows "Loading models..." while `loading` or `loadingMore` is true, instead of only `loading`, so it reflects the background page-skipping `useModelSearch` does when a page is entirely filtered out.
- Added a regression test covering the empty-state-vs-loading-more case.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: internal bug fix, no user-facing docs.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `uv run pre-commit run -a` — passed
- `pnpm --filter @nemo/common exec eslint src/components/ModelSelectV2/ModelDropdown.test.tsx src/components/ModelSelectV2/ModelDropdownList.tsx` — passed, no output
- `pnpm --filter @nemo/common typecheck` — passed
- `pnpm --filter @nemo/common test src/components/ModelSelectV2/ModelDropdown.test.tsx` — 14 passed (13 existing + 1 new regression test)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - The model selector now displays “Loading models...” while additional model results are being fetched, instead of showing an empty-state message prematurely.

- **Tests**
  - Added coverage to verify the correct loading message appears when filtered results are unavailable during pagination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->