### PR TITLE
fix(release): add Gym container metadata

### DIFF
--- a/.github/assets/ngc/containers/nmp-gym-tasks.md
+++ b/.github/assets/ngc/containers/nmp-gym-tasks.md
@@ -1,8 +1,10 @@
-<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
-<!-- SPDX-License-Identifier: Apache-2.0 -->
-
 ---
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 description: Job runner for Gym agent evaluations, part of NeMo Platform
+labels:
+  - NeMo
 ---
 ## NeMo Platform Gym Tasks Container
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
Make the Gym tasks container metadata parseable so NGC receives its description, publisher, and labels instead of placeholder values.

## Changes
- Move the SPDX header inside the YAML front matter, matching the other NGC metadata assets.
- Add the `NeMo` catalog label explicitly.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [x] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: the metadata parser tests pass and the metadata dry run discovers `nmp-gym-tasks`.
- [ ] Tests not applicable — justification:
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `uv run --no-cache .github/scripts/tests/test_ngc_metadata.py` — 14 passed.
- `uv run --no-cache .github/scripts/ngc_metadata.py --org 0921617854601259 --team nemo-platform-dev --dry-run` — discovered `nmp-gym-tasks`.
- `uv run pre-commit run -a` — relevant Ruff, typecheck, config reference, copyright, merge-conflict, and Flox checks passed; the full gate was blocked by missing `helm-docs`, the host uv version differing from the pinned hook version, and missing Studio `lint-staged` under the host Node installation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the NMP Gym Tasks documentation header to use YAML front matter.
  * Added SPDX metadata and NeMo labeling while retaining the job-runner description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->