### PR TITLE
feat(models): support boolean fileset filter on ModelEntityFilter

### DIFF
--- a/openapi/ga/individual/platform.openapi.yaml
+++ b/openapi/ga/individual/platform.openapi.yaml
@@ -15566,9 +15566,12 @@ components:
           description: Filter by description.
           title: Description
         fileset:
-          description: Filter by fileset reference in the form {workspace}/{fileset_name}.
+          anyOf:
+          - type: boolean
+          - type: string
+          description: 'Filter by fileset: true = has a fileset, false = no fileset,
+            string = match fileset reference in the form {workspace}/{fileset_name}.'
           title: Fileset
-          type: string
         created_at:
           allOf:
           - $ref: '#/components/schemas/DatetimeFilter'

--- a/openapi/ga/openapi.yaml
+++ b/openapi/ga/openapi.yaml
@@ -15566,9 +15566,12 @@ components:
           description: Filter by description.
           title: Description
         fileset:
-          description: Filter by fileset reference in the form {workspace}/{fileset_name}.
+          anyOf:
+          - type: boolean
+          - type: string
+          description: 'Filter by fileset: true = has a fileset, false = no fileset,
+            string = match fileset reference in the form {workspace}/{fileset_name}.'
           title: Fileset
-          type: string
         created_at:
           allOf:
           - $ref: '#/components/schemas/DatetimeFilter'

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -15566,9 +15566,12 @@ components:
           description: Filter by description.
           title: Description
         fileset:
-          description: Filter by fileset reference in the form {workspace}/{fileset_name}.
+          anyOf:
+          - type: boolean
+          - type: string
+          description: 'Filter by fileset: true = has a fileset, false = no fileset,
+            string = match fileset reference in the form {workspace}/{fileset_name}.'
           title: Fileset
-          type: string
         created_at:
           allOf:
           - $ref: '#/components/schemas/DatetimeFilter'

--- a/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
+++ b/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
@@ -15569,9 +15569,12 @@ components:
           description: Filter by description.
           title: Description
         fileset:
-          description: Filter by fileset reference in the form {workspace}/{fileset_name}.
+          anyOf:
+          - type: boolean
+          - type: string
+          description: 'Filter by fileset: true = has a fileset, false = no fileset,
+            string = match fileset reference in the form {workspace}/{fileset_name}.'
           title: Fileset
-          type: string
         created_at:
           allOf:
           - $ref: '#/components/schemas/DatetimeFilter'

--- a/sdk/python/nemo-platform/src/nemo_platform/types/models/model_entity_filter_param.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/models/model_entity_filter_param.py
@@ -26,13 +26,15 @@ from ..shared_params.string_filter import StringFilter
 from .finetuning_type_filter_param import FinetuningTypeFilterParam
 from ..shared_params.datetime_filter import DatetimeFilter
 
-__all__ = ["ModelEntityFilterParam", "Adapters", "BaseModel", "Description", "Name"]
+__all__ = ["ModelEntityFilterParam", "Adapters", "BaseModel", "Description", "Fileset", "Name"]
 
 Adapters: TypeAlias = Union[FinetuningTypeFilterParam, bool]
 
 BaseModel: TypeAlias = Union[BaseModelFilterParam, bool, str]
 
 Description: TypeAlias = Union[StringFilter, str]
+
+Fileset: TypeAlias = Union[bool, str]
 
 Name: TypeAlias = Union[StringFilter, str]
 
@@ -55,8 +57,11 @@ class ModelEntityFilterParam(TypedDict, total=False):
     description: Description
     """Filter by description."""
 
-    fileset: str
-    """Filter by fileset reference in the form {workspace}/{fileset_name}."""
+    fileset: Fileset
+    """
+    Filter by fileset: true = has a fileset, false = no fileset, string = match
+    fileset reference in the form {workspace}/{fileset_name}.
+    """
 
     finetuning_type: Union[FinetuningType, bool]
     """Filter models that have been perviously finetuned."""

--- a/services/core/models/src/nmp/core/models/schemas.py
+++ b/services/core/models/src/nmp/core/models/schemas.py
@@ -1278,9 +1278,10 @@ class ModelEntityFilter(Filter):
         description="Filter models by whether their deployment config has LoRA enabled.",
     )
     description: StringFilter | str | None = Field(None, description="Filter by description.")
