### PR TITLE
feat(studio): offer Deploy on the model side panel

### DIFF
--- a/web/packages/studio/src/components/DeployModelButton/index.test.tsx
+++ b/web/packages/studio/src/components/DeployModelButton/index.test.tsx
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ModelEntity } from '@nemo/sdk/generated/platform/schema';
+import { DeployModelButton } from '@studio/components/DeployModelButton';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
+
+const mockNavigate = vi.fn();
+const mockDeploymentStatus = vi.fn();
+const mockEnvironment = vi.hoisted(() => ({ deploymentsEnabled: true }));
+
+vi.mock('@studio/constants/environment', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@studio/constants/environment')>();
+  return {
+    ...actual,
+    get DEPLOYMENTS_ENABLED() {
+      return mockEnvironment.deploymentsEnabled;
+    },
+  };
+});
+
+vi.mock('@studio/hooks/useModelDeploymentStatus', () => ({
+  useModelDeploymentStatus: (...args: unknown[]) => mockDeploymentStatus(...args),
+}));
+
+vi.mock('react-router', async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...(actual as object), useNavigate: () => mockNavigate };
+});
+
+const buildModel = (overrides: Partial<ModelEntity> = {}) =>
+  ({
+    id: 'model-1',
+    name: 'my-model',
+    workspace: 'ws',
+    fileset: 'ws/my-fs',
+    ...overrides,
+  }) as ModelEntity;
+
+const renderButton = (model?: ModelEntity) =>
+  render(
+    <MemoryRouter>
+      <DeployModelButton workspace="ws" model={model} />
+    </MemoryRouter>
+  );
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockEnvironment.deploymentsEnabled = true;
+  mockDeploymentStatus.mockReturnValue({ deploymentRef: null, isLoading: false });
+});
+
+describe('DeployModelButton', () => {
+  it('offers Deploy for a deployable, undeployed model', () => {
+    renderButton(buildModel());
+    expect(screen.getByRole('button', { name: /Deploy/ })).toBeInTheDocument();
+  });
+
+  it('deep links to the create-deployment wizard prefilled with the model', async () => {
+    const user = userEvent.setup();
+    renderButton(buildModel());
+
+    await user.click(screen.getByRole('button', { name: /Deploy/ }));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/workspaces/ws/deployments?model=ws%2Fmy-model');
+  });
+
+  it('renders nothing when deployments are disabled, so the CTA cannot link into a 404', () => {
+    mockEnvironment.deploymentsEnabled = false;
+    const { container } = renderButton(buildModel());
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing for a model with no fileset, which the wizard cannot deploy', () => {
+    const { container } = renderButton(buildModel({ fileset: undefined }));
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing without a model', () => {
+    const { container } = renderButton(undefined);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('links to the existing deployment instead of offering to create another', async () => {
+    const user = userEvent.setup();
+    mockDeploymentStatus.mockReturnValue({
+      deploymentRef: { workspace: 'ws', name: 'my-deployment' },
+      isLoading: false,
+    });
+
+    renderButton(buildModel());
+
+    expect(screen.queryByRole('button', { name: /^Deploy$/ })).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /View Deployment/ }));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/workspaces/ws/deployments/my-deployment/details');
+  });
+
+  it('follows a cross-workspace deployment to its own workspace', async () => {
+    const user = userEvent.setup();
+    mockDeploymentStatus.mockReturnValue({
+      deploymentRef: { workspace: 'other-ws', name: 'shared' },
+      isLoading: false,
+    });
+
+    renderButton(buildModel());
+    await user.click(screen.getByRole('button', { name: /View Deployment/ }));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/workspaces/other-ws/deployments/shared/details');
+  });
+});

