### PR TITLE
fix(studio): Remove incorrect row reporting in Customizer details

### DIFF
--- a/web/packages/studio/src/components/CustomizationFilesetDetailsPanel/index.tsx
+++ b/web/packages/studio/src/components/CustomizationFilesetDetailsPanel/index.tsx
@@ -13,7 +13,6 @@ import {
   Grid,
   Panel,
   SidePanel,
-  Skeleton,
   Stack,
   Text,
 } from '@nvidia/foundations-react-core';
@@ -29,7 +28,6 @@ type Row = {
   path: string;
   size: number;
   type: CustomizationFileType;
-  records: number;
   content: string;
 };
 
@@ -46,10 +44,11 @@ export const CustomizationFilesetDetailsPanel = ({ filesetUri }: Props) => {
   });
   const {
     rows,
-    totalRecords,
     isPending: isFilesLoading,
     isFetchingRows,
-  } = useCustomizationFilesAsRows({ fileset: filesetUri });
+  } = useCustomizationFilesAsRows({
+    fileset: filesetUri,
+  });
 
   const loading = isLoading || isFilesLoading;
   const makeColumns: ComponentProps<typeof DataView.Root<Row>>['makeColumns'] = (
@@ -67,21 +66,6 @@ export const CustomizationFilesetDetailsPanel = ({ filesetUri }: Props) => {
       header: 'Files',
       size: 200,
       cell: ({ row }) => <Text>{row.original?.path}</Text>,
-    },
-    {
-      id: 'records',
-      header: 'Records',
-      size: 200,
-      cell: ({ row }) => {
-        const percentage = totalRecords !== 0 ? (row.original?.records / totalRecords) * 100 : 0;
-        return isFetchingRows ? (
-          <Skeleton />
-        ) : (
-          <Text>
-            {row.original?.records} ({Math.round(percentage)}%)
-          </Text>
-        );
-      },
     },
     {
       id: 'size',

--- a/web/packages/studio/src/components/CustomizationOverview/index.tsx
+++ b/web/packages/studio/src/components/CustomizationOverview/index.tsx
@@ -11,22 +11,18 @@ import { TrainingLossPanel } from '@studio/components/CustomizationOverview/Trai
 import { ErrorMessageWithRetry } from '@studio/components/ErrorMessageWithRetry';
 import { Loading } from '@studio/components/Layouts/Loading';
 import { CustomizationConfigSidePanel } from '@studio/components/sidePanels/CustomizationConfigSidePanel';
-import { useCustomizationFilesAsRows } from '@studio/hooks/useCustomizationFiles';
 import { useCustomizationJob } from '@studio/hooks/useCustomizationJob';
 import { useCustomizationJobStatus } from '@studio/hooks/useCustomizationJobStatus';
 import { hasMetrics } from '@studio/types/customization';
-import { isGrpoJob, isRlJob } from '@studio/util/customizationBackend';
+import { isGrpoJob } from '@studio/util/customizationBackend';
 import { resolveCustomizationFailure } from '@studio/util/customizationFailure';
 import {
-  getCustomizationTrainingSteps,
-  getDatasetUri,
   getGrpoProgressTiles,
   getGrpoSummaryTiles,
   getJobDuration,
   getJobStartDate,
   getLossTiles,
   getTrainingProgressTiles,
-  getTrainingBatchSize,
   getTrainingDiagnosticsTiles,
   getTrainingTelemetry,
 } from '@studio/util/customizations';
@@ -66,30 +62,12 @@ export const CustomizationOverview: FC<Props> = ({ customizationJobName, workspa
     startDate: isTerminalStatus ? undefined : getJobStartDate(steps),
   });
 
-  // Reading record counts costs a fileset listing plus a download per file, and only the loss
-  // chart's x-axis uses them — the GRPO panel scales off the reported steps instead.
-  const isGrpo = Boolean(customization && isGrpoJob(customization));
-  const {
-    trainingRecords,
-    validationRecords,
-    isPending: isFilesLoading,
-  } = useCustomizationFilesAsRows({
-    fileset: isGrpo ? undefined : getDatasetUri(customization) || undefined,
-  });
-
-  const epochs = customization
-    ? isRlJob(customization)
-      ? customization.spec?.training?.epochs
-      : customization.spec?.schedule?.epochs
-    : undefined;
-  const batchSize = getTrainingBatchSize(customization);
-  const maxXAxisValue = getCustomizationTrainingSteps({
-    epochs: epochs ?? 0,
-    batchSize,
-    trainingRecords,
-    hasValidationDataset: validationRecords > 0,
-  });
-  const isLoading = isLoadingCustomization || isFilesLoading;
+  // The backend reports max_steps once at training start, and it is the same number the
+  // Steps Completed tile shows. Estimating it from record counts instead meant downloading
+  // every dataset file to scale one axis, and the count was capped at a preview of the
+  // file, so the estimate came out low on any dataset past that cap.
+  const maxXAxisValue = telemetry.maxSteps ?? 0;
+  const isLoading = isLoadingCustomization;
 
   if (isLoading) {
     return <Loading />;

--- a/web/packages/studio/src/hooks/useCustomizationFiles/index.ts
+++ b/web/packages/studio/src/hooks/useCustomizationFiles/index.ts
@@ -6,7 +6,6 @@ import { datasetFileContentQueryOptions } from '@studio/api/datasets/useDatasetF
 import { CustomizationFileType } from '@studio/constants/customization';
 import { parseFilesetUri } from '@studio/hooks/useCustomizationFiles/utils';
 import { useDatasetFileDiscovery } from '@studio/hooks/useDatasetFileDiscovery';
-import { parseFileContent } from '@studio/util/files';
 import { useQueries } from '@tanstack/react-query';
 
 export { parseFilesetUri } from '@studio/hooks/useCustomizationFiles/utils';
@@ -98,8 +97,11 @@ export const useCustomizationFilesPreview = ({
 
 /**
  * This hook returns the rows of the customization training and validation files as an array of objects.
- * Each object contains the type of the file (training or validation), the path of the file, the number of records in the file, the size of the file, and the content of the file.
- * It also returns the total number of samples in the training and validation files, and the total number of samples in the fileset.
+ * Each object contains the type of the file (training or validation), the path of the file, the
+ * size of the file, and the content of the file.
+ *
+ * `content` is the size-capped preview from `datasetFileContentQueryOptions`, not the whole file,
+ * so it cannot be used to count the file's rows.
  * @param fileset - The fileset URI to fetch the customization files from (e.g. fileset://workspace/name).
  * @returns
  */
@@ -128,11 +130,9 @@ export const useCustomizationFilesAsRows = ({ fileset }: UseCustomizationFilesOp
     combine: (results) => ({
       rows: results.map((result, index) => {
         const { file, type } = taggedFiles[index];
-        const records = result.data ? parseFileContent({ content: result.data }).rows.length : 0;
         return {
           type,
           path: file.path,
-          records,
           size: file.size,
           content: result.data ?? '',
         };
@@ -140,23 +140,8 @@ export const useCustomizationFilesAsRows = ({ fileset }: UseCustomizationFilesOp
       isFetching: results.some((result) => result.isFetching),
     }),
   });
-  const [trainingRecords, validationRecords] = rows.reduce(
-    (acc, row) => {
-      if (row.type === CustomizationFileType.Training) {
-        acc[0] += row.records;
-      } else {
-        acc[1] += row.records;
-      }
-      return acc;
-    },
-    [0, 0]
-  );
-  const totalRecords = trainingRecords + validationRecords;
   return {
     rows,
-    trainingRecords,
-    validationRecords,
-    totalRecords,
     isFetchingRows,
     ...queryResults,
   };

--- a/web/packages/studio/src/util/customizations.test.ts
+++ b/web/packages/studio/src/util/customizations.test.ts
@@ -16,7 +16,6 @@ import {
   formatTrainingPhase,
   getBaseModel,
   getCustomizationTrainingProgress,
-  getCustomizationTrainingSteps,
   getDatasetUri,
   getFinetuningType,
   getFormattedCustomizationStatus,
@@ -177,50 +176,6 @@ describe('getCustomizationTrainingProgress', () => {
     const job = automodelJob({ schedule: { epochs: 3 } });
     (job as { status_details?: unknown }).status_details = { percentage_done: 60 };
     expect(getCustomizationTrainingProgress(job)).toBe('0/3 (60%)');
-  });
-});
-
-describe('getCustomizationTrainingSteps', () => {
-  it('returns 0 when epochs is 0', () => {
-    expect(getCustomizationTrainingSteps({ epochs: 0, trainingRecords: 100, batchSize: 10 })).toBe(
-      0
-    );
-  });
-
-  it('returns 0 when batchSize is 0', () => {
-    expect(getCustomizationTrainingSteps({ epochs: 3, trainingRecords: 100, batchSize: 0 })).toBe(
-      0
-    );
-  });
-
-  it('returns 0 when trainingRecords is 0', () => {
-    expect(getCustomizationTrainingSteps({ epochs: 3, trainingRecords: 0, batchSize: 10 })).toBe(0);
-  });
-
-  it('calculates steps with validation dataset', () => {
-    // 3 * ceil(100/10) = 30
-    expect(
-      getCustomizationTrainingSteps({
-        epochs: 3,
-        trainingRecords: 100,
-        batchSize: 10,
-        hasValidationDataset: true,
-      })
-    ).toBe(30);
-  });
-
-  it('calculates steps without validation dataset (90% split)', () => {
-    // 3 * ceil(ceil(100 * 0.9) / 10) = 3 * ceil(90/10) = 3 * 9 = 27
-    expect(getCustomizationTrainingSteps({ epochs: 3, trainingRecords: 100, batchSize: 10 })).toBe(
-      27
-    );
-  });
-
-  it('handles non-even batch divisions', () => {
-    // 2 * ceil(ceil(95 * 0.9) / 8) = 2 * ceil(86/8) = 2 * ceil(10.75) = 2 * 11 = 22
-    expect(getCustomizationTrainingSteps({ epochs: 2, trainingRecords: 95, batchSize: 8 })).toBe(
-      22
-    );
   });
 });
 

--- a/web/packages/studio/src/util/customizations.tsx
+++ b/web/packages/studio/src/util/customizations.tsx
@@ -654,31 +654,3 @@ export const getTrainingOptionBadges = (job: CustomizationJob | null | undefined
 
   return [];
 };
-
-/**
- * The number of steps completed during training.
- * Used for showing a max x-axis value in the loss line chart.
- */
-interface GetCustomizationTrainingStepsParams {
-  epochs: number;
-  trainingRecords: number;
-  batchSize: number;
-  hasValidationDataset?: boolean;
-}
-export const getCustomizationTrainingSteps = ({
-  epochs,
-  trainingRecords,
-  batchSize,
-  hasValidationDataset,
-}: GetCustomizationTrainingStepsParams): number => {
-  if (epochs === 0 || batchSize === 0 || trainingRecords === 0) {
-    return 0;
-  }
-  if (hasValidationDataset) {
-    // When both training and validation datasets are used
-    return epochs * Math.ceil(trainingRecords / batchSize);
-  } else {
-    // When only training dataset is used (90% split for training)
-    return epochs * Math.ceil(Math.ceil(trainingRecords * 0.9) / batchSize);
-  }
-};


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
Removing incorrect row reporting from customizer and it's use as the loss charts max x value.

## Related Issue
https://linear.app/nvidia/issue/ASTD-564/correct-dataset-record-count-on-job-page

## Changes
Just removed it and used the API provided step values. 

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [ ] Targeted tests pass, or tests are marked not applicable above
- [ ] No secrets, API keys, or credentials are included

Targeted validation:

<!-- List each command and result. Explain skipped, blocked, or non-successful checks without marking them as passed. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Customization file previews now show file type, path, size, and content preview without record-count details.
  * Removed dataset record estimates and file listings from the customization overview.
  * Training progress charts now use reported maximum steps for their scale.
  * Customization loading indicators continue to reflect active job and file-data loading states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->