-    fileset: Optional[str] = Field(
+    fileset: Optional[Union[bool, str]] = Field(
         None,
-        description="Filter by fileset reference in the form {workspace}/{fileset_name}.",
+        description="Filter by fileset: true = has a fileset, false = no fileset, "
+        "string = match fileset reference in the form {workspace}/{fileset_name}.",
     )
     created_at: Optional[DatetimeFilter] = Field(None, description="Filter entities based on creation date.")
     updated_at: Optional[DatetimeFilter] = Field(None, description="Filter entities based on update date.")

--- a/services/core/models/tests/unit/api/test_models_api.py
+++ b/services/core/models/tests/unit/api/test_models_api.py
@@ -252,6 +252,46 @@ def test_list_models_with_base_model_filter_name(client, mock_model_entity_servi
     assert parsed_filter.extract("data.base_model") == "llama-3"
 
 
+def test_list_models_with_fileset_filter_ref(client, mock_model_entity_service, sample_page):
+    """Test listing models filtered by fileset reference using $eq."""
+    mock_model_entity_service.list_model_entities.return_value = sample_page
+
+    response = client.get("/apis/models/v2/workspaces/nvidia/models?filter[fileset]=nvidia/my-fileset")
+
+    assert response.status_code == 200
+    call_args = mock_model_entity_service.list_model_entities.call_args
+    parsed_filter = call_args.kwargs["parsed_filter"]
+    assert parsed_filter.extract("data.fileset") == "nvidia/my-fileset"
+
+
+def test_list_models_with_fileset_filter_true(client, mock_model_entity_service, sample_page):
+    """Test listing models filtered by fileset=true → $not { data.fileset $eq null }."""
+    mock_model_entity_service.list_model_entities.return_value = sample_page
+
+    response = client.get("/apis/models/v2/workspaces/nvidia/models?filter[fileset]=true")
+
+    assert response.status_code == 200
+    call_args = mock_model_entity_service.list_model_entities.call_args
+    parsed_filter = call_args.kwargs["parsed_filter"]
+    assert parsed_filter.operation is not None
+    # Bool "true" is coerced to a not-null check
+    assert parsed_filter.operation.to_dict() == {"$not": {"data.fileset": {"$eq": None}}}
+
+
+def test_list_models_with_fileset_filter_false(client, mock_model_entity_service, sample_page):
+    """Test listing models filtered by fileset=false → data.fileset $eq null."""
+    mock_model_entity_service.list_model_entities.return_value = sample_page
+
+    response = client.get("/apis/models/v2/workspaces/nvidia/models?filter[fileset]=false")
+
+    assert response.status_code == 200
+    call_args = mock_model_entity_service.list_model_entities.call_args
+    parsed_filter = call_args.kwargs["parsed_filter"]
+    assert parsed_filter.operation is not None
+    # Bool "false" is coerced to a null check
+    assert parsed_filter.operation.to_dict() == {"data.fileset": {"$eq": None}}
+
+
 def test_list_models_with_name_filter(client, mock_model_entity_service, sample_page):
     """Test listing models with name filter using $like operator."""
     mock_model_entity_service.list_model_entities.return_value = sample_page


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
`ModelEntityFilter.fileset` only supported exact-match to one fileset reference, unlike `base_model` which already supports `true`/`false` for "has a value" / "has no value" via the generic bool-coercible-field filter machinery. This widens `fileset` the same way, so callers can filter for models that do (or don't) have a fileset without pulling every page and filtering client-side.

## Related Issue
Related to [ASTD-567](https://linear.app/nvidia/issue/ASTD-567/base-model-dropdown-server-side-filter-for-fileset-eligible-models) — the Base Model dropdown filters for fine-tunable models (`fileset` set) entirely client-side today (`web/packages/common/src/api/models/useModelSearch.ts`), which forces it to page past runs of ineligible models one round trip at a time on a slow connection. This PR unblocks moving that filter server-side; the dropdown-side change to actually use `filter[fileset]=true` is not included here — draft until that follow-up work is settled.

## Changes
- `services/core/models/src/nmp/core/models/schemas.py`: widen `ModelEntityFilter.fileset` from `Optional[str]` to `Optional[Union[bool, str]]`, mirroring `base_model`'s existing type.
- `services/core/models/tests/unit/api/test_models_api.py`: add `fileset` filter tests mirroring the existing `base_model` filter tests (exact-ref match, `true`, `false`).
- `openapi/openapi.yaml`, `openapi/ga/openapi.yaml`, `openapi/ga/individual/platform.openapi.yaml`: regenerated via `make refresh-openapi` to reflect the widened `fileset` schema.
- `sdk/python/nemo-platform/src/nemo_platform/types/models/model_entity_filter_param.py`, `sdk/python/nemo-platform/.nmpcontext/openapi.yaml`: **hand-patched**, not Stainless-generated — see note below.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: filter description string is the only user-facing doc surface, and it's updated inline in the schema change.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `uv run pre-commit run -a` — passed
- `pytest services/core/models/tests/unit/api/test_models_api.py -v` — 34 passed (3 new `fileset` filter tests + all existing, including `base_model`'s equivalent tests unaffected)
- `ruff check` / `ruff format --check` on changed files — passed
- `ty check` on `schemas.py` — passed
- `make refresh-openapi` — regenerated cleanly, diff scoped to the `fileset` schema change only

`make stainless` (vendored Python SDK regen) was attempted repeatedly but Stainless's cloud build queue is stuck — every recent build (ours and others across the project) sits at `not_started` indefinitely; the queue's oldest unprocessed build predates this PR by a week. Given that, `sdk/python/nemo-platform/src/nemo_platform/types/models/model_entity_filter_param.py` and its `.nmpcontext/openapi.yaml` snapshot were **hand-patched** to mirror `base_model`'s existing pattern, purely so `nemo-platform-sdk-tools is-up-to-date` (CI's `lint-python-sdk`) passes — confirmed locally. This is a stopgap, not a real Stainless generation, and is called out as such in its commit message; once Stainless recovers, someone should run `make stainless` for real, which may reformat these files slightly differently than this manual edit did.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Model filtering now supports checking whether entities have a fileset (`true`) or do not have one (`false`).
  - Filtering by a specific `{workspace}/{fileset_name}` reference remains supported.
  - The enhanced fileset filter is available across the platform’s model listing APIs.

- **Bug Fixes**
  - Improved fileset filter handling for presence and absence checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