--- a/web/packages/studio/src/components/DeployModelButton/index.tsx
+++ b/web/packages/studio/src/components/DeployModelButton/index.tsx
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { LoadingButton } from '@nemo/common/src/components/LoadingButton';
+import { getURNFromNamedEntityRef } from '@nemo/common/src/namedEntity';
+import type { ModelEntity } from '@nemo/sdk/generated/platform/schema';
+import { DEPLOYMENTS_ENABLED } from '@studio/constants/environment';
+import { canFineTuneModel } from '@studio/hooks/useModelCustomizationEligibility';
+import { useModelDeploymentStatus } from '@studio/hooks/useModelDeploymentStatus';
+import {
+  getWorkspaceDeploymentDetailsRoute,
+  getWorkspaceDeploymentsRoute,
+} from '@studio/routes/utils';
+import type { FC } from 'react';
+import { useNavigate } from 'react-router';
+
+export interface DeployModelButtonProps {
+  workspace: string;
+  model?: ModelEntity;
+}
+
+/**
+ * Deploy a model, or jump to the deployment already serving it.
+ *
+ * Renders nothing unless the model can actually be deployed. Deploying from
+ * Studio goes through the create-deployment wizard's Workspace source, which
+ * only lists models that have a fileset (see `WorkspaceSourceFields`), so
+ * offering the action for a fileset-less model would be a dead link. That is
+ * the same `canFineTuneModel` predicate the fine-tune picker filters on — every
+ * model you can fine-tune is a model you can deploy.
+ */
+export const DeployModelButton: FC<DeployModelButtonProps> = ({ workspace, model }) => {
+  const navigate = useNavigate();
+  const { deploymentRef, isLoading } = useModelDeploymentStatus(model);
+
+  if (!DEPLOYMENTS_ENABLED || !model || !canFineTuneModel(model)) return null;
+
+  // A deployment already serves this model — point at it instead of offering to
+  // create a second one.
+  if (deploymentRef) {
+    return (
+      <LoadingButton
+        kind="secondary"
+        size="small"
+        className="flex-1"
+        height={28}
+        loading={isLoading}
+        onClick={() =>
+          navigate(getWorkspaceDeploymentDetailsRoute(deploymentRef.workspace, deploymentRef.name))
+        }
+      >
+        View Deployment
+      </LoadingButton>
+    );
+  }
+
+  return (
+    <LoadingButton
+      kind="secondary"
+      size="small"
+      className="flex-1"
+      height={28}
+      loading={isLoading}
+      onClick={() =>
+        navigate(
+          getWorkspaceDeploymentsRoute(workspace, { model: getURNFromNamedEntityRef(model) })
+        )
+      }
+    >
+      Deploy
+    </LoadingButton>
+  );
+};

--- a/web/packages/studio/src/routes/CustomizationJobListRoute/index.tsx
+++ b/web/packages/studio/src/routes/CustomizationJobListRoute/index.tsx
@@ -6,6 +6,7 @@ import type { Adapter, ModelEntity } from '@nemo/sdk/generated/platform/schema';
 import { Button, Flex, PageHeader, Stack } from '@nvidia/foundations-react-core';
 import { CustomModelsDataView } from '@studio/components/dataViews/CustomModelsDataView';
 import { CustomizeModelButton } from '@studio/components/dataViews/CustomModelsDataView/CustomizeModelButton';
+import { DeployModelButton } from '@studio/components/DeployModelButton';
 import { ModelPanel, ModelPanelTab } from '@studio/components/sidePanels/ModelPanels/ModelPanel';
 import { INTAKE_ENABLED } from '@studio/constants/environment';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
