### PR TITLE
feat(studio): give fine-tuning deployment its own section

### DIFF
--- a/web/packages/studio/src/components/NewCustomizationForm/ComputeResourcesSection.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/ComputeResourcesSection.tsx
@@ -12,7 +12,6 @@ import {
   Stack,
   Text,
 } from '@nvidia/foundations-react-core';
-import { ControlledJsonInput } from '@studio/components/NewCustomizationForm/ControlledJsonInput';
 import { FormSection } from '@studio/components/NewCustomizationForm/FormSection';
 import type { CustomizationFormFields } from '@studio/util/forms/customization';
 import { useFormContext } from 'react-hook-form';
@@ -189,12 +188,9 @@ const UnslothHardware = ({ disabled }: { disabled: boolean }) => {
         placeholder="0  or  0,1"
         disabled={disabled}
       />
-      <ControlledJsonInput
-        useControllerProps={{ name: 'unsloth.deployment_config', control }}
-        formFieldProps={{ slotLabel: 'Deployment Config (name or JSON)' }}
-        placeholder='"my-config"  or  { "gpu": 1 }'
-        disabled={disabled}
-      />
+      {/* `unsloth.deployment_config` used to live here. It is about serving the
+          output, not about the hardware the job trains on, and nobody was going
+          to find it under Compute Resources. It now has its own section. */}
     </Stack>
   );
 };

--- a/web/packages/studio/src/components/NewCustomizationForm/DeploymentSection.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/DeploymentSection.tsx
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Stack, Text } from '@nvidia/foundations-react-core';
+import { ControlledJsonInput } from '@studio/components/NewCustomizationForm/ControlledJsonInput';
+import { FormSection } from '@studio/components/NewCustomizationForm/FormSection';
+import { producesAdapter, type CustomizationFormFields } from '@studio/util/forms/customization';
+import type { FC } from 'react';
+import { useFormContext, useWatch } from 'react-hook-form';
+
+/**
+ * How the fine-tuned model gets served once the job finishes.
+ *
+ * Only rendered for the unsloth backend. `deployment_config` exists solely on
+ * `UnslothJobInput`; `AutomodelJobInput` and `RlJobInput` carry no deployment
+ * field at all, so there is nothing to submit for them and an always-visible
+ * section would promise something the API cannot honour. Those backends deploy
+ * from the Deployments page after the job completes.
+ */
+export const DeploymentSection: FC = () => {
+  const { control, formState } = useFormContext<CustomizationFormFields>();
+  const backend = useWatch({ control, name: 'backend' });
+  const unslothFinetuningType = useWatch({
+    control,
+    name: 'unsloth.training.finetuning_type',
+  });
+
+  if (backend !== 'unsloth') return null;
+
+  const isAdapterRun = producesAdapter({
+    backend,
+    unsloth: { training: { finetuning_type: unslothFinetuningType } },
+  });
+
+  return (
+    <FormSection
+      title="Deployment"
+      description="Optional. Leave blank to skip deployment and serve the model later from the Deployments page."
+    >
+      <Stack gap="density-lg">
+        <ControlledJsonInput
+          useControllerProps={{ name: 'unsloth.deployment_config', control }}
+          formFieldProps={{
+            slotLabel: 'Deploy After Training',
+            slotInfo:
+              'Name an existing deployment config to reuse it, or give inline NIM parameters as JSON (for example { "gpu": 1 }).',
+          }}
+          placeholder='"my-config"  or  { "gpu": 1 }'
+          disabled={formState.isSubmitting}
+        />
+        {isAdapterRun ? (
+          <Text kind="body/regular/sm" className="text-subtle">
+            This run produces a LoRA adapter, which is served by a deployment of its base model with
+            LoRA enabled — it is not deployed on its own.
+          </Text>
+        ) : (
+          <Text kind="body/regular/sm" className="text-subtle">
+            Set <code>lora_enabled</code> in the deployment parameters if you plan to serve LoRA
+            adapters against these weights later.
+          </Text>
+        )}
+      </Stack>
+    </FormSection>
+  );
+};

