### PR TITLE
feat(evaluator): collect Gym model-call captures from a sandboxed host

### DIFF
--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/results.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/results.py
@@ -203,6 +203,19 @@ def _capture_path(record: Mapping[str, Any], capture_dir: Path | None) -> Path |
     """
     if capture_dir is None:
         return None
+    name = capture_filename(record)
+    if name is None:
+        return None
+    path = capture_dir / name
+    return path if path.exists() else None
+
+
+def capture_filename(record: Mapping[str, Any]) -> str | None:
+    """Gym's capture filename for this rollout, or ``None`` when its indices do not name one.
+
+    The single definition of that name: the sandboxed runner writes captures under it and
+    :func:`_capture_path` reads them back, so the two cannot drift apart.
+    """
     task, rollout = record.get(NG_TASK_INDEX), record.get(NG_ROLLOUT_INDEX)
     if not isinstance(task, int) or not isinstance(rollout, int):
         return None
@@ -210,8 +223,7 @@ def _capture_path(record: Mapping[str, Any], capture_dir: Path | None) -> Path |
     attempt = record.get(NG_ATTEMPT_INDEX)
     if isinstance(attempt, int) and attempt > 0:
         rollout_id = f"{rollout_id}-a{attempt}"
-    path = capture_dir / f"{rollout_id}.capture.jsonl"
-    return path if path.exists() else None
+    return f"{rollout_id}.capture.jsonl"
 
 
 def _read_model_calls(capture_path: Path | None, *, trial_id: str) -> list[dict[str, Any]]:

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/results.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/results.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import Any
 
 from google.protobuf.json_format import MessageToDict
-from nemo_evaluator_sdk.agent_eval.runtimes.gym.config import DEFAULT_REWARD_KEY
+from nemo_evaluator_sdk.agent_eval.runtimes.gym.config import DEFAULT_REWARD_KEY, model_call_capture_dir
 from nemo_evaluator_sdk.agent_eval.runtimes.gym.records import (
     ENV_LOG_NAME,
     NG_ATTEMPT_INDEX,
@@ -390,9 +390,17 @@ def ensure_fresh_output(rollouts_path: Path) -> None:
     Gym appends to the failures sidecar (``open("ab")``) and doesn't clear it between runs, so reusing
     a populated directory would silently mix this run's failures with a prior run's. Rather than clear
     (which would clobber an earlier run's results — infra failures are useful signal), refuse to run
-    into a directory that already holds Gym rollout output.
+    into a directory that already holds Gym rollout output: rollouts, failures, or model-call
+    captures.
     """
