### PR TITLE
feat(studio): return the resolved deployment from useModelDeploymentStatus

### DIFF
--- a/web/packages/studio/src/hooks/useModelDeploymentStatus/index.test.tsx
+++ b/web/packages/studio/src/hooks/useModelDeploymentStatus/index.test.tsx
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ModelEntity } from '@nemo/sdk/generated/platform/schema';
+import { useModelDeploymentStatus } from '@studio/hooks/useModelDeploymentStatus';
+import { renderHook } from '@testing-library/react';
+
+const mockGetProvider = vi.fn();
+const mockGetLatestDeployment = vi.fn();
+
+vi.mock('@nemo/sdk/generated/platform/model-providers', () => ({
+  useModelsGetProvider: (...args: unknown[]) => mockGetProvider(...args),
+}));
+
+vi.mock('@nemo/sdk/generated/platform/model-deployments', () => ({
+  useModelsGetLatestDeployment: (...args: unknown[]) => mockGetLatestDeployment(...args),
+}));
+
+const buildModel = (overrides: Partial<ModelEntity> = {}) =>
+  ({ id: 'model-1', name: 'my-model', workspace: 'ws', ...overrides }) as ModelEntity;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetProvider.mockReturnValue({ data: undefined, isLoading: false });
+  mockGetLatestDeployment.mockReturnValue({ data: undefined, isLoading: false });
+});
+
+describe('useModelDeploymentStatus', () => {
+  it('returns nulls when the model has no providers', () => {
+    const { result } = renderHook(() => useModelDeploymentStatus(buildModel()));
+
+    expect(result.current.status).toBeNull();
+    expect(result.current.deployment).toBeNull();
+    expect(result.current.deploymentRef).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('resolves the deployment through model_providers -> provider -> deployment', () => {
+    mockGetProvider.mockReturnValue({
+      data: { model_deployment_id: 'ws/my-deployment' },
+      isLoading: false,
+    });
+    mockGetLatestDeployment.mockReturnValue({
+      data: { name: 'my-deployment', workspace: 'ws', status: 'ready' },
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() =>
+      useModelDeploymentStatus(buildModel({ model_providers: ['ws/my-provider'] }))
+    );
+
+    expect(result.current.status).toBe('ready');
+    expect(result.current.deployment).toEqual({
+      name: 'my-deployment',
+      workspace: 'ws',
+      status: 'ready',
+    });
+    expect(result.current.deploymentRef).toEqual({ workspace: 'ws', name: 'my-deployment' });
+  });
+
+  it('exposes deploymentRef before the deployment itself has loaded, so a link can render early', () => {
+    mockGetProvider.mockReturnValue({
+      data: { model_deployment_id: 'ws/my-deployment' },
+      isLoading: false,
+    });
+    mockGetLatestDeployment.mockReturnValue({ data: undefined, isLoading: true });
+
+    const { result } = renderHook(() =>
+      useModelDeploymentStatus(buildModel({ model_providers: ['ws/my-provider'] }))
+    );
+
+    expect(result.current.deployment).toBeNull();
+    expect(result.current.status).toBeNull();
+    expect(result.current.deploymentRef).toEqual({ workspace: 'ws', name: 'my-deployment' });
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('keeps deploymentRef null when the provider names no deployment', () => {
+    mockGetProvider.mockReturnValue({ data: { model_deployment_id: undefined }, isLoading: false });
+
+    const { result } = renderHook(() =>
+      useModelDeploymentStatus(buildModel({ model_providers: ['ws/my-provider'] }))
+    );
+
+    expect(result.current.deploymentRef).toBeNull();
+    expect(result.current.deployment).toBeNull();
+  });
+
+  it('resolves a cross-workspace deployment reference to its own workspace', () => {
+    mockGetProvider.mockReturnValue({
+      data: { model_deployment_id: 'other-ws/shared-deployment' },
+      isLoading: false,
+    });
+    mockGetLatestDeployment.mockReturnValue({
+      data: { name: 'shared-deployment', workspace: 'other-ws', status: 'ready' },
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() =>
+      useModelDeploymentStatus(buildModel({ model_providers: ['ws/my-provider'] }))
+    );
+
+    expect(result.current.deploymentRef).toEqual({
+      workspace: 'other-ws',
+      name: 'shared-deployment',
+    });
+  });
+});

--- a/web/packages/studio/src/hooks/useModelDeploymentStatus/index.ts
+++ b/web/packages/studio/src/hooks/useModelDeploymentStatus/index.ts
@@ -40,6 +40,24 @@ export function useModelDeploymentStatus(model: ModelEntity | undefined) {
   return {
     /** The resolved deployment status, or null if no deployment found */
     status,
+    /**
+     * The resolved deployment itself, or null if none was found.
+     *
+     * Callers that need to link to the deployment (rather than merely report
+     * that one exists) need its name, which only this object carries.
+     */
+    deployment: deployment ?? null,
+    /**
+     * `{ workspace, name }` for the resolved deployment, or null.
+     *
+     * Mirrors the arguments the deployment query above was issued with, so a
+     * caller building a link cannot drift from what was actually fetched.
+     * Non-null whenever the provider named a deployment, even if that
+     * deployment has not loaded yet.
+     */
+    deploymentRef: deploymentParts?.name
+      ? { workspace: deploymentParts.workspace ?? workspace, name: deploymentParts.name }
+      : null,
     /** Whether the provider/deployment chain is still loading */
     isLoading,
   };

--- a/web/packages/studio/src/routes/WorkspaceBaseModelsRoute/index.tsx
+++ b/web/packages/studio/src/routes/WorkspaceBaseModelsRoute/index.tsx
@@ -41,6 +41,7 @@ import { CustomizeModelButton } from '@studio/components/dataViews/CustomModelsD
 import { ModelPanel, ModelPanelTab } from '@studio/components/sidePanels/ModelPanels/ModelPanel';
 import { VirtualizedCardGrid } from '@studio/components/VirtualizedCardGrid';
 import { CUSTOMIZER_ENABLED } from '@studio/constants/environment';
+import { useModelDeploymentStatus } from '@studio/hooks/useModelDeploymentStatus';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
 import { getWorkspaceBaseModelsRoute } from '@studio/routes/utils';
@@ -257,6 +258,12 @@ export const WorkspaceBaseModelsRoute: FC = () => {
   /** Base models can only be deleted when no `model_providers` entries reference them. */
   const allowModelDelete = !!selectedModel && !(selectedModel.model_providers?.length ?? 0);
 
+  // Feeds the panel's Status row, which had no source until the hook started
+  // returning the deployment itself rather than only its status.
+  const { deployment: selectedModelDeployment } = useModelDeploymentStatus(
+    selectedModel ?? undefined
+  );
+
   const sortSelectValue = dataViewState.sorting.state[0]
     ? dataViewState.sorting.state[0].desc
       ? `-${dataViewState.sorting.state[0].id}`
@@ -285,6 +292,7 @@ export const WorkspaceBaseModelsRoute: FC = () => {
           ),
         }}
         model={selectedModel ?? undefined}
+        deployment={selectedModelDeployment}
         showCustomizationDetails={CUSTOMIZER_ENABLED}
         defaultTab={tabFromUrl}
         onTabChange={(tab) =>


### PR DESCRIPTION
## Summary

`useModelDeploymentStatus` already walked `model_providers → ModelProvider → ModelDeployment` and fetched the whole deployment object, then returned only `{ status, isLoading }`. Nothing in Studio could name the deployment serving a model, because the one place that knew threw it away.

This returns the deployment alongside its status. No new request — both additions come from data the hook had already resolved.

## Changes

- Add `deployment` and `deploymentRef` to the hook's return value.
- Wire `ModelPanel`'s `deployment` prop from the Base Models route.
- Add the hook's first test file.

### Why this matters

The only "where is it deployed" affordance that ships today (`FilesetMetadataPanel`) links to the deployments *list* page and leaves the user to find the row. `getWorkspaceDeploymentDetailsRoute` needs a deployment **name**, and no hook surfaced one — so no model-side UI could link to a specific deployment.

`deploymentRef` mirrors the arguments the deployment query was issued with, so a caller building a link cannot drift from what was actually fetched. It is populated as soon as the provider names a deployment — *before* the deployment itself has loaded — so a link can render without waiting on the second request.

### Dead UI now renders

`ModelPanel` has accepted a `deployment?: ModelDeployment | null` prop since it was written, driving a status dot and a `Status` row. **No caller ever passed it**, so that UI was unreachable. The Base Models route now supplies it.

### Backward compatibility

Both existing consumers — `useModelChatAvailability` and `DeploymentIndicator` — destructure only `status` and `isLoading`, so they are unaffected.

## Base

Targets `main` directly. This is the bottom of stack #1914 — the only genuine dependency edge in the original series. Both #1893 (Deploy CTA) and #1894 (Deployment column) fail to compile without the `deploymentRef` this PR adds:

```
Property 'deploymentRef' does not exist on type '{ status: ModelDeploymentStatus | null; isLoading: boolean; }'
```

Note that #1893 and #1894 depend on *this* PR but not on each other — they touch no file in common, and #1894 typechecks and passes its tests with only this PR applied. They are stacked sequentially for convenience, not necessity, and can be reviewed in either order.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: internal hook contract; the only user-visible effect is a status row that was already designed and built.

New `useModelDeploymentStatus/index.test.tsx` covers: the no-providers case, the full provider→deployment walk, a provider naming no deployment, a cross-workspace deployment reference, and the render-early contract for `deploymentRef`.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `pnpm --filter nemo-studio-ui test src/hooks/useModelDeploymentStatus` — 5 tests passed (new file)
- `pnpm --filter nemo-studio-ui test src/hooks src/routes/WorkspaceBaseModelsRoute src/components/dataViews/CustomModelsDataView src/components/sidePanels/ModelPanels` — 10 files, 72 tests passed
- `pnpm --filter nemo-studio-ui typecheck` — clean
- `pnpm --filter nemo-studio-ui lint:fix` — clean
- `uv run pre-commit run -a` not run in full; the commit-scoped pre-commit hooks ran and passed on commit.
