### PR TITLE
chore(studio): reorder deployment tab options (ASTD-578)

### DIFF
--- a/web/packages/studio/e2e-tests/deployments.test.ts
+++ b/web/packages/studio/e2e-tests/deployments.test.ts
@@ -90,11 +90,15 @@ test.describe('Model Deployments', () => {
     await test.step('Open Create Deployment side panel', async () => {
       await page.getByRole('button', { name: 'Create Deployment' }).first().click();
 
-      // NGC is the default source. The Deploy submit button only renders inside the open panel.
+      // The Deploy submit button only renders inside the open panel.
       await expect(page.getByRole('button', { name: 'Deploy', exact: true })).toBeVisible();
     });
 
     await test.step('Fill the NGC NIM Container form', async () => {
+      // Select the source explicitly rather than relying on which one the wizard
+      // preselects — this test covers the NGC path, not the default.
+      await page.getByRole('radio', { name: 'NGC NIM Container' }).click();
+
       const nameField = page.getByRole('textbox', { name: 'Name', exact: true });
       // The wizard pre-fills a generated name; clear it before typing.
       await nameField.fill(baseName);

--- a/web/packages/studio/src/routes/DeploymentsListRoute/CreateDeploymentSidePanel/index.tsx
+++ b/web/packages/studio/src/routes/DeploymentsListRoute/CreateDeploymentSidePanel/index.tsx
@@ -193,9 +193,9 @@ export const CreateDeploymentSidePanel: FC<CreateDeploymentSidePanelProps> = ({
             });
           }}
           items={[
-            { value: SOURCE_NGC, children: 'NGC NIM Container' },
             { value: SOURCE_HF, children: 'HuggingFace' },
             { value: SOURCE_WORKSPACE, children: 'Workspace' },
+            { value: SOURCE_NGC, children: 'NGC NIM Container' },
           ]}
         />
         {(source === SOURCE_HF || source === SOURCE_WORKSPACE) && (

--- a/web/packages/studio/src/routes/DeploymentsListRoute/CreateDeploymentSidePanel/schema.test.ts
+++ b/web/packages/studio/src/routes/DeploymentsListRoute/CreateDeploymentSidePanel/schema.test.ts
@@ -9,6 +9,7 @@ import {
   defaultWizardValues,
   deploymentNameFromWizardBaseName,
   engineRequiresImage,
+  sourceSupportsEngineChoice,
   WORKSPACE_PICKER_FILESET,
   WORKSPACE_PICKER_MODEL,
   SOURCE_HF,
@@ -61,9 +62,9 @@ describe('additionalEnvsFormToApi', () => {
 });
 
 describe('defaultWizardValues', () => {
-  it('returns NGC source with defaults', () => {
+  it('returns HuggingFace source with defaults', () => {
     const vals = defaultWizardValues();
-    expect(vals.source).toBe(SOURCE_NGC);
+    expect(vals.source).toBe(SOURCE_HF);
     expect(vals.gpu).toBe(1);
     expect(vals.loraEnabled).toBe(true);
     expect(typeof vals.name).toBe('string');
@@ -73,6 +74,12 @@ describe('defaultWizardValues', () => {
   it('defaults the engine to vLLM, which needs no image', () => {
     expect(defaultWizardValues().engine).toBe(Engine.vllm);
     expect(engineRequiresImage(Engine.vllm)).toBe(false);
+  });
+
+  it('defaults to a source that actually reads the default engine', () => {
+    // The NGC source overrides `engine` to `nim` when building its request, so
+    // an NGC default made `engine: vllm` unreachable without switching tabs.
+    expect(sourceSupportsEngineChoice(defaultWizardValues().source)).toBe(true);
   });
 });
 

--- a/web/packages/studio/src/routes/DeploymentsListRoute/CreateDeploymentSidePanel/schema.ts
+++ b/web/packages/studio/src/routes/DeploymentsListRoute/CreateDeploymentSidePanel/schema.ts
@@ -108,7 +108,7 @@ function requireImageForEngine(
 
 export const createDeploymentWizardSchema = z
   .object({
-    source: z.enum([SOURCE_NGC, SOURCE_HF, SOURCE_WORKSPACE]),
+    source: z.enum([SOURCE_HF, SOURCE_WORKSPACE, SOURCE_NGC]),
     /** Base name: NGC NIM `model_name`, and API deployment/config become `<name>-deployment` / `<name>-config`. */
     name: wizardBaseNameSchema,
     /** Inference engine. Ignored for the NGC source, which is always a NIM container. */
@@ -191,7 +191,11 @@ export const createDeploymentWizardSchema = z
 export type WizardFormValues = z.infer<typeof createDeploymentWizardSchema>;
 
 export const defaultWizardValues = (): WizardFormValues => ({
-  source: SOURCE_NGC,
+  // Matches the leftmost segment in the panel's source control. HuggingFace is
+  // also the only default that agrees with `engine` below: the NGC source
+  // ignores the engine entirely, so defaulting to it left the two defaults
+  // describing different deployments.
+  source: SOURCE_HF,
   name: generateDefaultName(),
   // vLLM serves any architecture from a model-agnostic default image, so it is
   // the safe default for the sources that expose the picker. The NGC source


### PR DESCRIPTION
## Summary

Puts the common sources first in the create-deployment side panel: the segmented control now reads **HuggingFace | Workspace | NGC NIM Container**, and the wizard opens on HuggingFace instead of NGC.

The reorder itself is inert — every consumer branches on the source *value*, never its index. What it forces is a decision about the default, which this PR settles deliberately.

<img width="597" height="278" alt="image" src="https://github.com/user-attachments/assets/cc60003b-f92d-47ad-b474-c536dbc2ef76" />

## Changes

- Reorder the `SegmentedControl` items in `CreateDeploymentSidePanel/index.tsx`.
- Move `defaultWizardValues()` from `SOURCE_NGC` to `SOURCE_HF`, and reorder the zod enum to match.
- Update `schema.test.ts` to assert the new default, plus a new case pinning that the default source is one `sourceSupportsEngineChoice()` accepts.
- Make the e2e deployment flow select the NGC segment explicitly instead of relying on preselection.

### Why the default had to move

`defaultWizardValues()` hardcoded `source: SOURCE_NGC`, which only looked right because NGC happened to be leftmost. Left alone, the panel would have opened with the *third* segment selected.

Moving it to HuggingFace also settles an existing inconsistency: `defaultWizardValues()` sets `engine: Engine.vllm`, but the NGC source ignores the engine entirely and overrides it to `nim` when building its request. Defaulting to NGC therefore shipped two defaults that described different deployments. HuggingFace is one of the two sources that actually reads the engine picker.

### Deep links

Unaffected. `?model=` and `?fileset=` force the Workspace source by value, so reordering cannot break them.

## Base

Targets `main` directly and depends on nothing else. It was previously the bottom of a stacked series; verified independent by cherry-picking it onto the base alone (applies with no conflict, typecheck clean). Nothing in the related deployment PRs references `CreateDeploymentSidePanel`, `SOURCE_HF`, `defaultWizardValues`, or `sourceSupportsEngineChoice` — the stacking was an artifact of authoring order, not a code dependency.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: no user-facing docs describe the wizard's tab order or default source.

Two tests were silently pinning the old default and are updated rather than deleted:

- `schema.test.ts:66` asserted `SOURCE_NGC`.
- `e2e-tests/deployments.test.ts` filled the NGC form *without ever clicking a segment*, so it depended on the preselection. It now selects NGC explicitly, meaning it covers the NGC path rather than whatever happens to be default.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `pnpm --filter nemo-studio-ui test src/routes/DeploymentsListRoute` — 4 files, 40 tests passed
- `pnpm --filter nemo-studio-ui typecheck` — clean
- `pnpm --filter nemo-studio-ui lint:fix` — clean
- Full `pnpm --filter nemo-studio-ui test` — 338 files, 3320 tests passed (run on the tip of this stack)
- `uv run pre-commit run -a` not run in full; the commit-scoped pre-commit hooks ran and passed on commit.

The e2e test is not executed here — E2E is currently disabled per `AGENTS.md`. The change to it is mechanical (an added explicit segment click).

