### PR TITLE
fix(models): prevent Istio from blocking weight pullers

### DIFF
--- a/plugins/nemo-deployments/openapi/openapi.yaml
+++ b/plugins/nemo-deployments/openapi/openapi.yaml
@@ -1177,6 +1177,11 @@ components:
         serviceAccount:
           title: Serviceaccount
           type: string
+        podAnnotations:
+          additionalProperties:
+            type: string
+          type: object
+          title: Podannotations
         tolerations:
           items:
             $ref: '#/components/schemas/Toleration'

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/deployments.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/deployments.py
@@ -117,6 +117,7 @@ def build_deployment_body(
         executor_image_pull_secrets=executor_image_pull_secrets,
         secret_env=secret_env,
     )
+    pod_annotations = k8s_config.pod_annotations if k8s_config is not None else {}
     deployment = k8s.client.V1Deployment(
         api_version="apps/v1",
         kind="Deployment",
@@ -125,7 +126,7 @@ def build_deployment_body(
             replicas=1,
             selector=k8s.client.V1LabelSelector(match_labels=selector_labels),
             template=k8s.client.V1PodTemplateSpec(
-                metadata=k8s.client.V1ObjectMeta(labels=pod_labels),
+                metadata=k8s.client.V1ObjectMeta(labels=pod_labels, annotations=pod_annotations or None),
                 spec=k8s.client.V1PodSpec(**compiled.pod_spec_kwargs),
             ),
         ),

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/jobs.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/jobs.py
@@ -161,6 +161,7 @@ def build_job_body(
         executor_image_pull_secrets=executor_image_pull_secrets,
         secret_env=secret_env,
     )
+    pod_annotations = k8s_config.pod_annotations if k8s_config is not None else {}
     job = k8s.client.V1Job(
         api_version="batch/v1",
         kind="Job",
@@ -168,7 +169,7 @@ def build_job_body(
         spec=k8s.client.V1JobSpec(
             backoff_limit=job_backoff_limit(config),
             template=k8s.client.V1PodTemplateSpec(
-                metadata=k8s.client.V1ObjectMeta(labels=labels),
+                metadata=k8s.client.V1ObjectMeta(labels=labels, annotations=pod_annotations or None),
                 spec=k8s.client.V1PodSpec(**compiled.pod_spec_kwargs),
             ),
         ),

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/entities.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/entities.py
@@ -190,6 +190,7 @@ class DockerDeploymentConfig(BaseModel):
 class K8sDeploymentConfig(BaseModel):
     namespace: str | None = None
     service_account: str | None = Field(default=None, alias="serviceAccount")
+    pod_annotations: dict[str, str] = Field(default_factory=dict, alias="podAnnotations")
     tolerations: list[Toleration] = Field(default_factory=list)
     affinity: Affinity | None = None
     security_context: PodSecurityContext | None = Field(default=None, alias="securityContext")

--- a/plugins/nemo-deployments/tests/unit/backends/k8s/test_deployments.py
+++ b/plugins/nemo-deployments/tests/unit/backends/k8s/test_deployments.py
@@ -81,6 +81,25 @@ def test_build_in_cluster_endpoints_uses_cluster_dns() -> None:
     assert endpoints[0].url == f"http://{resource_name}.nemo-deployments.svc.cluster.local:8080"
 
 
+@pytest.mark.asyncio
+async def test_create_deployment_applies_pod_annotations(
+    k8s_backend, mock_k8s_clients: MagicMock, mock_entities: AsyncMock
+) -> None:
+    mock_entities.get.return_value = sample_always_config()
+    mock_k8s_clients.apps_v1.create_namespaced_deployment.return_value = mock_deployment()
+
+    await k8s_backend.create_deployment(
+        workspace="default",
+        name="task",
+        config_name="config1",
+        labels={},
+        backend_config={"k8s": {"podAnnotations": {"example.com/annotation": "value"}}},
+    )
+
+    body = mock_k8s_clients.apps_v1.create_namespaced_deployment.call_args.kwargs["body"]
+    assert body.spec.template.metadata.annotations == {"example.com/annotation": "value"}
+
+
 def test_build_in_cluster_endpoints_uses_tcp_scheme_for_udp() -> None:
     resource_name = k8s_deployment_resource_name("default", "task")
     container = (

--- a/plugins/nemo-deployments/tests/unit/backends/k8s/test_jobs.py
+++ b/plugins/nemo-deployments/tests/unit/backends/k8s/test_jobs.py
@@ -83,6 +83,25 @@ async def test_create_job_on_failure_uses_requested_restart_policy(
 
 
 @pytest.mark.asyncio
+async def test_create_job_applies_pod_annotations(
+    k8s_backend, mock_k8s_clients: MagicMock, mock_entities: AsyncMock
+) -> None:
+    mock_entities.get.return_value = sample_config(restart_policy="OnFailure")
+    mock_k8s_clients.batch_v1.create_namespaced_job.return_value = mock_job(restart_policy="OnFailure", active=1)
+
+    await k8s_backend.create_deployment(
+        workspace="default",
+        name="task",
+        config_name="config1",
+        labels={},
+        backend_config={"k8s": {"podAnnotations": {"sidecar.istio.io/inject": "false"}}},
+    )
+
+    body = mock_k8s_clients.batch_v1.create_namespaced_job.call_args.kwargs["body"]
+    assert body.spec.template.metadata.annotations == {"sidecar.istio.io/inject": "false"}
+
+
+@pytest.mark.asyncio
 async def test_create_job_emits_separate_command_and_args(
     k8s_backend, mock_k8s_clients: MagicMock, mock_entities: AsyncMock
 ) -> None:

--- a/services/core/models/src/nmp/core/models/controllers/backends/deployments_plugin/compiler.py
+++ b/services/core/models/src/nmp/core/models/controllers/backends/deployments_plugin/compiler.py
@@ -17,6 +17,7 @@ from nemo_deployments_plugin.entities import (
     DockerVolumeConfig,
     EnvVar,
     HTTPGetAction,
+    K8sDeploymentConfig,
     K8sVolumeConfig,
     Probe,
     Volume,
@@ -69,6 +70,7 @@ from nmp.core.models.controllers.backends.vllm_compiler import (
 _WEIGHTS_MOUNT = "/model-store"
 _SCRATCH_MOUNT = "/scratch"
 _LORA_MOUNT = "/scratch/loras"
+_ISTIO_INJECT_ANNOTATION = "sidecar.istio.io/inject"
 # The adapters sidecar writes under the XDG base dirs: $XDG_STATE_HOME (default
 # ~/.local/state), $XDG_DATA_HOME (default ~/.local/share, via nmp_user_data_dir()),
 # and $XDG_CONFIG_HOME (default ~/.config). The pod runs it as the vLLM uid (2000),
@@ -300,6 +302,11 @@ def compile_model_deployment(
             env=_env(puller_env),
             volumeMounts=[VolumeMount(name=names.volume, mountPath=_WEIGHTS_MOUNT)],
         )
+        puller_backend_config = (backend_config or DeploymentBackendConfig()).model_copy(deep=True)
+        if resolved.runtime == Runtime.KUBERNETES:
+            if puller_backend_config.k8s is None:
+                puller_backend_config.k8s = K8sDeploymentConfig()
+            puller_backend_config.k8s.pod_annotations[_ISTIO_INJECT_ANNOTATION] = "false"
         puller_config = DeploymentConfig(
             name=names.puller,
             workspace=resolved.deployment.workspace,
@@ -307,7 +314,7 @@ def compile_model_deployment(
             labels=_labels(resolved, engine, "puller"),
             restartPolicy="OnFailure",
             backoffLimit=config.max_restart_count,
-            backendConfig=backend_config or DeploymentBackendConfig(),
+            backendConfig=puller_backend_config,
             workloadIdentity=workload_identity,
         )
 

--- a/services/core/models/tests/unit/controllers/backends/deployments_plugin/test_compiler.py
+++ b/services/core/models/tests/unit/controllers/backends/deployments_plugin/test_compiler.py
@@ -45,6 +45,15 @@ def test_vllm_weighted_chain_has_on_failure_puller_and_always_server() -> None:
     assert compiled.server_config.containers[0].volume_mounts[0].read_only is True
 
 
+def test_k8s_weight_puller_disables_istio_injection_only_for_puller() -> None:
+    compiled = compile_model_deployment(_resolved("vllm"), DeploymentsPluginConfig())
+    assert compiled.puller_config is not None
+    assert compiled.puller_config.backend_config.k8s is not None
+    assert compiled.puller_config.backend_config.k8s.pod_annotations == {"sidecar.istio.io/inject": "false"}
+    assert compiled.server_config.backend_config.k8s is not None
+    assert compiled.server_config.backend_config.k8s.pod_annotations == {}
+
+
 def test_docker_weights_volume_requests_init_chmod() -> None:
     # Docker named volumes are root-owned with no fs_group, so the weights volume
     # must be made writable (chmod) for the non-root puller. The compiler requests


### PR DESCRIPTION
## Summary
Kubernetes model weight pullers can finish downloading successfully but remain active when automatic Istio injection leaves the proxy sidecar running. Disable Istio injection only for the finite weight-puller pod so its Job can complete; model server pods keep their existing mesh configuration.

## Changes
- Add Kubernetes pod annotation support to deployment backend configuration and pod templates.
- Set sidecar.istio.io/inject=false on Kubernetes model weight pullers only.
- Update the deployments OpenAPI schema and add coverage for Jobs, Deployments, and model compilation.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: Internal Kubernetes runtime behavior; the public configuration schema is updated.

## Verification

- [x] Pull request title follows the repository standard
- [x] Every commit includes an appropriate Signed-off-by trailer
- [x] uv run pre-commit run -a passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- 254 passed: Kubernetes deployments backend, deployment entity/API, and models deployments-plugin unit tests.
- Full pre-commit suite passed under the repository-pinned Flox toolchain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Kubernetes deployment configurations now support optional pod annotations.
  - Pod annotations are applied to Kubernetes deployments and jobs.
  - Weight-puller Kubernetes workloads automatically disable Istio sidecar injection without affecting serving workloads.

- **Bug Fixes**
  - Deployment configuration is preserved when customizing weight-puller settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->