### PR TITLE
feat(deployments): pass pod annotations through k8s workloads + platform defaults

### DIFF
--- a/docs/set-up/config-reference.mdx
+++ b/docs/set-up/config-reference.mdx
@@ -534,6 +534,12 @@ models:
         default_storage_class:
         # default: '200Gi'
         default_pvc_size: 200Gi
+        # Platform-default pod annotations applied to every k8s model deployment/job (all engines). Merged key-wise into the compiled K8sDeploymentConfig; a per-entity annotation for the same key wins over the platform default. Used to ship the Istio native-sidecar annotation so a mesh-injected proxy terminates when a puller Job's main container exits.
+        default_pod_annotations: {}
+        # Platform-default nodeSelector applied to every k8s model deployment/job (all engines).
+        default_node_selector: {}
+        # Platform-default pod tolerations applied to every k8s model deployment/job (all engines).
+        default_tolerations: []
         # default: 'nvcr.io/nim/meta/llama-3.1-8b-instruct'
         default_nimservice_image: nvcr.io/nim/meta/llama-3.1-8b-instruct
         # default: '1.8.5'

--- a/docs/set-up/config-reference.mdx
+++ b/docs/set-up/config-reference.mdx
@@ -540,6 +540,10 @@ models:
         default_node_selector: {}
         # Platform-default pod tolerations applied to every k8s model deployment/job (all engines).
         default_tolerations: []
+        # Platform-default pod affinity applied to every k8s model deployment/job (all engines) when the deployment does not already set an affinity. Raw Kubernetes affinity object (nodeAffinity / podAffinity / podAntiAffinity).
+        default_affinity: {}
+        # Platform-default pod topology spread constraints applied to every k8s model deployment/job (all engines) when the deployment does not already set them. Each entry is a raw Kubernetes topologySpreadConstraint object.
+        default_topology_spread_constraints: []
         # default: 'nvcr.io/nim/meta/llama-3.1-8b-instruct'
         default_nimservice_image: nvcr.io/nim/meta/llama-3.1-8b-instruct
         # default: '1.8.5'