--- a/web/packages/studio/src/components/NewCustomizationForm/index.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/index.tsx
@@ -21,6 +21,7 @@ import {
 import { CustomizationFilesetSelect } from '@studio/components/customizer/CustomizationFilesetSelect';
 import { BackendSelectionSection } from '@studio/components/NewCustomizationForm/BackendSelectionSection';
 import { ComputeResourcesSection } from '@studio/components/NewCustomizationForm/ComputeResourcesSection';
+import { DeploymentSection } from '@studio/components/NewCustomizationForm/DeploymentSection';
 import { DpoParametersSection } from '@studio/components/NewCustomizationForm/DpoParametersSection';
 import { GeneralParametersSection } from '@studio/components/NewCustomizationForm/GeneralParametersSection';
 import { GrpoParametersSection } from '@studio/components/NewCustomizationForm/GrpoParametersSection';
@@ -93,7 +94,10 @@ export const NewCustomizationForm: FC<NewCustomizationFormProps> = ({
   // carrying the other arm's fields. `formToRlCreate` sets `type` from this on submit.
   const grpoTrainingType = useWatch({ control: form.control, name: 'grpo.trainingType' });
   const finetuningType = backend === 'automodel' ? automodelFinetuningType : unslothFinetuningType;
-  const isLora =
+  // Gates the LoRA *hyperparameter* controls, so it includes `lora_merged`,
+  // which trains with LoRA. It is NOT "the output is an adapter" — a merged run
+  // emits full weights. Use `producesAdapter` for anything about serving.
+  const usesLoraControls =
     backend !== 'rl' && (finetuningType === 'lora' || finetuningType === 'lora_merged');
   const isDpo = backend === 'rl' && grpoTrainingType !== 'grpo';
   const isGrpo = backend === 'rl' && grpoTrainingType === 'grpo';
@@ -217,7 +221,7 @@ export const NewCustomizationForm: FC<NewCustomizationFormProps> = ({
                     <CustomizationFilesetSelect disabled={isPending} />
                     <Divider />
                     {isGrpo ? <GrpoParametersSection /> : <GeneralParametersSection />}
-                    {isLora && (
+                    {usesLoraControls && (
                       <>
                         <Divider />
                         <LoraParametersSection />
@@ -237,6 +241,12 @@ export const NewCustomizationForm: FC<NewCustomizationFormProps> = ({
                     )}
                     <Divider />
                     <ComputeResourcesSection />
+                    {backend === 'unsloth' && (
+                      <>
+                        <Divider />
+                        <DeploymentSection />
+                      </>
+                    )}
                     {validationErrors.length > 0 && (
                       <Banner kind="inline" ref={errorBannerRef} status="error">
                         Please fix the following errors: {validationErrors.join(', ')}

--- a/web/packages/studio/src/util/forms/customization.ts
+++ b/web/packages/studio/src/util/forms/customization.ts
@@ -124,6 +124,53 @@ export const DATASET_FIELD_BY_BACKEND: Record<CustomizationBackend, DatasetField
   rl: 'rl.dataset',
 };
 
+/**
+ * The subset of the form these predicates read.
+ *
+ * Stated structurally rather than as `Partial<CustomizationFormFields>` so that
+ * callers watching two or three individual fields can pass what they have —
+ * `Partial` only loosens the top level, which would force a cast at every call
+ * site. `CustomizationFormFields` satisfies this shape.
+ */
+export interface FinetuningTypeSource {
+  backend: CustomizationBackend;
+  automodel?: { training?: { finetuning_type?: string } };
+  unsloth?: { training?: { finetuning_type?: string } };
+  grpo?: { trainingType?: string; finetuning_type?: string };
+}
+
+/**
+ * The active backend's `finetuning_type`, or undefined when it has none.
+ *
+ * The field lives at a different path per backend, and RL keeps it in the
+ * form-only `grpo` namespace rather than on `rl.training` (see `GrpoFormFields`).
+ * DPO has no `finetuning_type` at all — it is always full-weight.
+ */
+export const getActiveFinetuningType = (fields: FinetuningTypeSource): string | undefined => {
+  switch (fields.backend) {
+    case 'automodel':
+      return fields.automodel?.training?.finetuning_type;
+    case 'unsloth':
+      return fields.unsloth?.training?.finetuning_type;
+    case 'rl':
+      return fields.grpo?.trainingType === 'grpo' ? fields.grpo?.finetuning_type : undefined;
+    default:
+      return undefined;
+  }
+};
+
+/**
+ * Whether the run's **output** is a separately deployable LoRA adapter.
+ *
+ * Deliberately narrower than "trains with LoRA": `lora_merged` uses LoRA during
+ * training but merges the result into full weights, so its output is a normal
+ * model, not an adapter. Anything reasoning about how the output gets *served*
+ * wants this predicate; anything deciding whether to show LoRA hyperparameter
+ * controls wants the broader test and must not use it.
+ */
+export const producesAdapter = (fields: FinetuningTypeSource): boolean =>
+  getActiveFinetuningType(fields) === 'lora';
+
 type ModelFieldName = 'automodel.model' | 'unsloth.model.name' | 'rl.model';
 
 /** Likewise for the base model reference. */

--- a/web/packages/studio/src/util/forms/producesAdapter.test.ts
+++ b/web/packages/studio/src/util/forms/producesAdapter.test.ts
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  getActiveFinetuningType,
+  producesAdapter,
+  type FinetuningTypeSource,
+} from '@studio/util/forms/customization';
+
+const fields = (overrides: FinetuningTypeSource) => overrides;
+
+describe('getActiveFinetuningType', () => {
+  it('reads automodel from automodel.training', () => {
+    expect(
+      getActiveFinetuningType(
+        fields({ backend: 'automodel', automodel: { training: { finetuning_type: 'lora' } } })
+      )
+    ).toBe('lora');
+  });
+
+  it('reads unsloth from unsloth.training', () => {
+    expect(
+      getActiveFinetuningType(
+        fields({ backend: 'unsloth', unsloth: { training: { finetuning_type: 'all_weights' } } })
+      )
+    ).toBe('all_weights');
+  });
+
+  // RL keeps finetuning_type in the form-only `grpo` namespace, not on
+  // `rl.training`, because one `rl.training` object is shared by DPO and GRPO.
+  it('reads GRPO from the grpo namespace', () => {
+    expect(
+      getActiveFinetuningType(
+        fields({ backend: 'rl', grpo: { trainingType: 'grpo', finetuning_type: 'lora' } })
+      )
+    ).toBe('lora');
+  });
+
+  it('returns undefined for DPO, which is always full-weight', () => {
+    expect(
+      getActiveFinetuningType(
+        fields({ backend: 'rl', grpo: { trainingType: 'dpo', finetuning_type: 'lora' } })
+      )
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when the backend branch is absent', () => {
+    expect(getActiveFinetuningType(fields({ backend: 'automodel' }))).toBeUndefined();
+  });
+});
+
+describe('producesAdapter', () => {
+  it('is true for a plain LoRA run', () => {
+    expect(
+      producesAdapter(
+        fields({ backend: 'automodel', automodel: { training: { finetuning_type: 'lora' } } })
+      )
+    ).toBe(true);
+  });
+
+  // The distinction this predicate exists for: lora_merged trains with LoRA but
+  // merges into full weights, so its output is not a separately servable adapter.
+  it('is false for lora_merged, whose output is full weights', () => {
+    expect(
+      producesAdapter(
+        fields({
+          backend: 'automodel',
+          automodel: { training: { finetuning_type: 'lora_merged' } },
+        })
+      )
+    ).toBe(false);
+  });
+
+  it('is false for all_weights', () => {
+    expect(
+      producesAdapter(
+        fields({ backend: 'unsloth', unsloth: { training: { finetuning_type: 'all_weights' } } })
+      )
+    ).toBe(false);
+  });
+
+  it('is true for a GRPO LoRA run', () => {
+    expect(
+      producesAdapter(
+        fields({ backend: 'rl', grpo: { trainingType: 'grpo', finetuning_type: 'lora' } })
+      )
+    ).toBe(true);
+  });
+
+  it('is false for DPO', () => {
+    expect(producesAdapter(fields({ backend: 'rl', grpo: { trainingType: 'dpo' } }))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

**Partial implementation, deliberately.** This promotes the deployment capability Studio already had but hid, and fixes the predicate the rest of the feature will rest on. The auto-deploy story for automodel and RL needs an API decision and is **not** invented here.

## Changes

### The buried field

`unsloth.deployment_config` was a raw JSON textbox inside **Compute Resources**, labelled "Deployment Config (name or JSON)". It is about serving the output, not about the hardware the job trains on, and nobody was going to find it there. It now has its own **Deployment** section with a label that says what it does and help text explaining the name-or-inline-JSON form.

### ⚠️ Why the section is unsloth-only — needs a decision

`deployment_config` exists **solely** on `UnslothJobInput`. `AutomodelJobInput` and `RlJobInput` have no deployment field at all — only `output: {name, description}` — and `plugins/nemo-customizer/openapi/openapi.yaml` agrees. Since `FORM_DEFAULTS.backend` is `automodel`, **the default path has no deployment concept to expose.**

Rendering an always-visible section would promise something those APIs cannot honour, so it hides rather than lies. Closing the gap needs a choice that is not Studio's to make alone:

1. Add `deployment_config` to the automodel and RL job schemas, or
2. Have Studio create the deployment itself after the job succeeds (client-side), or
3. Accept unsloth-only permanently.

**This PR does not pick one.** Reviewers: this is the open question.

### `isLora` was two predicates wearing one name

```ts
const isLora = backend !== 'rl' && (type === 'lora' || type === 'lora_merged');
```

That is the right test for "show the LoRA hyperparameter controls" and the **wrong** one for "the output is an adapter" — `lora_merged` trains with LoRA and merges into full weights, so its output is a normal model. Anything deciding how the output gets *served* must not use it. Renamed to `usesLoraControls`.

Adds `producesAdapter()` and `getActiveFinetuningType()` for the serving question. They take a structural `FinetuningTypeSource` rather than `Partial<CustomizationFormFields>`, because `Partial` only loosens the top level and would force a cast at every call site that watches two or three fields.

**Note a deviation from the tracking issue:** it asked for one predicate replacing five inline derivations. Two of those five (`formToAutomodelCreate`, `formToUnslothCreate`) gate LoRA *hyperparameters in the payload* — the training question, not the serving one. Collapsing them into `producesAdapter` would have been a behaviour change and a bug. They are left alone.

## Base

Targets `main` directly and depends on nothing else. It was previously the top of a stacked series; verified independent by cherry-picking it onto the base alone — applies with no conflict, typecheck clean, and its targeted tests pass (5 files, 71 tests). It shares no file and no symbol with the deployment PRs in stack #1914.

This matters here: the open API question below means this PR may sit for a while. Standing alone, it no longer blocks — or is blocked by — anything else.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: no shipped docs describe the fine-tuning form's sections.

New `util/forms/producesAdapter.test.ts` (10 tests) covers each backend's `finetuning_type` path, DPO returning undefined, GRPO reading from the form-only `grpo` namespace, and specifically that `lora_merged` is **not** an adapter run.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `pnpm --filter nemo-studio-ui test src/util/forms src/components/NewCustomizationForm` — 5 files, 71 tests passed (re-run standalone on `main`)
- `pnpm --filter nemo-studio-ui test` — 342 files, 3354 tests passed (full suite, run before the branch was made independent)
- `pnpm --filter nemo-studio-ui typecheck` — clean
- `pnpm --filter nemo-studio-ui lint:fix` — clean
- `uv run pre-commit run -a` not run in full; the commit-scoped pre-commit hooks ran and passed on commit.

Two flaky failures were seen on an earlier full-suite run (`util/forms/transforms.test.ts`, an MSW `beforeAll` hook timeout, and `IntakeLists/IntakeTracesTable.test.tsx`). Both passed in isolation and the suite was green on re-run; neither file is touched by this change.

Not verified in a running app — the new section's layout is worth a visual check before merge.