@@ -65,6 +66,15 @@ export const CustomizationJobListRoute: FC = () => {
             <Flex gap="density-md" align="center">
               {selectedModel && (
                 <CustomizeModelButton model={selectedModel} workspace={workspace} />
+              )}
+              {/*
+                Skipped for adapters: an adapter is served by the deployment
+                that loaded its base model, so "Deploy" would point at the wrong
+                entity. Surfacing the base model's deployment gap is tracked
+                separately.
+              */}
+              {selectedModel && !selectedAdapter && (
+                <DeployModelButton model={selectedModel} workspace={workspace} />
               )}
               {INTAKE_ENABLED && (
                 <Button

--- a/web/packages/studio/src/routes/WorkspaceBaseModelsRoute/index.tsx
+++ b/web/packages/studio/src/routes/WorkspaceBaseModelsRoute/index.tsx
@@ -38,6 +38,7 @@ import {
 } from '@nvidia/foundations-react-core';
 import { BaseModelCard } from '@studio/components/BaseModelCard';
 import { CustomizeModelButton } from '@studio/components/dataViews/CustomModelsDataView/CustomizeModelButton';
+import { DeployModelButton } from '@studio/components/DeployModelButton';
 import { ModelPanel, ModelPanelTab } from '@studio/components/sidePanels/ModelPanels/ModelPanel';
 import { VirtualizedCardGrid } from '@studio/components/VirtualizedCardGrid';
 import { CUSTOMIZER_ENABLED } from '@studio/constants/environment';
@@ -288,6 +289,7 @@ export const WorkspaceBaseModelsRoute: FC = () => {
               {CUSTOMIZER_ENABLED && selectedModel && (
                 <CustomizeModelButton model={selectedModel} workspace={workspace} />
               )}
+              {selectedModel && <DeployModelButton model={selectedModel} workspace={workspace} />}
             </Flex>
           ),
         }}

--- a/web/packages/studio/src/routes/constants.ts
+++ b/web/packages/studio/src/routes/constants.ts
@@ -5,6 +5,7 @@ export const QUERY_PARAMETERS = {
   completionsTableFilter: 'completionsTableFilter',
   filesetFolder: 'filesetFolder',
   file: 'file',
+  fileset: 'fileset',
   model: 'model',
   rating: 'rating',
   exportJobId: 'exportJobId',

--- a/web/packages/studio/src/routes/utils.test.ts
+++ b/web/packages/studio/src/routes/utils.test.ts
@@ -13,6 +13,7 @@ import {
   getIntakeSessionRoute,
   getIntakeSessionTraceRoute,
   getWorkspaceBaseModelsRoute,
+  getWorkspaceDeploymentsRoute,
   getWorkspaceInferenceProvidersRoute,
 } from '@studio/routes/utils';
 
@@ -203,6 +204,39 @@ describe('getFilesetDetailsRoute', () => {
   it('encodes the folder query param without double-encoding', () => {
     expect(getFilesetDetailsRoute('my-workspace', 'default/set', 'nested/folder 1')).toBe(
       '/workspaces/my-workspace/filesets/default%2Fset?filesetFolder=nested%2Ffolder+1'
+    );
+  });
+});
+
+describe('getWorkspaceDeploymentsRoute', () => {
+  it('returns the bare list route with no options', () => {
+    expect(getWorkspaceDeploymentsRoute('ws')).toBe('/workspaces/ws/deployments');
+  });
+
+  // DeploymentsListRoute reads these params and auto-opens the create wizard
+  // prefilled on the Workspace source, so the encoding has to survive the trip.
+  it('encodes a model reference into the prefill param', () => {
+    expect(getWorkspaceDeploymentsRoute('ws', { model: 'ws/my-model' })).toBe(
+      '/workspaces/ws/deployments?model=ws%2Fmy-model'
+    );
+  });
+
+  it('encodes a fileset reference into the prefill param', () => {
+    expect(getWorkspaceDeploymentsRoute('ws', { fileset: 'ws/my-fileset' })).toBe(
+      '/workspaces/ws/deployments?fileset=ws%2Fmy-fileset'
+    );
+  });
+
+  // Matches DeploymentsListRoute, which checks `model` before `fileset`.
+  it('prefers model over fileset when both are given', () => {
+    expect(getWorkspaceDeploymentsRoute('ws', { model: 'ws/m', fileset: 'ws/f' })).toBe(
+      '/workspaces/ws/deployments?model=ws%2Fm'
+    );
+  });
+
+  it('encodes special characters exactly once', () => {
+    expect(getWorkspaceDeploymentsRoute('ws', { model: 'ws/100% coverage' })).toBe(
+      '/workspaces/ws/deployments?model=ws%2F100%25%20coverage'
     );
   });
 });

--- a/web/packages/studio/src/routes/utils.ts
+++ b/web/packages/studio/src/routes/utils.ts
@@ -236,8 +236,21 @@ export const getVirtualModelChatRoute = (workspace: string, virtualModelName: st
   return generatePath(ROUTES.workspace.virtualModelChat, { workspace, virtualModelName });
 };
 
-export const getWorkspaceDeploymentsRoute = (workspace: string) => {
-  return generatePath(ROUTES.workspace.deployments, { workspace });
+export const getWorkspaceDeploymentsRoute = (
+  workspace: string,
+  options?: { model?: string; fileset?: string }
+) => {
+  const basePath = generatePath(ROUTES.workspace.deployments, { workspace });
+  // `DeploymentsListRoute` reads these and auto-opens the create wizard on the
+  // Workspace source, prefilled. `model` wins when both are given, matching the
+  // route's own precedence.
+  if (options?.model) {
+    return `${basePath}?${QUERY_PARAMETERS.model}=${encodeURIComponent(options.model)}`;
+  }
+  if (options?.fileset) {
+    return `${basePath}?${QUERY_PARAMETERS.fileset}=${encodeURIComponent(options.fileset)}`;
+  }
+  return basePath;
 };
 
 /** Default segment for the deployment details side panel URL. */


### PR DESCRIPTION
## Summary

The model side panel could tell you everything about a model except how to serve it. Adds a **Deploy** action — and a **View Deployment** link when one already serves the model.

## Changes

- New `DeployModelButton`, rendered in the panel's `slotActions` on both `ModelPanel` callers.
- `getWorkspaceDeploymentsRoute` gains `model` / `fileset` options, mirroring `getNewCustomizationJobRoute`.
- `QUERY_PARAMETERS` gains `fileset`.

### The CTA is a link, not a new flow

`DeploymentsListRoute` already reads `?model=` and auto-opens the create wizard prefilled on the Workspace source, so this navigates there. `model` takes precedence over `fileset` in the helper, matching the route's own ordering.

### Placement

`slotActions`, beside Fine-tune — the closest sibling in meaning. It is also the only placement that works on both callers: the Custom Models route renders no panel footer at all, so a footer-only action would silently not exist there.

### Three gates, so the action can never be a dead link

1. `DEPLOYMENTS_ENABLED` — otherwise it navigates into a 404.
2. **The model must have a fileset.** The wizard's Workspace source only lists models that have one, so offering it otherwise would land on a picker that cannot select the model. This is the same `canFineTuneModel` predicate the fine-tune picker filters on — *every model you can fine-tune is a model you can deploy*, which is what makes the CTA safe by construction.
3. **Already deployed** → the action becomes "View Deployment" and links by name, newly possible now that `useModelDeploymentStatus` returns `deploymentRef`.

### Adapters excluded on Custom Models

An adapter is served by the deployment that loaded its base model, so "Deploy" would point at the wrong entity. Surfacing the base model's deployment gap is separate work.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: no shipped docs describe the model side panel's actions.

New `DeployModelButton/index.test.tsx` (7 tests) covers the deploy link and its exact encoded URL, both hidden states (flag off, no fileset), the no-model case, the already-deployed branch, and a cross-workspace deployment. `routes/utils.test.ts` gains 5 cases for the new helper options, including single-encoding and model-over-fileset precedence.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `pnpm --filter nemo-studio-ui test src/components/DeployModelButton` — 7 tests passed
- `pnpm --filter nemo-studio-ui test src/routes/utils.test.ts` — 27 tests passed
- `pnpm --filter nemo-studio-ui test` — 340 files, 3337 tests passed
- `pnpm --filter nemo-studio-ui typecheck` — clean
- `pnpm --filter nemo-studio-ui lint:fix` — clean
- `uv run pre-commit run -a` not run in full; the commit-scoped pre-commit hooks ran and passed on commit.

Not verified in a running app — this was not exercised against a live platform instance.