-    preexisting = [path for path in (rollouts_path, _failures_path_for(rollouts_path)) if path.exists()]
+    preexisting = [path for path in (rollouts_path, _failures_path_for(rollouts_path)) if path.is_file()]
+    # Model-call captures count as output too, and the sandboxed runner writes them *before*
+    # `rollouts.jsonl`, so a run that died in between leaves captures with no file above to catch
+    # it. Their names -- `{task}-{rollout}` -- repeat across runs of one dataset, so the next run
+    # would attach a previous run's timing to its own trials.
+    captures = model_call_capture_dir(rollouts_path.parent)
+    if captures.is_dir() and any(captures.iterdir()):
+        preexisting.append(captures)
     if preexisting:
         names = ", ".join(path.name for path in preexisting)
         raise FileExistsError(

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/sandboxed.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/sandboxed.py
@@ -41,6 +41,7 @@ from typing import Any
 import httpx
 from nemo_evaluator_sdk.agent_eval.runtimes.gym.config import DEFAULT_REWARD_KEY
 from nemo_evaluator_sdk.agent_eval.runtimes.gym.dataset import materialize_dataset, source_datasets
+from nemo_evaluator_sdk.agent_eval.runtimes.gym.records import NG_ROLLOUT_INDEX, NG_TASK_INDEX
 from nemo_evaluator_sdk.agent_eval.runtimes.gym.results import (
     aggregate_scores_from_gym,
     capture_filename,
@@ -70,6 +71,25 @@ PROXY_AUTH_HEADER = "X-Sandboxed-Gym-Token"
 MODEL_CALLS_RESULT_KEY = "_nmp_model_calls"
 #: Where captures are written locally, matching the CLI runtime's ``model_call_capture_dir``.
 _CAPTURE_SUBDIR = "model_calls"
+
+
+def _stamp_rollout_indices(examples: list[dict[str, Any]]) -> None:
+    """Number each example within its task, as Gym's CLI preprocessing does.
+
+    ``run_examples`` does not assign ``_ng_rollout_index`` -- only ``gym eval run`` does, while
+    preprocessing the dataset. Without it Gym's ``maybe_rollout_id_from_run_body`` returns None, so
+    it writes **no model-call capture at all**, and the trial falls back to a synthesized id.
+    Confirmed by running a real sandboxed rollout: the capture directory was created and stayed
+    empty until the index was supplied.
+
+    Only where the row is silent, so a caller that numbers its own repeats keeps its numbering.
+    """
+    seen: dict[Any, int] = {}
+    for example in examples:
+        if example.get(NG_ROLLOUT_INDEX) is not None:
+            continue
+        task = example.get(NG_TASK_INDEX)
+        example[NG_ROLLOUT_INDEX] = seen[task] = seen.get(task, -1) + 1
 
 
 def _unpack_model_call_captures(records: list[dict[str, Any]], work_dir: Path) -> Path | None:
@@ -295,6 +315,7 @@ class SandboxedGymAgentTaskRunner:
             # which is how multi-agent Gym datasets are meant to work.
             for example in examples:
                 example.setdefault("agent_ref", {"name": cfg.agent_ref_name})
+        _stamp_rollout_indices(examples)
         logger.info(
             "Collecting %d example(s) from %s via sandboxed Gym host %s.",
             len(examples),

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/sandboxed.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/sandboxed.py
@@ -20,8 +20,9 @@ host's ``/rollouts/run`` and writes the returned records where the parser expect
 Attribution survives that hop because the host copies each example's ``_ng_task_index`` onto its
 result. Nothing here joins by position.
 
-One thing does not survive yet (AALGO-593): the host does not enable Gym's model-call capture, so trials from
-this runner carry a trace projected from the rollout record alone, without per-call timing.
+Gym's model-call captures make the same hop: the host enables capture, reads each rollout's file,
+and returns it on the record. This runner writes them back out in the layout the CLI runner's parser
+expects, so per-call timing reaches a trace either way.
 
 The host itself is provisioned by ``sandboxed-gym``: start a session, take its rollout URL and
 token off the descriptor, and hand them to this runner.
@@ -42,6 +43,7 @@ from nemo_evaluator_sdk.agent_eval.runtimes.gym.config import DEFAULT_REWARD_KEY
 from nemo_evaluator_sdk.agent_eval.runtimes.gym.dataset import materialize_dataset, source_datasets
 from nemo_evaluator_sdk.agent_eval.runtimes.gym.results import (
     aggregate_scores_from_gym,
+    capture_filename,
     ensure_fresh_output,
     read_run_aggregations,
     require_full_coverage,
@@ -59,6 +61,49 @@ logger = logging.getLogger(__name__)
 #: duplicated rather than imported so this module carries no dependency on that package: a caller
 #: who has a session descriptor already has the token, and the header name is part of the contract.
 PROXY_AUTH_HEADER = "X-Sandboxed-Gym-Token"
+
+
+#: Key the sandboxed host attaches a rollout's captured model calls under. Mirrors
+#: ``sandboxed_gym.runtime.gym_host_runtime.MODEL_CALLS_RESULT_KEY``, duplicated rather than
+#: imported so this runner carries no dependency on that package -- a caller with a session
+#: descriptor never needs it installed.
+MODEL_CALLS_RESULT_KEY = "_nmp_model_calls"
+#: Where captures are written locally, matching the CLI runtime's ``model_call_capture_dir``.
+_CAPTURE_SUBDIR = "model_calls"
+
+
+def _unpack_model_call_captures(records: list[dict[str, Any]], work_dir: Path) -> Path | None:
+    """Write each record's captured model calls to disk, and return the directory holding them.
+
+    The captures cross the wire attached to their rollout, but the parser reads them from a
+    directory, so they are unpacked here. Deliberately on-disk rather than passed in memory: one
+    code path reads a capture whichever runner produced it, so a parsing bug cannot hide in the
+    sandboxed runner and not the CLI one.
+
+    Mutates each record to drop the transport key, so the ``rollouts.jsonl`` this runner writes is
+    the shape Gym itself would have written.
+
+    Returns None when no record carried a capture -- an older host, or a run where none was
+    written. Passing a directory that will never contain anything would make the parser warn once
+    per trial about a capture nobody asked for.
+    """
+    capture_dir = work_dir / _CAPTURE_SUBDIR
+    written = 0
+    for record in records:
+        calls = record.pop(MODEL_CALLS_RESULT_KEY, None)
+        name = capture_filename(record) if isinstance(calls, list) and calls else None
+        if name is None:
+            continue
+        capture_dir.mkdir(parents=True, exist_ok=True)
+        (capture_dir / name).write_text(
+            "".join(f"{json.dumps(call)}\n" for call in calls),
+            encoding="utf-8",
+        )
+        written += 1
+    if not written:
+        logger.info("Sandboxed Gym host returned no model-call captures; traces will carry no per-call timing.")
+        return None
+    return capture_dir
 
 
 class SandboxedGymRuntimeConfig(BaseModel):
@@ -259,6 +304,10 @@ class SandboxedGymAgentTaskRunner:
 
         records = await self._collect(examples)
 
+        # Before the records are written: unpacking strips the transport key, and `rollouts.jsonl`
+        # has to be the shape Gym itself would have written for the shared parser to read it.
+        capture_dir = _unpack_model_call_captures(records, work_dir)
+
         # Written where the parser expects it, so the records are read by exactly the code that
         # reads the CLI runner's output -- including its handling of records with no usable index.
         rollouts_path.write_text(
@@ -267,12 +316,8 @@ class SandboxedGymAgentTaskRunner:
         )
 
         self._run_aggregations = read_run_aggregations(rollouts_path)
-        # No capture_dir yet (AALGO-593): the host does not switch Gym's model-call capture on, so
-        # its captures never leave the sandbox and traces from this runner carry no per-call timing.
-        # Unimplemented rather than impossible -- the host drives Gym through its Python API, whose
-        # global config takes the same observability keys the CLI runtime sets.
         trials = trials_from_rollouts(
-            rollouts_path, tasks, index_to_task_id, reward_key=cfg.reward_key, capture_dir=None
+            rollouts_path, tasks, index_to_task_id, reward_key=cfg.reward_key, capture_dir=capture_dir
         )
         require_full_coverage(tasks, covered_task_ids={trial.task_id for trial in trials}, rollouts_path=rollouts_path)
         return trials

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_gym_runtime.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_gym_runtime.py
@@ -25,7 +25,12 @@ from nemo_evaluator_sdk.agent_eval.runtimes.gym import (
     GymRuntimeConfig,
     discover_gym_tasks,
 )
-from nemo_evaluator_sdk.agent_eval.runtimes.gym.config import _flatten_overrides, hydra_scalar, selection_args
+from nemo_evaluator_sdk.agent_eval.runtimes.gym.config import (
+    _flatten_overrides,
+    hydra_scalar,
+    model_call_capture_dir,
+    selection_args,
+)
 from nemo_evaluator_sdk.agent_eval.runtimes.gym.dataset import (
     _canonical_row_hash,
     _content_text,
@@ -1373,3 +1378,23 @@ async def test_collection_redirects_hydra_output_under_the_run_work_dir(tmp_path
 
     argv = (tmp_path / "argv.txt").read_text().splitlines()
     assert f"hydra.run.dir={hydra_scalar(str(tmp_path / 'gym_hydra'))}" in argv
+
+
+def test_leftover_captures_refuse_a_second_run_into_the_same_dir(tmp_path: Path) -> None:
+    # The sandboxed runner writes captures *before* `rollouts.jsonl`, so a run that died in between
+    # leaves them with no file above to catch it. Capture names repeat across runs of one dataset,
+    # so without this the next run attaches a previous run's timing to its own trials.
+    captures = model_call_capture_dir(tmp_path)
+    captures.mkdir(parents=True)
+    (captures / "0-0.capture.jsonl").write_text('{"model_call_id": "old"}\n', encoding="utf-8")
+
+    with pytest.raises(FileExistsError, match="already holds Gym rollout output"):
+        ensure_fresh_output(tmp_path / "rollouts.jsonl")
+
+
+def test_an_empty_capture_directory_does_not_refuse_a_run(tmp_path: Path) -> None:
+    # The host creates the directory whether or not Gym writes into it, so its mere existence is
+    # not evidence of a previous run.
+    model_call_capture_dir(tmp_path).mkdir(parents=True)
+
+    ensure_fresh_output(tmp_path / "rollouts.jsonl")

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_gym_sandboxed_runtime.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_gym_sandboxed_runtime.py
@@ -24,6 +24,7 @@ from nemo_evaluator_sdk.agent_eval.runtimes.gym.sandboxed import (
     PROXY_AUTH_HEADER,
     SandboxedGymAgentTaskRunner,
     SandboxedGymRuntimeConfig,
+    _stamp_rollout_indices,
 )
 from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalRunConfig
 from nemo_evaluator_sdk.values.evidence import EVIDENCE_FORMAT_OTLP, EVIDENCE_TRACE
@@ -76,7 +77,10 @@ class _FakeHost:
             results = [
                 {
                     NG_TASK_INDEX: example[NG_TASK_INDEX],
-                    NG_ROLLOUT_INDEX: 0,
+                    # Echoed, never invented: Gym's `run_examples` copies the row's identity onto
+                    # the result and assigns nothing of its own. A fake that supplies an index the
+                    # caller failed to send would hide exactly the bug this mirrors.
+                    NG_ROLLOUT_INDEX: example.get(NG_ROLLOUT_INDEX),
                     "reward": rewards.get(example[NG_TASK_INDEX], 1.0),
                     "response": f"answer-{example[NG_TASK_INDEX]}",
                     **({MODEL_CALLS_RESULT_KEY: self._model_calls} if self._model_calls else {}),
@@ -394,3 +398,33 @@ async def test_a_host_that_returns_no_captures_still_produces_trials(tasks, tmp_
 
     assert len(trials) == len(tasks)
     assert not (tmp_path / "gym_run" / "model_calls").exists()
+
+
+async def test_examples_carry_a_rollout_index_so_gym_will_capture(tasks, tmp_path, monkeypatch) -> None:
+    # `run_examples` assigns no `_ng_rollout_index` -- only `gym eval run`'s preprocessing does.
+    # Without it Gym's `maybe_rollout_id_from_run_body` returns None and it writes *no capture at
+    # all*. Found by running a real sandboxed rollout, whose capture directory stayed empty.
+    host = _FakeHost()
+    runner = runner_against(host, monkeypatch)
+
+    await runner.run_tasks(tasks, AgentEvalRunConfig(work_dir=tmp_path))
+
+    assert all(example.get(NG_ROLLOUT_INDEX) is not None for example in host.posted)
+
+
+def test_rollout_indices_number_repeats_within_each_task() -> None:
+    # Per task, not across the batch: the index distinguishes repeats of one task, and a global
+    # counter would make every rollout look like a different task's first attempt.
+    examples = [{NG_TASK_INDEX: 0}, {NG_TASK_INDEX: 1}, {NG_TASK_INDEX: 0}]
+
+    _stamp_rollout_indices(examples)
+
+    assert [example[NG_ROLLOUT_INDEX] for example in examples] == [0, 0, 1]
+
+
+def test_a_caller_that_numbers_its_own_repeats_keeps_its_numbering() -> None:
+    examples = [{NG_TASK_INDEX: 0, NG_ROLLOUT_INDEX: 7}, {NG_TASK_INDEX: 0}]
+
+    _stamp_rollout_indices(examples)
+
+    assert [example[NG_ROLLOUT_INDEX] for example in examples] == [7, 0]

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_gym_sandboxed_runtime.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_gym_sandboxed_runtime.py
@@ -20,11 +20,13 @@ import pytest
 from nemo_evaluator_sdk.agent_eval.runtimes.gym import discover_gym_tasks
 from nemo_evaluator_sdk.agent_eval.runtimes.gym.records import NG_ROLLOUT_INDEX, NG_TASK_INDEX
 from nemo_evaluator_sdk.agent_eval.runtimes.gym.sandboxed import (
+    MODEL_CALLS_RESULT_KEY,
     PROXY_AUTH_HEADER,
     SandboxedGymAgentTaskRunner,
     SandboxedGymRuntimeConfig,
 )
 from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalRunConfig
+from nemo_evaluator_sdk.values.evidence import EVIDENCE_FORMAT_OTLP, EVIDENCE_TRACE
 
 ROLLOUT_URL = "http://gym-host.example/rollouts/run"
 
@@ -47,10 +49,12 @@ class _FakeHost:
 
     def __init__(
         self,
+        *,
         status: int = 200,
         body: Any = None,
         content: bytes | None = None,
         rewards: dict[int, float] | None = None,
+        model_calls: list[dict[str, Any]] | None = None,
     ) -> None:
         self.requests: list[httpx.Request] = []
         self.posted: list[dict[str, Any]] = []
@@ -58,6 +62,7 @@ class _FakeHost:
         self._body = body
         self._content = content
         self._rewards = rewards
+        self._model_calls = model_calls
 
     def transport(self) -> httpx.MockTransport:
         def handle(request: httpx.Request) -> httpx.Response:
@@ -74,6 +79,7 @@ class _FakeHost:
                     NG_ROLLOUT_INDEX: 0,
                     "reward": rewards.get(example[NG_TASK_INDEX], 1.0),
                     "response": f"answer-{example[NG_TASK_INDEX]}",
+                    **({MODEL_CALLS_RESULT_KEY: self._model_calls} if self._model_calls else {}),
                 }
                 for example in self.posted
             ]
@@ -318,3 +324,73 @@ def test_runner_info_records_the_host_but_not_the_token() -> None:
     assert info.config["mode"] == "sandboxed"
     assert info.config["rollout_url"] == ROLLOUT_URL
     assert "sk-secret-value" not in json.dumps(info.config), "the token must not reach the run bundle"
+
+
+def _model_call(call_id: str, started_at: float) -> dict[str, Any]:
+    return {
+        "model_call_id": call_id,
+        "model_ref": {"name": "policy_model"},
+        "status_code": 200,
+        "started_at": started_at,
+        "completed_at": started_at + 0.25,
+        "latency_ttft_ms": 12.5,
+        "response": {"usage": {"input_tokens": 5, "output_tokens": 2}},
+    }
+
+
+async def test_captures_from_the_host_become_timed_per_call_spans(tasks, tmp_path, monkeypatch) -> None:
+    # The point of the whole hop: without the capture a trial's trace is one AGENT span and no
+    # timing, which is what this runner produced before.
+    host = _FakeHost(model_calls=[_model_call("c0", 1788534870.5), _model_call("c1", 1788534871.0)])
+    runner = runner_against(host, monkeypatch)
+
+    trials = await runner.run_tasks(tasks, AgentEvalRunConfig(work_dir=tmp_path))
+
+    trial = trials[0]
+    assert trial.evidence is not None
+    resource_spans = await (await trial.evidence.trace(EVIDENCE_TRACE, format=EVIDENCE_FORMAT_OTLP)).resource_spans()
+    llm = [
+        span
+        for resource_span in resource_spans
+        for scope_spans in resource_span.scope_spans
+        for span in scope_spans.spans
+        for attribute in span.attributes
+        if attribute.key == "openinference.span.kind" and attribute.value.string_value == "LLM"
+    ]
+    assert len(llm) == 2
+    assert all(span.start_time_unix_nano > 0 and span.end_time_unix_nano > span.start_time_unix_nano for span in llm)
+
+
+async def test_the_raw_capture_is_kept_as_its_own_evidence(tasks, tmp_path, monkeypatch) -> None:
+    # The OTLP view is a projection of the capture, and a projection is not a reason to lose what it
+    # was projected from.
+    host = _FakeHost(model_calls=[_model_call("c0", 1788534870.5)])
+    runner = runner_against(host, monkeypatch)
+
+    trials = await runner.run_tasks(tasks, AgentEvalRunConfig(work_dir=tmp_path))
+
+    assert trials[0].evidence is not None
+    assert trials[0].evidence.get("ng_trajectory") is not None
+
+
+async def test_the_transport_key_never_reaches_the_rollouts_file(tasks, tmp_path, monkeypatch) -> None:
+    # `rollouts.jsonl` is read by the same parser as the CLI runner's output, so it has to be the
+    # shape Gym itself would have written -- this key is ours, not Gym's.
+    host = _FakeHost(model_calls=[_model_call("c0", 1788534870.5)])
+    runner = runner_against(host, monkeypatch)
+
+    await runner.run_tasks(tasks, AgentEvalRunConfig(work_dir=tmp_path))
+
+    written = (tmp_path / "gym_run" / "rollouts.jsonl").read_text(encoding="utf-8")
+    assert MODEL_CALLS_RESULT_KEY not in written
+
+
+async def test_a_host_that_returns_no_captures_still_produces_trials(tasks, tmp_path, monkeypatch) -> None:
+    # An older host, or a run where the work path was unwritable. The trial's reward and output
+    # stand on their own; only the per-call timing is missing.
+    runner = runner_against(_FakeHost(), monkeypatch)
+
+    trials = await runner.run_tasks(tasks, AgentEvalRunConfig(work_dir=tmp_path))
+
+    assert len(trials) == len(tasks)
+    assert not (tmp_path / "gym_run" / "model_calls").exists()

--- a/packages/sandboxed_gym/src/sandboxed_gym/runtime/gym_host_runtime.py
+++ b/packages/sandboxed_gym/src/sandboxed_gym/runtime/gym_host_runtime.py
@@ -520,8 +520,10 @@ def _read_capture(capture_dir: str, result: dict, *, budget: int) -> tuple[list[
             # Dropped whole rather than truncated: half a capture would project into a trace that
             # looks complete and silently under-reports the calls the agent actually made.
             return [], 0
-        raw = open(path, encoding="utf-8").read()
-    except OSError:
+        with open(path, "rb") as handle:
+            data = handle.read()
+        raw = data.decode("utf-8")
+    except (OSError, UnicodeDecodeError):
         return [], 0
     calls = []
     for line in raw.splitlines():
@@ -533,7 +535,9 @@ def _read_capture(capture_dir: str, result: dict, *, budget: int) -> tuple[list[
             continue
         if isinstance(call, dict):
             calls.append(call)
-    return (calls, len(raw)) if calls else ([], 0)
+    # Bytes, not characters: the budget is spent against a byte cap, and `len` on the decoded text
+    # counts code points -- a CJK capture reports about a third of what it costs on the wire.
+    return (calls, len(data)) if calls else ([], 0)
 
 
 async def _collect_rollout_results(

--- a/packages/sandboxed_gym/src/sandboxed_gym/runtime/gym_host_runtime.py
+++ b/packages/sandboxed_gym/src/sandboxed_gym/runtime/gym_host_runtime.py
@@ -44,6 +44,18 @@ UV_CACHE_DIR_KEY = "uv_cache_dir"
 UV_VENV_DIR_KEY = "uv_venv_dir"
 # Writable /job/work subdirectory where wheels are installed for the running Gym host.
 WHEELS_V1_INSTALL_SUBDIR = "wheels-v1-site-packages"
+# Writable /job/work subdirectory Gym writes one `<rollout_id>.capture.jsonl` per rollout into.
+# Under /job/work rather than beside the Gym tree because that is the one path the job image
+# guarantees is writable by uid 1000; /opt is not, which is why gym_host.sh stages Gym to /tmp.
+MODEL_CALL_CAPTURE_SUBDIR = "model-call-captures"
+#: Gym global-config keys that turn per-model-call capture on. Off, a rollout reports one usage
+#: block summed over the turn and no timing at all, so a trace projected from it has no per-call
+#: spans -- which is the whole reason a caller wants the capture.
+OBSERVABILITY_ENABLED_KEY = "observability_enabled"
+MODEL_CALL_CAPTURE_DIR_KEY = "model_call_capture_dir"
+#: Key this host attaches a rollout's captured model calls under, on the result it returns.
+#: Namespaced so it cannot collide with a Gym field or an environment's own extras.
+MODEL_CALLS_RESULT_KEY = "_nmp_model_calls"
 # uv setting that points Gym's per-server dependency resolver at the staged wheelhouse.
 UV_FIND_LINKS_ENV_KEY = "UV_FIND_LINKS"
 NEMO_GYM_EXTRA_ROOTS_ENV_KEY = "NEMO_GYM_EXTRA_ROOTS"
@@ -124,6 +136,32 @@ def _allocate_head_server_port(global_config: dict[str, Any]) -> int:
     port = _free_port_in_range(low, high)
     global_config[HEAD_SERVER_KEY_NAME] = {"host": "0.0.0.0", "port": port}
     return port
+
+
+def model_call_capture_dir(work_path: str) -> str:
+    """Absolute directory Gym writes this host's model-call captures into. Gym requires it absolute."""
+    return os.path.abspath(os.path.join(work_path, MODEL_CALL_CAPTURE_SUBDIR))
+
+
+def _apply_model_call_capture(global_config: dict[str, Any], work_path: str) -> None:
+    """Turn Gym's per-model-call capture on, writing into a directory this host can read back.
+
+    Set rather than defaulted: a caller's global config that leaves observability off would
+    otherwise silently produce traces with no per-call timing, which is indistinguishable from a
+    model that was never called.
+
+    An unwritable work path leaves capture off instead of raising. Whether that directory can be
+    created varies by sandbox provider -- the job image is why ``gym_host.sh`` stages Gym to /tmp --
+    and a host that refuses to start is a far worse outcome than one whose traces lack timing.
+    """
+    capture_dir = model_call_capture_dir(work_path)
+    try:
+        os.makedirs(capture_dir, exist_ok=True)
+    except OSError as error:
+        print(f"gym-host: model-call capture disabled, cannot create {capture_dir}: {error}", file=sys.stderr)
+        return
+    global_config[OBSERVABILITY_ENABLED_KEY] = True
+    global_config[MODEL_CALL_CAPTURE_DIR_KEY] = capture_dir
 
 
 def _create_rollout_helper() -> Any:
@@ -374,6 +412,7 @@ def bootstrap_gym_host() -> tuple[Any, Any, Any]:
     global_config = _load_global_config_dict()
     # Apply writable uv locations before Gym creates per-component environments.
     _apply_uv_dirs(global_config)
+    _apply_model_call_capture(global_config, os.environ.get("NMP_WORK_PATH", "/job/work"))
     environment_package = _load_runtime_environment_package(
         os.environ.get("NMP_ENVIRONMENT_PATH", ""),
         required=_environment_package_required(),
@@ -415,12 +454,15 @@ def bootstrap_gym_host() -> tuple[Any, Any, Any]:
 #: ``_ng_task_index`` and assigns ``_ng_rollout_index`` itself per attempt.
 NG_TASK_INDEX = "_ng_task_index"
 NG_ROLLOUT_INDEX = "_ng_rollout_index"
+#: Present past the first attempt only, and part of the capture filename when it is.
+NG_ATTEMPT_INDEX = "_ng_attempt_index"
 #: Identifies one entry of a request's ``examples``. Opaque, owned by the caller, never read by
 #: Gym, and scoped to the request rather than durable. Gym's own indices cannot stand in for it:
 #: ``_ng_task_index`` identifies a task, so a caller running several rollouts per task has no
 #: per-example value in it, and overwriting it is not open either -- Gym groups reward-profile
-#: metrics and builds model-call capture ids by task. ``_ng_rollout_index`` would complete the
-#: pair, but Gym assigns it, so a caller cannot stamp it on the way out.
+#: metrics and builds model-call capture ids by task, as the capture id below does.
+#: ``_ng_rollout_index`` would complete the pair, but Gym assigns it, so a caller cannot stamp it
+#: on the way out.
 SG_EXAMPLE_ID = "_sg_example_id"
 
 _ROW_IDENTITY_KEYS = (NG_TASK_INDEX, NG_ROLLOUT_INDEX, SG_EXAMPLE_ID)
@@ -446,15 +488,72 @@ def _with_row_identity(result: Any, row: Any) -> Any:
     return {**result, **missing} if missing else result
 
 
+def _capture_filename(result: dict) -> str | None:
+    """Gym's capture filename for this rollout, or None when it did not name one.
+
+    Gym keys a capture ``"{task}-{rollout}"``, suffixed ``-a{attempt}`` past the first attempt
+    (``nemo_gym.rollout_correlation``). A result missing either index has no capture written for it
+    either, so there is nothing to look for rather than something to search for.
+    """
+    task = result.get(NG_TASK_INDEX)
+    rollout = result.get(NG_ROLLOUT_INDEX)
+    if not isinstance(task, int) or not isinstance(rollout, int) or isinstance(task, bool) or isinstance(rollout, bool):
+        return None
+    attempt = result.get(NG_ATTEMPT_INDEX)
+    suffix = f"-a{attempt}" if isinstance(attempt, int) and not isinstance(attempt, bool) and attempt > 0 else ""
+    return f"{task}-{rollout}{suffix}.capture.jsonl"
+
+
+def _read_capture(capture_dir: str, result: dict, *, budget: int) -> tuple[list[dict], int]:
+    """This rollout's captured model calls and the bytes they cost, or ``([], 0)``.
+
+    Returns nothing rather than raising on every failure here -- a missing, unreadable, or
+    oversized capture costs the trace its per-call timing, and must not cost the caller the rollout
+    it is attached to.
+    """
+    name = _capture_filename(result)
+    if name is None or budget <= 0:
+        return [], 0
+    path = os.path.join(capture_dir, name)
+    try:
+        if os.path.getsize(path) > budget:
+            # Dropped whole rather than truncated: half a capture would project into a trace that
+            # looks complete and silently under-reports the calls the agent actually made.
+            return [], 0
+        raw = open(path, encoding="utf-8").read()
+    except OSError:
+        return [], 0
+    calls = []
+    for line in raw.splitlines():
+        if not line.strip():
+            continue
+        try:
+            call = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(call, dict):
+            calls.append(call)
+    return (calls, len(raw)) if calls else ([], 0)
+
+
 async def _collect_rollout_results(
     examples: list[dict],
     head_server_config: Any,
     rollout_helper: Any,
+    capture_dir: str | None = None,
+    capture_budget: int = 0,
 ) -> list[dict]:
     results: list[dict] = []
+    remaining = capture_budget
     for task in rollout_helper.run_examples(examples=examples, head_server_config=head_server_config):
         row, nemo_gym_result = await task
-        results.append(_with_row_identity(nemo_gym_result, row))
+        result = _with_row_identity(nemo_gym_result, row)
+        if capture_dir is not None:
+            calls, spent = _read_capture(capture_dir, result, budget=remaining)
+            if calls:
+                remaining -= spent
+                result = {**result, MODEL_CALLS_RESULT_KEY: calls}
+        results.append(result)
     return results
 
 
@@ -476,6 +575,8 @@ def submit_rollouts(
     examples: list[dict],
     head_server_config: Any,
     rollout_helper: Any,
+    capture_dir: str | None = None,
+    capture_budget: int = 0,
 ) -> concurrent.futures.Future[list[dict]]:
     """Start ``examples`` on the shared loop and return without waiting.
 
@@ -485,7 +586,9 @@ def submit_rollouts(
     # Handler threads hand work to the one loop, so concurrent /rollouts/run calls interleave on
     # it rather than each running a loop of its own.
     return asyncio.run_coroutine_threadsafe(
-        _collect_rollout_results(examples, head_server_config, rollout_helper),
+        _collect_rollout_results(
+            examples, head_server_config, rollout_helper, capture_dir, capture_budget
+        ),
         _ensure_event_loop(),
     )
 
@@ -494,8 +597,12 @@ def run_rollouts_sync(
     examples: list[dict],
     head_server_config: Any,
     rollout_helper: Any,
+    capture_dir: str | None = None,
+    capture_budget: int = 0,
 ) -> list[dict]:
-    return submit_rollouts(examples, head_server_config, rollout_helper).result()
+    return submit_rollouts(
+        examples, head_server_config, rollout_helper, capture_dir, capture_budget
+    ).result()
 
 
 class Handler(BaseHTTPRequestHandler):
@@ -568,7 +675,17 @@ class Handler(BaseHTTPRequestHandler):
         # servers filter their own 200s.
         print(f"gym-host: rollouts/run <- {len(examples)} example(s)", flush=True)
         started = time.monotonic()
-        future = submit_rollouts(examples, _HEAD_SERVER_CONFIG, _ROLLOUT_HELPER)
+        future = submit_rollouts(
+            examples,
+            _HEAD_SERVER_CONFIG,
+            _ROLLOUT_HELPER,
+            capture_dir=model_call_capture_dir(os.environ.get("NMP_WORK_PATH", "/job/work")),
+            # Captures share the response with the rollouts they annotate, and a response over
+            # the cap is refused whole -- so an unbudgeted capture would turn "traces too big"
+            # into "every result lost". Half leaves the records themselves the same room they
+            # have today; past it, captures stop and rollouts still return.
+            capture_budget=self.max_response_bytes // 2,
+        )
 
         # Committed to 200 before the work is done, so the first byte leaves immediately and no hop
         # can mistake a long batch for a dead one. Everything judgeable from the request alone was

--- a/packages/sandboxed_gym/src/sandboxed_gym/runtime/gym_host_runtime.py
+++ b/packages/sandboxed_gym/src/sandboxed_gym/runtime/gym_host_runtime.py
@@ -586,9 +586,7 @@ def submit_rollouts(
     # Handler threads hand work to the one loop, so concurrent /rollouts/run calls interleave on
     # it rather than each running a loop of its own.
     return asyncio.run_coroutine_threadsafe(
-        _collect_rollout_results(
-            examples, head_server_config, rollout_helper, capture_dir, capture_budget
-        ),
+        _collect_rollout_results(examples, head_server_config, rollout_helper, capture_dir, capture_budget),
         _ensure_event_loop(),
     )
 
@@ -600,9 +598,7 @@ def run_rollouts_sync(
     capture_dir: str | None = None,
     capture_budget: int = 0,
 ) -> list[dict]:
-    return submit_rollouts(
-        examples, head_server_config, rollout_helper, capture_dir, capture_budget
-    ).result()
+    return submit_rollouts(examples, head_server_config, rollout_helper, capture_dir, capture_budget).result()
 
 
 class Handler(BaseHTTPRequestHandler):

--- a/packages/sandboxed_gym/tests/test_gym_host_runtime.py
+++ b/packages/sandboxed_gym/tests/test_gym_host_runtime.py
@@ -939,6 +939,7 @@ def test_concurrent_rollout_batches_interleave_on_that_loop():
 
     assert [len(batch) for batch in results] == [1, 1, 1, 1]
 
+
 def _capture_line(**overrides):
     call = {"model_call_id": "c0", "status_code": 200, "started_at": 1.5, "completed_at": 1.75}
     return json.dumps({**call, **overrides})
@@ -971,7 +972,8 @@ def test_capture_filename_follows_gyms_rollout_id(result, expected):
 
 
 def test_a_capture_is_read_back_onto_its_rollout(tmp_path):
-    (tmp_path / "0-1.capture.jsonl").write_text(f"{_capture_line()}\n", encoding="utf-8")
+    # Trailing blank line included: Gym appends per call, so a partially-flushed file has one.
+    (tmp_path / "0-1.capture.jsonl").write_text(f"{_capture_line()}\n\n", encoding="utf-8")
 
     calls, spent = runtime._read_capture(str(tmp_path), {"_ng_task_index": 0, "_ng_rollout_index": 1}, budget=10_000)
 
@@ -1011,3 +1013,54 @@ def test_an_unwritable_work_path_disables_capture_rather_than_failing_the_host(t
     runtime._apply_model_call_capture(config, str(unwritable))
 
     assert config == {}
+
+
+class _IndexedRolloutHelper:
+    """Yields a result per example, carrying the rollout identity a capture is keyed by."""
+
+    def run_examples(self, examples, head_server_config=None):
+        async def _one(row):
+            return row, {"response": {"output": []}, "reward": 0.0, **row}
+
+        return [_one(row) for row in examples]
+
+
+def _rollout_examples(count):
+    return [{"_ng_task_index": i, "_ng_rollout_index": 0} for i in range(count)]
+
+
+async def _collect(tmp_path, examples, budget):
+    return await runtime._collect_rollout_results(examples, MagicMock(), _IndexedRolloutHelper(), str(tmp_path), budget)
+
+
+def test_each_rollouts_capture_is_attached_to_its_own_result(tmp_path):
+    # The whole point of the hop: without this the record crosses the wire bare and the trace it
+    # projects into has no per-call timing.
+    for index in range(2):
+        (tmp_path / f"{index}-0.capture.jsonl").write_text(f"{_capture_line(model_call_id=f'c{index}')}\n")
+
+    results = asyncio.run(_collect(tmp_path, _rollout_examples(2), 10_000))
+
+    attached = [[call["model_call_id"] for call in result[runtime.MODEL_CALLS_RESULT_KEY]] for result in results]
+    assert attached == [["c0"], ["c1"]]
+
+
+def test_the_budget_is_spent_across_rollouts_not_per_rollout(tmp_path):
+    # Captures share one response, so the budget has to deplete. Applied per rollout instead, a
+    # large run would blow the response cap and the host would refuse every result.
+    for index in range(3):
+        (tmp_path / f"{index}-0.capture.jsonl").write_text(f"{_capture_line(model_call_id=f'c{index}')}\n")
+    one_capture = (tmp_path / "0-0.capture.jsonl").stat().st_size
+
+    results = asyncio.run(_collect(tmp_path, _rollout_examples(3), one_capture * 2))
+
+    # The first two fit; the third finds nothing left and returns without its capture.
+    assert [runtime.MODEL_CALLS_RESULT_KEY in result for result in results] == [True, True, False]
+
+
+def test_rollouts_still_return_when_no_capture_was_written(tmp_path):
+    # The reward and output stand on their own; only the per-call timing is missing.
+    results = asyncio.run(_collect(tmp_path, _rollout_examples(2), 10_000))
+
+    assert len(results) == 2
+    assert all(runtime.MODEL_CALLS_RESULT_KEY not in result for result in results)

--- a/packages/sandboxed_gym/tests/test_gym_host_runtime.py
+++ b/packages/sandboxed_gym/tests/test_gym_host_runtime.py
@@ -938,3 +938,76 @@ def test_concurrent_rollout_batches_interleave_on_that_loop():
     results = [future.result(timeout=10) for future in futures]
 
     assert [len(batch) for batch in results] == [1, 1, 1, 1]
+
+def _capture_line(**overrides):
+    call = {"model_call_id": "c0", "status_code": 200, "started_at": 1.5, "completed_at": 1.75}
+    return json.dumps({**call, **overrides})
+
+
+def test_capture_is_enabled_so_a_rollout_records_per_call_timing(tmp_path):
+    # Set, not defaulted: a caller's global config that left observability off would produce traces
+    # with no per-call timing, which reads the same as a model that was never called.
+    config = {"observability_enabled": False}
+
+    runtime._apply_model_call_capture(config, str(tmp_path))
+
+    assert config["observability_enabled"] is True
+    assert config["model_call_capture_dir"] == str(tmp_path / runtime.MODEL_CALL_CAPTURE_SUBDIR)
+    assert (tmp_path / runtime.MODEL_CALL_CAPTURE_SUBDIR).is_dir()
+
+
+@pytest.mark.parametrize(
+    ("result", "expected"),
+    [
+        ({"_ng_task_index": 0, "_ng_rollout_index": 1}, "0-1.capture.jsonl"),
+        ({"_ng_task_index": 0, "_ng_rollout_index": 1, "_ng_attempt_index": 0}, "0-1.capture.jsonl"),
+        ({"_ng_task_index": 0, "_ng_rollout_index": 1, "_ng_attempt_index": 2}, "0-1-a2.capture.jsonl"),
+        ({"_ng_task_index": 0}, None),
+        ({"_ng_task_index": True, "_ng_rollout_index": 1}, None),
+    ],
+)
+def test_capture_filename_follows_gyms_rollout_id(result, expected):
+    assert runtime._capture_filename(result) == expected
+
+
+def test_a_capture_is_read_back_onto_its_rollout(tmp_path):
+    (tmp_path / "0-1.capture.jsonl").write_text(f"{_capture_line()}\n", encoding="utf-8")
+
+    calls, spent = runtime._read_capture(str(tmp_path), {"_ng_task_index": 0, "_ng_rollout_index": 1}, budget=10_000)
+
+    assert [call["model_call_id"] for call in calls] == ["c0"]
+    assert spent > 0
+
+
+def test_a_capture_over_budget_is_dropped_whole_rather_than_truncated(tmp_path):
+    # Half a capture would project into a trace that looks complete while under-reporting the calls
+    # the agent actually made.
+    (tmp_path / "0-1.capture.jsonl").write_text(f"{_capture_line()}\n{_capture_line(model_call_id='c1')}\n")
+
+    calls, spent = runtime._read_capture(str(tmp_path), {"_ng_task_index": 0, "_ng_rollout_index": 1}, budget=10)
+
+    assert calls == []
+    assert spent == 0
+
+
+@pytest.mark.parametrize("body", ["", "{not json}\n", "[1, 2]\n"])
+def test_an_unreadable_capture_costs_the_timing_not_the_rollout(tmp_path, body):
+    (tmp_path / "0-1.capture.jsonl").write_text(body, encoding="utf-8")
+
+    assert runtime._read_capture(str(tmp_path), {"_ng_task_index": 0, "_ng_rollout_index": 1}, budget=10_000) == ([], 0)
+
+
+def test_a_missing_capture_is_not_an_error(tmp_path):
+    assert runtime._read_capture(str(tmp_path), {"_ng_task_index": 9, "_ng_rollout_index": 9}, budget=10_000) == ([], 0)
+
+
+def test_an_unwritable_work_path_disables_capture_rather_than_failing_the_host(tmp_path):
+    # Whether the work path is writable varies by sandbox provider. A host that refuses to start is
+    # a far worse outcome than one whose traces lack per-call timing.
+    unwritable = tmp_path / "file-not-a-dir"
+    unwritable.write_text("", encoding="utf-8")
+    config = {}
+
+    runtime._apply_model_call_capture(config, str(unwritable))
+
+    assert config == {}

--- a/packages/sandboxed_gym/tests/test_gym_host_runtime.py
+++ b/packages/sandboxed_gym/tests/test_gym_host_runtime.py
@@ -1064,3 +1064,28 @@ def test_rollouts_still_return_when_no_capture_was_written(tmp_path):
 
     assert len(results) == 2
     assert all(runtime.MODEL_CALLS_RESULT_KEY not in result for result in results)
+
+
+def test_capture_spend_is_measured_in_bytes_not_characters(tmp_path):
+    # The budget is spent against a byte cap. `len` on decoded text counts code points, so a CJK
+    # capture would report about a third of what it costs on the wire -- the aggregate then
+    # overshoots `max_response_bytes`, and an oversized response is refused whole.
+    # `ensure_ascii=False` on purpose: escaped to \uXXXX the file would be pure ASCII, byte count
+    # would equal character count, and the test would pass against the bug it is written for.
+    payload = json.dumps(
+        {"model_call_id": "c0", "note": "四十二といえば生命、宇宙、そして万物についての究極の疑問の答え"},
+        ensure_ascii=False,
+    )
+    path = tmp_path / "0-1.capture.jsonl"
+    path.write_text(f"{payload}\n", encoding="utf-8")
+    assert path.stat().st_size > len(payload) + 1, "test data must be genuinely multibyte"
+
+    _, spent = runtime._read_capture(str(tmp_path), {"_ng_task_index": 0, "_ng_rollout_index": 1}, budget=10_000)
+
+    assert spent == path.stat().st_size
+
+
+def test_a_capture_that_is_not_valid_utf8_costs_the_timing_not_the_rollout(tmp_path):
+    (tmp_path / "0-1.capture.jsonl").write_bytes(b'{"model_call_id": "\xff\xfe"}\n')
+
+    assert runtime._read_capture(str(tmp_path), {"_ng_task_index": 0, "_ng_rollout_index": 1}, budget=10_000) == ([], 0)


### PR DESCRIPTION
Closes [AALGO-593](https://linear.app/nvidia/issue/AALGO-593/enable-gym-model-call-capture-on-the-sandboxed-host-so-sandboxed-runs).

Part 3 of a stack, on top of #1815 → #1814. **Review those first**; this diff only makes sense against them.

## The gap

#1814 gave Gym trials an OTLP trace with one LLM span per model call. The **sandboxed** runner didn't get that: Gym writes its captures inside the sandbox, `/rollouts/run` returned only the rollout records, and nothing carried the captures out. Those trials got a trace projected from the record alone — no per-call spans, no timing, no `ng_trajectory` evidence.

## What changed

- **Host** (`gym_host_runtime.py`) — enables Gym's model-call capture during bootstrap, reads each rollout's capture, and returns it on the record under `_nmp_model_calls`.
- **Client** (`sandboxed.py`) — unpacks those to `work_dir/model_calls/` in the CLI runner's layout and passes `capture_dir`, so `results.py` stays on **one** code path. On disk rather than in memory on purpose: one parser reads a capture whichever runner produced it, so a parsing bug can't hide in one and not the other.
- **Rollout index** — see below. This is the commit that makes the feature work at all.
- **`capture_filename`** — writer and reader now share one definition.

## Verified live, and it took a live run to find the real bug

Run against a real container (`docker/gym-host`), real NeMo-Gym 0.5.0, real `mcqa` grading, offline model stub.

**The first live run failed.** Two COMPLETED trials, zero captures: the capture directory was created and stayed empty. Trial ids came back `...:noidx1`, which was the tell — records carried `_ng_task_index` but `_ng_rollout_index: None`.

Cause, read out of Gym in the image rather than guessed: `maybe_rollout_id_from_run_body` returns `None` unless **both** indices are on the run body, and Gym writes no capture at all when it can't form a rollout id. Only `gym eval run`'s dataset preprocessing assigns the rollout index; this path calls `run_examples` directly, so nothing did.

Same shape as the `agent_ref.name` gotcha already documented on this runner: **the Python API does not do the CLI's preprocessing**, so a dataset that works under the CLI arrives incomplete at a sandboxed host.

After stamping the index, same setup:

```
trial ...:0   descriptors: ['ng_trajectory', 'rollouts', 'trace', 'trace:otlp']
              LLM spans: 1  timed: 1   model call: 22.25ms
trial ...:0   descriptors: ['ng_trajectory', 'rollouts', 'trace', 'trace:otlp']
              LLM spans: 1  timed: 1   model call: 23.46ms
captures: 2 files unpacked locally: ['0-0.capture.jsonl', '1-0.capture.jsonl']
```

Re-run after the stack was rebased onto current `main`, so these numbers are against the base as it stands. Side benefit: trial ids are now a stable `task:0` rather than a synthesized `task:noidx1`, and those ids are what a re-publish replaces on.

**Why the tests didn't catch it:** the fake host was supplying the very index production was missing. It now *echoes* what the example carried rather than inventing one, so removing the stamping fails three tests instead of none.

## Two decisions worth reviewing

**Byte budget.** Captures share the response with the rollouts they annotate, and a response over `max_response_bytes` is refused *whole* — so an unbudgeted capture would turn "traces too big" into "every result lost". They get at most half the cap, and are dropped **whole rather than truncated**, because half a capture projects into a trace that looks complete while under-reporting the calls the agent made.

**Enabling capture is non-fatal.** My first cut called `os.makedirs` unguarded and broke two existing bootstrap tests — a real regression: an unwritable work path would have crashed the host where it previously started fine. Given the ticket flagged uid-1000 writability under OpenSandbox, that's the case that would have bitten. It now logs and leaves capture off.

## Testing

**2824 passed, 38 skipped** (SDK + evaluator plugin) and **310 passed, 5 skipped** (`sandboxed_gym`), against the rebased base.

11 mutations, all caught. Coverage drove two of the additions: the host loop that attaches captures was uncovered on the first pass (the helpers were tested, the loop using them wasn't), as was the budget accounting across rollouts — applied per rollout instead of depleting, a large run would blow the response cap and lose every result.

## Still not covered

OpenSandbox. This is Docker, which validates the code path and not the isolation boundary — no PVC mounts, no egress enforcement, no readiness probe under a real cluster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for preserving model-call captures and per-call timing in sandboxed Gym evaluations.
  * Captures are associated with the correct rollout and made available in the expected output format.
  * Rollout indices are automatically maintained when not provided.
* **Reliability**
  * Capture collection respects response-size limits and continues evaluations when capture files are missing, malformed, oversized, or unavailable.
  * Existing hosts that do not provide capture data remain supported.
  * Fresh-output checks now detect existing model-call captures to prevent accidental overwrites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->