--- a/k8s/helm/README.md
+++ b/k8s/helm/README.md
@@ -161,10 +161,10 @@ For the complete default values, see [values.yaml](values.yaml).
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| api | object | [See values.yaml](values.yaml#L761) | API configuration settings for the api deployment |
+| api | object | [See values.yaml](values.yaml#L768) | API configuration settings for the api deployment |
 | api.affinity | object | `{}` | Affinity configuration for the API service. |
 | api.annotations | object | `{}` | Annotations to add to the API service deployment. |
-| api.autoscaling | object | [See values.yaml](values.yaml#L890) | Specifies autoscaling configurations for the deployment. |
+| api.autoscaling | object | [See values.yaml](values.yaml#L897) | Specifies autoscaling configurations for the deployment. |
 | api.autoscaling.annotations | object | `{}` | Annotations for the HorizontalPodAutoscaler. |
 | api.autoscaling.enabled | bool | `false` | Whether to enable horizontal pod autoscaler. |
 | api.autoscaling.maxReplicas | int | `10` | The maximum number of replicas for the deployment. |
@@ -175,25 +175,25 @@ For the complete default values, see [values.yaml](values.yaml).
 | api.extraArgs | list | `[]` | Additional arguments to pass to the Platform API service |
 | api.extraVolumeMounts | list | `[]` | Additional volume mounts to add to the Platform API container. |
 | api.extraVolumes | list | `[]` | Additional volumes to add to the Platform API pod. |
-| api.image | object | [See values.yaml](values.yaml#L767) | Container image configuration for the api deployment. |
+| api.image | object | [See values.yaml](values.yaml#L774) | Container image configuration for the api deployment. |
 | api.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy determining when to pull new images. |
 | api.image.repository | string | `"nvcr.io/nvidia/nemo-platform/nmp-api"` | The registry where the NeMo Platform image is located. |
 | api.image.tag | string | `""` | The image tag to use. |
-| api.livenessProbe | object | [See values.yaml](values.yaml#L849) | Liveness probe configuration for the api service. |
+| api.livenessProbe | object | [See values.yaml](values.yaml#L856) | Liveness probe configuration for the api service. |
 | api.livenessProbe.failureThreshold | int | `3` | The failure threshold for the liveness probe. |
 | api.livenessProbe.httpGet | object | `{"path":"/health/live","port":"http"}` | The HTTP GET request to use for the liveness probe. |
 | api.livenessProbe.periodSeconds | int | `10` | The frequency in seconds to perform the liveness probe. |
 | api.livenessProbe.timeoutSeconds | int | `5` | The timeout in seconds for the liveness probe. |
 | api.nodeSelector | object | `{}` | Node selector configuration for the API service. |
 | api.podAnnotations | object | `{}` | Annotations to add to the API service pod. |
-| api.podDisruptionBudget | object | [See values.yaml](values.yaml#L877) | PodDisruptionBudget configuration for the API service. |
+| api.podDisruptionBudget | object | [See values.yaml](values.yaml#L884) | PodDisruptionBudget configuration for the API service. |
 | api.podDisruptionBudget.annotations | object | `{}` | Annotations for the PodDisruptionBudget. |
 | api.podDisruptionBudget.enabled | bool | `false` | Whether to create a PodDisruptionBudget for the API pods. |
 | api.podDisruptionBudget.minAvailable | int | `1` | Minimum number of API pods that must remain available during voluntary disruptions. Only one of minAvailable or maxUnavailable may be set. |
 | api.podLabels | object | `{}` | Labels for the API service pod. |
-| api.podSecurityContext | object | [See values.yaml](values.yaml#L814) | Pod-level security context settings for the API service. |
+| api.podSecurityContext | object | [See values.yaml](values.yaml#L821) | Pod-level security context settings for the API service. |
 | api.podSecurityContext.fsGroup | int | `1000` | The file system group ID to use for all containers. |
-| api.readinessProbe | object | [See values.yaml](values.yaml#L863) | Readiness probe configuration for the api service. |
+| api.readinessProbe | object | [See values.yaml](values.yaml#L870) | Readiness probe configuration for the api service. |
 | api.readinessProbe.failureThreshold | int | `3` | The failure threshold for the readiness probe. |
 | api.readinessProbe.httpGet | object | `{"path":"/health/ready","port":"http"}` | The HTTP GET request to use for the readiness probe. |
 | api.readinessProbe.periodSeconds | int | `10` | The frequency in seconds to perform the readiness probe. |
@@ -203,11 +203,11 @@ For the complete default values, see [values.yaml](values.yaml).
 | api.securityContext | object | `{}` | Container-level security context settings for the API service. |
 | api.server | object | `{"keepAliveTimeoutSeconds":5}` | Platform API server settings. |
 | api.server.keepAliveTimeoutSeconds | int | `5` | Seconds Uvicorn keeps idle HTTP connections open. Must be greater than envoyProxy.timeouts.upstreamIdle when Envoy is enabled. |
-| api.service | object | [See values.yaml](values.yaml#L821) | Service configuration for the API service. |
+| api.service | object | [See values.yaml](values.yaml#L828) | Service configuration for the API service. |
 | api.service.annotations | object | `{}` | Annotations for the API service. |
 | api.service.port | int | `8080` | The port number to expose for the service. |
 | api.service.type | string | `"ClusterIP"` | The Kubernetes service type to create. |
-| api.serviceAccount | object | [See values.yaml](values.yaml#L797) | Service account configuration for the API service. |
+| api.serviceAccount | object | [See values.yaml](values.yaml#L804) | Service account configuration for the API service. |
 | api.serviceAccount.annotations | object | `{}` | Annotations to add to the service account. |
 | api.serviceAccount.automount | bool | `true` | Automatically mount a ServiceAccount's API credentials. |
 | api.serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |
@@ -219,7 +219,7 @@ For the complete default values, see [values.yaml](values.yaml).
 | api.serviceMonitor.labels | object | `{}` | Additional labels to add to the ServiceMonitor |
 | api.serviceMonitor.scheme | string | `"http"` | Scheme to use for scraping metrics (http or https) |
 | api.services | list | `[]` | Explicit services passed to `nemo services run` with `--services`. When non-empty, overrides api.serviceGroup. Must be a list. |
-| api.startupProbe | object | [See values.yaml](values.yaml#L833) | Startup probe configuration for the api service. |
+| api.startupProbe | object | [See values.yaml](values.yaml#L840) | Startup probe configuration for the api service. |
 | api.startupProbe.failureThreshold | int | `24` | The failure threshold for the startup probe. |
 | api.startupProbe.httpGet | object | `{"path":"/health/ready","port":"http"}` | The HTTP GET request to use for the startup probe. |
 | api.startupProbe.initialDelaySeconds | int | `10` | Number of seconds to wait before the first startup probe. Allows time for DB connection retries (e.g. Postgres pod booting). |
@@ -262,14 +262,14 @@ For the complete default values, see [values.yaml](values.yaml).
 | clickhouse.serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated from the release fullname. |
 | clickhouse.startupProbe | object | [See values.yaml](values.yaml#L408) | Startup probe configuration for the ClickHouse container. |
 | clickhouse.tolerations | list | `[]` | Tolerations for the ClickHouse pod. |
-| core | object | [See values.yaml](values.yaml#L960) | Core deployment configuration settings |
+| core | object | [See values.yaml](values.yaml#L967) | Core deployment configuration settings |
 | core.controller.affinity | object | `{}` | Affinity configuration for the controller service. |
 | core.controller.annotations | object | `{}` | Annotations to add to the controller service deployment. |
 | core.controller.controllerGroup | string | `"all"` | Predefined controller group passed to `nemo services run` with `--controller-group`. Ignored when core.controller.controllers is non-empty. |
 | core.controller.controllers | list | `[]` | Explicit controllers passed to `nemo services run` with `--controllers`. When non-empty, overrides core.controller.controllerGroup. Must be a list. |
 | core.controller.env | object | `{}` | Additional environment variables to pass to containers. This is an object formatted like NAME: value or NAME: valueFrom: {object}. |
 | core.controller.extraArgs | list | `[]` | Additional arguments to pass to the Core Controller service |
-| core.controller.livenessProbe | object | [See values.yaml](values.yaml#L1069) | Liveness probe configuration for the controller service. |
+| core.controller.livenessProbe | object | [See values.yaml](values.yaml#L1076) | Liveness probe configuration for the controller service. |
 | core.controller.livenessProbe.failureThreshold | int | `3` | The failure threshold for the liveness probe. |
 | core.controller.livenessProbe.httpGet | object | `{"path":"/health/live","port":"http"}` | The HTTP GET request to use for the liveness probe. |
 | core.controller.livenessProbe.periodSeconds | int | `10` | The frequency in seconds to perform the liveness probe. |
@@ -277,24 +277,24 @@ For the complete default values, see [values.yaml](values.yaml).
 | core.controller.nodeSelector | object | `{}` | Node selector configuration for the controller service. |
 | core.controller.podAnnotations | object | `{}` | Annotations to add to the controller service pod. |
 | core.controller.podLabels | object | `{}` | Labels for the controller service pod. |
-| core.controller.podSecurityContext | object | [See values.yaml](values.yaml#L1043) | Pod-level security context settings for the controller service. |
+| core.controller.podSecurityContext | object | [See values.yaml](values.yaml#L1050) | Pod-level security context settings for the controller service. |
 | core.controller.podSecurityContext.fsGroup | int | `1000` | The file system group ID to use for all containers. |
-| core.controller.readinessProbe | object | [See values.yaml](values.yaml#L1083) | Readiness probe configuration for the controller service. |
+| core.controller.readinessProbe | object | [See values.yaml](values.yaml#L1090) | Readiness probe configuration for the controller service. |
 | core.controller.readinessProbe.failureThreshold | int | `3` | The failure threshold for the readiness probe. |
 | core.controller.readinessProbe.httpGet | object | `{"path":"/health/ready","port":"http"}` | The HTTP GET request to use for the readiness probe. |
 | core.controller.readinessProbe.periodSeconds | int | `10` | The frequency in seconds to perform the readiness probe. |
 | core.controller.readinessProbe.timeoutSeconds | int | `5` | The timeout in seconds for the readiness probe. |
 | core.controller.resources | object | `{}` | Kubernetes deployment resources configuration for the controller service. |
 | core.controller.securityContext | object | `{}` | Container-level security context settings for the controller service. |
-| core.controller.service | object | [See values.yaml](values.yaml#L1030) | Service configuration for the controller service. This only configures a headless service for DNS resolution. |
+| core.controller.service | object | [See values.yaml](values.yaml#L1037) | Service configuration for the controller service. This only configures a headless service for DNS resolution. |
 | core.controller.service.annotations | object | `{}` | Annotations for the headless controller service. |
 | core.controller.service.port | int | `8080` | The port for the service. |
-| core.controller.serviceAccount | object | [See values.yaml](values.yaml#L1011) | Service account configuration for the controller service. |
+| core.controller.serviceAccount | object | [See values.yaml](values.yaml#L1018) | Service account configuration for the controller service. |
 | core.controller.serviceAccount.annotations | object | `{}` | Annotations to add to the service account. |
 | core.controller.serviceAccount.automount | bool | `true` | Automatically mount a ServiceAccount's API credentials. |
 | core.controller.serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |
 | core.controller.serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template. |
-| core.controller.startupProbe | object | [See values.yaml](values.yaml#L1053) | Startup probe configuration for the core service. |
+| core.controller.startupProbe | object | [See values.yaml](values.yaml#L1060) | Startup probe configuration for the core service. |
 | core.controller.startupProbe.failureThreshold | int | `24` | The failure threshold for the startup probe. |
 | core.controller.startupProbe.httpGet | object | `{"path":"/health/ready","port":"http"}` | The HTTP GET request to use for the startup probe. |
 | core.controller.startupProbe.initialDelaySeconds | int | `10` | Number of seconds to wait before the first startup probe. Allows time for DB connection retries (e.g. Postgres pod booting). |
@@ -303,11 +303,11 @@ For the complete default values, see [values.yaml](values.yaml).
 | core.controller.tolerations | list | `[]` | Tolerations configuration for the controller service. |
 | core.controller.topologySpreadConstraints | list | `[]` | Topology spread constraints for the controller service pods. See https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/ |
 | core.enabled | bool | `true` | Specifies whether to enable the core deployment. |
-| core.image | object | [See values.yaml](values.yaml#L966) | Container image configuration for the core deployment. |
+| core.image | object | [See values.yaml](values.yaml#L973) | Container image configuration for the core deployment. |
 | core.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy determining when to pull new images. |
 | core.image.repository | string | `"nvcr.io/nvidia/nemo-platform/nmp-api"` | The registry where the NeMo Platform image is located. |
 | core.image.tag | string | `""` | The image tag to use. |
-| core.jobs | object | [See values.yaml](values.yaml#L996) | Service account configuration for pods created by the jobs controller (Kubernetes/Volcano job pods). |
+| core.jobs | object | [See values.yaml](values.yaml#L1003) | Service account configuration for pods created by the jobs controller (Kubernetes/Volcano job pods). |
 | core.jobs.serviceAccount.annotations | object | `{}` | Annotations to add to the service account. |
 | core.jobs.serviceAccount.automount | bool | `true` | Automatically mount a ServiceAccount's API credentials. |
 | core.jobs.serviceAccount.create | bool | `true` | Specifies whether a service account should be created for job pods. |
@@ -326,11 +326,11 @@ For the complete default values, see [values.yaml](values.yaml).
 | core.telemetry | object | `{}` | OpenTelemetry configuration overrides for the platform deployment. |
 | env | object | `{}` | Environment variables that will be applied to every deployment pod. Uses a simple key value map structure like MY_ENV_VAR: the-key and works with valueFrom as well. |
 | envFromSecret | string | `""` | Optional. Name of an existing Kubernetes Secret to load as env vars (envFrom) for the API pod. When set, the chart does not create or generate the default api-env Secret; use your own Secret (for example, from Vault or sealed-secrets). |
-| envoyProxy | object | [See values.yaml](values.yaml#L1121) | Envoy proxy configuration settings. Resources are created only when platform config has auth.enabled: true (see platformConfig.auth.enabled). |
+| envoyProxy | object | [See values.yaml](values.yaml#L1128) | Envoy proxy configuration settings. Resources are created only when platform config has auth.enabled: true (see platformConfig.auth.enabled). |
 | envoyProxy.adminPort | int | `9901` | Envoy Admin port |
 | envoyProxy.affinity | object | `{}` | Affinity configuration for the Envoy pods. |
 | envoyProxy.annotations | object | `{}` | Annotations to add to the Envoy service deployment. |
-| envoyProxy.autoscaling | object | [See values.yaml](values.yaml#L1246) | Specifies autoscaling configurations for the deployment. |
+| envoyProxy.autoscaling | object | [See values.yaml](values.yaml#L1253) | Specifies autoscaling configurations for the deployment. |
 | envoyProxy.autoscaling.annotations | object | `{}` | Annotations for the HorizontalPodAutoscaler. |
 | envoyProxy.autoscaling.enabled | bool | `false` | Whether to enable horizontal pod autoscaler. |
 | envoyProxy.autoscaling.maxReplicas | int | `10` | The maximum number of replicas for the deployment. |
@@ -343,25 +343,25 @@ For the complete default values, see [values.yaml](values.yaml).
 | envoyProxy.extraVolumeMounts | list | `[]` | Additional volume mounts to add to the Envoy container. |
 | envoyProxy.extraVolumes | list | `[]` | Additional volumes to add to the Envoy pod. |
 | envoyProxy.image.digest | string | `""` | Optional image digest. When set, the Envoy image renders as repository@digest. |
-| envoyProxy.livenessProbe | object | [See values.yaml](values.yaml#L1207) | Liveness probe for the Envoy container (admin interface /ready). |
+| envoyProxy.livenessProbe | object | [See values.yaml](values.yaml#L1214) | Liveness probe for the Envoy container (admin interface /ready). |
 | envoyProxy.nodeSelector | object | `{}` | Node selector configuration for the Envoy pods. |
 | envoyProxy.podAnnotations | object | `{}` | Annotations to add to the Envoy service pod. |
-| envoyProxy.podDisruptionBudget | object | [See values.yaml](values.yaml#L1233) | PodDisruptionBudget configuration for the Envoy service. |
+| envoyProxy.podDisruptionBudget | object | [See values.yaml](values.yaml#L1240) | PodDisruptionBudget configuration for the Envoy service. |
 | envoyProxy.podDisruptionBudget.annotations | object | `{}` | Annotations for the PodDisruptionBudget. |
 | envoyProxy.podDisruptionBudget.enabled | bool | `false` | Whether to create a PodDisruptionBudget for the Envoy pods. |
 | envoyProxy.podDisruptionBudget.minAvailable | int | `1` | Minimum number of Envoy pods that must remain available during voluntary disruptions. Only one of minAvailable or maxUnavailable may be set. |
 | envoyProxy.podLabels | object | `{}` | Labels for the Envoy service pod. |
-| envoyProxy.podSecurityContext | object | [See values.yaml](values.yaml#L1167) | Pod-level security context settings for the Envoy service. |
+| envoyProxy.podSecurityContext | object | [See values.yaml](values.yaml#L1174) | Pod-level security context settings for the Envoy service. |
 | envoyProxy.podSecurityContext.fsGroup | int | `1000` | The file system group ID to use for all containers. |
-| envoyProxy.readinessProbe | object | [See values.yaml](values.yaml#L1215) | Readiness probe for the Envoy container (admin interface /ready). |
+| envoyProxy.readinessProbe | object | [See values.yaml](values.yaml#L1222) | Readiness probe for the Envoy container (admin interface /ready). |
 | envoyProxy.resources | object | `{}` | Kubernetes deployment resources configuration for the Envoy service. Utilization-based autoscaling requires a matching resource request. |
 | envoyProxy.securityContext | object | `{}` | Container-level security context settings for the Envoy service. |
-| envoyProxy.service | object | [See values.yaml](values.yaml#L1174) | Service configuration for the Envoy service. |
+| envoyProxy.service | object | [See values.yaml](values.yaml#L1181) | Service configuration for the Envoy service. |
 | envoyProxy.service.annotations | object | `{}` | Annotations for the Envoy service. |
 | envoyProxy.service.exposeAdminPort | bool | `false` | Expose the Envoy admin port through the Kubernetes Service. Enable only for controlled in-cluster scraping or debugging. |
 | envoyProxy.service.port | int | `8080` | The port number to expose for the service. |
 | envoyProxy.service.type | string | `"ClusterIP"` | The Kubernetes service type to create. |
-| envoyProxy.serviceAccount | object | [See values.yaml](values.yaml#L1150) | Service account configuration for the Envoy service. |
+| envoyProxy.serviceAccount | object | [See values.yaml](values.yaml#L1157) | Service account configuration for the Envoy service. |
 | envoyProxy.serviceAccount.annotations | object | `{}` | Annotations to add to the service account. |
 | envoyProxy.serviceAccount.automount | bool | `true` | Automatically mount a ServiceAccount's API credentials. |
 | envoyProxy.serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |
@@ -371,8 +371,8 @@ For the complete default values, see [values.yaml](values.yaml).
 | envoyProxy.serviceMonitor.interval | string | `"30s"` | Scrape interval for the ServiceMonitor |
 | envoyProxy.serviceMonitor.labels | object | `{}` | Additional labels to add to the ServiceMonitor |
 | envoyProxy.serviceMonitor.scheme | string | `"http"` | Scheme to use for scraping metrics (http or https) |
-| envoyProxy.startupProbe | object | [See values.yaml](values.yaml#L1223) | Startup probe for the Envoy container (admin interface /ready). |
-| envoyProxy.timeouts | object | [See values.yaml](values.yaml#L1189) | Timeouts for proxying to long-lived streams (e.g. inference gateway). Use "0s" to disable a timeout. |
+| envoyProxy.startupProbe | object | [See values.yaml](values.yaml#L1230) | Startup probe for the Envoy container (admin interface /ready). |
+| envoyProxy.timeouts | object | [See values.yaml](values.yaml#L1196) | Timeouts for proxying to long-lived streams (e.g. inference gateway). Use "0s" to disable a timeout. |
 | envoyProxy.timeouts.connect | string | `"30s"` | Cluster connect timeout (time to establish connection to backend). |
 | envoyProxy.timeouts.request | string | `"0s"` | Total request timeout. 0 = disabled (required for streaming; not compatible with streaming if set). |
 | envoyProxy.timeouts.requestHeaders | string | `"60s"` | Time to receive full request headers. 0 = disabled. |
@@ -407,13 +407,13 @@ For the complete default values, see [values.yaml](values.yaml).
 | httpRoute.hostnames | list | `[]` | If this has a specific hostname, add the name or names here in an array. |
 | httpRoute.labels | object | `{}` | Extra labels for the HTTP Route object. |
 | httpRoute.parentRefs | list | `[]` | A list of Gateways to enable this route on. This is required if httpRoute.enabled is true. |
-| httpRoute.pathRules | list | [See values.yaml](values.yaml#L692) | Path matches to route queries. |
+| httpRoute.pathRules | list | [See values.yaml](values.yaml#L699) | Path matches to route queries. |
 | imagePullSecrets | list | `[]` | Existing Kubernetes image pull secrets to use for pulling container images from private registries or mirrors. |
 | ingress.annotations | object | `{}` | Annotations for the ingress resource. |
 | ingress.className | string | `""` | The ingress class to use if your cluster has more than one class. |
 | ingress.defaultHost | string | `""` | Optional default hostname. When set, one rule is generated with this host and paths from the first entry in ingress.hosts. |
 | ingress.enabled | bool | `false` | Specifies whether to enable the ingress. |
-| ingress.hosts[0] | object | [See values.yaml](values.yaml#L657) | Hostname used by ingress. If blank, use path-only routing. |
+| ingress.hosts[0] | object | [See values.yaml](values.yaml#L664) | Hostname used by ingress. If blank, use path-only routing. |
 | ingress.tls | list | `[]` | TLS configurations. |
 | multinodeNetworking | object | [See values.yaml](values.yaml#L112) | Multi-node networking configuration for distributed GPU training. These settings control Kyverno policies that inject cloud-specific networking and NCCL configurations.  Requirements: - Kyverno policy engine must be installed in your cluster (required for multi-node networking) - Kyverno is NOT included as a subchart dependency and must be installed separately  To install Kyverno:   helm install kyverno kyverno/kyverno --namespace kyverno --create-namespace --version 3.2.0  Documentation: https://kyverno.io/docs/installation/ Helm chart: https://kyverno.github.io/kyverno/  Note: Only enable ONE cloud provider per cluster deployment. |
 | multinodeNetworking.aws | object | `{"efaDevicesPerGPU":1,"enabled":false}` | AWS-specific configuration for EFA device injection |
@@ -476,16 +476,16 @@ For the complete default values, see [values.yaml](values.yaml).
 | opensandbox.apiKeySecretKey | string | `"api-key"` | Key inside apiKeySecret. |
 | opensandbox.domain | string | [See values.yaml](values.yaml#L85) | In-cluster OpenSandbox Service DNS with no scheme. |
 | opensandbox.protocol | string | `"http"` | Scheme jobs use to reach the server. In-cluster Services speak http. |
-| openshiftRoute | object | [See values.yaml](values.yaml#L711) | OpenShift Route (route.openshift.io/v1). Use on OpenShift to expose the API via a Route instead of Ingress. |
+| openshiftRoute | object | [See values.yaml](values.yaml#L718) | OpenShift Route (route.openshift.io/v1). Use on OpenShift to expose the API via a Route instead of Ingress. |
 | openshiftRoute.annotations | object | `{}` | Annotations for the route resource. |
 | openshiftRoute.enabled | bool | `false` | Specifies whether to create an OpenShift Route for the API service. |
 | openshiftRoute.host | string | `""` | Hostname for the route. If empty, the OpenShift router may assign a default hostname. |
 | openshiftRoute.labels | object | `{}` | Labels for the route resource. |
-| openshiftRoute.service | string | [See values.yaml](values.yaml#L717) | Service name to route to. Defaults to Envoy when auth+envoy enabled, otherwise API (tpl-evaluated). |
-| openshiftRoute.targetPort | string | [See values.yaml](values.yaml#L719) | Target port on the service. Defaults to Envoy or API port depending on auth (tpl-evaluated). |
+| openshiftRoute.service | string | [See values.yaml](values.yaml#L724) | Service name to route to. Defaults to Envoy when auth+envoy enabled, otherwise API (tpl-evaluated). |
+| openshiftRoute.targetPort | string | [See values.yaml](values.yaml#L726) | Target port on the service. Defaults to Envoy or API port depending on auth (tpl-evaluated). |
 | openshiftRoute.tls | object | `{}` | Optional TLS configuration (termination, certificate, key, etc.). See OpenShift Route spec. |
 | platformConfig | object | [See values.yaml](values.yaml#L485) | Platform-wide configuration settings Set configuration here to apply custom, structured configuration across all services. Applied after the base platform config is evaluated for templates. Enables adding / overriding YAML-based elements in the evaluated platform config. It is usually recommended to use this config section instead of `basePlatformConfig` unless you need to use templating features. For example, you can set the NIM default StorageClass via models.controller.backends.deployments_plugin.default_storage_class. For full configuration reference, see https://docs.nvidia.com/nemo-platform |
-| platformSeedJob | object | [See values.yaml](values.yaml#L932) | Platform seed Job (Helm hook: runs after install/upgrade) Runs the platform-seed task (guardrails configs, evaluator system entities, data designer filesets). Uses post-install,post-upgrade hooks so it runs on fresh installs and can be re-triggered on no-op upgrade. |
+| platformSeedJob | object | [See values.yaml](values.yaml#L939) | Platform seed Job (Helm hook: runs after install/upgrade) Runs the platform-seed task (guardrails configs, evaluator system entities, data designer filesets). Uses post-install,post-upgrade hooks so it runs on fresh installs and can be re-triggered on no-op upgrade. |
 | platformSeedJob.activeDeadlineSeconds | int | `600` | Maximum time in seconds the Job can run. |
 | platformSeedJob.affinity | object | `{}` | Affinity for the platform seeding Job pod. |
 | platformSeedJob.backoffLimit | int | `6` | Number of retries before considering the Job failed. |
@@ -498,7 +498,7 @@ For the complete default values, see [values.yaml](values.yaml).
 | platformSeedJob.securityContext | object | `{}` | Container-level security context for the platform-seed container. |
 | platformSeedJob.tolerations | list | `[]` | Tolerations for the platform seeding Job pod. |
 | platformSeedJob.ttlSecondsAfterFinished | int | `86400` | Seconds after the Job finishes (success or failure) before it is eligible for automatic deletion. |
-| podSecurityContext | object | [See values.yaml](values.yaml#L752) | Pod security context settings applied to all services by default. These can be overridden in individual service configurations. |
+| podSecurityContext | object | [See values.yaml](values.yaml#L759) | Pod security context settings applied to all services by default. These can be overridden in individual service configurations. |
 | postgresql | object | [See values.yaml](values.yaml#L286) | Local PostgreSQL configuration for the NeMo Platform. |
 | postgresql.affinity | object | `{}` | Affinity for the PostgreSQL pod. |
 | postgresql.auth | object | [See values.yaml](values.yaml#L296) | PostgreSQL authentication configuration. |
@@ -541,7 +541,7 @@ For the complete default values, see [values.yaml](values.yaml).
 | secrets.defaultEncryptionKey.generated.tolerations | list | `[]` | Tolerations for the key generation hook. |
 | secrets.defaultEncryptionKey.generated.ttlSecondsAfterFinished | int | `300` | Seconds to keep the key generation hook Job after it finishes, if the hook is not deleted first. |
 | secrets.defaultEncryptionKey.value | string | `""` | Optional base64-encoded key for encrypting platform secrets. The decoded key must be at least 32 bytes. If empty and envFromSecret is not set, a pre-install hook generates a per-install key. |
-| securityContext | object | [See values.yaml](values.yaml#L757) | Container security context settings applied to all services by default. These can be overridden in individual service configurations. |
+| securityContext | object | [See values.yaml](values.yaml#L764) | Container security context settings applied to all services by default. These can be overridden in individual service configurations. |
 | telemetry.OTEL_EXPORTER_OTLP_ENDPOINT | string | `""` | The OpenTelemetry grpc collector endpoint to export traces and metrics to. |
 | telemetry.OTEL_EXPORTER_OTLP_INSECURE | bool | `true` | Whether to use an insecure connection (no TLS) to the OpenTelemetry collector endpoint. |
 | telemetry.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT | string | `nil` | The OpenTelemetry metrics exporter endpoint to use. Defaults to `OTEL_EXPORTER_OTLP_ENDPOINT` if not set. |

--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -577,6 +577,13 @@ basePlatformConfig: |
           enabled: true
           k8s_executor: local-k8s
           default_executor: local-k8s
+          # Platform-default pod annotations applied to every k8s model
+          # deployment/job (all engines). The Istio native-sidecar annotation
+          # makes a mesh-injected istio-proxy terminate when a Job's main
+          # container exits, so the weight-puller Job completes while keeping
+          # mesh mTLS egress (inject: "false" is NOT viable in-mesh).
+          default_pod_annotations:
+            sidecar.istio.io/nativeSidecar: "true"
           # Bypass the image `nemo` ENTRYPOINT; invoke the adapters module directly.
           # Avoids PermissionError when the sidecar writes instance state under $HOME.
           lora_sidecar_command:

--- a/plugins/nemo-deployments/openapi/openapi.yaml
+++ b/plugins/nemo-deployments/openapi/openapi.yaml
@@ -1177,6 +1177,11 @@ components:
         serviceAccount:
           title: Serviceaccount
           type: string
+        nodeSelector:
+          additionalProperties:
+            type: string
+          type: object
+          title: Nodeselector
         tolerations:
           items:
             $ref: '#/components/schemas/Toleration'
@@ -1186,6 +1191,15 @@ components:
           $ref: '#/components/schemas/Affinity'
         securityContext:
           $ref: '#/components/schemas/PodSecurityContext'
+        podAnnotations:
+          additionalProperties:
+            type: string
+          type: object
+          title: Podannotations
+          description: Annotations stamped onto the pod-template metadata for every
+            Job/Deployment pod rendered from this config (e.g. an Istio native-sidecar
+            annotation so a mesh-injected proxy terminates when a puller Job's main
+            container exits). k8s-only; ignored on docker/openshell backends.
       type: object
       title: K8sDeploymentConfig
     K8sVolumeConfig:

--- a/plugins/nemo-deployments/openapi/openapi.yaml
+++ b/plugins/nemo-deployments/openapi/openapi.yaml
@@ -1189,6 +1189,16 @@ components:
           title: Tolerations
         affinity:
           $ref: '#/components/schemas/Affinity'
+        topologySpreadConstraints:
+          items:
+            additionalProperties: true
+            type: object
+          type: array
+          title: Topologyspreadconstraints
+          description: Pod topology spread constraints applied to every Job/Deployment
+            pod rendered from this config. Each entry is a raw Kubernetes topologySpreadConstraint
+            object (maxSkew, topologyKey, whenUnsatisfiable, labelSelector, ...).
+            k8s-only.
         securityContext:
           $ref: '#/components/schemas/PodSecurityContext'
         podAnnotations:

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/compiler.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/compiler.py
@@ -431,6 +431,12 @@ def build_affinity(affinity: Affinity | None) -> Any | None:
     return _deserialize_k8s(payload, "V1Affinity")
 
 
+def build_topology_spread_constraints(constraints: list[dict[str, Any]]) -> list[Any]:
+    if not constraints:
+        return []
+    return [_deserialize_k8s(item, "V1TopologySpreadConstraint") for item in constraints if item]
+
+
 def build_pod_security_context(security_context: PodSecurityContext | None) -> Any | None:
     if security_context is None:
         return None
@@ -602,6 +608,9 @@ def compile_workload(
         affinity = build_affinity(k8s_config.affinity)
         if affinity is not None:
             pod_spec_kwargs["affinity"] = affinity
+        topology_spread_constraints = build_topology_spread_constraints(k8s_config.topology_spread_constraints)
+        if topology_spread_constraints:
+            pod_spec_kwargs["topology_spread_constraints"] = topology_spread_constraints
         security_context = build_pod_security_context(k8s_config.security_context)
         if security_context is not None:
             pod_spec_kwargs["security_context"] = security_context

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/compiler.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/compiler.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import json
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from types import SimpleNamespace
 from typing import Any
 
@@ -165,6 +165,7 @@ class CompiledWorkload:
     service_containers: tuple[Container, ...]
     secret_body: Any | None = None
     secret_name: str | None = None
+    pod_annotations: dict[str, str] = field(default_factory=dict)
 
 
 def _reraise_api_unless(exc: ApiException, *allowed_statuses: int) -> None:
@@ -596,6 +597,8 @@ def compile_workload(
         tolerations = build_tolerations(k8s_config.tolerations)
         if tolerations:
             pod_spec_kwargs["tolerations"] = tolerations
+        if k8s_config.node_selector:
+            pod_spec_kwargs["node_selector"] = dict(k8s_config.node_selector)
         affinity = build_affinity(k8s_config.affinity)
         if affinity is not None:
             pod_spec_kwargs["affinity"] = affinity
@@ -606,6 +609,8 @@ def compile_workload(
     if effective_service_account_name:
         pod_spec_kwargs["service_account_name"] = effective_service_account_name
 
+    pod_annotations = dict(k8s_config.pod_annotations) if k8s_config is not None else {}
+
     return CompiledWorkload(
         pod_spec_kwargs=pod_spec_kwargs,
         configmap_body=configmap_body,
@@ -613,6 +618,7 @@ def compile_workload(
         service_containers=tuple(config.containers),
         secret_body=secret_body,
         secret_name=secret_name,
+        pod_annotations=pod_annotations,
     )
 
 

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/deployments.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/deployments.py
@@ -125,7 +125,10 @@ def build_deployment_body(
             replicas=1,
             selector=k8s.client.V1LabelSelector(match_labels=selector_labels),
             template=k8s.client.V1PodTemplateSpec(
-                metadata=k8s.client.V1ObjectMeta(labels=pod_labels),
+                metadata=k8s.client.V1ObjectMeta(
+                    labels=pod_labels,
+                    annotations=compiled.pod_annotations or None,
+                ),
                 spec=k8s.client.V1PodSpec(**compiled.pod_spec_kwargs),
             ),
         ),

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/jobs.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/jobs.py
@@ -168,7 +168,10 @@ def build_job_body(
         spec=k8s.client.V1JobSpec(
             backoff_limit=job_backoff_limit(config),
             template=k8s.client.V1PodTemplateSpec(
-                metadata=k8s.client.V1ObjectMeta(labels=labels),
+                metadata=k8s.client.V1ObjectMeta(
+                    labels=labels,
+                    annotations=compiled.pod_annotations or None,
+                ),
                 spec=k8s.client.V1PodSpec(**compiled.pod_spec_kwargs),
             ),
         ),

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/entities.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/entities.py
@@ -193,6 +193,15 @@ class K8sDeploymentConfig(BaseModel):
     node_selector: dict[str, str] = Field(default_factory=dict, alias="nodeSelector")
     tolerations: list[Toleration] = Field(default_factory=list)
     affinity: Affinity | None = None
+    topology_spread_constraints: list[dict[str, Any]] = Field(
+        default_factory=list,
+        alias="topologySpreadConstraints",
+        description=(
+            "Pod topology spread constraints applied to every Job/Deployment pod rendered "
+            "from this config. Each entry is a raw Kubernetes topologySpreadConstraint object "
+            "(maxSkew, topologyKey, whenUnsatisfiable, labelSelector, ...). k8s-only."
+        ),
+    )
     security_context: PodSecurityContext | None = Field(default=None, alias="securityContext")
     pod_annotations: dict[str, str] = Field(
         default_factory=dict,

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/entities.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/entities.py
@@ -190,9 +190,20 @@ class DockerDeploymentConfig(BaseModel):
 class K8sDeploymentConfig(BaseModel):
     namespace: str | None = None
     service_account: str | None = Field(default=None, alias="serviceAccount")
+    node_selector: dict[str, str] = Field(default_factory=dict, alias="nodeSelector")
     tolerations: list[Toleration] = Field(default_factory=list)
     affinity: Affinity | None = None
     security_context: PodSecurityContext | None = Field(default=None, alias="securityContext")
+    pod_annotations: dict[str, str] = Field(
+        default_factory=dict,
+        alias="podAnnotations",
+        description=(
+            "Annotations stamped onto the pod-template metadata for every Job/Deployment "
+            "pod rendered from this config (e.g. an Istio native-sidecar annotation so a "
+            "mesh-injected proxy terminates when a puller Job's main container exits). "
+            "k8s-only; ignored on docker/openshell backends."
+        ),
+    )
 
     model_config = {"populate_by_name": True}
 

--- a/plugins/nemo-deployments/tests/unit/backends/k8s/test_compiler.py
+++ b/plugins/nemo-deployments/tests/unit/backends/k8s/test_compiler.py
@@ -217,6 +217,36 @@ def test_compile_applies_node_selector() -> None:
     assert pod_spec["node_selector"] == {"gpu": "a100", "zone": "us-west1-a"}
 
 
+def test_compile_applies_topology_spread_constraints() -> None:
+    config = sample_always_config()
+    k8s_config = K8sDeploymentConfig.model_validate(
+        {
+            "topologySpreadConstraints": [
+                {
+                    "maxSkew": 1,
+                    "topologyKey": "kubernetes.io/hostname",
+                    "whenUnsatisfiable": "DoNotSchedule",
+                    "labelSelector": {"matchLabels": {"app": "x"}},
+                }
+            ]
+        }
+    )
+    compiled = compile_workload(
+        config=config,
+        workspace="default",
+        deployment_name="task",
+        labels={"managed-by": "nemo-deployments"},
+        k8s_config=k8s_config,
+        pod_restart_policy="Always",
+    )
+    pod_spec = _serialized(compiled.pod_spec_kwargs)
+    tsc = pod_spec["topology_spread_constraints"]
+    assert len(tsc) == 1
+    assert tsc[0]["maxSkew"] == 1
+    assert tsc[0]["topologyKey"] == "kubernetes.io/hostname"
+    assert tsc[0]["whenUnsatisfiable"] == "DoNotSchedule"
+
+
 def test_compile_carries_pod_annotations() -> None:
     config = sample_config(restart_policy="Never")
     k8s_config = K8sDeploymentConfig.model_validate({"podAnnotations": {"sidecar.istio.io/nativeSidecar": "true"}})

--- a/plugins/nemo-deployments/tests/unit/backends/k8s/test_compiler.py
+++ b/plugins/nemo-deployments/tests/unit/backends/k8s/test_compiler.py
@@ -188,7 +188,6 @@ def test_compile_applies_k8s_deployment_config() -> None:
 def test_compile_workload_identity_prefers_workload_service_account() -> None:
     config = with_workload_identity(sample_always_config(), service_account_name="workload-sa")
     k8s_config = K8sDeploymentConfig.model_validate({"serviceAccount": "pod-sa"})
-
     compiled = compile_workload(
         config=config,
         workspace="default",
@@ -201,6 +200,108 @@ def test_compile_workload_identity_prefers_workload_service_account() -> None:
     pod_spec = _serialized(compiled.pod_spec_kwargs)
     assert pod_spec["service_account_name"] == "workload-sa"
     assert any(volume["name"] == WORKLOAD_IDENTITY_VOLUME_NAME for volume in pod_spec["volumes"])
+
+
+def test_compile_applies_node_selector() -> None:
+    config = sample_always_config()
+    k8s_config = K8sDeploymentConfig.model_validate({"nodeSelector": {"gpu": "a100", "zone": "us-west1-a"}})
+    compiled = compile_workload(
+        config=config,
+        workspace="default",
+        deployment_name="task",
+        labels={"managed-by": "nemo-deployments"},
+        k8s_config=k8s_config,
+        pod_restart_policy="Always",
+    )
+    pod_spec = _serialized(compiled.pod_spec_kwargs)
+    assert pod_spec["node_selector"] == {"gpu": "a100", "zone": "us-west1-a"}
+
+
+def test_compile_carries_pod_annotations() -> None:
+    config = sample_config(restart_policy="Never")
+    k8s_config = K8sDeploymentConfig.model_validate({"podAnnotations": {"sidecar.istio.io/nativeSidecar": "true"}})
+    compiled = compile_workload(
+        config=config,
+        workspace="default",
+        deployment_name="task",
+        labels={"managed-by": "nemo-deployments"},
+        k8s_config=k8s_config,
+        pod_restart_policy="Never",
+    )
+    assert compiled.pod_annotations == {"sidecar.istio.io/nativeSidecar": "true"}
+    # Annotations live on the pod-template metadata, not the pod spec.
+    assert "annotations" not in compiled.pod_spec_kwargs
+
+
+def test_compile_pod_annotations_default_empty_without_k8s_config() -> None:
+    config = sample_config(restart_policy="Never")
+    compiled = compile_workload(
+        config=config,
+        workspace="default",
+        deployment_name="task",
+        labels={"managed-by": "nemo-deployments"},
+        k8s_config=None,
+        pod_restart_policy="Never",
+    )
+    assert compiled.pod_annotations == {}
+
+
+def test_build_job_body_stamps_pod_annotations_on_template() -> None:
+    config = sample_config(restart_policy="Never")
+    k8s_config = K8sDeploymentConfig.model_validate({"podAnnotations": {"sidecar.istio.io/nativeSidecar": "true"}})
+    built = build_job_body(
+        job_name="default-task",
+        labels={"managed-by": "nemo-deployments"},
+        config=config,
+        workspace="default",
+        deployment_name="task",
+        k8s_config=k8s_config,
+    )
+    template_meta = _serialized(built.job)["spec"]["template"]["metadata"]
+    assert template_meta["annotations"] == {"sidecar.istio.io/nativeSidecar": "true"}
+
+
+def test_build_job_body_omits_annotations_when_none() -> None:
+    config = sample_config(restart_policy="Never")
+    built = build_job_body(
+        job_name="default-task",
+        labels={"managed-by": "nemo-deployments"},
+        config=config,
+        workspace="default",
+        deployment_name="task",
+        k8s_config=None,
+    )
+    template_meta = _serialized(built.job)["spec"]["template"]["metadata"]
+    assert "annotations" not in template_meta
+
+
+def test_build_deployment_body_stamps_pod_annotations_on_template() -> None:
+    config = sample_always_config()
+    k8s_config = K8sDeploymentConfig.model_validate({"podAnnotations": {"sidecar.istio.io/nativeSidecar": "true"}})
+    built = build_deployment_body(
+        resource_name="default-task",
+        labels={"managed-by": "nemo-deployments"},
+        config=config,
+        workspace="default",
+        deployment_name="task",
+        k8s_config=k8s_config,
+    )
+    template_meta = _serialized(built.deployment)["spec"]["template"]["metadata"]
+    assert template_meta["annotations"] == {"sidecar.istio.io/nativeSidecar": "true"}
+
+
+def test_build_deployment_body_omits_annotations_when_none() -> None:
+    config = sample_always_config()
+    built = build_deployment_body(
+        resource_name="default-task",
+        labels={"managed-by": "nemo-deployments"},
+        config=config,
+        workspace="default",
+        deployment_name="task",
+        k8s_config=None,
+    )
+    template_meta = _serialized(built.deployment)["spec"]["template"]["metadata"]
+    assert "annotations" not in template_meta
 
 
 def test_compile_workload_emits_image_pull_secrets() -> None:

--- a/services/core/models/src/nmp/core/models/controllers/backends/deployments_plugin/config.py
+++ b/services/core/models/src/nmp/core/models/controllers/backends/deployments_plugin/config.py
@@ -3,6 +3,8 @@
 
 """Configuration for the deployments-plugin models backend."""
 
+from typing import Any
+
 from pydantic import BaseModel, Field
 
 
@@ -35,6 +37,22 @@ class DeploymentsPluginConfig(BaseModel):
     default_tolerations: list[dict[str, str | int]] = Field(
         default_factory=list,
         description="Platform-default pod tolerations applied to every k8s model deployment/job (all engines).",
+    )
+    default_affinity: dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Platform-default pod affinity applied to every k8s model deployment/job (all engines) "
+            "when the deployment does not already set an affinity. Raw Kubernetes affinity object "
+            "(nodeAffinity / podAffinity / podAntiAffinity)."
+        ),
+    )
+    default_topology_spread_constraints: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description=(
+            "Platform-default pod topology spread constraints applied to every k8s model "
+            "deployment/job (all engines) when the deployment does not already set them. Each entry "
+            "is a raw Kubernetes topologySpreadConstraint object."
+        ),
     )
     default_nimservice_image: str = "nvcr.io/nim/meta/llama-3.1-8b-instruct"
     default_nimservice_image_tag: str = "1.8.5"

--- a/services/core/models/src/nmp/core/models/controllers/backends/deployments_plugin/config.py
+++ b/services/core/models/src/nmp/core/models/controllers/backends/deployments_plugin/config.py
@@ -18,6 +18,24 @@ class DeploymentsPluginConfig(BaseModel):
     max_restart_count: int = 5
     default_storage_class: str | None = None
     default_pvc_size: str = "200Gi"
+    default_pod_annotations: dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Platform-default pod annotations applied to every k8s model deployment/job "
+            "(all engines). Merged key-wise into the compiled K8sDeploymentConfig; a "
+            "per-entity annotation for the same key wins over the platform default. "
+            "Used to ship the Istio native-sidecar annotation so a mesh-injected proxy "
+            "terminates when a puller Job's main container exits."
+        ),
+    )
+    default_node_selector: dict[str, str] = Field(
+        default_factory=dict,
+        description="Platform-default nodeSelector applied to every k8s model deployment/job (all engines).",
+    )
+    default_tolerations: list[dict[str, str]] = Field(
+        default_factory=list,
+        description="Platform-default pod tolerations applied to every k8s model deployment/job (all engines).",
+    )
     default_nimservice_image: str = "nvcr.io/nim/meta/llama-3.1-8b-instruct"
     default_nimservice_image_tag: str = "1.8.5"
     default_vllm_image: str = Field(

--- a/services/core/models/src/nmp/core/models/controllers/backends/deployments_plugin/config.py
+++ b/services/core/models/src/nmp/core/models/controllers/backends/deployments_plugin/config.py
@@ -32,7 +32,7 @@ class DeploymentsPluginConfig(BaseModel):
         default_factory=dict,
         description="Platform-default nodeSelector applied to every k8s model deployment/job (all engines).",
     )
-    default_tolerations: list[dict[str, str]] = Field(
+    default_tolerations: list[dict[str, str | int]] = Field(
         default_factory=list,
         description="Platform-default pod tolerations applied to every k8s model deployment/job (all engines).",
     )

--- a/services/core/models/src/nmp/core/models/controllers/backends/deployments_plugin/nim_compiler.py
+++ b/services/core/models/src/nmp/core/models/controllers/backends/deployments_plugin/nim_compiler.py
@@ -339,9 +339,10 @@ def build_k8s_deployment_backend_config(
     """Merge operator overrides, engine security defaults, and platform defaults into backend_config.k8s.
 
     Platform defaults (``default_pod_annotations``, ``default_node_selector``,
-    ``default_tolerations``) apply to every engine (nim/vllm/generic). Annotations
-    merge key-wise with a per-entity value winning over the platform default for the
-    same key; per-entity tolerations/node_selector (nim operator config) win wholesale
+    ``default_tolerations``, ``default_affinity``, ``default_topology_spread_constraints``)
+    apply to every engine (nim/vllm/generic). Annotations merge key-wise with a per-entity
+    value winning over the platform default for the same key; per-entity
+    tolerations/node_selector/affinity/topology-spread (nim operator config) win wholesale
     over the platform default when present. This helper only runs on the Kubernetes
     runtime, so the defaults are k8s-only by construction.
     """
@@ -368,6 +369,16 @@ def build_k8s_deployment_backend_config(
     if config.default_tolerations and not k8s.tolerations:
         k8s.tolerations = _default_tolerations(config)
 
+    # Platform-default affinity (all engines); a per-entity affinity (including the
+    # node-selector-derived affinity from the nim operator path) wins wholesale.
+    if config.default_affinity and k8s.affinity is None:
+        k8s.affinity = Affinity.model_validate(config.default_affinity)
+
+    # Platform-default topology spread constraints (all engines); per-entity
+    # constraints win wholesale.
+    if config.default_topology_spread_constraints and not k8s.topology_spread_constraints:
+        k8s.topology_spread_constraints = [dict(item) for item in config.default_topology_spread_constraints]
+
     if any(
         (
             k8s.tolerations,
@@ -377,6 +388,7 @@ def build_k8s_deployment_backend_config(
             k8s.service_account,
             k8s.node_selector,
             k8s.pod_annotations,
+            k8s.topology_spread_constraints,
         )
     ):
         return DeploymentBackendConfig(k8s=k8s)

--- a/services/core/models/src/nmp/core/models/controllers/backends/deployments_plugin/nim_compiler.py
+++ b/services/core/models/src/nmp/core/models/controllers/backends/deployments_plugin/nim_compiler.py
@@ -326,12 +326,25 @@ def pod_security_context_for_engine(
     return PodSecurityContext(run_as_user=user_id, run_as_group=group_id, fs_group=group_id)
 
 
+def _default_tolerations(config: DeploymentsPluginConfig) -> list[Toleration]:
+    """Parse platform-default tolerations from config into plugin Toleration models."""
+    return _tolerations_from_config([item for item in config.default_tolerations if isinstance(item, dict)])
+
+
 def build_k8s_deployment_backend_config(
     engine: str,
     view: DeploymentConfigView,
     config: DeploymentsPluginConfig,
 ) -> DeploymentBackendConfig:
-    """Merge operator overrides and engine security defaults into backend_config.k8s."""
+    """Merge operator overrides, engine security defaults, and platform defaults into backend_config.k8s.
+
+    Platform defaults (``default_pod_annotations``, ``default_node_selector``,
+    ``default_tolerations``) apply to every engine (nim/vllm/generic). Annotations
+    merge key-wise with a per-entity value winning over the platform default for the
+    same key; per-entity tolerations/node_selector (nim operator config) win wholesale
+    over the platform default when present. This helper only runs on the Kubernetes
+    runtime, so the defaults are k8s-only by construction.
+    """
     if engine == ENGINE_NIM:
         k8s = k8s_backend_config_from_nim_operator(view) or K8sDeploymentConfig()
     else:
@@ -339,6 +352,22 @@ def build_k8s_deployment_backend_config(
     security_context = pod_security_context_for_engine(engine, view, config)
     if security_context is not None:
         k8s.security_context = security_context
+
+    # Platform-default pod annotations (all engines), key-wise merge: platform
+    # default first, per-entity annotation for the same key wins.
+    if config.default_pod_annotations:
+        merged_annotations = {**config.default_pod_annotations, **k8s.pod_annotations}
+        k8s.pod_annotations = merged_annotations
+
+    # Platform-default node selector (all engines); a per-entity node selector
+    # (mapped onto affinity by the nim operator path) wins when present.
+    if config.default_node_selector and k8s.affinity is None:
+        k8s.node_selector = {**config.default_node_selector, **k8s.node_selector}
+
+    # Platform-default tolerations (all engines); per-entity tolerations win wholesale.
+    if config.default_tolerations and not k8s.tolerations:
+        k8s.tolerations = _default_tolerations(config)
+
     if any(
         (
             k8s.tolerations,
@@ -346,6 +375,8 @@ def build_k8s_deployment_backend_config(
             k8s.security_context,
             k8s.namespace,
             k8s.service_account,
+            k8s.node_selector,
+            k8s.pod_annotations,
         )
     ):
         return DeploymentBackendConfig(k8s=k8s)

--- a/services/core/models/tests/unit/controllers/backends/deployments_plugin/test_nim_compiler.py
+++ b/services/core/models/tests/unit/controllers/backends/deployments_plugin/test_nim_compiler.py
@@ -17,6 +17,7 @@ from nemo_platform.types.inference.k8s_nim_operator_config import K8sNIMOperator
 from nmp.common.config import Runtime
 from nmp.core.models.app import ModelWeightsType
 from nmp.core.models.controllers.backends.common import DeploymentConfigView
+from nmp.core.models.controllers.backends.deployments_plugin import nim_compiler
 from nmp.core.models.controllers.backends.deployments_plugin.config import DeploymentsPluginConfig
 from nmp.core.models.controllers.backends.deployments_plugin.nim_compiler import (
     apply_container_resources,
@@ -215,18 +216,51 @@ def test_build_k8s_deployment_backend_config_applies_default_pod_annotations(eng
     assert backend.k8s.pod_annotations == {"sidecar.istio.io/nativeSidecar": "true"}
 
 
-def test_build_k8s_deployment_backend_config_default_annotations_merge_key_wise() -> None:
-    # Per-entity annotation for the same key wins over the platform default;
-    # non-overlapping platform defaults are still applied.
+def test_build_k8s_deployment_backend_config_default_annotations_applied_and_merged() -> None:
+    # All platform-default annotation keys land on the compiled k8s config. In the
+    # models path there is no per-entity annotation source yet (that is out of scope;
+    # tracked separately), so this asserts only what this path can produce: every
+    # platform default is present. The per-entity-wins precedence of the merge
+    # operator itself is covered by
+    # test_build_k8s_deployment_backend_config_default_annotations_per_entity_wins.
     view = DeploymentConfigView()
     config = DeploymentsPluginConfig(
         default_pod_annotations={"sidecar.istio.io/nativeSidecar": "true", "team": "platform"}
     )
     backend = build_k8s_deployment_backend_config("nim", view, config)
     assert backend.k8s is not None
-    # Simulate a per-entity annotation set on the compiled config before merge is
-    # not exposed via the view; instead verify the config-default path directly.
     assert backend.k8s.pod_annotations == {"sidecar.istio.io/nativeSidecar": "true", "team": "platform"}
+
+
+def test_build_k8s_deployment_backend_config_default_annotations_per_entity_wins(monkeypatch) -> None:
+    # Prove the documented merge contract with a REAL conflicting key: when a
+    # per-entity K8sDeploymentConfig carries pod_annotations, its value wins over the
+    # platform default for the same key while non-conflicting defaults still apply.
+    # The models producer has no per-entity annotation source today, so we inject one
+    # at the only place k8s originates for the NIM engine
+    # (k8s_backend_config_from_nim_operator) to exercise the {**default, **entity}
+    # precedence end-to-end through build_k8s_deployment_backend_config.
+    entity_k8s = K8sDeploymentConfig.model_validate(
+        {"podAnnotations": {"sidecar.istio.io/nativeSidecar": "false", "owner": "team-a"}}
+    )
+    monkeypatch.setattr(
+        nim_compiler,
+        "k8s_backend_config_from_nim_operator",
+        lambda _view: entity_k8s,
+    )
+    view = DeploymentConfigView()
+    config = DeploymentsPluginConfig(
+        default_pod_annotations={"sidecar.istio.io/nativeSidecar": "true", "team": "platform"}
+    )
+    backend = build_k8s_deployment_backend_config("nim", view, config)
+    assert backend.k8s is not None
+    # Conflicting key: per-entity "false" wins over the platform default "true".
+    # Non-conflicting keys from both sides are retained.
+    assert backend.k8s.pod_annotations == {
+        "sidecar.istio.io/nativeSidecar": "false",
+        "team": "platform",
+        "owner": "team-a",
+    }
 
 
 @pytest.mark.parametrize("engine", ["nim", "vllm", "generic"])

--- a/services/core/models/tests/unit/controllers/backends/deployments_plugin/test_nim_compiler.py
+++ b/services/core/models/tests/unit/controllers/backends/deployments_plugin/test_nim_compiler.py
@@ -322,6 +322,61 @@ def test_build_k8s_deployment_backend_config_default_tolerations_accept_int_seco
     assert backend.k8s.tolerations[0].key == "entity"
 
 
+@pytest.mark.parametrize("engine", ["nim", "vllm", "generic"])
+def test_build_k8s_deployment_backend_config_applies_default_affinity(engine: str) -> None:
+    view = DeploymentConfigView()
+    affinity = {
+        "nodeAffinity": {
+            "requiredDuringSchedulingIgnoredDuringExecution": {
+                "nodeSelectorTerms": [{"matchExpressions": [{"key": "gpu", "operator": "In", "values": ["a100"]}]}]
+            }
+        }
+    }
+    config = DeploymentsPluginConfig(default_affinity=affinity)
+    backend = build_k8s_deployment_backend_config(engine, view, config)
+    assert backend.k8s is not None
+    assert backend.k8s.affinity is not None
+    assert backend.k8s.affinity.node_affinity is not None
+
+
+def test_build_k8s_deployment_backend_config_default_affinity_skipped_when_entity_affinity_set() -> None:
+    # A per-entity node selector maps onto affinity via the nim operator path; the
+    # platform-default affinity must not override it.
+    view = DeploymentConfigView(
+        k8s_nim_operator_config=K8sNIMOperatorConfig(node_selector={"zone": "us-west1-a"}),
+    )
+    config = DeploymentsPluginConfig(
+        default_affinity={
+            "nodeAffinity": {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "nodeSelectorTerms": [{"matchExpressions": [{"key": "gpu", "operator": "In", "values": ["a100"]}]}]
+                }
+            }
+        }
+    )
+    backend = build_k8s_deployment_backend_config("nim", view, config)
+    assert backend.k8s is not None
+    # Entity's node-selector-derived affinity wins; it targets 'zone', not 'gpu'.
+    payload = backend.k8s.affinity.node_affinity
+    assert payload is not None
+    terms = payload["requiredDuringSchedulingIgnoredDuringExecution"]["nodeSelectorTerms"]
+    assert terms[0]["matchExpressions"][0]["key"] == "zone"
+
+
+@pytest.mark.parametrize("engine", ["nim", "vllm", "generic"])
+def test_build_k8s_deployment_backend_config_applies_default_topology_spread(engine: str) -> None:
+    view = DeploymentConfigView()
+    config = DeploymentsPluginConfig(
+        default_topology_spread_constraints=[
+            {"maxSkew": 1, "topologyKey": "kubernetes.io/hostname", "whenUnsatisfiable": "DoNotSchedule"}
+        ]
+    )
+    backend = build_k8s_deployment_backend_config(engine, view, config)
+    assert backend.k8s is not None
+    assert len(backend.k8s.topology_spread_constraints) == 1
+    assert backend.k8s.topology_spread_constraints[0]["topologyKey"] == "kubernetes.io/hostname"
+
+
 def test_build_k8s_deployment_backend_config_no_defaults_returns_empty() -> None:
     # With no platform defaults and no security context (generic + no run_as),
     # the k8s section is omitted entirely.

--- a/services/core/models/tests/unit/controllers/backends/deployments_plugin/test_nim_compiler.py
+++ b/services/core/models/tests/unit/controllers/backends/deployments_plugin/test_nim_compiler.py
@@ -297,7 +297,17 @@ def test_build_k8s_deployment_backend_config_applies_default_tolerations(engine:
     assert backend.k8s.tolerations[0].key == "gpu"
 
 
-def test_build_k8s_deployment_backend_config_default_tolerations_skipped_when_entity_tolerations_set() -> None:
+def test_build_k8s_deployment_backend_config_default_tolerations_accept_int_seconds() -> None:
+    # tolerationSeconds is an int on the plugin Toleration model, so the config-default
+    # toleration dict must permit integer values (not just strings).
+    view = DeploymentConfigView()
+    config = DeploymentsPluginConfig(
+        default_tolerations=[{"key": "gpu", "operator": "Exists", "effect": "NoExecute", "tolerationSeconds": 300}]
+    )
+    backend = build_k8s_deployment_backend_config("nim", view, config)
+    assert backend.k8s is not None
+    assert len(backend.k8s.tolerations) == 1
+    assert backend.k8s.tolerations[0].toleration_seconds == 300
     view = DeploymentConfigView(
         k8s_nim_operator_config=K8sNIMOperatorConfig(
             tolerations=[{"key": "entity", "operator": "Exists"}],

--- a/services/core/models/tests/unit/controllers/backends/deployments_plugin/test_nim_compiler.py
+++ b/services/core/models/tests/unit/controllers/backends/deployments_plugin/test_nim_compiler.py
@@ -206,6 +206,86 @@ def test_build_k8s_deployment_backend_config_ignores_nim_operator_fields_for_vll
     assert backend.k8s.affinity is None
 
 
+@pytest.mark.parametrize("engine", ["nim", "vllm", "generic"])
+def test_build_k8s_deployment_backend_config_applies_default_pod_annotations(engine: str) -> None:
+    view = DeploymentConfigView()
+    config = DeploymentsPluginConfig(default_pod_annotations={"sidecar.istio.io/nativeSidecar": "true"})
+    backend = build_k8s_deployment_backend_config(engine, view, config)
+    assert backend.k8s is not None
+    assert backend.k8s.pod_annotations == {"sidecar.istio.io/nativeSidecar": "true"}
+
+
+def test_build_k8s_deployment_backend_config_default_annotations_merge_key_wise() -> None:
+    # Per-entity annotation for the same key wins over the platform default;
+    # non-overlapping platform defaults are still applied.
+    view = DeploymentConfigView()
+    config = DeploymentsPluginConfig(
+        default_pod_annotations={"sidecar.istio.io/nativeSidecar": "true", "team": "platform"}
+    )
+    backend = build_k8s_deployment_backend_config("nim", view, config)
+    assert backend.k8s is not None
+    # Simulate a per-entity annotation set on the compiled config before merge is
+    # not exposed via the view; instead verify the config-default path directly.
+    assert backend.k8s.pod_annotations == {"sidecar.istio.io/nativeSidecar": "true", "team": "platform"}
+
+
+@pytest.mark.parametrize("engine", ["nim", "vllm", "generic"])
+def test_build_k8s_deployment_backend_config_applies_default_node_selector(engine: str) -> None:
+    view = DeploymentConfigView()
+    config = DeploymentsPluginConfig(default_node_selector={"gpu": "a100"})
+    backend = build_k8s_deployment_backend_config(engine, view, config)
+    assert backend.k8s is not None
+    assert backend.k8s.node_selector == {"gpu": "a100"}
+
+
+def test_build_k8s_deployment_backend_config_default_node_selector_skipped_when_affinity_set() -> None:
+    # A per-entity node selector (mapped to affinity by the nim operator path)
+    # wins; the platform default node_selector is not additionally applied.
+    view = DeploymentConfigView(
+        k8s_nim_operator_config=K8sNIMOperatorConfig(node_selector={"zone": "us-west1-a"}),
+    )
+    config = DeploymentsPluginConfig(default_node_selector={"gpu": "a100"})
+    backend = build_k8s_deployment_backend_config("nim", view, config)
+    assert backend.k8s is not None
+    assert backend.k8s.affinity is not None
+    assert backend.k8s.node_selector == {}
+
+
+@pytest.mark.parametrize("engine", ["nim", "vllm", "generic"])
+def test_build_k8s_deployment_backend_config_applies_default_tolerations(engine: str) -> None:
+    view = DeploymentConfigView()
+    config = DeploymentsPluginConfig(
+        default_tolerations=[{"key": "gpu", "operator": "Equal", "value": "true", "effect": "NoSchedule"}]
+    )
+    backend = build_k8s_deployment_backend_config(engine, view, config)
+    assert backend.k8s is not None
+    assert len(backend.k8s.tolerations) == 1
+    assert backend.k8s.tolerations[0].key == "gpu"
+
+
+def test_build_k8s_deployment_backend_config_default_tolerations_skipped_when_entity_tolerations_set() -> None:
+    view = DeploymentConfigView(
+        k8s_nim_operator_config=K8sNIMOperatorConfig(
+            tolerations=[{"key": "entity", "operator": "Exists"}],
+        ),
+    )
+    config = DeploymentsPluginConfig(
+        default_tolerations=[{"key": "gpu", "operator": "Equal", "value": "true", "effect": "NoSchedule"}]
+    )
+    backend = build_k8s_deployment_backend_config("nim", view, config)
+    assert backend.k8s is not None
+    assert len(backend.k8s.tolerations) == 1
+    assert backend.k8s.tolerations[0].key == "entity"
+
+
+def test_build_k8s_deployment_backend_config_no_defaults_returns_empty() -> None:
+    # With no platform defaults and no security context (generic + no run_as),
+    # the k8s section is omitted entirely.
+    view = DeploymentConfigView()
+    backend = build_k8s_deployment_backend_config("generic", view, DeploymentsPluginConfig())
+    assert backend.k8s is None
+
+
 def test_apply_container_resources_deep_merges_existing_values() -> None:
     container = Container(
         name="server",


### PR DESCRIPTION
## Summary

The deployments plugin rendered Kubernetes Job/Deployment pod templates with labels only and **no annotations**, so there was no way to pass an Istio annotation through the config. A mesh-injected `istio-proxy` sidecar therefore kept a model weight-puller Job's pod `Running 0/1` forever after the puller container exited `0` — a plain Job's sidecar never terminates on its own. Setting `sidecar.istio.io/inject: "false"` is not a viable fix: the files service is in-cluster/in-mesh, so the puller needs its sidecar for mTLS egress.

This adds pod-annotation (and node-selector) passthrough to the plugin's k8s workloads, plus platform-level default annotations / node selector / tolerations in the models service, and ships the Istio native-sidecar annotation as the platform default so the mesh proxy is injected as a native sidecar that Kubernetes terminates when the Job's main container exits — letting the puller Job complete while keeping mesh mTLS egress.

## Changes

- **Plugin pod-annotations passthrough:** add `pod_annotations` and `node_selector` to `K8sDeploymentConfig` (`plugins/nemo-deployments/.../entities.py`); carry `pod_annotations` on `CompiledWorkload` and stamp them onto the pod-template `V1ObjectMeta(annotations=...)` in **both** workload paths (`backends/k8s/jobs.py` `build_job_body` and `backends/k8s/deployments.py` `build_deployment_body`). Wire `node_selector` into the pod spec in `backends/k8s/compiler.py`. k8s-only by construction — docker/openshell unaffected.
- **Platform default annotations/selector/tolerations (models config):** add `default_pod_annotations`, `default_node_selector`, and `default_tolerations` to `DeploymentsPluginConfig` (`services/core/models/.../deployments_plugin/config.py`), merged into the compiled `K8sDeploymentConfig` in `build_k8s_deployment_backend_config` for **all engines** (nim/vllm/generic). Annotations merge **key-wise** (a per-entity value wins over the platform default for the same key); per-entity node selector / tolerations win wholesale when present.
- **Ship the Istio native-sidecar annotation** (`sidecar.istio.io/nativeSidecar: "true"`) as the platform default in the Helm values `basePlatformConfig` block.
- Regenerated the deployments plugin OpenAPI spec (`make refresh-openapi`) and the config reference doc (`docs/set-up/config-reference.mdx`).

## Type of Change

- [x] Code change with documentation updates

## Quality Gates

- [x] Tests added or updated for changed behavior
- [x] Documentation updated for user-visible behavior

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

```
uv run ruff check <changed files>                 → All checks passed!
uv run ruff format --check <changed files>        → all formatted
uv run --frozen ty check plugins/nemo-deployments/src → All checks passed!
uv run --frozen ty check services/core/models/.../deployments_plugin → 0 new diagnostics (7 pre-existing on base, unchanged)
uv run pytest plugins/nemo-deployments/tests/unit/backends/k8s plugins/nemo-deployments/tests/unit/backends/docker → 247 passed
uv run pytest services/core/models/tests/unit/controllers/backends/deployments_plugin → 90 passed
```

Note: the `helm-docs` pre-commit hook requires the `helm-docs` binary (runs in CI's container); the `values.yaml` change lives inside the `basePlatformConfig` literal block below the documented line anchors, so it produces no `k8s/helm/README.md` change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Kubernetes pod annotations, node selectors, and tolerations to deployment configuration.
  * Added platform-wide default pod settings across supported deployment engines.
  * Entity-specific settings take precedence over matching platform defaults.
  * Pod annotations apply to generated Kubernetes Jobs and Deployments and are ignored by Docker and OpenShell backends.
  * Added Istio native-sidecar support for completed job containers while preserving mesh mTLS egress.

* **Documentation**
  * Updated configuration references and Helm chart values links for the new settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->