### PR TITLE
feat(evaluator): add typed trial measurements

### DIFF
--- a/docs/evaluator/agent-eval/writing-metrics.mdx
+++ b/docs/evaluator/agent-eval/writing-metrics.mdx
@@ -39,8 +39,13 @@ No base class — a metric is any object with these three members (a structural 
 | Field | Type | What it holds |
 |---|---|---|
 | `candidate.output_text` | `str \| None` | the agent's final answer |
+| `candidate.response` | `Any \| None` | the raw model or agent response payload |
+| `candidate.trajectory` | `Any \| None` | the candidate trajectory when supplied directly |
 | `candidate.evidence` | `CandidateEvidence \| None` | trajectory, final filesystem state, logs — see [Reading evidence](#reading-evidence) |
-| `candidate.metadata` | `dict` | trial metadata (e.g. a reward a runner stamped on) |
+| `candidate.metadata` | `dict` | free-form trial and output metadata, excluding the dedicated fields above; empty when the trial has no output |
+
+For a trial with an output, `candidate.metadata` starts with `AgentEvalTrial.metadata` and then adds
+`AgentOutput.metadata`. If both contain the same key, the value from the output wins.
 
 `input.row.data` is a dict describing the task and trial:
 
@@ -49,7 +54,8 @@ No base class — a metric is any object with these three members (a structural 
 | `input.row.data["reference"]` | grader-only ground truth (the task's `reference`), never shown to the agent |
 | `input.row.data["inputs"]` | the task `inputs` (`instruction`, …) |
 | `input.row.data["task"]` | `{id, intent, metadata}` |
-| `input.row.data["trial"]` | `{id, task_id, status, metadata}` |
+| `input.row.data["trial"]` | `{id, task_id, status, error, measurements, metadata}` |
+
 
 So an **outcome** metric reads `candidate.output_text` and `row.data["reference"]`; a **trajectory**
 metric reads `candidate.evidence`.
@@ -165,6 +171,32 @@ class KeywordMatchMetric:
         expected = str(input.row.data.get("reference", {}).get("expected", "")).lower()
         answer = (input.candidate.output_text or "").lower()
         return MetricResult(outputs=[MetricOutput(name="score", value=1.0 if expected and expected in answer else 0.0)])
+```
+
+## Reading measurements
+
+Metrics read measurements from `input.row.data["trial"]["measurements"]`. The complete
+[`TrialMeasurements`](https://github.com/NVIDIA-NeMo/nemo-platform/blob/main/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/trials.py)
+schema is always present: unavailable values are `None`, while a measured zero remains `0` (or
+`0.0`). Persisted or imported measurement values belong exclusively in `measurements`; free-form
+metadata values are never converted into measurements, even when their keys resemble measurement
+names.
+
+```python
+class TotalTokensMetric:
+    @property
+    def type(self) -> str:
+        return "usage"
+
+    def output_spec(self) -> list[MetricOutputSpec]:
+        return [MetricOutputSpec.discrete_score("total_tokens", required=False)]
+
+    async def compute_scores(self, input: MetricInput) -> MetricResult:
+        total_tokens = input.row.data["trial"]["measurements"]["total_tokens"]
+        outputs = []
+        if total_tokens is not None:
+            outputs.append(MetricOutput(name="total_tokens", value=total_tokens))
+        return MetricResult(outputs=outputs)
 ```
 
 ## Reading evidence

--- a/packages/nemo_evaluator_sdk/examples/run_agent_eval/gating.py
+++ b/packages/nemo_evaluator_sdk/examples/run_agent_eval/gating.py
@@ -10,7 +10,7 @@ of the persisted run bundle. Note ``pass_rate`` here is a per-task pass/fail cou
 against a reward threshold — deliberately different from
 :class:`~nemo_evaluator_sdk.agent_eval.results.AgentEvalSummary`'s mean-per-output.
 Token/runtime are read via
-:class:`~nemo_evaluator_sdk.agent_eval.metrics.TrialMeasurements`.
+:class:`~nemo_evaluator_sdk.agent_eval.trials.TrialMeasurements`.
 """
 
 from __future__ import annotations
@@ -20,9 +20,9 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
 
-from nemo_evaluator_sdk.agent_eval.metrics import TrialMeasurements
 from nemo_evaluator_sdk.agent_eval.results import AgentEvalResult
 from nemo_evaluator_sdk.agent_eval.scores import AgentEvalScoreStatus, AgentEvalTaskScore
+from nemo_evaluator_sdk.agent_eval.trials import TrialMeasurements
 from pydantic import BaseModel
 
 # Metric outputs, in priority order, that represent a task's pass/reward signal.
@@ -102,15 +102,15 @@ def summarize_run(
 ) -> dict[str, Any]:
     """Aggregate pass-rate, token, and runtime for one run.
 
-    Token/runtime are read via :class:`TrialMeasurements`; the reward used for
-    pass-rate prefers a scored metric output (``reward_outputs``) and falls back
-    to the trial's recorded reward.
+    Token/runtime are read via :class:`TrialMeasurements`; pass-rate uses only
+    completed canonical score outputs. Tasks without one are reported as unscored.
     """
     trials_by_task = {trial.task_id: trial for trial in result.trials}
     reward_by_task = _rewards_by_task(result.scores, reward_outputs)
     task_ids = sorted({task.id for task in result.tasks} | set(trials_by_task))
 
     passed = 0
+    unscored_task_ids: list[str] = []
     token_sum = 0
     token_count = 0
     token_unavailable: list[str] = []
@@ -120,12 +120,12 @@ def summarize_run(
 
     for task_id in task_ids:
         trial = trials_by_task.get(task_id)
-        measurements = TrialMeasurements.from_metadata(trial.metadata if trial is not None else {})
+        measurements = trial.measurements if trial is not None else TrialMeasurements()
 
         reward_value = reward_by_task.get(task_id)
         if reward_value is None:
-            reward_value = measurements.reward if measurements.reward is not None else 0.0
-        if reward_value >= 1.0:
+            unscored_task_ids.append(task_id)
+        elif reward_value >= 1.0:
             passed += 1
 
         if measurements.total_tokens is not None:
@@ -147,6 +147,7 @@ def summarize_run(
         "total_tasks": total,
         "passed_tasks": passed,
         "pass_rate": (passed / total) if total else 0.0,
+        "unscored_task_ids": sorted(unscored_task_ids),
         "task_names": task_ids,
         "total_tokens_sum": token_sum if token_count else None,
         "avg_total_tokens": (token_sum / token_count) if token_count else None,

--- a/packages/nemo_evaluator_sdk/examples/run_agent_eval/platform_runtime.py
+++ b/packages/nemo_evaluator_sdk/examples/run_agent_eval/platform_runtime.py
@@ -38,6 +38,7 @@ from nemo_evaluator_sdk.agent_eval.trials import (
     AgentEvalTrialStatus,
     AgentOutput,
     RunnerInfo,
+    TrialMeasurements,
     resolve_trial_status,
     standard_evidence_descriptors,
 )
@@ -453,19 +454,23 @@ def build_trial_from_artifacts(
     )
 
     output_text = log_text.strip() or ("" if agent_ok else "(agent phase failed)")
+    measurements = TrialMeasurements(
+        prompt_tokens=usage["prompt_tokens"],
+        completion_tokens=usage["completion_tokens"],
+        cache_creation_tokens=usage["cache_creation_tokens"],
+        cache_read_tokens=usage["cache_read_tokens"],
+        runtime_sec=runtime_sec,
+    )
     metadata: dict[str, Any] = {
         "agent_runtime": runtime_name,
         "agent_model": agent_model,
         "agent_ok": agent_ok,
         "exit_code": exit_code,
-        "runtime_sec": runtime_sec,
         "run_dir": str(layout.run_dir),
         "agent_log_dir": str(layout.agent_log_dir),
         "workspace_dir": str(layout.workspace_dir),
         "state_dir": str(layout.state_dir),
         "generated": True,
-        # Token measurements (same keys nat_runner writes into result.json["metrics"]).
-        **{key: value for key, value in usage.items() if value is not None},
     }
     return AgentEvalTrial(
         id=f"{task.id}:{runtime_name}",
@@ -476,6 +481,7 @@ def build_trial_from_artifacts(
             metadata={"runtime": runtime_name, "agent_model": agent_model},
         ),
         evidence=CandidateEvidence(descriptors=descriptors, metadata={"runtime": runtime_name}),
+        measurements=measurements,
         metadata=metadata,
     )
 

--- a/packages/nemo_evaluator_sdk/examples/run_agent_eval/run_agent_eval.py
+++ b/packages/nemo_evaluator_sdk/examples/run_agent_eval/run_agent_eval.py
@@ -29,7 +29,6 @@ if __package__ in {None, ""}:
         "  python -m packages.nemo_evaluator_sdk.examples.run_agent_eval.run_agent_eval --task all"
     )
 
-from nemo_evaluator_sdk.agent_eval.metrics import TrialMeasurements
 from nemo_evaluator_sdk.agent_eval.results import AgentEvalResult
 from nemo_evaluator_sdk.metrics.protocol import Metric
 
@@ -166,7 +165,7 @@ def _print_result(result: AgentEvalResult) -> None:
 
 def _print_measurements(result: AgentEvalResult) -> None:
     """Print token/runtime totals (the same measurements nat_runner records)."""
-    measurements = [TrialMeasurements.from_metadata(trial.metadata) for trial in result.trials]
+    measurements = [trial.measurements for trial in result.trials]
     total_tokens = [m.total_tokens for m in measurements if m.total_tokens is not None]
     runtimes = [m.runtime_sec for m in measurements if m.runtime_sec is not None]
     if total_tokens:

--- a/packages/nemo_evaluator_sdk/examples/run_agent_eval/usage.py
+++ b/packages/nemo_evaluator_sdk/examples/run_agent_eval/usage.py
@@ -3,18 +3,27 @@
 
 """Token-usage extraction ported from ``tests/agentic-use/nat_runner.py``.
 
-Reports the same token/runtime measurements ``nat_runner`` writes into
-``result.json["metrics"]`` (the keys the SDK's ``TrialMeasurements`` reads):
+Normalizes the token/runtime measurements ``nat_runner`` writes into
+``result.json["metrics"]`` for construction of ``TrialMeasurements``:
 ``prompt_tokens``/``completion_tokens``/``cache_creation_tokens``/
-``cache_read_tokens`` plus their ``total_tokens`` sum, and ``duration_ms``
-(the ``runtime_sec`` fallback). Buckets follow Anthropic's prompt-caching shape
-so AUT (``nemo agents invoke``) and other backends are comparable.
+``cache_read_tokens`` plus the canonical prompt/completion total, and
+``duration_ms``. Cache subsets are included in prompt exactly once.
 """
 
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any, TypedDict
+
+logger = logging.getLogger(__name__)
+
+_INPUT_TOKEN_KEYS = ("input_tokens", "prompt_tokens", "inputTokens")
+_OUTPUT_TOKEN_KEYS = ("output_tokens", "completion_tokens", "outputTokens")
+_CACHE_CREATION_KEYS = ("cache_creation_input_tokens", "cacheWriteTokens")
+_SEPARATE_CACHE_READ_KEYS = ("cache_read_input_tokens", "cacheReadTokens")
+_CACHE_READ_KEYS = (*_SEPARATE_CACHE_READ_KEYS, "cached_input_tokens")
+_SEPARATE_CACHE_KEYS = (*_CACHE_CREATION_KEYS, *_SEPARATE_CACHE_READ_KEYS)
 
 
 class TokenMetrics(TypedDict):
@@ -26,6 +35,10 @@ class TokenMetrics(TypedDict):
     cache_creation_tokens: int | None
     cache_read_tokens: int | None
     duration_ms: float | None
+
+
+def _is_nonnegative_int(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value >= 0
 
 
 def iter_agent_log_json_payloads(agent_log: str) -> list[dict[str, Any]]:
@@ -59,37 +72,58 @@ def agent_log_has_workflow_error(agent_log: str) -> bool:
 def _first_int(usage_obj: dict[str, Any], keys: tuple[str, ...]) -> tuple[int | None, bool]:
     for key in keys:
         value = usage_obj.get(key)
-        if isinstance(value, int):
+        if _is_nonnegative_int(value):
             return value, True
+        if key in usage_obj and value is not None:
+            logger.warning("Invalid usage %s=%r; expected a non-negative integer and omitted it", key, value)
     return None, False
 
 
-def _bucket_from_usage(usage_obj: dict[str, Any]) -> tuple[int | None, int | None, int | None, int | None, bool]:
-    """Return ``(input, output, cache_creation, cache_read, has_known_key)``."""
-    input_tokens, has_input = _first_int(usage_obj, ("input_tokens", "prompt_tokens", "inputTokens"))
-    output_tokens, has_output = _first_int(usage_obj, ("output_tokens", "completion_tokens", "outputTokens"))
-    cache_creation_tokens, has_cache_creation = _first_int(
-        usage_obj, ("cache_creation_input_tokens", "cacheWriteTokens")
-    )
-    cache_read_tokens, has_cache_read = _first_int(
-        usage_obj, ("cache_read_input_tokens", "cacheReadTokens", "cached_input_tokens")
-    )
+def _bucket_from_usage(
+    usage_obj: dict[str, Any],
+) -> tuple[int | None, int | None, int | None, int | None, bool, set[str]]:
+    """Return normalized buckets, whether usage was recognized, and invalid buckets."""
+    input_tokens, has_input = _first_int(usage_obj, _INPUT_TOKEN_KEYS)
+    output_tokens, has_output = _first_int(usage_obj, _OUTPUT_TOKEN_KEYS)
+    cache_creation_tokens, has_cache_creation = _first_int(usage_obj, _CACHE_CREATION_KEYS)
+    cache_read_tokens, has_cache_read = _first_int(usage_obj, _CACHE_READ_KEYS)
     details = usage_obj.get("input_token_details")
     if isinstance(details, dict):
         if not has_cache_creation:
             cache_creation_tokens, has_cache_creation = _first_int(details, ("cache_creation",))
         if not has_cache_read:
             cache_read_tokens, has_cache_read = _first_int(details, ("cache_read",))
-    if (
-        "cached_input_tokens" in usage_obj
-        and has_input
-        and has_cache_read
-        and input_tokens is not None
-        and cache_read_tokens is not None
-    ):
-        input_tokens = max(input_tokens - cache_read_tokens, 0)
-    has_known_key = has_input or has_output or has_cache_creation or has_cache_read
-    return input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, has_known_key
+    separate_cache = any(key in usage_obj for key in _SEPARATE_CACHE_KEYS)
+    invalid_cache_creation = any(
+        key in usage_obj and usage_obj[key] is not None and not _is_nonnegative_int(usage_obj[key])
+        for key in _CACHE_CREATION_KEYS
+    )
+    invalid_cache_read = any(
+        key in usage_obj and usage_obj[key] is not None and not _is_nonnegative_int(usage_obj[key])
+        for key in _SEPARATE_CACHE_READ_KEYS
+    )
+    invalid_separate_cache = invalid_cache_creation or invalid_cache_read
+    inclusive_cache = "cached_input_tokens" in usage_obj
+    if separate_cache and inclusive_cache:
+        logger.warning(
+            "Usage contains both inclusive cached_input_tokens and separate cache fields; "
+            "omitting ambiguous prompt/cache measurements"
+        )
+        poisoned_buckets = {"input_tokens", "cache_creation_tokens", "cache_read_tokens"}
+        return None, output_tokens, None, None, True, poisoned_buckets
+    if separate_cache and input_tokens is not None:
+        input_tokens = (
+            None if invalid_separate_cache else input_tokens + (cache_creation_tokens or 0) + (cache_read_tokens or 0)
+        )
+    poisoned_buckets: set[str] = set()
+    if invalid_separate_cache:
+        poisoned_buckets.add("input_tokens")
+        if invalid_cache_creation:
+            poisoned_buckets.add("cache_creation_tokens")
+        if invalid_cache_read:
+            poisoned_buckets.add("cache_read_tokens")
+    has_known_key = has_input or has_output or has_cache_creation or has_cache_read or bool(poisoned_buckets)
+    return input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, has_known_key, poisoned_buckets
 
 
 def _looks_usage_bearing(d: dict[str, Any]) -> bool:
@@ -140,13 +174,15 @@ def extract_usage_metrics(agent_log: str) -> TokenMetrics:
 
     sums = {"input_tokens": 0, "output_tokens": 0, "cache_creation_tokens": 0, "cache_read_tokens": 0}
     bucket_presence = dict.fromkeys(sums, False)
+    poisoned_buckets: set[str] = set()
     has_data = False
 
     def _accumulate(usage_obj: dict[str, Any], *, replace: bool) -> bool:
         nonlocal has_data
-        input_tokens, output_tokens, cache_creation, cache_read, has_known_key = _bucket_from_usage(usage_obj)
+        input_tokens, output_tokens, cache_creation, cache_read, has_known_key, poisoned = _bucket_from_usage(usage_obj)
         if not has_known_key:
             return False
+        poisoned_buckets.update(poisoned)
         for key, value in (
             ("input_tokens", input_tokens),
             ("output_tokens", output_tokens),
@@ -197,12 +233,15 @@ def extract_usage_metrics(agent_log: str) -> TokenMetrics:
     if not has_data:
         return zero
 
-    present = {key: sums[key] if bucket_presence[key] else None for key in sums}
-    components = [value for value in present.values() if value is not None]
+    present = {key: sums[key] if bucket_presence[key] and key not in poisoned_buckets else None for key in sums}
+    input_tokens = present["input_tokens"]
+    output_tokens = present["output_tokens"]
     out: TokenMetrics = {
         "prompt_tokens": present["input_tokens"],
         "completion_tokens": present["output_tokens"],
-        "total_tokens": sum(components) if components else None,
+        "total_tokens": input_tokens + output_tokens
+        if input_tokens is not None and output_tokens is not None
+        else None,
         "cache_creation_tokens": present["cache_creation_tokens"],
         "cache_read_tokens": present["cache_read_tokens"],
         "duration_ms": None,

--- a/packages/nemo_evaluator_sdk/examples/run_agent_eval/usage.py
+++ b/packages/nemo_evaluator_sdk/examples/run_agent_eval/usage.py
@@ -93,7 +93,7 @@ def _bucket_from_usage(
             cache_creation_tokens, has_cache_creation = _first_int(details, ("cache_creation",))
         if not has_cache_read:
             cache_read_tokens, has_cache_read = _first_int(details, ("cache_read",))
-    separate_cache = any(key in usage_obj for key in _SEPARATE_CACHE_KEYS)
+    separate_cache = any(usage_obj.get(key) is not None for key in _SEPARATE_CACHE_KEYS)
     invalid_cache_creation = any(
         key in usage_obj and usage_obj[key] is not None and not _is_nonnegative_int(usage_obj[key])
         for key in _CACHE_CREATION_KEYS
@@ -103,7 +103,7 @@ def _bucket_from_usage(
         for key in _SEPARATE_CACHE_READ_KEYS
     )
     invalid_separate_cache = invalid_cache_creation or invalid_cache_read
-    inclusive_cache = "cached_input_tokens" in usage_obj
+    inclusive_cache = usage_obj.get("cached_input_tokens") is not None
     if separate_cache and inclusive_cache:
         logger.warning(
             "Usage contains both inclusive cached_input_tokens and separate cache fields; "

--- a/packages/nemo_evaluator_sdk/examples/run_agent_eval/workflow_runtime.py
+++ b/packages/nemo_evaluator_sdk/examples/run_agent_eval/workflow_runtime.py
@@ -31,6 +31,7 @@ from nemo_evaluator_sdk.agent_eval.trials import (
     AgentEvalTrialStatus,
     AgentOutput,
     RunnerInfo,
+    TrialMeasurements,
     resolve_trial_status,
     standard_evidence_descriptors,
 )
@@ -152,12 +153,12 @@ class WorkflowAgentRuntime:
                 metadata={"runtime": RUNTIME_NAME, "agent_model": self.config.agent_model},
             ),
             evidence=CandidateEvidence(descriptors=descriptors, metadata={"runtime": RUNTIME_NAME}),
+            measurements=TrialMeasurements(runtime_sec=runtime_sec),
             metadata={
                 "runtime": RUNTIME_NAME,
                 "agent_model": self.config.agent_model,
                 "agent_ok": agent_ok,
                 "exit_code": process.returncode,
-                "runtime_sec": runtime_sec,
                 "run_dir": str(layout.run_dir),
                 "generated": True,
             },

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/evaluator.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/evaluator.py
@@ -39,6 +39,19 @@ from nemo_evaluator_sdk.agent_eval.trials import (
     RunAggregationsProvider,
     RunnerInfo,
     TrialAwareMetricsProvider,
+    TrialMeasurements,
+)
+from nemo_evaluator_sdk.agent_eval.usage_keys import (
+    CACHE_CREATION_INPUT_TOKENS_KEY,
+    CACHE_READ_INPUT_TOKENS_KEY,
+    CACHED_TOKENS_KEY,
+    COMPLETION_TOKEN_KEYS,
+    PROMPT_TOKEN_KEYS,
+    SEPARATE_CACHE_KEYS,
+    USAGE_COUNT_KEYS,
+    USAGE_DETAILS_KEYS,
+    _first_nonnegative_int,
+    _first_usage_details,
 )
 from nemo_evaluator_sdk.agent_inference import (
     AgentInferenceContext,
@@ -175,31 +188,31 @@ class AgentEvaluator:
             # Branch on which seam was supplied so the type checker narrows each of ``trials`` and
             # ``target`` to a concrete type without a cast. The final arm is the "neither" case.
             if trials is not None:
-                trial_list = list(trials)
+                source_trial_list = list(trials)
             elif target is not None:
-                trial_list = await self._generate_trials(tasks=task_list, target=target, config=runtime_config)
+                source_trial_list = await self._generate_trials(tasks=task_list, target=target, config=runtime_config)
             else:
                 raise ValueError(seam_error)
+            # ``model_copy(update=...)`` skips nested validation. Revalidate so corrupted
+            # measurements cannot reach scoring, and derived fields (e.g. total_tokens) are filled.
+            trial_list = [AgentEvalTrial.model_validate(trial) for trial in source_trial_list]
             if isinstance(target, TrialAwareMetricsProvider):
                 # Some runners only know their full metric list after trials exist
                 # (Harbor extras in reward_details). Ask for this task's metrics and
                 # copy the task with that list before scoring.
                 trials_by_task = _trials_by_task(task_list, trial_list)
                 original_task_ids = tuple(trial.task_id for trial in trial_list)
+                # Revalidation creates normalized copies. Audit the runner-returned instances too:
+                # a provider can retain and mutate those references instead of the sequence it receives.
+                source_task_ids = tuple(trial.task_id for trial in source_trial_list)
                 task_list = [
                     _task_with_updated_metrics(task, target.scoring_metrics(task, trials_by_task[task.id]))
                     for task in task_list
                 ]
-                changed_assignments = [
-                    (index, trial.id, original_task_id, trial.task_id)
-                    for index, (trial, original_task_id) in enumerate(zip(trial_list, original_task_ids, strict=True))
-                    if trial.task_id != original_task_id
-                ]
+                changed_assignments = _changed_trial_assignments(trial_list, original_task_ids)
+                changed_assignments.extend(_changed_trial_assignments(source_trial_list, source_task_ids))
                 if changed_assignments:
-                    raise ValueError(
-                        "scoring_metrics changed trial task assignments "
-                        f"(row, trial_id, original_task_id, task_id): {changed_assignments}"
-                    )
+                    raise ValueError(_scoring_metrics_assignment_error(changed_assignments))
             scores = await self._score_trials(
                 tasks=task_list,
                 trials=trial_list,
@@ -431,6 +444,39 @@ def _trials_by_task(
     return dict(trials_by_task)
 
 
+def _changed_trial_assignments(
+    trials: Sequence[AgentEvalTrial],
+    original_task_ids: Sequence[str],
+) -> list[tuple[int, str, str, str]]:
+    """Rows whose ``task_id`` changed from the snapshot in ``original_task_ids``.
+
+    ``scoring_metrics`` must not reassign trials. Compare after the hook so a
+    balanced swap (which regrouping would miss) still fails.
+    """
+    return [
+        (index, trial.id, original_task_id, trial.task_id)
+        for index, (trial, original_task_id) in enumerate(zip(trials, original_task_ids, strict=True))
+        if trial.task_id != original_task_id
+    ]
+
+
+def _scoring_metrics_assignment_error(changed: Sequence[tuple[int, str, str, str]]) -> str:
+    """Explain a ``task_id`` mutation and what ``scoring_metrics`` should do instead."""
+    seen: set[tuple[str, str, str]] = set()
+    parts: list[str] = []
+    for _, trial_id, original_task_id, task_id in changed:
+        key = (trial_id, original_task_id, task_id)
+        if key in seen:
+            continue
+        seen.add(key)
+        parts.append(f"trial {trial_id!r} task_id {original_task_id!r} -> {task_id!r}")
+    return (
+        "scoring_metrics must not mutate trials "
+        f"({'; '.join(parts)}). Return a new metric list; leave each trial.task_id "
+        "as the runner assigned it."
+    )
+
+
 def _task_with_updated_metrics(task: AgentEvalTask, metrics: Sequence[Metric]) -> AgentEvalTask:
     """Copy ``task`` with ``metrics`` replaced, through the constructor rather than ``model_copy``.
 
@@ -563,9 +609,10 @@ def _trial_from_sample(task: AgentEvalTask, target: Model | Agent, sample: dict[
     invocation_metadata = sample.get("invocation_metadata")
     if not isinstance(invocation_metadata, dict):
         invocation_metadata = {}
+    trial_id = f"{task.id}:{target.name}"
 
     return AgentEvalTrial(
-        id=f"{task.id}:{target.name}",
+        id=trial_id,
         task_id=task.id,
         status=status,
         output=AgentOutput(
@@ -579,6 +626,7 @@ def _trial_from_sample(task: AgentEvalTask, target: Model | Agent, sample: dict[
             },
         ),
         evidence=evidence,
+        measurements=_live_response_usage_measurements(sample.get("response"), trial_id=trial_id),
         metadata={
             **invocation_metadata,
             "model_id": target.name,
@@ -586,6 +634,84 @@ def _trial_from_sample(task: AgentEvalTask, target: Model | Agent, sample: dict[
             "generated": True,
         },
     )
+
+
+def _live_response_usage_measurements(response: Any, *, trial_id: str) -> TrialMeasurements:
+    """Normalize a live model or agent response's usage into typed measurements."""
+    if not isinstance(response, Mapping):
+        return TrialMeasurements()
+    usage = response.get("usage")
+    if usage is None:
+        return TrialMeasurements()
+    if not isinstance(usage, Mapping):
+        log.warning("Trial %r has invalid live response usage=%r; expected an object and omitted it", trial_id, usage)
+        return TrialMeasurements()
+
+    _warn_invalid_live_usage_counts(trial_id, usage)
+    separate_cache = any(key in usage for key in SEPARATE_CACHE_KEYS)
+    details = _first_usage_details(usage)
+    inclusive_cache = details is not None and CACHED_TOKENS_KEY in details
+    completion = _first_nonnegative_int(usage, *COMPLETION_TOKEN_KEYS)
+    if separate_cache and inclusive_cache:
+        log.warning(
+            "Trial %r live response usage contains both inclusive cache details and separate cache fields; "
+            "omitting ambiguous prompt/cache measurements",
+            trial_id,
+        )
+        return TrialMeasurements(completion_tokens=completion)
+
+    prompt = _first_nonnegative_int(usage, *PROMPT_TOKEN_KEYS)
+    cache_read = _first_nonnegative_int(usage, CACHE_READ_INPUT_TOKENS_KEY) if separate_cache else None
+    cache_creation = _first_nonnegative_int(usage, CACHE_CREATION_INPUT_TOKENS_KEY) if separate_cache else None
+    invalid_separate_cache = any(
+        key in usage and usage[key] is not None and _first_nonnegative_int(usage, key) is None
+        for key in SEPARATE_CACHE_KEYS
+    )
+    if separate_cache and prompt is not None:
+        prompt = None if invalid_separate_cache else prompt + (cache_creation or 0) + (cache_read or 0)
+    elif details is not None and CACHED_TOKENS_KEY in details:
+        cache_read = _first_nonnegative_int(details, CACHED_TOKENS_KEY)
+
+    return TrialMeasurements(
+        prompt_tokens=prompt,
+        completion_tokens=completion,
+        cache_creation_tokens=cache_creation,
+        cache_read_tokens=cache_read,
+    )
+
+
+def _warn_invalid_live_usage_counts(trial_id: str, usage: Mapping[str, Any]) -> None:
+    """Log malformed live usage fields that the adapter omits."""
+    for key in USAGE_COUNT_KEYS:
+        if key in usage and usage[key] is not None and _first_nonnegative_int(usage, key) is None:
+            log.warning(
+                "Trial %r has invalid live response usage %s=%r; expected a non-negative integer and omitted it",
+                trial_id,
+                key,
+                usage[key],
+            )
+    for details_key in USAGE_DETAILS_KEYS:
+        details = usage.get(details_key)
+        if details is not None and not isinstance(details, Mapping):
+            log.warning(
+                "Trial %r has invalid live response usage %s=%r; expected an object and omitted it",
+                trial_id,
+                details_key,
+                details,
+            )
+        elif (
+            isinstance(details, Mapping)
+            and CACHED_TOKENS_KEY in details
+            and details[CACHED_TOKENS_KEY] is not None
+            and _first_nonnegative_int(details, CACHED_TOKENS_KEY) is None
+        ):
+            log.warning(
+                "Trial %r has invalid live response usage %s.cached_tokens=%r; "
+                "expected a non-negative integer and omitted it",
+                trial_id,
+                details_key,
+                details[CACHED_TOKENS_KEY],
+            )
 
 
 def _reasoning_content_fallback(response: Any) -> str | None:
@@ -708,6 +834,14 @@ def _score_id(run_id: str, task_id: str, trial_id: str, metric_type: str) -> str
 
 
 def _trial_sample(trial: AgentEvalTrial) -> dict[str, Any]:
+    """Flatten one trial into the sample dict that becomes ``MetricInput.candidate``.
+
+    A metric never calls this. Scoring path, once per ``(task, trial, metric)``::
+
+        _score_metric
+          -> build_metric_input(_metric_row(task, trial), _trial_sample(trial), ...)
+          -> metric.compute_scores(MetricInput)
+    """
     if trial.output is None:
         return {}
     sample: dict[str, Any] = {
@@ -790,7 +924,8 @@ def _metric_row(task: AgentEvalTask, trial: AgentEvalTrial) -> dict[str, Any]:
             "status": trial.status.value,
             # How the trial failed, for a metric that grades on it. None when the producer reported no failure.
             "error": trial.error.model_dump(mode="json") if trial.error is not None else None,
-            "metadata": trial.metadata,
+            "measurements": trial.measurements.model_dump(mode="json"),
+            "metadata": dict(trial.metadata),
         },
     }
 

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/evaluator.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/evaluator.py
@@ -648,9 +648,9 @@ def _live_response_usage_measurements(response: Any, *, trial_id: str) -> TrialM
         return TrialMeasurements()
 
     _warn_invalid_live_usage_counts(trial_id, usage)
-    separate_cache = any(key in usage for key in SEPARATE_CACHE_KEYS)
+    separate_cache = any(usage.get(key) is not None for key in SEPARATE_CACHE_KEYS)
     details = _first_usage_details(usage)
-    inclusive_cache = details is not None and CACHED_TOKENS_KEY in details
+    inclusive_cache = details is not None and details.get(CACHED_TOKENS_KEY) is not None
     completion = _first_nonnegative_int(usage, *COMPLETION_TOKEN_KEYS)
     if separate_cache and inclusive_cache:
         log.warning(

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/metrics.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/metrics.py
@@ -1,17 +1,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Reusable agent-eval metrics and the typed view over trial measurements.
+"""Reusable metrics for scoring agent-evaluation trials.
 
-Two complementary pieces, both keyed off ``AgentEvalTrial``:
+The metrics are keyed off ``AgentEvalTrial``:
 
 * Metrics (scorers) — ``AgentPhaseSuccessMetric`` reads the agent-phase outcome
   stamped on trial metadata; ``EvidencePresenceMetric`` is a genuine
   *metric-over-evidence* that scores by inspecting ``candidate.evidence`` (a
   filesystem evidence handle) rather than trusting a verifier's stamped reward.
-* ``TrialMeasurements`` — the single documented place that names the loose
-  metadata keys gating/reporting read, applying the fallbacks (``duration_ms`` →
-  ``runtime_sec``, ``passed`` → ``reward``).
+
+``TrialMeasurements`` is re-exported from this module for import compatibility;
+its durable model is owned by :mod:`nemo_evaluator_sdk.agent_eval.trials`.
 """
 
 from __future__ import annotations
@@ -21,7 +21,7 @@ import logging
 from collections.abc import Mapping
 from typing import Any, ClassVar, Literal
 
-from nemo_evaluator_sdk.agent_eval.trials import EVIDENCE_FINAL_STATE
+from nemo_evaluator_sdk.agent_eval.trials import TrialMeasurements  # noqa: F401 - compatibility re-export
 from nemo_evaluator_sdk.enums import MetricType
 from nemo_evaluator_sdk.metrics.protocol import (
     CandidateOutput,
@@ -30,9 +30,9 @@ from nemo_evaluator_sdk.metrics.protocol import (
     MetricOutputSpec,
     MetricResult,
 )
-from nemo_evaluator_sdk.metrics.utils import as_finite_float
 from nemo_evaluator_sdk.values.atif import Trajectory
 from nemo_evaluator_sdk.values.evidence import (
+    EVIDENCE_FINAL_STATE,
     EVIDENCE_FORMAT_ATIF,
     EVIDENCE_FORMAT_OTLP,
     EVIDENCE_TRACE,
@@ -41,18 +41,9 @@ from nemo_evaluator_sdk.values.evidence import (
 from nemo_evaluator_sdk.values.metrics import MetricBase
 from nemo_evaluator_sdk.values.otlp import span_text_strings
 from opentelemetry.proto.trace.v1.trace_pb2 import ResourceSpans
-from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+from pydantic import Field, ValidationError
 
 logger = logging.getLogger(__name__)
-
-# Token-measurement keys carried on trial metadata (and in result.json["metrics"]).
-TOKEN_KEYS: tuple[str, ...] = (
-    "prompt_tokens",
-    "completion_tokens",
-    "total_tokens",
-    "cache_creation_tokens",
-    "cache_read_tokens",
-)
 
 
 class AgentPhaseSuccessMetric(MetricBase):
@@ -210,62 +201,6 @@ def _otlp_references(resource_spans: list[ResourceSpans], needle: str) -> bool:
     return any(needle in blob for blob in span_text_strings(resource_spans))
 
 
-class TrialMeasurements(BaseModel):
-    """Numeric measurements projected from trial metadata.
-
-    Reporting/gating consume it via :meth:`from_metadata`; producers keep writing
-    the same keys onto ``AgentEvalTrial.metadata``.
-    """
-
-    model_config = ConfigDict(extra="forbid")
-
-    prompt_tokens: int | None = None
-    completion_tokens: int | None = None
-    total_tokens: int | None = None
-    cache_creation_tokens: int | None = None
-    cache_read_tokens: int | None = None
-    runtime_sec: float | None = None
-    cost_usd: float | None = Field(default=None, allow_inf_nan=False)
-    reward: float | None = None
-    passed: bool | None = None
-
-    @field_validator("cost_usd", mode="before")
-    @classmethod
-    def _reject_boolean_cost(cls, value: Any) -> Any:
-        """Refuse a ``bool`` cost, which coercion would otherwise hide.
-
-        ``bool`` is an ``int`` subclass, so ``True`` would validate as a cost of 1.0. Every other
-        unusable value is already refused: ``allow_inf_nan=False`` covers NaN and the infinities
-        however they were spelled, and float coercion covers an int too large to represent.
-        """
-        if isinstance(value, bool):
-            raise ValueError("cost_usd must be a number, not a bool")
-        return value
-
-    @classmethod
-    def from_metadata(cls, metadata: Mapping[str, Any] | None) -> TrialMeasurements:
-        """Project loose trial metadata onto the typed contract.
-
-        Applies the historical fallbacks so callers don't re-implement them:
-        ``runtime_sec`` falls back to ``duration_ms / 1000``; ``reward`` falls
-        back to ``1.0``/``0.0`` derived from ``passed`` when no explicit reward
-        is recorded.
-        """
-        metadata = metadata or {}
-
-        tokens = {key: _as_int(metadata.get(key)) for key in TOKEN_KEYS}
-        passed = metadata.get("passed")
-        passed = bool(passed) if isinstance(passed, bool) else None
-
-        return cls(
-            **tokens,
-            runtime_sec=_runtime_sec(metadata),
-            cost_usd=as_finite_float(metadata.get("cost_usd")),
-            reward=_reward(metadata, passed),
-            passed=passed,
-        )
-
-
 def _trajectory_references(trajectory: Trajectory, needle: str) -> bool:
     """Whether ``needle`` appears anywhere an agent action could reference the skill.
 
@@ -284,32 +219,3 @@ def _trajectory_references(trajectory: Trajectory, needle: str) -> bool:
                 if result.content is not None and needle in json.dumps(result.content, default=str):
                     return True
     return False
-
-
-def _as_int(value: Any) -> int | None:
-    # bool is an int subclass; never treat True/False as a token count.
-    if isinstance(value, bool):
-        return None
-    return value if isinstance(value, int) else None
-
-
-def _runtime_sec(metadata: Mapping[str, Any]) -> float | None:
-    runtime_sec = metadata.get("runtime_sec")
-    if isinstance(runtime_sec, int | float) and not isinstance(runtime_sec, bool):
-        return float(runtime_sec)
-    duration_ms = metadata.get("duration_ms")
-    if isinstance(duration_ms, int | float) and not isinstance(duration_ms, bool):
-        return float(duration_ms) / 1000.0
-    return None
-
-
-def _reward(metadata: Mapping[str, Any], passed: bool | None) -> float | None:
-    reward = metadata.get("reward")
-    if reward is not None:
-        try:
-            return float(reward)
-        except (TypeError, ValueError):
-            return None
-    if passed is not None:
-        return 1.0 if passed else 0.0
-    return None

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/persistence.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/persistence.py
@@ -34,6 +34,7 @@ def persist_run(
     Set ``write_html_dashboard=False`` to skip rendering ``report.html`` — the dashboard is written
     here so the manifest can record it in a single pass.
     """
+    validated_trials = [AgentEvalTrial.model_validate(trial) for trial in result.trials]
     path = Path(output_dir)
     path.mkdir(parents=True, exist_ok=True)
 
@@ -42,7 +43,7 @@ def persist_run(
 
     _write_json(path / "metadata.json", result.metadata)
     _write_jsonl(path / "tasks.jsonl", result.tasks)
-    _write_trials(path / "trials.jsonl", result.trials, base=path)
+    _write_trials(path / "trials.jsonl", validated_trials, base=path)
     _write_jsonl(path / "scores.jsonl", result.scores)
     _write_json(path / "summary.json", result.summary)
 
@@ -82,7 +83,7 @@ def _write_jsonl(path: Path, rows: Sequence[BaseModel]) -> None:
             handle.write("\n")
 
 
-def _write_trials(path: Path, trials: Sequence[BaseModel], *, base: Path) -> None:
+def _write_trials(path: Path, trials: Sequence[AgentEvalTrial], *, base: Path) -> None:
     """Write trials, rewriting evidence refs bundle-relative so the bundle is self-contained.
 
     A trial's evidence lives under the bundle (``<output_dir>/evidence/...``); storing the ref relative to
@@ -111,7 +112,7 @@ def _relativize_ref(ref: str | None, base: Path) -> str | None:
 
 
 def read_trials(run_dir: str | Path) -> list[AgentEvalTrial]:
-    """Hydrate the persisted trials of a run bundle — the inverse of the ``trials.jsonl`` ``persist_run`` writes.
+    """Read the persisted trials of a run bundle — the inverse of the ``trials.jsonl`` ``persist_run`` writes.
 
     Each row is loaded back into an ``AgentEvalTrial`` with its evidence pointing at the on-disk
     deliverables, so a stored run can be **re-scored** — ``AgentEvaluator().run(tasks=…, trials=…)`` with
@@ -156,7 +157,7 @@ def _resolves_within(base: Path, path: Path) -> bool:
     """Whether ``path`` exists and stays inside ``base`` after resolving — no ``..``/symlink escape.
 
     Rebuilt refs are joined onto ``run_dir``; a bundle is designed to be moved/copied, so a ref with ``..``
-    (or a symlink) must not be allowed to point the hydrated evidence outside the bundle it was loaded from.
+    (or a symlink) must not be allowed to point loaded evidence outside the bundle it was loaded from.
     """
     resolved = path.resolve()
     if not resolved.exists():

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/reward_keys.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/reward_keys.py
@@ -28,8 +28,7 @@ RewardKeyRejection = Literal["invalid_key", "reserved_key"]
 HarborRewardValueRejection = Literal["boolean", "non_numeric", "non_finite"]
 
 #: Trial-metadata keys carrying one parsed Harbor reward mapping. Named here rather than spelled
-#: at each writer and reader, the same reason :data:`~nemo_evaluator_sdk.agent_eval.metrics.TOKEN_KEYS`
-#: exists.
+#: independently at each writer and reader so the durable vocabulary stays centralized.
 REWARD_DETAILS_KEY = "reward_details"
 REWARD_REJECTIONS_KEY = "reward_rejections"
 REWARD_ENTRY_REJECTIONS_KEY = "reward_entry_rejections"

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/callable_runtime.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/callable_runtime.py
@@ -16,6 +16,7 @@ from nemo_evaluator_sdk.agent_eval.trials import (
     AgentEvalTrialStatus,
     AgentOutput,
     RunnerInfo,
+    TrialMeasurements,
     callable_identity,
 )
 from nemo_evaluator_sdk.values.evidence import CandidateEvidence
@@ -32,6 +33,7 @@ class TrialDraft:
     output: AgentOutput
     evidence: CandidateEvidence | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
+    measurements: TrialMeasurements = field(default_factory=TrialMeasurements)
 
 
 AgentTaskFn = Callable[[AgentEvalTask], Awaitable[TrialDraft | AgentOutput | str]]
@@ -100,6 +102,7 @@ class CallableAgentTaskRunner:
             status=AgentEvalTrialStatus.COMPLETED,
             output=draft.output,
             evidence=draft.evidence,
+            measurements=draft.measurements,
             metadata=draft.metadata,
         )
 

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/fabric/runtime.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/fabric/runtime.py
@@ -34,6 +34,7 @@ import asyncio
 import copy
 import json
 import logging
+import math
 import shutil
 from collections.abc import Mapping, Sequence
 from datetime import UTC, datetime
@@ -53,16 +54,21 @@ from nemo_evaluator_sdk.agent_eval.runtimes.fabric.skills import (
     resolve_skill_mode,
 )
 from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalRunConfig, AgentEvalTask
-from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial, AgentEvalTrialStatus, AgentOutput, RunnerInfo
+from nemo_evaluator_sdk.agent_eval.trials import (
+    AgentEvalTrial,
+    AgentEvalTrialStatus,
+    AgentOutput,
+    RunnerInfo,
+    TrialMeasurements,
+)
 from nemo_evaluator_sdk.agent_eval.workspace_seeds import SEED_FILES_INPUT_KEY, seed_workspace
-from nemo_evaluator_sdk.values.atif import FinalMetrics
 from nemo_evaluator_sdk.values.evidence import (
     EVIDENCE_FORMAT_ATIF,
     EVIDENCE_TRACE,
     CandidateEvidence,
     EvidenceDescriptor,
 )
-from pydantic import JsonValue, ValidationError
+from pydantic import JsonValue
 
 if TYPE_CHECKING:
     # Annotations use nemo_fabric's real types (single source of truth). nemo_fabric is an optional
@@ -362,11 +368,19 @@ class FabricAgentRuntime:
                     hook_extras = None
         except TimeoutError as exc:
             return self._failed_trial(
-                task, evidence_dir, exc, extra_metadata=self._failed_metadata(skill_provenances, evidence_dir)
+                task,
+                evidence_dir,
+                exc,
+                extra_metadata=self._skill_metadata(skill_provenances),
+                measurements=_atif_measurements(_relay_atif_path(evidence_dir)),
             )
         except Exception as exc:  # noqa: BLE001 - a task failure must not abort the whole run
             return self._failed_trial(
-                task, evidence_dir, exc, extra_metadata=self._failed_metadata(skill_provenances, evidence_dir)
+                task,
+                evidence_dir,
+                exc,
+                extra_metadata=self._skill_metadata(skill_provenances),
+                measurements=_atif_measurements(_relay_atif_path(evidence_dir)),
             )
         finally:
             if self._task_hook is not None:
@@ -403,18 +417,6 @@ class FabricAgentRuntime:
         """
         return {"skill": provenances[0] if len(provenances) == 1 else None, "skills": provenances}
 
-    @staticmethod
-    def _failed_metadata(provenances: list[SkillProvenance], evidence_dir: Path) -> dict[str, Any]:
-        """Trial metadata for a timed-out/errored task: skill provenance plus whatever tokens Relay flushed.
-
-        Timeouts never reach ``_to_trial``, and there is no ``RunResult`` here, so the trajectory is read
-        straight from the relay dir — these are the long, expensive rows the token count matters most for.
-        """
-        return {
-            **FabricAgentRuntime._skill_metadata(provenances),
-            **_atif_token_metadata(_relay_atif_path(evidence_dir)),
-        }
-
     def _to_trial(
         self,
         task: AgentEvalTask,
@@ -430,6 +432,7 @@ class FabricAgentRuntime:
         result_path.write_text(json.dumps(result.to_mapping(), indent=2, default=str), encoding="utf-8")
 
         extras = dict(hook_extras) if hook_extras else {}
+        measurements = _atif_measurements(_atif_artifact_path(result))
         base_metadata: dict[str, Any] = {
             "runtime": self._runtime_name,
             "harness": result.harness,
@@ -440,9 +443,6 @@ class FabricAgentRuntime:
             # Skill provenance (name + content hash + injection mode) for the A/B diff.
             **self._skill_metadata(skill_provenances or []),
             **extras,
-            # Token usage from the Relay ATIF trajectory; Fabric's RunResult carries no usage of its
-            # own. Merged last so a hook extra can't shadow it.
-            **_atif_token_metadata(_atif_artifact_path(result)),
         }
 
         if result.status != "succeeded":
@@ -466,9 +466,12 @@ class FabricAgentRuntime:
                         metadata={**base_metadata, "evidence_dir": str(evidence_dir)},
                     ),
                     evidence=self._evidence(result, result_path, workspace_dir),
+                    measurements=measurements,
                     metadata={**base_metadata, "generated": True, "agent_ok": True},
                 )
-            return self._failed_trial(task, evidence_dir, _result_error(result), extra_metadata=base_metadata)
+            return self._failed_trial(
+                task, evidence_dir, _result_error(result), extra_metadata=base_metadata, measurements=measurements
+            )
 
         # Fabric wraps the output in a ``RunOutput`` mapping (RunOutput response contract, #52),
         # which is not itself a JSON value; normalize it to a plain mapping so it round-trips through the
@@ -492,6 +495,7 @@ class FabricAgentRuntime:
                 metadata={**base_metadata, "evidence_dir": str(evidence_dir)},
             ),
             evidence=self._evidence(result, result_path, workspace_dir),
+            measurements=measurements,
             # AgentPhaseSuccessMetric reads agent_ok to score whether the agent phase finished cleanly
             # (an explicit bool, not just trial status).
             metadata={**base_metadata, "generated": True, "agent_ok": True},
@@ -537,6 +541,7 @@ class FabricAgentRuntime:
         evidence_dir: Path,
         error: Exception | Mapping[str, Any],
         extra_metadata: Mapping[str, Any] | None = None,
+        measurements: TrialMeasurements | None = None,
     ) -> AgentEvalTrial:
         if isinstance(error, Mapping):
             error_type = str(error.get("code") or error.get("stage") or "FabricError")
@@ -555,6 +560,7 @@ class FabricAgentRuntime:
                 descriptors={"error": EvidenceDescriptor(kind="error", format="json", ref=str(error_path))},
                 metadata={"runtime": self._runtime_name},
             ),
+            measurements=measurements if measurements is not None else TrialMeasurements(),
             metadata={
                 **(dict(extra_metadata) if extra_metadata else {}),
                 "runtime": self._runtime_name,
@@ -760,58 +766,91 @@ def _relay_atif_path(evidence_dir: Path) -> Path | None:
     return None
 
 
-def _atif_token_metadata(path: Path | None) -> dict[str, int]:
-    """Project an ATIF trajectory's token totals onto the trial-metadata ``TOKEN_KEYS``.
+def _atif_measurements(path: Path | None) -> TrialMeasurements:
+    """Build typed measurements from a Relay ATIF trajectory.
 
-    Each token field is resolved on its own: the trajectory-level ``final_metrics`` aggregate when it
-    reports that field, else the sum of the matching per-step ``metrics``. Every ``final_metrics``
-    field is optional, so a block carrying only ``total_steps`` or a cost — or one that fails to
-    validate — must not suppress counts the steps do carry. That partial shape is likeliest on the
-    timeout path, where the trajectory was flushed mid-run and the counts matter most.
+    Each field is resolved on its own: a valid trajectory-level ``final_metrics``
+    value wins; when absent, the matching per-step values are summed. An
+    explicitly invalid final value or step contributor poisons only that field.
+    This per-field fallback matters most on timeout, when Relay may flush a
+    partial trajectory.
 
-    ``total_tokens`` and ``cache_creation_tokens`` have no ATIF source and stay unset — Intake
-    recomputes the total. A missing or unreadable trajectory yields ``{}``: an absent token count
-    must not fail the trial.
+    ``cache_creation_tokens`` has no ATIF source and stays unset. A missing or
+    unreadable trajectory yields empty measurements and never fails the trial.
     """
     if path is None:
-        return {}
+        return TrialMeasurements()
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, ValueError) as exc:
         logger.warning("Fabric token capture: unreadable ATIF trajectory %s (%s)", path, exc)
-        return {}
+        return TrialMeasurements()
     if not isinstance(payload, Mapping):
-        return {}
+        return TrialMeasurements()
 
-    totals = FinalMetrics()
     final_metrics = payload.get("final_metrics")
-    if isinstance(final_metrics, Mapping):
-        try:
-            totals = FinalMetrics.model_validate(final_metrics)
-        except ValidationError as exc:
-            logger.warning("Fabric token capture: invalid final_metrics in %s (%s)", path, exc)
-
-    captured = {
-        "prompt_tokens": (totals.total_prompt_tokens, "prompt_tokens"),
-        "completion_tokens": (totals.total_completion_tokens, "completion_tokens"),
-        "cache_read_tokens": (totals.total_cached_tokens, "cached_tokens"),
+    final = final_metrics if isinstance(final_metrics, Mapping) else {}
+    fields = {
+        "prompt_tokens": ("total_prompt_tokens", "prompt_tokens", False),
+        "completion_tokens": ("total_completion_tokens", "completion_tokens", False),
+        "cache_read_tokens": ("total_cached_tokens", "cached_tokens", False),
+        "cost_usd": ("total_cost_usd", "cost_usd", True),
     }
-    resolved = {
-        key: total if total is not None else _sum_step_metric(payload, step_key)
-        for key, (total, step_key) in captured.items()
-    }
-    return {key: value for key, value in resolved.items() if value is not None}
+    resolved: dict[str, int | float] = {}
+    for sdk_key, (final_key, step_key, is_float) in fields.items():
+        if final_key in final and final[final_key] is not None:
+            value = final[final_key]
+            if _valid_atif_measurement(value, is_float=is_float):
+                resolved[sdk_key] = float(value) if is_float else int(value)
+            else:
+                logger.warning(
+                    "Fabric token capture: invalid %s=%r in %s; omitting %s", final_key, value, path, sdk_key
+                )
+            continue
+        value, valid = _sum_step_metric(payload, step_key, is_float=is_float)
+        if valid and value is not None:
+            resolved[sdk_key] = value
+        elif not valid:
+            logger.warning("Fabric token capture: invalid step %s in %s; omitting %s", step_key, path, sdk_key)
+    return TrialMeasurements.model_validate(resolved)
 
 
-def _sum_step_metric(payload: Mapping[str, Any], key: str) -> int | None:
-    """Sum one per-step ATIF metric across the trajectory, or ``None`` when no step reported it."""
-    total: int | None = None
-    for step in payload.get("steps") or []:
+def _sum_step_metric(payload: Mapping[str, Any], key: str, *, is_float: bool) -> tuple[int | float | None, bool]:
+    """Sum one per-step ATIF metric, poisoning an explicitly invalid contributor."""
+    values: list[int | float] = []
+    steps = payload.get("steps")
+    if steps is None:
+        return None, True
+    if not isinstance(steps, list):
+        return None, False
+    for step in steps:
         metrics = step.get("metrics") if isinstance(step, Mapping) else None
-        value = metrics.get(key) if isinstance(metrics, Mapping) else None
-        if isinstance(value, int) and not isinstance(value, bool):
-            total = value if total is None else total + value
-    return total
+        if not isinstance(metrics, Mapping) or key not in metrics or metrics[key] is None:
+            continue
+        value = metrics[key]
+        if not _valid_atif_measurement(value, is_float=is_float):
+            return None, False
+        values.append(value)
+    if not values:
+        return None, True
+    try:
+        total = math.fsum(float(value) for value in values) if is_float else sum(int(value) for value in values)
+    except OverflowError:
+        return None, False
+    if not _valid_atif_measurement(total, is_float=is_float):
+        return None, False
+    return (float(total) if is_float else int(total), True)
+
+
+def _valid_atif_measurement(value: Any, *, is_float: bool) -> bool:
+    if isinstance(value, bool) or not isinstance(value, int | float) or value < 0:
+        return False
+    if not is_float and not isinstance(value, int):
+        return False
+    try:
+        return math.isfinite(value)
+    except OverflowError:
+        return False
 
 
 def _safe_path_name(value: str) -> str:

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/results.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/results.py
@@ -27,7 +27,19 @@ from nemo_evaluator_sdk.agent_eval.runtimes.gym.records import (
     read_jsonl,
 )
 from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalTask
-from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial, AgentEvalTrialStatus, AgentOutput
+from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial, AgentEvalTrialStatus, AgentOutput, TrialMeasurements
+from nemo_evaluator_sdk.agent_eval.usage_keys import (
+    CACHE_CREATION_INPUT_TOKENS_KEY,
+    CACHE_READ_INPUT_TOKENS_KEY,
+    CACHED_TOKENS_KEY,
+    COMPLETION_TOKEN_KEYS,
+    PROMPT_TOKEN_KEYS,
+    SEPARATE_CACHE_KEYS,
+    USAGE_COUNT_KEYS,
+    USAGE_DETAILS_KEYS,
+    _first_nonnegative_int,
+    _first_usage_details,
+)
 from nemo_evaluator_sdk.ng_trajectory_otlp import rollout_to_resource_spans
 from nemo_evaluator_sdk.values.evidence import (
     EVIDENCE_FORMAT_OTLP,
@@ -101,6 +113,73 @@ def _agent_never_ran(record: Mapping[str, Any]) -> bool:
     # only `completion_tokens: 0` — rather than excluding those shapes one at a time.
     input_side = [usage[key] for key in _INPUT_TOKEN_KEYS if isinstance(usage.get(key), (int, float))]
     return bool(input_side) and all(value == 0 for value in input_side)
+
+
+def _usage_measurements(record: Mapping[str, Any]) -> TrialMeasurements:
+    """Normalize Gym response usage for both rollout and failure records."""
+    response = record.get("response")
+    usage = response.get("usage") if isinstance(response, Mapping) else None
+    if not isinstance(usage, Mapping):
+        return TrialMeasurements()
+    _warn_invalid_usage_counts(record, usage)
+
+    separate_cache = any(key in usage for key in SEPARATE_CACHE_KEYS)
+    details = _first_usage_details(usage)
+    inclusive_cache = details is not None and CACHED_TOKENS_KEY in details
+    completion = _first_nonnegative_int(usage, *COMPLETION_TOKEN_KEYS)
+    if separate_cache and inclusive_cache:
+        logger.warning(
+            "Gym task=%r rollout=%r usage contains both inclusive cache details and separate cache fields; "
+            "omitting ambiguous prompt/cache measurements",
+            record.get(NG_TASK_INDEX),
+            record.get(NG_ROLLOUT_INDEX),
+        )
+        return TrialMeasurements(completion_tokens=completion)
+
+    prompt = _first_nonnegative_int(usage, *PROMPT_TOKEN_KEYS)
+    cache_read = _first_nonnegative_int(usage, CACHE_READ_INPUT_TOKENS_KEY) if separate_cache else None
+    cache_creation = _first_nonnegative_int(usage, CACHE_CREATION_INPUT_TOKENS_KEY) if separate_cache else None
+    invalid_separate_cache = any(
+        key in usage and usage[key] is not None and _first_nonnegative_int(usage, key) is None
+        for key in SEPARATE_CACHE_KEYS
+    )
+    if separate_cache and prompt is not None:
+        prompt = None if invalid_separate_cache else prompt + (cache_creation or 0) + (cache_read or 0)
+    elif details is not None and CACHED_TOKENS_KEY in details:
+        cache_read = _first_nonnegative_int(details, CACHED_TOKENS_KEY)
+
+    return TrialMeasurements(
+        prompt_tokens=prompt,
+        completion_tokens=completion,
+        cache_creation_tokens=cache_creation,
+        cache_read_tokens=cache_read,
+    )
+
+
+def _warn_invalid_usage_counts(record: Mapping[str, Any], usage: Mapping[str, Any]) -> None:
+    trial_label = f"task={record.get(NG_TASK_INDEX)!r} rollout={record.get(NG_ROLLOUT_INDEX)!r}"
+    for key in USAGE_COUNT_KEYS:
+        if key in usage and usage[key] is not None and _first_nonnegative_int(usage, key) is None:
+            logger.warning(
+                "Gym %s has invalid usage %s=%r; expected a non-negative integer and omitted it",
+                trial_label,
+                key,
+                usage[key],
+            )
+    for details_key in USAGE_DETAILS_KEYS:
+        details = usage.get(details_key)
+        if (
+            isinstance(details, Mapping)
+            and CACHED_TOKENS_KEY in details
+            and details[CACHED_TOKENS_KEY] is not None
+            and _first_nonnegative_int(details, CACHED_TOKENS_KEY) is None
+        ):
+            logger.warning(
+                "Gym %s has invalid usage %s.cached_tokens=%r; expected a non-negative integer and omitted it",
+                trial_label,
+                details_key,
+                details[CACHED_TOKENS_KEY],
+            )
 
 
 def require_full_coverage(tasks: Sequence[AgentEvalTask], *, covered_task_ids: set[str], rollouts_path: Path) -> None:
@@ -576,6 +655,7 @@ def trials_from_rollouts(
                     trial_id=trial_id,
                     capture_dir=capture_dir,
                 ),
+                measurements=_usage_measurements(record),
                 metadata=metadata,
             )
         )
@@ -612,6 +692,7 @@ def trials_from_rollouts(
                         response=record.get("response"), metadata={"agent_ref": record.get("agent_ref")}
                     ),
                     evidence=failure_evidence,
+                    measurements=_usage_measurements(record),
                     metadata={
                         "reward": None,
                         # best-effort: Gym's failure-record schema isn't contractual, so probe common keys.

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/results.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/results.py
@@ -123,9 +123,9 @@ def _usage_measurements(record: Mapping[str, Any]) -> TrialMeasurements:
         return TrialMeasurements()
     _warn_invalid_usage_counts(record, usage)
 
-    separate_cache = any(key in usage for key in SEPARATE_CACHE_KEYS)
+    separate_cache = any(usage.get(key) is not None for key in SEPARATE_CACHE_KEYS)
     details = _first_usage_details(usage)
-    inclusive_cache = details is not None and CACHED_TOKENS_KEY in details
+    inclusive_cache = details is not None and details.get(CACHED_TOKENS_KEY) is not None
     completion = _first_nonnegative_int(usage, *COMPLETION_TOKEN_KEYS)
     if separate_cache and inclusive_cache:
         logger.warning(

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/harbor_runtime.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/harbor_runtime.py
@@ -1150,9 +1150,8 @@ def build_trials_from_job_dir(
     Reads ``<job_dir>/<task>__<hash>/result.json`` (the top-level aggregate
     ``<job_dir>/result.json`` is skipped because it is not nested). Each Harbor
     trial whose ``task_name`` matches a supplied task id becomes one trial, with
-    the verifier reward, exception type, and token/cost measurements stamped on
-    ``metadata`` and standard evidence descriptors pointing at the trial's
-    on-disk artifacts.
+    the verifier reward in ``metadata``, typed error and measurement fields, and
+    standard evidence descriptors pointing at the trial's on-disk artifacts.
     """
     validate_reward_key(reward_key)
     job_path = Path(job_dir)

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/harbor_trial_adapter.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/harbor_trial_adapter.py
@@ -32,6 +32,7 @@ from nemo_evaluator_sdk.agent_eval.trials import (
     AgentEvalTrialStatus,
     AgentOutput,
     TrialError,
+    TrialMeasurements,
     standard_evidence_descriptors,
 )
 from nemo_evaluator_sdk.values.evidence import (
@@ -143,7 +144,7 @@ def _trial_from_harbor_result(
         **rewards.to_metadata(),
         "harbor_trial_dir": str(trial_dir),
     }
-    metadata.update(_trial_measurements(data))
+    measurements = _trial_measurements(data)
 
     is_complete = error is None and reward is not None
     status = AgentEvalTrialStatus.COMPLETED if is_complete else AgentEvalTrialStatus.PARTIAL
@@ -173,6 +174,7 @@ def _trial_from_harbor_result(
         ),
         evidence=CandidateEvidence(descriptors=descriptors),
         error=error,
+        measurements=measurements,
         metadata=metadata,
     )
 
@@ -626,41 +628,51 @@ def _error_timestamp(value: Any) -> datetime | None:
     return None
 
 
-def _token_measurements(agent_result: Any) -> dict[str, int | float]:
-    """Extract valid token counts and cost from one Harbor agent result.
+def _token_measurements(agent_result: Any, *, trial_id: str) -> tuple[dict[str, int | float], set[str]]:
+    """Extract token counts and cost from one Harbor agent result.
 
     Args:
         agent_result: Harbor agent-result payload to inspect.
 
     Returns:
-        SDK measurement keys for integer token counts and finite numeric cost.
-        Missing, malformed, boolean, and non-finite values are omitted.
+        Valid SDK measurement values and fields that were explicitly invalid.
     """
     if not isinstance(agent_result, Mapping):
-        return {}
+        return {}, set()
     mapping = {
         "prompt_tokens": "n_input_tokens",
         "completion_tokens": "n_output_tokens",
         "cache_read_tokens": "n_cache_tokens",
     }
     out: dict[str, int | float] = {}
+    invalid: set[str] = set()
     for sdk_key, harbor_key in mapping.items():
+        if harbor_key not in agent_result or agent_result[harbor_key] is None:
+            continue
         value = agent_result.get(harbor_key)
-        if isinstance(value, int) and not isinstance(value, bool):
+        if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
             out[sdk_key] = value
-    cost = agent_result.get("cost_usd")
-    if isinstance(cost, (int, float)) and not isinstance(cost, bool):
-        try:
-            numeric_cost = float(cost)
-        except (OverflowError, TypeError, ValueError):
-            numeric_cost = None
-        if numeric_cost is not None and math.isfinite(numeric_cost):
-            out["cost_usd"] = numeric_cost
-    return out
+        else:
+            invalid.add(sdk_key)
+            logger.warning(
+                "Harbor trial %s has invalid %s=%r; omitting %s",
+                trial_id,
+                harbor_key,
+                value,
+                sdk_key,
+            )
+    if "cost_usd" in agent_result and agent_result["cost_usd"] is not None:
+        cost = agent_result["cost_usd"]
+        if _is_finite_nonnegative_number(cost):
+            out["cost_usd"] = float(cost)
+        else:
+            invalid.add("cost_usd")
+            logger.warning("Harbor trial %s has invalid cost_usd=%r; omitting cost_usd", trial_id, cost)
+    return out, invalid
 
 
-def _trial_measurements(data: Mapping[str, Any]) -> dict[str, int | float]:
-    """Extract Harbor token and cost metadata from one result source.
+def _trial_measurements(data: Mapping[str, Any]) -> TrialMeasurements:
+    """Build canonical Harbor measurements from one result source.
 
     A top-level ``agent_result`` takes precedence. When it is absent, valid
     measurements from step-level agent results are aggregated exactly once.
@@ -669,32 +681,113 @@ def _trial_measurements(data: Mapping[str, Any]) -> dict[str, int | float]:
         data: Parsed Harbor ``result.json`` payload.
 
     Returns:
-        SDK measurement keys for token counts and finite cost. Returns an empty
-        mapping when neither result source contains valid measurements.
+        Validated measurements; malformed optional source values are omitted.
     """
+    trial_id = str(data.get("trial_name") or data.get("task_name") or "unknown")
     top_level = data.get("agent_result")
     if isinstance(top_level, Mapping):
-        return _token_measurements(top_level)
+        values, _ = _token_measurements(top_level, trial_id=trial_id)
+    else:
+        values = _aggregate_step_measurements(data.get("step_results"), trial_id=trial_id)
 
-    step_results = data.get("step_results")
+    runtime = _harbor_runtime_sec(data, trial_id=trial_id)
+    if runtime is not None:
+        values["runtime_sec"] = runtime
+    return TrialMeasurements.model_validate(values)
+
+
+def _aggregate_step_measurements(step_results: Any, *, trial_id: str) -> dict[str, int | float]:
     if not isinstance(step_results, list):
         return {}
 
-    totals: dict[str, int | float] = {}
-    costs: list[float] = []
+    contributors: dict[str, list[int | float]] = {}
+    invalid: set[str] = set()
     for step in step_results:
         if not isinstance(step, Mapping):
             continue
-        for key, value in _token_measurements(step.get("agent_result")).items():
-            if key == "cost_usd":
-                costs.append(float(value))
-            else:
-                totals[key] = int(totals.get(key, 0)) + int(value)
-    if costs:
+        captured, rejected = _token_measurements(step.get("agent_result"), trial_id=trial_id)
+        invalid.update(rejected)
+        for key, value in captured.items():
+            contributors.setdefault(key, []).append(value)
+
+    totals: dict[str, int | float] = {}
+    for key, values in contributors.items():
+        if key in invalid:
+            continue
         try:
-            total_cost = math.fsum(costs)
+            total = math.fsum(float(value) for value in values) if key == "cost_usd" else sum(int(v) for v in values)
         except OverflowError:
-            total_cost = None
-        if total_cost is not None and math.isfinite(total_cost):
-            totals["cost_usd"] = total_cost
+            total = float("inf")
+        if _is_finite_nonnegative_number(total):
+            totals[key] = float(total) if key == "cost_usd" else int(total)
+        else:
+            logger.warning("Harbor trial %s has invalid aggregate %s=%r; omitting it", trial_id, key, total)
     return totals
+
+
+def _harbor_runtime_sec(data: Mapping[str, Any], *, trial_id: str) -> float | None:
+    top_level = data.get("agent_execution")
+    if top_level is not None:
+        duration = _execution_duration(top_level)
+        if duration is None:
+            logger.warning(
+                "Harbor trial %s has an invalid top-level agent_execution window; omitting runtime", trial_id
+            )
+        return duration
+
+    step_results = data.get("step_results")
+    if not isinstance(step_results, list):
+        return None
+    durations: list[float] = []
+    for step in step_results:
+        if not isinstance(step, Mapping) or step.get("agent_execution") is None:
+            continue
+        duration = _execution_duration(step.get("agent_execution"))
+        if duration is None:
+            logger.warning("Harbor trial %s has an invalid step agent_execution window; omitting runtime", trial_id)
+            return None
+        durations.append(duration)
+    if not durations:
+        return None
+    try:
+        total = math.fsum(durations)
+    except OverflowError:
+        total = float("inf")
+    if not math.isfinite(total):
+        logger.warning("Harbor trial %s has a non-finite aggregate runtime; omitting runtime", trial_id)
+        return None
+    return total
+
+
+def _execution_duration(window: Any) -> float | None:
+    if not isinstance(window, Mapping):
+        return None
+    started = _as_datetime(window.get("started_at"))
+    finished = _as_datetime(window.get("finished_at"))
+    if started is None or finished is None:
+        return None
+    try:
+        duration = (finished - started).total_seconds()
+    except TypeError:
+        return None
+    if not math.isfinite(duration) or duration < 0:
+        return None
+    return duration
+
+
+def _as_datetime(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        with contextlib.suppress(ValueError):
+            return datetime.fromisoformat(value)
+    return None
+
+
+def _is_finite_nonnegative_number(value: Any) -> bool:
+    if not isinstance(value, int | float) or isinstance(value, bool) or value < 0:
+        return False
+    try:
+        return math.isfinite(value)
+    except OverflowError:
+        return False

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/trials.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/trials.py
@@ -1,9 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Trial artifacts, the runtime/serde interfaces that produce them, and the
-runtime-agnostic helpers for shaping trials from artifacts (status mapping +
-the standard evidence-key builder)."""
+"""Typed trial artifacts and runtime/serde interfaces."""
 
 from __future__ import annotations
 
@@ -11,7 +9,7 @@ from collections.abc import Sequence
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import Annotated, Any, Protocol, runtime_checkable
+from typing import Annotated, Any, Protocol, Self, runtime_checkable
 
 from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalRunConfig, AgentEvalTask
 from nemo_evaluator_sdk.metrics.protocol import Metric
@@ -133,10 +131,50 @@ class TrialError(BaseModel):
         return value
 
 
-class AgentEvalTrial(BaseModel):
-    """Durable trial artifact for one task: output, evidence, status, error, and metadata."""
+NonNegativeTokenCount = Annotated[int, Field(strict=True, ge=0)]
+FiniteNonNegativeFloat = Annotated[float, Field(ge=0, allow_inf_nan=False)]
 
-    model_config = ConfigDict(extra="forbid")
+
+class TrialMeasurements(BaseModel):
+    """Validated usage, runtime, and cost measurements for one trial."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, revalidate_instances="always")
+
+    prompt_tokens: NonNegativeTokenCount | None = None
+    completion_tokens: NonNegativeTokenCount | None = None
+    total_tokens: NonNegativeTokenCount | None = None
+    cache_creation_tokens: NonNegativeTokenCount | None = None
+    cache_read_tokens: NonNegativeTokenCount | None = None
+    runtime_sec: FiniteNonNegativeFloat | None = None
+    cost_usd: FiniteNonNegativeFloat | None = None
+
+    @field_validator("runtime_sec", "cost_usd", mode="before")
+    @classmethod
+    def _require_real_number(cls, value: Any) -> Any:
+        if value is None:
+            return value
+        if isinstance(value, bool) or not isinstance(value, int | float):
+            raise ValueError("measurement must be a real number, not a Boolean or string")
+        return value
+
+    @model_validator(mode="after")
+    def _require_canonical_total(self) -> Self:
+        if self.prompt_tokens is None or self.completion_tokens is None:
+            if self.total_tokens is not None:
+                raise ValueError("total_tokens requires prompt_tokens and completion_tokens")
+            return self
+        expected = self.prompt_tokens + self.completion_tokens
+        if self.total_tokens is None:
+            object.__setattr__(self, "total_tokens", expected)
+        elif self.total_tokens != expected:
+            raise ValueError("total_tokens must equal prompt_tokens + completion_tokens")
+        return self
+
+
+class AgentEvalTrial(BaseModel):
+    """Durable trial artifact: output, evidence, status, error, measurements, and metadata."""
+
+    model_config = ConfigDict(extra="forbid", validate_assignment=True, revalidate_instances="always")
 
     id: str = Field(description="Stable identifier for this trial.")
     task_id: str = Field(description="Identifier of the AgentEvalTask this trial was produced for.")
@@ -155,6 +193,10 @@ class AgentEvalTrial(BaseModel):
             "What went wrong producing this trial, when the producer reported a failure. Populated "
             "by a runner runtime. Drives AgentEvalSummary.error_trial_ids."
         ),
+    )
+    measurements: TrialMeasurements = Field(
+        default_factory=TrialMeasurements,
+        description="Validated token usage, agent runtime, and cost measurements for the trial.",
     )
     metadata: dict[str, Any] = Field(
         default_factory=dict,

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/usage_keys.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/usage_keys.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Provider usage-key aliases shared by live eval, Gym, and the Intake row adapter.
+
+Owns the Chat Completions / Responses / Anthropic vocabulary those adapters would otherwise
+each restate: which keys mean prompt, completion, and cache, and the preference order when a
+payload carries more than one name for the same count. Kept stdlib-only so the light
+``agent_eval`` path, Gym results, and the evaluator plugin can depend on it without pulling
+each other in.
+
+Tuples are preference-ordered alias groups, not unordered sets. Chat Completions names come
+first so a mixed-schema payload is read as chat, not Responses.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+#: Chat Completions ``prompt_tokens`` before Responses ``input_tokens``.
+PROMPT_TOKEN_KEYS = ("prompt_tokens", "input_tokens")
+#: Chat Completions ``completion_tokens`` before Responses ``output_tokens``.
+COMPLETION_TOKEN_KEYS = ("completion_tokens", "output_tokens")
+CACHE_READ_INPUT_TOKENS_KEY = "cache_read_input_tokens"
+CACHE_CREATION_INPUT_TOKENS_KEY = "cache_creation_input_tokens"
+SEPARATE_CACHE_KEYS = (CACHE_READ_INPUT_TOKENS_KEY, CACHE_CREATION_INPUT_TOKENS_KEY)
+#: Warn-loop order: prompt aliases, then completion aliases, then Anthropic cache fields.
+USAGE_COUNT_KEYS = PROMPT_TOKEN_KEYS + COMPLETION_TOKEN_KEYS + SEPARATE_CACHE_KEYS
+#: Chat Completions details before Responses details.
+USAGE_DETAILS_KEYS = ("prompt_tokens_details", "input_tokens_details")
+CACHED_TOKENS_KEY = "cached_tokens"
+
+
+def _first_usage_details(usage: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    """Return the first mapping-shaped usage-details field in preference order."""
+    for key in USAGE_DETAILS_KEYS:
+        details = usage.get(key)
+        if isinstance(details, Mapping):
+            return details
+    return None
+
+
+def _first_nonnegative_int(values: Mapping[str, Any], *keys: str) -> int | None:
+    """Return the first non-negative int among ``keys``, else ``None``.
+
+    Usage objects alias the same count under different names (``prompt_tokens`` vs
+    ``input_tokens``). Scanning aliases in preference order picks the first usable value
+    without treating a missing key as zero. ``bool`` is excluded because it is a subclass
+    of ``int``; strings, floats, and negatives are skipped so a malformed count is omitted
+    rather than coerced.
+    """
+    for key in keys:
+        value = values.get(key)
+        if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+            return value
+    return None

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_callable_runtime.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_callable_runtime.py
@@ -7,7 +7,7 @@ from nemo_evaluator_sdk.agent_eval.runtimes.callable_runtime import (
     TrialDraft,
 )
 from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalRunConfig, AgentEvalTask
-from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrialStatus, AgentOutput
+from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrialStatus, AgentOutput, TrialMeasurements
 
 
 def _task(task_id: str) -> AgentEvalTask:
@@ -18,7 +18,11 @@ def _task(task_id: str) -> AgentEvalTask:
 async def test_callable_runtime_wraps_str_output_and_trialdraft_in_order() -> None:
     async def agent_fn(task: AgentEvalTask) -> TrialDraft | str:
         if task.id == "t2":
-            return TrialDraft(output=AgentOutput(output_text="drafted"), metadata={"k": "v"})
+            return TrialDraft(
+                output=AgentOutput(output_text="drafted"),
+                metadata={"k": "v"},
+                measurements=TrialMeasurements(prompt_tokens=4, completion_tokens=1),
+            )
         return f"answer-{task.id}"
 
     runtime = CallableAgentTaskRunner(agent_fn, parallelism=2)
@@ -30,6 +34,8 @@ async def test_callable_runtime_wraps_str_output_and_trialdraft_in_order() -> No
     assert trials[0].output is not None and trials[0].output.output_text == "answer-t1"
     assert trials[1].output is not None and trials[1].output.output_text == "drafted"
     assert trials[1].metadata == {"k": "v"}
+    assert trials[1].measurements.total_tokens == 5
+    assert trials[0].measurements == TrialMeasurements()
 
 
 @pytest.mark.asyncio

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_docker_sandbox_runtime.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_docker_sandbox_runtime.py
@@ -284,6 +284,7 @@ async def test_completed_run_writes_artifacts_and_evidence(monkeypatch: pytest.M
     assert client.created[0].options.image == "python:test"
     assert client.deleted == client.created
     assert trials[0].status == "completed"
+    assert trials[0].measurements.model_dump(exclude_none=True) == {}
     assert trials[0].output is not None
     assert trials[0].output.output_text == "Runtime answer"
     assert (evidence_dir / "final_output.txt").read_text(encoding="utf-8") == "Runtime answer"
@@ -369,6 +370,7 @@ async def test_runtime_exception_returns_failed_trial(
 
     error_path = tmp_path / "agent-runtime" / "run-1" / "000000-task-1" / "error.json"
     assert trials[0].status == "failed"
+    assert trials[0].measurements.model_dump(exclude_none=True) == {}
     assert trials[0].output is None
     assert trials[0].metadata["error"] == "sandbox run failed"
     assert trials[0].evidence is not None

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_evaluator.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_evaluator.py
@@ -10,10 +10,13 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from nemo_evaluator_sdk.agent_eval.evaluator import (
     AgentEvaluator,
+    _live_response_usage_measurements,
     _metric_row,
     _new_run_id,
     _task_row,
     _trial_from_sample,
+    _trial_sample,
+    _warn_invalid_live_usage_counts,
 )
 from nemo_evaluator_sdk.agent_eval.results import AgentEvalSummary
 from nemo_evaluator_sdk.agent_eval.scores import (
@@ -34,6 +37,7 @@ from nemo_evaluator_sdk.agent_eval.trials import (
     AgentOutput,
     RunnerInfo,
     TrialError,
+    TrialMeasurements,
 )
 from nemo_evaluator_sdk.agent_inference import AgentInferenceContext, AgentInvocationResult, AgentInvocationStatus
 from nemo_evaluator_sdk.enums import AgentFormat, ModelFormat
@@ -54,6 +58,7 @@ from nemo_evaluator_sdk.values import (
     RunConfigOnlineModel,
 )
 from nemo_evaluator_sdk.values.evidence import CandidateEvidence, EvidenceDescriptor
+from pydantic import ValidationError
 
 
 def test_trial_from_sample_falls_back_to_reasoning_content() -> None:
@@ -124,6 +129,229 @@ def test_trial_from_sample_preserves_typed_trace_and_canonical_metadata() -> Non
     assert trial.metadata["generated"] is True
 
 
+@pytest.mark.parametrize(
+    ("target", "usage", "expected"),
+    [
+        pytest.param(
+            Model(name="chat-model", url="https://example/v1/chat/completions"),
+            {
+                "prompt_tokens": 10,
+                "completion_tokens": 2,
+                "total_tokens": 999,
+                "prompt_tokens_details": {"cached_tokens": 3},
+            },
+            TrialMeasurements(prompt_tokens=10, completion_tokens=2, cache_read_tokens=3),
+            id="openai-chat",
+        ),
+        pytest.param(
+            Model(name="responses-model", url="https://example/v1/responses"),
+            {
+                "input_tokens": 8,
+                "output_tokens": 4,
+                "input_tokens_details": {"cached_tokens": 2},
+            },
+            TrialMeasurements(prompt_tokens=8, completion_tokens=4, cache_read_tokens=2),
+            id="openai-responses",
+        ),
+        pytest.param(
+            GenericAgent(
+                name="anthropic-agent",
+                url="https://example/agent",
+                format=AgentFormat.GENERIC,
+                body={"input": "{{ instruction }}"},
+                response_path="$.answer",
+            ),
+            {
+                "input_tokens": 5,
+                "output_tokens": 2,
+                "cache_creation_input_tokens": 1,
+                "cache_read_input_tokens": 4,
+            },
+            TrialMeasurements(
+                prompt_tokens=10,
+                completion_tokens=2,
+                cache_creation_tokens=1,
+                cache_read_tokens=4,
+            ),
+            id="anthropic-agent",
+        ),
+    ],
+)
+def test_trial_from_sample_normalizes_live_usage(
+    target: Model | Agent,
+    usage: dict[str, Any],
+    expected: TrialMeasurements,
+) -> None:
+    task = AgentEvalTask(id="task-1", intent="Answer.", inputs={"instruction": "Q?"})
+
+    trial = _trial_from_sample(
+        task,
+        target,
+        {"output_text": "answer", "response": {"usage": usage}},
+    )
+
+    assert trial.measurements == expected
+    assert trial.measurements.total_tokens == expected.total_tokens
+    assert trial.measurements.runtime_sec is None
+    assert trial.measurements.cost_usd is None
+
+
+def test_trial_from_sample_omits_ambiguous_prompt_cache_usage(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    task = AgentEvalTask(id="task-1", intent="Answer.", inputs={"instruction": "Q?"})
+    target = Model(name="target", url="https://example/v1/responses")
+
+    trial = _trial_from_sample(
+        task,
+        target,
+        {
+            "output_text": "answer",
+            "response": {
+                "usage": {
+                    "input_tokens": 8,
+                    "output_tokens": 4,
+                    "input_tokens_details": {"cached_tokens": 2},
+                    "cache_read_input_tokens": 2,
+                }
+            },
+        },
+    )
+
+    assert trial.measurements == TrialMeasurements(completion_tokens=4)
+    assert "both inclusive cache details and separate cache fields" in caplog.text
+
+
+def test_trial_from_sample_warns_and_preserves_independent_valid_usage(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    task = AgentEvalTask(id="task-1", intent="Answer.", inputs={"instruction": "Q?"})
+    target = Model(name="target", url="https://example/v1/chat/completions")
+
+    trial = _trial_from_sample(
+        task,
+        target,
+        {
+            "output_text": "answer",
+            "response": {
+                "usage": {
+                    "prompt_tokens": 8,
+                    "completion_tokens": "bad",
+                    "prompt_tokens_details": {"cached_tokens": -1},
+                }
+            },
+        },
+    )
+
+    assert trial.measurements == TrialMeasurements(prompt_tokens=8)
+    assert "completion_tokens='bad'" in caplog.text
+    assert "prompt_tokens_details.cached_tokens=-1" in caplog.text
+
+
+def test_live_response_usage_measurements_empty_when_usage_is_absent() -> None:
+    assert _live_response_usage_measurements(None, trial_id="trial-1") == TrialMeasurements()
+    assert _live_response_usage_measurements("not-a-mapping", trial_id="trial-1") == TrialMeasurements()
+    assert _live_response_usage_measurements({}, trial_id="trial-1") == TrialMeasurements()
+    assert _live_response_usage_measurements({"usage": None}, trial_id="trial-1") == TrialMeasurements()
+
+
+def test_live_response_usage_measurements_omits_non_object_usage(caplog: pytest.LogCaptureFixture) -> None:
+    assert _live_response_usage_measurements({"usage": "tokens"}, trial_id="trial-1") == TrialMeasurements()
+    assert "usage='tokens'" in caplog.text
+
+
+def test_live_response_usage_measurements_prefers_chat_aliases() -> None:
+    measurements = _live_response_usage_measurements(
+        {
+            "usage": {
+                "prompt_tokens": 10,
+                "input_tokens": 1,
+                "completion_tokens": 2,
+                "output_tokens": 9,
+                "total_tokens": 999,
+            }
+        },
+        trial_id="trial-1",
+    )
+
+    assert measurements == TrialMeasurements(prompt_tokens=10, completion_tokens=2)
+
+
+def test_live_response_usage_measurements_records_zero_usage() -> None:
+    measurements = _live_response_usage_measurements(
+        {"usage": {"prompt_tokens": 0, "completion_tokens": 0}},
+        trial_id="trial-1",
+    )
+
+    assert measurements.prompt_tokens == 0
+    assert measurements.completion_tokens == 0
+    assert measurements.total_tokens == 0
+
+
+def test_invalid_separate_cache_poisons_prompt_only(caplog: pytest.LogCaptureFixture) -> None:
+    measurements = _live_response_usage_measurements(
+        {"usage": {"input_tokens": 5, "output_tokens": 2, "cache_read_input_tokens": "bad"}},
+        trial_id="trial-1",
+    )
+
+    assert measurements == TrialMeasurements(completion_tokens=2)
+    assert "cache_read_input_tokens='bad'" in caplog.text
+
+
+def test_separate_cache_without_prompt_does_not_invent_a_prompt_total() -> None:
+    measurements = _live_response_usage_measurements(
+        {"usage": {"output_tokens": 2, "cache_read_input_tokens": 4}},
+        trial_id="trial-1",
+    )
+
+    assert measurements == TrialMeasurements(completion_tokens=2, cache_read_tokens=4)
+
+
+def test_inclusive_cache_falls_back_from_chat_details_to_responses_details(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    measurements = _live_response_usage_measurements(
+        {
+            "usage": {
+                "input_tokens": 8,
+                "output_tokens": 1,
+                "prompt_tokens_details": "not-an-object",
+                "input_tokens_details": {"cached_tokens": 3},
+            }
+        },
+        trial_id="trial-1",
+    )
+
+    assert measurements == TrialMeasurements(prompt_tokens=8, completion_tokens=1, cache_read_tokens=3)
+    assert "prompt_tokens_details='not-an-object'" in caplog.text
+
+
+def test_warn_invalid_live_usage_counts_skips_missing_and_null_values(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    usage = {"prompt_tokens": 8, "completion_tokens": None}
+
+    _warn_invalid_live_usage_counts("trial-1", usage)
+
+    assert caplog.text == ""
+    assert usage == {"prompt_tokens": 8, "completion_tokens": None}
+
+
+def test_warn_invalid_live_usage_counts_logs_malformed_fields(caplog: pytest.LogCaptureFixture) -> None:
+    _warn_invalid_live_usage_counts(
+        "trial-1",
+        {
+            "prompt_tokens": True,
+            "prompt_tokens_details": [1],
+            "input_tokens_details": {"cached_tokens": -1},
+        },
+    )
+
+    assert "prompt_tokens=True" in caplog.text
+    assert "prompt_tokens_details=[1]" in caplog.text
+    assert "input_tokens_details.cached_tokens=-1" in caplog.text
+
+
 def test_generated_run_ids_are_unique_within_the_same_second() -> None:
     with patch("nemo_evaluator_sdk.agent_eval.evaluator.datetime") as mock_datetime:
         mock_datetime.now.return_value.strftime.return_value = "20260628120000"
@@ -153,6 +381,53 @@ def test_metric_row_exposes_reference_but_task_row_hides_it() -> None:
     assert "reference" not in task_row
 
 
+def test_metric_row_keeps_measurements_separate_from_trial_metadata() -> None:
+    task = AgentEvalTask(id="task-1", intent="Fix it.", inputs={})
+    trial = AgentEvalTrial(
+        id="trial-1",
+        task_id=task.id,
+        status=AgentEvalTrialStatus.PARTIAL,
+        output=None,
+        measurements=TrialMeasurements(prompt_tokens=8, completion_tokens=2, runtime_sec=1.5),
+        metadata={"prompt_tokens": 999, "provenance": "kept"},
+    )
+
+    assert _trial_sample(trial) == {}
+    row = _metric_row(task, trial)
+    assert row["trial"]["measurements"] == trial.measurements.model_dump(mode="json")
+    assert row["trial"]["metadata"] == {"prompt_tokens": 999, "provenance": "kept"}
+    assert trial.metadata == {"prompt_tokens": 999, "provenance": "kept"}
+
+
+def test_metric_row_measurements_dump_does_not_alias_durable_trial_state() -> None:
+    trial = AgentEvalTrial(
+        id="trial-1",
+        task_id="task-1",
+        status=AgentEvalTrialStatus.PARTIAL,
+        measurements=TrialMeasurements(prompt_tokens=8, completion_tokens=2),
+    )
+    original = trial.measurements.model_copy()
+
+    row = _metric_row(AgentEvalTask(id="task-1", intent="Fix it.", inputs={}), trial)
+    row["trial"]["measurements"]["prompt_tokens"] = -1
+
+    assert trial.measurements == original
+
+
+def test_metric_row_metadata_does_not_alias_durable_trial_state() -> None:
+    trial = AgentEvalTrial(
+        id="trial-1",
+        task_id="task-1",
+        status=AgentEvalTrialStatus.PARTIAL,
+        metadata={"provenance": "kept"},
+    )
+
+    row = _metric_row(AgentEvalTask(id="task-1", intent="Fix it.", inputs={}), trial)
+    row["trial"]["metadata"]["provenance"] = "changed"
+
+    assert trial.metadata == {"provenance": "kept"}
+
+
 class _ConstantMetric:
     @property
     def type(self) -> str:
@@ -163,6 +438,15 @@ class _ConstantMetric:
 
     async def compute_scores(self, input: MetricInput) -> MetricResult:
         return MetricResult(outputs=[MetricOutput(name="score", value=0.75)])
+
+
+class _MeasurementCaptureMetric(_ConstantMetric):
+    def __init__(self) -> None:
+        self.input: MetricInput | None = None
+
+    async def compute_scores(self, input: MetricInput) -> MetricResult:
+        self.input = input
+        return await super().compute_scores(input)
 
 
 class _EvidenceMetric:
@@ -434,7 +718,10 @@ class _TrialSwappingTaskRunner(_TaskRunner):
 
 @pytest.mark.asyncio
 async def test_scoring_rejects_moved_trial_assignment() -> None:
-    with pytest.raises(ValueError, match="scoring_metrics changed trial task assignments"):
+    with pytest.raises(
+        ValueError,
+        match=r"must not mutate trials \(trial 'a:runtime' task_id 'a' -> 'b'\)",
+    ):
         await AgentEvaluator().run(
             tasks=[_task(task_id="a"), _task(task_id="b")],
             target=_TrialMovingTaskRunner(),
@@ -443,7 +730,10 @@ async def test_scoring_rejects_moved_trial_assignment() -> None:
 
 @pytest.mark.asyncio
 async def test_scoring_rejects_balanced_trial_assignment_swap() -> None:
-    with pytest.raises(ValueError, match="scoring_metrics changed trial task assignments"):
+    with pytest.raises(
+        ValueError,
+        match=r"must not mutate trials \(trial 'a:runtime' task_id 'a' -> 'b'; trial 'b:runtime' task_id 'b' -> 'a'\)",
+    ):
         await AgentEvaluator().run(
             tasks=[_task(task_id="a"), _task(task_id="b")],
             target=_TrialSwappingTaskRunner(),
@@ -542,6 +832,126 @@ async def test_scores_partial_trials() -> None:
     assert result.summary.score("constant_metric.score").mean == 0.75
 
 
+@pytest.mark.parametrize(
+    ("measurements", "output", "expected_candidate_metadata"),
+    [
+        pytest.param(
+            TrialMeasurements(prompt_tokens=8, completion_tokens=2, runtime_sec=1.5),
+            AgentOutput(output_text="answer", response={"answer": 42}, metadata={"shared": "output"}),
+            {"provenance": "kept", "shared": "output"},
+            id="populated-output",
+        ),
+        pytest.param(
+            TrialMeasurements(),
+            None,
+            {},
+            id="empty-outputless",
+        ),
+        pytest.param(
+            TrialMeasurements(prompt_tokens=0, completion_tokens=0, runtime_sec=0.0, cost_usd=0.0),
+            AgentOutput(output_text="zero", metadata={"shared": "output"}),
+            {"provenance": "kept", "shared": "output"},
+            id="zero-output",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_metric_input_uses_only_canonical_trial_measurements(
+    measurements: TrialMeasurements,
+    output: AgentOutput | None,
+    expected_candidate_metadata: dict[str, Any],
+) -> None:
+    metric = _MeasurementCaptureMetric()
+    task = AgentEvalTask(id="task-1", intent="Answer.", inputs={}, metrics=[metric])
+    evidence = (
+        CandidateEvidence(descriptors={"trace": EvidenceDescriptor(kind="trace", format="json", data={})})
+        if output is not None
+        else None
+    )
+    trial = AgentEvalTrial(
+        id="trial-1",
+        task_id=task.id,
+        status=AgentEvalTrialStatus.PARTIAL,
+        output=output,
+        evidence=evidence,
+        measurements=measurements,
+        metadata={"provenance": "kept", "shared": "trial"},
+    )
+    original_trial = trial.model_copy(deep=True)
+
+    result = await AgentEvaluator().run(tasks=[task], trials=[trial])
+
+    assert result.scores[0].status == AgentEvalScoreStatus.COMPLETED
+    assert metric.input is not None
+    assert metric.input.row.data["trial"]["measurements"] == trial.measurements.model_dump(mode="json")
+    assert metric.input.row.data["trial"]["metadata"] == trial.metadata
+    assert metric.input.candidate.metadata == expected_candidate_metadata
+    assert metric.input.candidate.output_text == (output.output_text if output is not None else None)
+    assert metric.input.candidate.response == (output.response if output is not None else None)
+    assert metric.input.candidate.evidence == evidence
+    assert trial == original_trial
+
+
+@pytest.mark.asyncio
+async def test_measurement_named_metadata_remains_opaque_in_metric_input() -> None:
+    metric = _MeasurementCaptureMetric()
+    task = AgentEvalTask(id="task-1", intent="Answer.", inputs={}, metrics=[metric])
+    trial = AgentEvalTrial(
+        id="trial-1",
+        task_id=task.id,
+        status=AgentEvalTrialStatus.PARTIAL,
+        output=AgentOutput(output_text="answer"),
+        measurements=TrialMeasurements(prompt_tokens=8),
+        metadata={"prompt_tokens": 999},
+    )
+
+    await AgentEvaluator().run(tasks=[task], trials=[trial])
+
+    assert metric.input is not None
+    assert metric.input.candidate.metadata["prompt_tokens"] == 999
+    assert metric.input.row.data["trial"]["metadata"]["prompt_tokens"] == 999
+    assert metric.input.row.data["trial"]["measurements"]["prompt_tokens"] == 8
+
+
+@pytest.mark.asyncio
+async def test_run_revalidates_model_copy_corrupted_measurements_before_scoring() -> None:
+    metric = _MeasurementCaptureMetric()
+    task = AgentEvalTask(id="task-1", intent="Answer.", inputs={}, metrics=[metric])
+    trial = AgentEvalTrial(
+        id="trial-1",
+        task_id=task.id,
+        status=AgentEvalTrialStatus.PARTIAL,
+        measurements=TrialMeasurements(prompt_tokens=8, completion_tokens=2),
+    )
+    corrupted_measurements = trial.measurements.model_copy(update={"prompt_tokens": -1})
+    corrupted_trial = trial.model_copy(update={"measurements": corrupted_measurements})
+
+    with pytest.raises(ValidationError):
+        await AgentEvaluator().run(tasks=[task], trials=[corrupted_trial])
+
+    assert metric.input is None
+
+
+@pytest.mark.asyncio
+async def test_run_uses_revalidated_model_copy_measurements_when_scoring() -> None:
+    metric = _MeasurementCaptureMetric()
+    task = AgentEvalTask(id="task-1", intent="Answer.", inputs={}, metrics=[metric])
+    trial = AgentEvalTrial(
+        id="trial-1",
+        task_id=task.id,
+        status=AgentEvalTrialStatus.PARTIAL,
+    ).model_copy(update={"measurements": {"prompt_tokens": 8, "completion_tokens": 2}})
+
+    result = await AgentEvaluator().run(tasks=[task], trials=[trial])
+
+    assert result.scores[0].status == AgentEvalScoreStatus.COMPLETED
+    assert metric.input is not None
+    assert metric.input.row.data["trial"]["measurements"] == TrialMeasurements(
+        prompt_tokens=8, completion_tokens=2
+    ).model_dump(mode="json")
+    assert result.trials[0].measurements == TrialMeasurements(prompt_tokens=8, completion_tokens=2)
+
+
 @pytest.mark.asyncio
 async def test_target_runtime_produces_trials_before_scoring() -> None:
     runtime = _TaskRunner()
@@ -567,7 +977,14 @@ async def test_live_model_generation_with_mocked_inference() -> None:
         del model, max_retries, kwargs
         assert request["messages"][0]["content"] == "What is the answer?"
         assert "prompt" not in request
-        return {"choices": [{"message": {"role": "assistant", "content": "Generated model answer"}}]}
+        return {
+            "choices": [{"message": {"role": "assistant", "content": "Generated model answer"}}],
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 2,
+                "prompt_tokens_details": {"cached_tokens": 3},
+            },
+        }
 
     model = Model(url="https://model.test/v1/chat/completions", name="target-model", format=ModelFormat.OPEN_AI)
     result = await AgentEvaluator(inference_fn=fake_model_inference).run(
@@ -579,6 +996,11 @@ async def test_live_model_generation_with_mocked_inference() -> None:
     assert result.trials[0].metadata["model_id"] == "target-model"
     assert result.trials[0].output is not None
     assert result.trials[0].output.output_text == "Generated model answer"
+    assert result.trials[0].measurements == TrialMeasurements(
+        prompt_tokens=10,
+        completion_tokens=2,
+        cache_read_tokens=3,
+    )
     assert result.summary.score("constant_metric.score").mean == 0.75
 
 
@@ -716,6 +1138,12 @@ async def test_live_agent_generation_preserves_trace_evidence_for_metrics() -> N
         return {
             "choices": [{"message": {"role": "assistant", "content": "Generated agent answer"}}],
             "trajectory": [{"tool": "search", "line": 3}],
+            "usage": {
+                "input_tokens": 5,
+                "output_tokens": 2,
+                "cache_creation_input_tokens": 1,
+                "cache_read_input_tokens": 4,
+            },
         }
 
     agent = GenericAgent(
@@ -735,6 +1163,12 @@ async def test_live_agent_generation_preserves_trace_evidence_for_metrics() -> N
     assert result.trials[0].evidence.require("trace").kind == "trace"
     assert result.trials[0].output is not None
     assert result.trials[0].output.output_text == "Generated agent answer"
+    assert result.trials[0].measurements == TrialMeasurements(
+        prompt_tokens=10,
+        completion_tokens=2,
+        cache_creation_tokens=1,
+        cache_read_tokens=4,
+    )
     assert metric.inputs[0].candidate.evidence == result.trials[0].evidence
 
 
@@ -1091,6 +1525,7 @@ def test_metric_row_error_is_none_for_a_trial_that_did_not_fail() -> None:
     row = _metric_row(AgentEvalTask(id="task-1", intent="Fix it.", inputs={}), _candidate_trial())
 
     assert row["trial"]["error"] is None
+    assert row["trial"]["measurements"] == TrialMeasurements().model_dump(mode="json")
 
 
 class _PreflightCountingMetric(_ConstantMetric):

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_evaluator.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_evaluator.py
@@ -222,6 +222,38 @@ def test_trial_from_sample_omits_ambiguous_prompt_cache_usage(
     assert "both inclusive cache details and separate cache fields" in caplog.text
 
 
+@pytest.mark.parametrize(
+    ("usage", "expected"),
+    [
+        pytest.param(
+            {
+                "input_tokens": 5,
+                "output_tokens": 2,
+                "input_tokens_details": {"cached_tokens": None},
+                "cache_read_input_tokens": 4,
+            },
+            TrialMeasurements(prompt_tokens=9, completion_tokens=2, cache_read_tokens=4),
+            id="null-inclusive-placeholder",
+        ),
+        pytest.param(
+            {
+                "input_tokens": 5,
+                "output_tokens": 2,
+                "input_tokens_details": {"cached_tokens": 4},
+                "cache_read_input_tokens": None,
+            },
+            TrialMeasurements(prompt_tokens=5, completion_tokens=2, cache_read_tokens=4),
+            id="null-separate-placeholder",
+        ),
+    ],
+)
+def test_live_response_usage_ignores_null_cache_format_placeholders(
+    usage: dict[str, Any],
+    expected: TrialMeasurements,
+) -> None:
+    assert _live_response_usage_measurements({"usage": usage}, trial_id="trial-1") == expected
+
+
 def test_trial_from_sample_warns_and_preserves_independent_valid_usage(
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_fabric_container_runtime.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_fabric_container_runtime.py
@@ -155,6 +155,7 @@ async def test_success_maps_evidence_contract(tmp_path: Path) -> None:
     (trial,) = trials
 
     assert trial.status == AgentEvalTrialStatus.COMPLETED
+    assert trial.measurements.model_dump(exclude_none=True) == {}
     assert trial.output is not None and trial.output.output_text == "fixed the bug"
     # Same evidence keys/kinds FabricAgentRuntime + Codex produce, so metrics work unchanged.
     ws = trial.evidence.require("workspace")
@@ -189,6 +190,7 @@ async def test_failed_trial_stamps_agent_ok_false(tmp_path: Path) -> None:
     provider = _FakeProvider(status="failed")
     (trial,) = await _run(_runtime(provider), [_task()], tmp_path)
     assert trial.status == AgentEvalTrialStatus.FAILED
+    assert trial.measurements.model_dump(exclude_none=True) == {}
     assert trial.metadata["agent_ok"] is False
 
 

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_fabric_runtime.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_fabric_runtime.py
@@ -349,6 +349,16 @@ async def test_fabric_runtime_maps_atif_artifact_to_trace_evidence(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     atif = _FakeArtifact("relay_atif", "atif", tmp_path / "trajectory.atif.json", "application/json")
+    atif.path.write_text(
+        json.dumps(
+            {
+                "schema_version": "ATIF-v1.7",
+                "steps": [_step(prompt_tokens=8, completion_tokens=2)],
+                "final_metrics": {"total_cost_usd": 0.25},
+            }
+        ),
+        encoding="utf-8",
+    )
 
     def handler(agent: Any, kwargs: dict[str, Any]) -> _FakeResult:
         return _FakeResult(status="succeeded", output={"response": "ok"}, artifacts=[atif])
@@ -365,6 +375,14 @@ async def test_fabric_runtime_maps_atif_artifact_to_trace_evidence(
     trace = evidence.descriptors[EVIDENCE_TRACE]
     assert trace.format == EVIDENCE_FORMAT_ATIF
     assert trace.ref == str(tmp_path / "trajectory.atif.json")
+    assert trials[0].measurements.model_dump(exclude_none=True) == {
+        "prompt_tokens": 8,
+        "completion_tokens": 2,
+        "total_tokens": 10,
+        "cost_usd": 0.25,
+    }
+    assert trials[0].measurements.runtime_sec is None
+    assert "prompt_tokens" not in trials[0].metadata
 
 
 def _workspace_from_config(config: Any) -> Path:
@@ -661,6 +679,13 @@ async def test_fabric_runtime_maps_timeout_to_failed_trial(tmp_path: Path, monke
 
     async def fake_wait_for(awaitable: Any, timeout: float) -> Any:
         awaitable.close()
+        evidence_dir = next((tmp_path / "fabric").glob("*/000000-task-1"))
+        relay_dir = evidence_dir / "relay"
+        relay_dir.mkdir(exist_ok=True)
+        (relay_dir / "trajectory-timeout.atif.json").write_text(
+            json.dumps({"schema_version": "ATIF-v1.7", "steps": [_step(prompt_tokens=5, completion_tokens=1)]}),
+            encoding="utf-8",
+        )
         raise TimeoutError
 
     monkeypatch.setattr(fabric_runtime.asyncio, "wait_for", fake_wait_for)
@@ -670,6 +695,7 @@ async def test_fabric_runtime_maps_timeout_to_failed_trial(tmp_path: Path, monke
 
     assert trials[0].status == "failed"
     assert trials[0].metadata["error_type"] == "TimeoutError"
+    assert trials[0].measurements.total_tokens == 6
 
 
 @pytest.mark.asyncio
@@ -1115,6 +1141,10 @@ def _step(**metrics: int) -> dict[str, Any]:
     return {"source": "agent", "message": "", "metrics": metrics}
 
 
+def _measurement_values(path: Path | None) -> dict[str, int | float]:
+    return fabric_runtime._atif_measurements(path).model_dump(exclude_none=True)
+
+
 def test_final_metrics_totals_are_projected_onto_the_token_keys(tmp_path: Path) -> None:
     path = _atif(
         tmp_path,
@@ -1128,9 +1158,10 @@ def test_final_metrics_totals_are_projected_onto_the_token_keys(tmp_path: Path) 
             },
         },
     )
-    assert fabric_runtime._atif_token_metadata(path) == {
+    assert _measurement_values(path) == {
         "prompt_tokens": 358,
         "completion_tokens": 19324,
+        "total_tokens": 19682,
         "cache_read_tokens": 3984621,
     }
 
@@ -1143,9 +1174,10 @@ def test_steps_are_summed_when_the_trajectory_has_no_aggregate_block(tmp_path: P
             "steps": [_step(prompt_tokens=100, completion_tokens=10), _step(prompt_tokens=58, cached_tokens=7)],
         },
     )
-    assert fabric_runtime._atif_token_metadata(path) == {
+    assert _measurement_values(path) == {
         "prompt_tokens": 158,
         "completion_tokens": 10,
+        "total_tokens": 168,
         "cache_read_tokens": 7,
     }
 
@@ -1161,7 +1193,12 @@ def test_a_partial_aggregate_does_not_suppress_the_fields_only_the_steps_report(
             "final_metrics": {"total_steps": 2, "total_cost_usd": 0.12},
         },
     )
-    assert fabric_runtime._atif_token_metadata(path) == {"prompt_tokens": 158, "completion_tokens": 10}
+    assert _measurement_values(path) == {
+        "prompt_tokens": 158,
+        "completion_tokens": 10,
+        "total_tokens": 168,
+        "cost_usd": 0.12,
+    }
 
 
 def test_a_reported_total_wins_over_the_step_sum_for_that_field_alone(tmp_path: Path) -> None:
@@ -1174,10 +1211,10 @@ def test_a_reported_total_wins_over_the_step_sum_for_that_field_alone(tmp_path: 
             "final_metrics": {"total_prompt_tokens": 358},
         },
     )
-    assert fabric_runtime._atif_token_metadata(path) == {"prompt_tokens": 358, "completion_tokens": 10}
+    assert _measurement_values(path) == {"prompt_tokens": 358, "completion_tokens": 10, "total_tokens": 368}
 
 
-def test_an_unvalidatable_aggregate_still_falls_back_to_the_steps(tmp_path: Path) -> None:
+def test_an_invalid_aggregate_field_is_omitted_instead_of_falling_back(tmp_path: Path) -> None:
     path = _atif(
         tmp_path,
         {
@@ -1186,21 +1223,44 @@ def test_an_unvalidatable_aggregate_still_falls_back_to_the_steps(tmp_path: Path
             "final_metrics": {"total_prompt_tokens": "not-an-int"},
         },
     )
-    assert fabric_runtime._atif_token_metadata(path) == {"prompt_tokens": 158}
+    assert _measurement_values(path) == {}
 
 
 def test_a_trajectory_with_no_counts_anywhere_records_nothing(tmp_path: Path) -> None:
     path = _atif(tmp_path, {"schema_version": "ATIF-v1.7", "steps": [_step()], "final_metrics": {}})
-    assert fabric_runtime._atif_token_metadata(path) == {}
+    assert _measurement_values(path) == {}
 
 
-@pytest.mark.parametrize("payload", ["[]", "{ not json", '"a string"'])
+@pytest.mark.parametrize("payload", ["[]", "{ not json", '"a string"', '{"steps": 7}'])
 def test_an_unreadable_trajectory_records_nothing_rather_than_failing(tmp_path: Path, payload: str) -> None:
     path = tmp_path / "trajectory-abc.atif.json"
     path.write_text(payload, encoding="utf-8")
-    assert fabric_runtime._atif_token_metadata(path) == {}
+    assert _measurement_values(path) == {}
 
 
 def test_a_missing_trajectory_records_nothing(tmp_path: Path) -> None:
-    assert fabric_runtime._atif_token_metadata(None) == {}
-    assert fabric_runtime._atif_token_metadata(tmp_path / "absent.atif.json") == {}
+    assert _measurement_values(None) == {}
+    assert _measurement_values(tmp_path / "absent.atif.json") == {}
+
+
+@pytest.mark.parametrize(
+    ("value", "is_float", "expected"),
+    [
+        (0, False, True),
+        (1.5, True, True),
+        (1.5, False, False),
+        (True, False, False),
+        (-1, False, False),
+        (float("nan"), True, False),
+        (float("inf"), True, False),
+        ("1", False, False),
+    ],
+)
+def test_valid_atif_measurement(value: object, is_float: bool, expected: bool) -> None:
+    assert fabric_runtime._valid_atif_measurement(value, is_float=is_float) is expected
+
+
+def test_sum_step_metric_treats_missing_steps_as_unmeasured_and_non_list_as_invalid() -> None:
+    assert fabric_runtime._sum_step_metric({}, "prompt_tokens", is_float=False) == (None, True)
+    assert fabric_runtime._sum_step_metric({"steps": None}, "prompt_tokens", is_float=False) == (None, True)
+    assert fabric_runtime._sum_step_metric({"steps": 7}, "prompt_tokens", is_float=False) == (None, False)

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_gym_runtime.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_gym_runtime.py
@@ -52,12 +52,14 @@ from nemo_evaluator_sdk.agent_eval.runtimes.gym.results import (
     _TOKEN_USAGE_KEYS,
     _agent_never_ran,
     _aggregate_metrics_path_for,
+    _usage_measurements,
+    _warn_invalid_usage_counts,
     ensure_fresh_output,
     read_run_aggregations,
     require_full_coverage,
     trials_from_rollouts,
 )
-from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrialStatus
+from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrialStatus, TrialMeasurements
 from nemo_evaluator_sdk.metrics.protocol import CandidateOutput, DatasetRow, MetricInput
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -359,14 +361,39 @@ def test_failures_sidecar_yields_failed_trials(tmp_path: Path) -> None:
     tasks = discover_gym_tasks(EXAMPLE)
     ordered, index_map = _index_map(tasks, tmp_path)
     bundle = tmp_path / "rollouts.jsonl"
-    bundle.write_text(json.dumps({NG_TASK_INDEX: 0, NG_ROLLOUT_INDEX: 0, "reward": 1.0}) + "\n", encoding="utf-8")
+    bundle.write_text(
+        json.dumps(
+            {
+                NG_TASK_INDEX: 0,
+                NG_ROLLOUT_INDEX: 0,
+                "reward": 1.0,
+                "response": {"usage": {"input_tokens": 8, "output_tokens": 2}},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
     failures = tmp_path / "rollouts_failures.jsonl"
-    failures.write_text(json.dumps({NG_TASK_INDEX: 1, NG_ROLLOUT_INDEX: 0, "error": "boom"}) + "\n", encoding="utf-8")
+    failures.write_text(
+        json.dumps(
+            {
+                NG_TASK_INDEX: 1,
+                NG_ROLLOUT_INDEX: 0,
+                "error": "boom",
+                "response": {"usage": {"prompt_tokens": 4, "completion_tokens": 1}},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
     trials = trials_from_rollouts(bundle, tasks, index_map)
     by_status = {trial.task_id: trial.status for trial in trials}
     assert by_status[ordered[0]] == AgentEvalTrialStatus.COMPLETED
     assert by_status[ordered[1]] == AgentEvalTrialStatus.FAILED
     failed = next(trial for trial in trials if trial.status == AgentEvalTrialStatus.FAILED)
+    completed = next(trial for trial in trials if trial.status == AgentEvalTrialStatus.COMPLETED)
+    assert completed.measurements.total_tokens == 10
+    assert failed.measurements.total_tokens == 5
     assert failed.metadata["reward"] is None
     assert failed.metadata["gym_failure"] == "boom"
 
@@ -1157,6 +1184,92 @@ def test_agent_never_ran_is_false_without_usage_to_corroborate() -> None:
     assert _agent_never_ran({"response": "Lyon", "reward": 0.0}) is False
 
 
+@pytest.mark.parametrize(
+    ("usage", "expected"),
+    [
+        (
+            {"prompt_tokens": 10, "completion_tokens": 2, "prompt_tokens_details": {"cached_tokens": 3}},
+            {"prompt_tokens": 10, "completion_tokens": 2, "total_tokens": 12, "cache_read_tokens": 3},
+        ),
+        (
+            {
+                "input_tokens": 5,
+                "output_tokens": 2,
+                "cache_creation_input_tokens": 1,
+                "cache_read_input_tokens": 4,
+            },
+            {
+                "prompt_tokens": 10,
+                "completion_tokens": 2,
+                "total_tokens": 12,
+                "cache_creation_tokens": 1,
+                "cache_read_tokens": 4,
+            },
+        ),
+        ({"input_tokens": 0, "output_tokens": 0}, {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}),
+        ({"input_tokens": True, "output_tokens": "2"}, {}),
+    ],
+)
+def test_gym_usage_is_captured_as_typed_measurements(usage: dict, expected: dict) -> None:
+    measurements = _usage_measurements({"response": {"usage": usage}})
+
+    assert measurements.model_dump(exclude_none=True) == expected
+
+
+def test_gym_usage_prefers_chat_aliases() -> None:
+    measurements = _usage_measurements(
+        {
+            "response": {
+                "usage": {
+                    "prompt_tokens": 10,
+                    "input_tokens": 1,
+                    "completion_tokens": 2,
+                    "output_tokens": 9,
+                    "total_tokens": 999,
+                }
+            }
+        }
+    )
+
+    assert measurements == TrialMeasurements(prompt_tokens=10, completion_tokens=2)
+
+
+def test_gym_usage_measurements_empty_when_response_or_usage_is_unusable() -> None:
+    assert _usage_measurements({}) == TrialMeasurements()
+    assert _usage_measurements({"response": "Lyon"}) == TrialMeasurements()
+    assert _usage_measurements({"response": {"usage": None}}) == TrialMeasurements()
+
+
+def test_gym_usage_omits_ambiguous_prompt_cache(caplog: pytest.LogCaptureFixture) -> None:
+    measurements = _usage_measurements(
+        {
+            NG_TASK_INDEX: 0,
+            NG_ROLLOUT_INDEX: 1,
+            "response": {
+                "usage": {
+                    "input_tokens": 8,
+                    "output_tokens": 4,
+                    "input_tokens_details": {"cached_tokens": 2},
+                    "cache_read_input_tokens": 2,
+                }
+            },
+        }
+    )
+
+    assert measurements == TrialMeasurements(completion_tokens=4)
+    assert "both inclusive cache details and separate cache fields" in caplog.text
+
+
+def test_gym_warn_invalid_usage_counts_logs_malformed_fields(caplog: pytest.LogCaptureFixture) -> None:
+    _warn_invalid_usage_counts(
+        {NG_TASK_INDEX: 0, NG_ROLLOUT_INDEX: 1},
+        {"prompt_tokens": True, "prompt_tokens_details": {"cached_tokens": -1}},
+    )
+
+    assert "prompt_tokens=True" in caplog.text
+    assert "prompt_tokens_details.cached_tokens=-1" in caplog.text
+
+
 def test_missing_results_file_names_the_logs_instead_of_raising_filenotfound(tmp_path: Path) -> None:
     # Raised by review on #1295. `ensure_fresh_output` deletes any stale file before the run and
     # `_collect_rollouts` already raised on a non-zero exit, so an absent file here means Gym
@@ -1303,11 +1416,13 @@ def test_some_rollouts_empty_fails_only_those_trials(tmp_path: Path) -> None:
     empty = by_task[tasks[0].id]
     real = by_task[tasks[1].id]
     assert empty.status is AgentEvalTrialStatus.FAILED
+    assert empty.measurements == TrialMeasurements(prompt_tokens=0, completion_tokens=0)
     # The reward Gym reported is withheld so it cannot be averaged in as a real 0.0...
     assert empty.metadata["reward"] is None
     # ...but the reason is recorded.
     assert "never called" in empty.metadata["gym_failure"]
     assert real.status is AgentEvalTrialStatus.COMPLETED
+    assert real.measurements == TrialMeasurements(prompt_tokens=1, completion_tokens=1)
     assert real.metadata["reward"] == 1.0
 
 

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_gym_runtime.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_gym_runtime.py
@@ -1260,6 +1260,38 @@ def test_gym_usage_omits_ambiguous_prompt_cache(caplog: pytest.LogCaptureFixture
     assert "both inclusive cache details and separate cache fields" in caplog.text
 
 
+@pytest.mark.parametrize(
+    ("usage", "expected"),
+    [
+        pytest.param(
+            {
+                "input_tokens": 5,
+                "output_tokens": 2,
+                "input_tokens_details": {"cached_tokens": None},
+                "cache_read_input_tokens": 4,
+            },
+            TrialMeasurements(prompt_tokens=9, completion_tokens=2, cache_read_tokens=4),
+            id="null-inclusive-placeholder",
+        ),
+        pytest.param(
+            {
+                "input_tokens": 5,
+                "output_tokens": 2,
+                "input_tokens_details": {"cached_tokens": 4},
+                "cache_read_input_tokens": None,
+            },
+            TrialMeasurements(prompt_tokens=5, completion_tokens=2, cache_read_tokens=4),
+            id="null-separate-placeholder",
+        ),
+    ],
+)
+def test_gym_usage_ignores_null_cache_format_placeholders(
+    usage: dict,
+    expected: TrialMeasurements,
+) -> None:
+    assert _usage_measurements({"response": {"usage": usage}}) == expected
+
+
 def test_gym_warn_invalid_usage_counts_logs_malformed_fields(caplog: pytest.LogCaptureFixture) -> None:
     _warn_invalid_usage_counts(
         {NG_TASK_INDEX: 0, NG_ROLLOUT_INDEX: 1},

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_harbor_runtime.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_harbor_runtime.py
@@ -300,12 +300,14 @@ async def test_harbor_runner_scores_through_agent_evaluator_and_adapts_legacy_pa
         AgentEvalTask(id="noreward-task", intent="z", inputs={"instruction": "r"}, metrics=[HarborRewardMetric()]),
     ]
 
-    # Direct adaptation: reward + tokens land on metadata, exception flips status to PARTIAL, evidence present.
+    # Direct adaptation: reward stays metadata while usage is typed; exceptions remain scoreable.
     trials = {t.task_id: t for t in build_trials_from_job_dir(job_dir, tasks)}
     assert trials["pass-task"].status == AgentEvalTrialStatus.COMPLETED
     assert trials["pass-task"].metadata["reward"] == 1.0
-    assert trials["pass-task"].metadata["prompt_tokens"] == 100
-    assert trials["pass-task"].metadata["cost_usd"] == 0.25
+    assert trials["pass-task"].measurements.prompt_tokens == 100
+    assert trials["pass-task"].measurements.cost_usd == 0.25
+    assert "prompt_tokens" not in trials["pass-task"].metadata
+    assert "cost_usd" not in trials["pass-task"].metadata
     assert trials["pass-task"].evidence is not None
     assert trials["fail-task"].status == AgentEvalTrialStatus.PARTIAL
     assert trials["fail-task"].error is not None
@@ -2270,8 +2272,19 @@ def _adapted_measurements(tmp_path: Path, result_data: dict[str, object]) -> dic
     }
     payload.update(result_data)
     trial = _trial_from_harbor_result(trial_dir, payload, reward_key="reward")
-    keys = ("prompt_tokens", "completion_tokens", "cache_read_tokens", "cost_usd")
-    return {key: trial.metadata[key] for key in keys if key in trial.metadata}
+    assert (
+        not {
+            "prompt_tokens",
+            "completion_tokens",
+            "total_tokens",
+            "cache_creation_tokens",
+            "cache_read_tokens",
+            "runtime_sec",
+            "cost_usd",
+        }
+        & trial.metadata.keys()
+    )
+    return trial.measurements.model_dump(exclude_none=True)
 
 
 def test_trial_measurements_use_one_source_and_are_total(tmp_path: Path) -> None:
@@ -2293,20 +2306,37 @@ def test_trial_measurements_use_one_source_and_are_total(tmp_path: Path) -> None
     ) == {
         "prompt_tokens": 5,
         "completion_tokens": 1,
+        "total_tokens": 6,
         "cache_read_tokens": 4,
         "cost_usd": pytest.approx(0.3),
     }
     assert _adapted_measurements(
         tmp_path, {"agent_result": {"n_input_tokens": 0, "n_output_tokens": 0, "n_cache_tokens": 0, "cost_usd": 0}}
-    ) == {"prompt_tokens": 0, "completion_tokens": 0, "cache_read_tokens": 0, "cost_usd": 0.0}
+    ) == {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0, "cache_read_tokens": 0, "cost_usd": 0.0}
     assert (
         _adapted_measurements(tmp_path, {"agent_result": {}, "step_results": [{"agent_result": {"n_input_tokens": 9}}]})
         == {}
     )
     assert _adapted_measurements(tmp_path, {"step_results": 7}) == {}
+    assert (
+        _adapted_measurements(
+            tmp_path, {"step_results": [None, "bad", {"agent_result": 7}, {"agent_result": {"n_input_tokens": -2}}]}
+        )
+        == {}
+    )
+
+
+def test_null_top_level_agent_result_uses_step_measurements(tmp_path: Path) -> None:
     assert _adapted_measurements(
-        tmp_path, {"step_results": [None, "bad", {"agent_result": 7}, {"agent_result": {"n_input_tokens": -2}}]}
-    ) == {"prompt_tokens": -2}
+        tmp_path,
+        {
+            "agent_result": None,
+            "step_results": [
+                {"agent_result": {"n_input_tokens": 2, "n_output_tokens": 1}},
+                {"agent_result": {"n_input_tokens": 3, "n_output_tokens": 2}},
+            ],
+        },
+    ) == {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8}
 
 
 @pytest.mark.parametrize("bad", [True, "12", float("nan"), float("inf"), float("-inf")])
@@ -2315,6 +2345,18 @@ def test_trial_measurements_reject_malformed_values(tmp_path: Path, bad: object)
         tmp_path,
         {"agent_result": {"n_input_tokens": bad, "n_output_tokens": 2, "cost_usd": bad}},
     ) == {"completion_tokens": 2}
+
+
+def test_invalid_step_field_poisons_only_that_aggregate(tmp_path: Path) -> None:
+    assert _adapted_measurements(
+        tmp_path,
+        {
+            "step_results": [
+                {"agent_result": {"n_input_tokens": 5, "n_output_tokens": 1}},
+                {"agent_result": {"n_input_tokens": "bad", "n_output_tokens": 2}},
+            ]
+        },
+    ) == {"completion_tokens": 3}
 
 
 def test_trial_measurements_omit_numeric_and_aggregate_cost_overflow(tmp_path: Path) -> None:
@@ -2330,6 +2372,80 @@ def test_trial_measurements_omit_numeric_and_aggregate_cost_overflow(tmp_path: P
             ]
         },
     ) == {"prompt_tokens": 3}
+
+
+def test_trial_measurements_use_top_level_runtime_without_combining_steps(tmp_path: Path) -> None:
+    assert _adapted_measurements(
+        tmp_path,
+        {
+            "agent_execution": {
+                "started_at": "2026-01-01T00:00:00+00:00",
+                "finished_at": "2026-01-01T00:00:02.500000+00:00",
+            },
+            "step_results": [
+                {
+                    "agent_execution": {
+                        "started_at": "2026-01-01T00:00:00+00:00",
+                        "finished_at": "2026-01-01T00:00:10+00:00",
+                    }
+                }
+            ],
+        },
+    ) == {"runtime_sec": 2.5}
+
+
+def test_trial_measurements_sum_step_runtime_when_top_level_is_absent(tmp_path: Path) -> None:
+    assert _adapted_measurements(
+        tmp_path,
+        {
+            "agent_execution": None,
+            "step_results": [
+                {
+                    "agent_execution": {
+                        "started_at": "2026-01-01T00:00:00+00:00",
+                        "finished_at": "2026-01-01T00:00:01+00:00",
+                    }
+                },
+                {},
+                {
+                    "agent_execution": {
+                        "started_at": "2026-01-01T00:00:03+00:00",
+                        "finished_at": "2026-01-01T00:00:05+00:00",
+                    }
+                },
+            ],
+        },
+    ) == {"runtime_sec": 3.0}
+
+
+@pytest.mark.parametrize(
+    "window",
+    [
+        {"started_at": "2026-01-01T00:00:00+00:00"},
+        {
+            "started_at": "2026-01-01T00:00:02+00:00",
+            "finished_at": "2026-01-01T00:00:01+00:00",
+        },
+    ],
+)
+def test_invalid_step_runtime_poisons_the_runtime_aggregate(tmp_path: Path, window: object) -> None:
+    assert (
+        _adapted_measurements(
+            tmp_path,
+            {
+                "step_results": [
+                    {
+                        "agent_execution": {
+                            "started_at": "2026-01-01T00:00:00+00:00",
+                            "finished_at": "2026-01-01T00:00:01+00:00",
+                        }
+                    },
+                    {"agent_execution": window},
+                ]
+            },
+        )
+        == {}
+    )
 
 
 def _write_evidence_trial(job_dir: Path, trial_name: str = "task__A1b2") -> Path:

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_measurement_contract.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_measurement_contract.py
@@ -1,0 +1,175 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_MEASUREMENT_KEYS = {
+    "prompt_tokens",
+    "completion_tokens",
+    "total_tokens",
+    "cache_creation_tokens",
+    "cache_read_tokens",
+    "runtime_sec",
+    "duration_ms",
+    "cost_usd",
+}
+
+
+def test_production_consumers_do_not_read_measurements_from_trial_metadata() -> None:
+    root = Path(__file__).resolve().parents[4]
+    scan_roots = (
+        root / "packages/nemo_evaluator_sdk/src",
+        root / "plugins/nemo-evaluator/src",
+        root / "packages/nemo_evaluator_sdk/examples",
+    )
+    violations: list[str] = []
+
+    for scan_root in scan_roots:
+        for path in scan_root.rglob("*.py"):
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            violations.extend(
+                f"{path.relative_to(root)}:{line}: {key}" for line, key in _measurement_metadata_reads(tree)
+            )
+
+    assert violations == [], "durable measurements must be read from trial.measurements:\n" + "\n".join(violations)
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        pytest.param('t.metadata["prompt_tokens"]', (1, "prompt_tokens"), id="renamed-receiver"),
+        pytest.param('trials[0].metadata.get("runtime_sec")', (1, "runtime_sec"), id="indexed-receiver"),
+        pytest.param('md = trial.metadata\nmd.pop("cost_usd")', (2, "cost_usd"), id="metadata-alias"),
+        pytest.param(
+            'md = trial.metadata\nmeasurements = md\nmeasurements["total_tokens"]',
+            (3, "total_tokens"),
+            id="chained-metadata-alias",
+        ),
+        pytest.param(
+            'trial.metadata.setdefault("completion_tokens", 0)',
+            (1, "completion_tokens"),
+            id="setdefault-read",
+        ),
+        pytest.param(
+            '"cache_read_tokens" in trial.metadata',
+            (1, "cache_read_tokens"),
+            id="membership-test",
+        ),
+        pytest.param(
+            '"cache_creation_tokens" not in trial.metadata',
+            (1, "cache_creation_tokens"),
+            id="negative-membership-test",
+        ),
+    ],
+)
+def test_tripwire_rejects_common_metadata_reads(source: str, expected: tuple[int, str]) -> None:
+    assert _measurement_metadata_reads(ast.parse(source)) == [expected]
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        pytest.param('usage["prompt_tokens"]', id="raw-usage-mapping"),
+        pytest.param('trial.metadata["reward"]', id="non-measurement-metadata"),
+        pytest.param(
+            'md = trial.metadata\ndef consumer():\n    md = usage\n    return md["prompt_tokens"]',
+            id="alias-does-not-leak-into-function-scope",
+        ),
+    ],
+)
+def test_tripwire_allows_non_trial_measurement_reads(source: str) -> None:
+    assert _measurement_metadata_reads(ast.parse(source)) == []
+
+
+def _measurement_metadata_reads(tree: ast.AST) -> list[tuple[int, str]]:
+    visitor = _MeasurementMetadataReadVisitor()
+    visitor.visit(tree)
+    return visitor.reads
+
+
+class _MeasurementMetadataReadVisitor(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.reads: list[tuple[int, str]] = []
+        self._metadata_aliases: set[str] = set()
+
+    def visit_Subscript(self, node: ast.Subscript) -> None:
+        if self._is_metadata_mapping(node.value):
+            self._record(node, _string_constant(node.slice))
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        if (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr in {"get", "pop", "setdefault"}
+            and self._is_metadata_mapping(node.func.value)
+            and node.args
+        ):
+            self._record(node, _string_constant(node.args[0]))
+        self.generic_visit(node)
+
+    def visit_Compare(self, node: ast.Compare) -> None:
+        left = node.left
+        for operator, comparator in zip(node.ops, node.comparators, strict=True):
+            if isinstance(operator, ast.In | ast.NotIn) and self._is_metadata_mapping(comparator):
+                self._record(node, _string_constant(left))
+            left = comparator
+        self.generic_visit(node)
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        is_metadata_mapping = self._is_metadata_mapping(node.value)
+        self.visit(node.value)
+        for target in node.targets:
+            self._bind_alias(target, is_metadata_mapping=is_metadata_mapping)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        if node.value is not None:
+            is_metadata_mapping = self._is_metadata_mapping(node.value)
+            self.visit(node.value)
+            self._bind_alias(node.target, is_metadata_mapping=is_metadata_mapping)
+        self.visit(node.annotation)
+
+    def visit_NamedExpr(self, node: ast.NamedExpr) -> None:
+        is_metadata_mapping = self._is_metadata_mapping(node.value)
+        self.visit(node.value)
+        self._bind_alias(node.target, is_metadata_mapping=is_metadata_mapping)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_scoped(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_scoped(node)
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        self._visit_scoped(node)
+
+    def _visit_scoped(self, node: ast.AST) -> None:
+        outer_aliases = self._metadata_aliases
+        self._metadata_aliases = set()
+        self.generic_visit(node)
+        self._metadata_aliases = outer_aliases
+
+    def _is_metadata_mapping(self, node: ast.AST) -> bool:
+        return (isinstance(node, ast.Attribute) and node.attr == "metadata") or (
+            isinstance(node, ast.Name) and node.id in self._metadata_aliases
+        )
+
+    def _bind_alias(self, target: ast.AST, *, is_metadata_mapping: bool) -> None:
+        if not isinstance(target, ast.Name):
+            return
+        if is_metadata_mapping:
+            self._metadata_aliases.add(target.id)
+        else:
+            self._metadata_aliases.discard(target.id)
+
+    def _record(self, node: ast.expr, key: str | None) -> None:
+        if key is not None and key in _MEASUREMENT_KEYS:
+            self.reads.append((node.lineno, key))
+
+
+def _string_constant(node: ast.AST) -> str | None:
+    return node.value if isinstance(node, ast.Constant) and isinstance(node.value, str) else None

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_metrics.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_metrics.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-from decimal import Decimal
 from pathlib import Path
 
 import pytest
@@ -15,7 +14,6 @@ from nemo_evaluator_sdk.agent_eval.metrics import (
     AgentPhaseSuccessMetric,
     EvidencePresenceMetric,
     SkillUsedMetric,
-    TrialMeasurements,
 )
 from nemo_evaluator_sdk.agent_eval.trials import standard_evidence_descriptors
 from nemo_evaluator_sdk.metrics.protocol import CandidateOutput, DatasetRow, MetricInput
@@ -73,71 +71,6 @@ async def test_evidence_presence_metric_scores_over_evidence(tmp_path: Path) -> 
     assert empty.outputs[0].value is False
     missing = await metric.compute_scores(MetricInput(row=DatasetRow(data={}), candidate=CandidateOutput()))
     assert missing.outputs[0].value is False
-
-
-def test_from_metadata_reads_tokens_runtime_reward() -> None:
-    measurements = TrialMeasurements.from_metadata(
-        {
-            "total_tokens": 120,
-            "prompt_tokens": 80,
-            "completion_tokens": 40,
-            "runtime_sec": 4.5,
-            "cost_usd": 0.134,
-            "reward": 1,
-            "passed": True,
-        }
-    )
-    assert measurements.total_tokens == 120
-    assert measurements.runtime_sec == 4.5
-    assert measurements.cost_usd == 0.134
-    assert measurements.reward == 1.0
-    assert measurements.passed is True
-
-
-def test_from_metadata_applies_fallbacks_and_ignores_bad_types() -> None:
-    # duration_ms -> runtime_sec, passed -> reward, bool is not a token count.
-    measurements = TrialMeasurements.from_metadata({"duration_ms": 2500, "passed": False, "total_tokens": True})
-    assert measurements.runtime_sec == 2.5
-    assert measurements.reward == 0.0
-    assert measurements.total_tokens is None
-
-    empty = TrialMeasurements.from_metadata(None)
-    assert empty.reward is None and empty.runtime_sec is None and empty.cost_usd is None
-
-
-@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf"), True, 10**1000])
-def test_from_metadata_rejects_unserialisable_cost(bad: object) -> None:
-    # A cost the wire cannot carry would fail the publish of an otherwise good trial. 10**1000 is
-    # an int no float can represent, which reaches here from any harness that reports JSON numbers.
-    assert TrialMeasurements.from_metadata({"cost_usd": bad}).cost_usd is None
-
-
-@pytest.mark.parametrize(
-    "bad",
-    [
-        float("nan"),
-        float("inf"),
-        float("-inf"),
-        True,
-        10**1000,
-        # These reach a float only through coercion, so they slip past any check made before it.
-        "nan",
-        "inf",
-        Decimal("NaN"),
-        Decimal("Infinity"),
-    ],
-)
-def test_direct_construction_rejects_unserialisable_cost(bad: object) -> None:
-    # from_metadata is not the only way in, so the model itself has to hold the invariant.
-    with pytest.raises(ValidationError):
-        TrialMeasurements(cost_usd=bad)  # ty: ignore[invalid-argument-type]
-
-
-@pytest.mark.parametrize("good", [0.134, 0, "0.5", Decimal("1.25")])
-def test_direct_construction_still_accepts_a_finite_cost(good: object) -> None:
-    # Rejecting non-finite values must not cost the ordinary coercion of a finite one.
-    measurement = TrialMeasurements(cost_usd=good)  # ty: ignore[invalid-argument-type]
-    assert measurement.cost_usd == float(good)  # ty: ignore[invalid-argument-type]
 
 
 @pytest.mark.parametrize(

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_persistence.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_persistence.py
@@ -12,8 +12,15 @@ from pathlib import Path
 import pytest
 from nemo_evaluator_sdk.agent_eval.persistence import persist_run, read_trials
 from nemo_evaluator_sdk.agent_eval.results import AgentEvalResult, AgentEvalSummary, TrialMetricValue
-from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial, AgentEvalTrialStatus, AgentOutput, TrialError
+from nemo_evaluator_sdk.agent_eval.trials import (
+    AgentEvalTrial,
+    AgentEvalTrialStatus,
+    AgentOutput,
+    TrialError,
+    TrialMeasurements,
+)
 from nemo_evaluator_sdk.values.evidence import CandidateEvidence, EvidenceDescriptor
+from pydantic import ValidationError
 
 
 def _write_trial(run_dir: Path, trial: AgentEvalTrial) -> None:
@@ -31,7 +38,7 @@ def _trial_with_workspace(ref: str) -> AgentEvalTrial:
     )
 
 
-def test_read_trials_hydrates_trial_and_keeps_valid_evidence_ref(tmp_path: Path) -> None:
+def test_read_trials_loads_trial_and_keeps_valid_evidence_ref(tmp_path: Path) -> None:
     # A stored bundle whose workspace evidence ref still resolves as-is (re-scoring reads the deliverables).
     workspace = tmp_path / "evidence" / "fabric" / "run" / "000000-taskA" / "workspace"
     (workspace / "output").mkdir(parents=True)
@@ -82,6 +89,28 @@ def test_persist_run_writes_bundle_relative_refs_that_survive_a_move(tmp_path: P
     (trial,) = read_trials(moved)
     resolved = Path(trial.evidence.require("workspace").ref)  # type: ignore[arg-type]
     assert resolved.is_dir() and resolved == moved / "evidence" / "fabric" / "r" / "000000-taskA" / "workspace"
+
+
+def test_persist_run_revalidates_model_copy_corrupted_measurements_before_writing(tmp_path: Path) -> None:
+    trial = _trial_with_workspace("workspace").model_copy(
+        update={"measurements": TrialMeasurements(prompt_tokens=8, completion_tokens=2)}
+    )
+    result = AgentEvalResult(
+        run_id="r",
+        tasks=[],
+        trials=[trial],
+        scores=[],
+        summary=AgentEvalSummary.from_scores([], tasks=[]),
+    )
+    corrupted_measurements = trial.measurements.model_copy(update={"prompt_tokens": -1})
+    corrupted_trial = trial.model_copy(update={"measurements": corrupted_measurements})
+    corrupted_result = result.model_copy(update={"trials": [corrupted_trial]})
+    bundle = tmp_path / "bundle"
+
+    with pytest.raises(ValidationError):
+        persist_run(corrupted_result, bundle, write_html_dashboard=False)
+
+    assert not bundle.exists()
 
 
 def test_persist_run_writes_per_task_values_to_summary(tmp_path: Path) -> None:
@@ -262,3 +291,82 @@ def test_trials_jsonl_round_trips_a_typed_error(tmp_path: Path) -> None:
     [reloaded] = read_trials(tmp_path)
 
     assert reloaded.error == trial.error
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_measurements"),
+    [
+        pytest.param(
+            {
+                "measurements": {
+                    "prompt_tokens": 8,
+                    "completion_tokens": 2,
+                    "runtime_sec": 0,
+                    "cost_usd": 0,
+                },
+                "metadata": {"provenance": "kept"},
+            },
+            TrialMeasurements(prompt_tokens=8, completion_tokens=2, runtime_sec=0, cost_usd=0),
+            id="typed",
+        ),
+        pytest.param(
+            {"metadata": {"prompt_tokens": 8, "completion_tokens": 2, "duration_ms": 1500}},
+            TrialMeasurements(),
+            id="metadata-only",
+        ),
+        pytest.param(
+            {
+                "measurements": {"prompt_tokens": 8, "completion_tokens": 2},
+                "metadata": {"prompt_tokens": 999, "completion_tokens": 999, "duration_ms": 1500},
+            },
+            TrialMeasurements(prompt_tokens=8, completion_tokens=2),
+            id="conflicting-metadata",
+        ),
+    ],
+)
+def test_trials_jsonl_preserves_typed_measurements_and_opaque_metadata(
+    tmp_path: Path,
+    payload: dict[str, object],
+    expected_measurements: TrialMeasurements,
+) -> None:
+    row = {"id": "task-a:trial", "task_id": "task-a", "status": "partial", **payload}
+    (tmp_path / "trials.jsonl").write_text(
+        json.dumps(row) + "\n",
+        encoding="utf-8",
+    )
+
+    [loaded] = read_trials(tmp_path)
+    assert loaded.measurements == expected_measurements
+    assert loaded.metadata == payload.get("metadata", {})
+
+    round_trip_dir = tmp_path / "round-trip"
+    persist_run(
+        AgentEvalResult(run_id="run", tasks=[], trials=[loaded], scores=[], summary=AgentEvalSummary()),
+        round_trip_dir,
+        write_html_dashboard=False,
+    )
+    [reloaded] = read_trials(round_trip_dir)
+    assert reloaded == loaded
+
+
+@pytest.mark.parametrize("measurements", [None, {"prompt_tokens": -1}])
+def test_trials_jsonl_rejects_invalid_typed_measurements_without_metadata_fallback(
+    tmp_path: Path,
+    measurements: object,
+) -> None:
+    (tmp_path / "trials.jsonl").write_text(
+        json.dumps(
+            {
+                "id": "task-a:invalid",
+                "task_id": "task-a",
+                "status": "partial",
+                "measurements": measurements,
+                "metadata": {"prompt_tokens": 8, "duration_ms": 1500},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValidationError):
+        read_trials(tmp_path)

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_run_agent_eval_measurements.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_run_agent_eval_measurements.py
@@ -1,0 +1,332 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib
+import io
+import json
+import sys
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import pytest
+from nemo_evaluator_sdk.agent_eval.results import AgentEvalResult, AgentEvalSummary
+from nemo_evaluator_sdk.agent_eval.scores import AgentEvalScoreStatus, AgentEvalTaskScore
+from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalRunConfig, AgentEvalTask
+from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial, AgentEvalTrialStatus, TrialMeasurements
+from nemo_evaluator_sdk.metrics.protocol import MetricOutput
+from pydantic import ValidationError
+
+
+def _example(name: str):
+    root = str(Path(__file__).resolve().parents[2])
+    if root not in sys.path:
+        sys.path.insert(0, root)
+    return importlib.import_module(f"examples.run_agent_eval.{name}")
+
+
+@pytest.mark.asyncio
+async def test_workflow_runtime_records_typed_runtime_only(tmp_path: Path) -> None:
+    workflow = _example("workflow_runtime")
+    task = AgentEvalTask(id="task-1", intent="Answer.", inputs={"instruction": "hello"})
+
+    [trial] = await workflow.WorkflowAgentRuntime().run_tasks(
+        [task], config=AgentEvalRunConfig(work_dir=tmp_path, parallelism=1)
+    )
+
+    assert trial.measurements.runtime_sec is not None
+    assert trial.measurements.runtime_sec >= 0
+    assert "runtime_sec" not in trial.metadata
+
+
+def test_platform_runtime_uses_outer_runtime_and_canonical_cache_total(tmp_path: Path) -> None:
+    platform = _example("platform_runtime")
+    layout = platform.AgenticRunLayout(
+        run_dir=tmp_path,
+        agent_log_dir=tmp_path / "agent",
+        workspace_dir=tmp_path / "workspace",
+        state_dir=tmp_path / "state",
+        instruction_path=tmp_path / "instruction.md",
+    )
+    for directory in (layout.agent_log_dir, layout.workspace_dir, layout.state_dir):
+        directory.mkdir()
+    (layout.agent_log_dir / "nat_agent.log").write_text(
+        json.dumps(
+            {
+                "usage": {
+                    "input_tokens": 5,
+                    "output_tokens": 2,
+                    "cache_creation_input_tokens": 1,
+                    "cache_read_input_tokens": 4,
+                },
+                "duration_ms": 999_000,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    trial = platform.build_trial_from_artifacts(
+        task=AgentEvalTask(id="task-1", intent="Answer.", inputs={}),
+        layout=layout,
+        runtime_name="workflow",
+        agent_model="model",
+        exit_code=0,
+        agent_ok=True,
+        runtime_sec=4.0,
+    )
+
+    assert trial.measurements == TrialMeasurements(
+        prompt_tokens=10,
+        completion_tokens=2,
+        cache_creation_tokens=1,
+        cache_read_tokens=4,
+        runtime_sec=4.0,
+    )
+    assert (
+        not {
+            "prompt_tokens",
+            "completion_tokens",
+            "total_tokens",
+            "cache_creation_tokens",
+            "cache_read_tokens",
+            "runtime_sec",
+            "duration_ms",
+        }
+        & trial.metadata.keys()
+    )
+
+
+def test_example_usage_handles_inclusive_ambiguous_and_invalid_cache_shapes(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    usage = _example("usage")
+
+    inclusive = usage.extract_usage_metrics(
+        json.dumps({"usage": {"input_tokens": 5, "output_tokens": 2, "cached_input_tokens": 4}})
+    )
+    assert inclusive["prompt_tokens"] == 5
+    assert inclusive["cache_read_tokens"] == 4
+    assert inclusive["total_tokens"] == 7
+
+    ambiguous = usage.extract_usage_metrics(
+        json.dumps(
+            {
+                "usage": {
+                    "input_tokens": 5,
+                    "output_tokens": 2,
+                    "cached_input_tokens": 4,
+                    "cache_read_input_tokens": 1,
+                }
+            }
+        )
+    )
+    assert ambiguous["prompt_tokens"] is None
+    assert ambiguous["completion_tokens"] == 2
+    assert ambiguous["cache_read_tokens"] is None
+
+    invalid = usage.extract_usage_metrics(
+        json.dumps({"usage": {"input_tokens": 5, "output_tokens": 2, "cache_read_input_tokens": "bad"}})
+    )
+    assert invalid["prompt_tokens"] is None
+    assert invalid["completion_tokens"] == 2
+    assert "omitting ambiguous prompt/cache measurements" in caplog.text
+    assert "cache_read_input_tokens='bad'" in caplog.text
+
+
+def test_example_usage_ambiguous_message_invalidates_trial_wide_prompt_and_cache() -> None:
+    usage = _example("usage")
+
+    metrics = usage.extract_usage_metrics(
+        json.dumps(
+            {
+                "messages": [
+                    {
+                        "usage": {
+                            "input_tokens": 10,
+                            "output_tokens": 1,
+                            "cache_read_input_tokens": 2,
+                        }
+                    },
+                    {
+                        "usage": {
+                            "input_tokens": 20,
+                            "output_tokens": 2,
+                            "cache_read_input_tokens": 3,
+                            "cached_input_tokens": 3,
+                        }
+                    },
+                ]
+            }
+        )
+    )
+
+    assert metrics == {
+        "prompt_tokens": None,
+        "completion_tokens": 3,
+        "total_tokens": None,
+        "cache_creation_tokens": None,
+        "cache_read_tokens": None,
+        "duration_ms": None,
+    }
+
+
+def test_example_reporting_reads_typed_measurements() -> None:
+    runner = _example("run_agent_eval")
+    trial = AgentEvalTrial(
+        id="trial-1",
+        task_id="task-1",
+        status=AgentEvalTrialStatus.PARTIAL,
+        measurements=TrialMeasurements(prompt_tokens=8, completion_tokens=2, runtime_sec=1.5),
+        metadata={"total_tokens": 999, "runtime_sec": 999},
+    )
+    result = AgentEvalResult(run_id="run-1", tasks=[], trials=[trial], scores=[], summary=AgentEvalSummary())
+
+    output = io.StringIO()
+    with redirect_stdout(output):
+        runner._print_measurements(result)
+
+    assert output.getvalue().splitlines() == [
+        "  total_tokens: 10 across 1/1 trials",
+        "  runtime_sec: 1.5 across 1/1 trials",
+    ]
+
+
+def test_gating_reads_typed_measurements_and_reports_unscored_tasks() -> None:
+    gating = _example("gating")
+    tasks = [
+        AgentEvalTask(id="task-1", intent="Answer.", inputs={}),
+        AgentEvalTask(id="task-2", intent="Answer.", inputs={}),
+    ]
+    trials = [
+        AgentEvalTrial(
+            id=f"{task.id}:trial",
+            task_id=task.id,
+            status=AgentEvalTrialStatus.PARTIAL,
+            measurements=TrialMeasurements(prompt_tokens=5, completion_tokens=1, runtime_sec=2.0),
+        )
+        for task in tasks
+    ]
+    score = AgentEvalTaskScore(
+        id="score-1",
+        run_id="run-1",
+        task_id="task-1",
+        trial_id=trials[0].id,
+        metric_type="verifier",
+        status=AgentEvalScoreStatus.COMPLETED,
+        outputs=[MetricOutput(name="verifier_reward", value=1.0)],
+    )
+    result = AgentEvalResult(
+        run_id="run-1",
+        tasks=tasks,
+        trials=trials,
+        scores=[score],
+        summary=AgentEvalSummary(),
+    )
+
+    summary = gating.summarize_run(result)
+
+    assert summary["total_tokens_sum"] == 12
+    assert summary["runtime_sec_sum"] == 4.0
+    assert summary["passed_tasks"] == 1
+    assert summary["unscored_task_ids"] == ["task-2"]
+
+
+def test_fabric_measurements_remain_outside_runtime_gating() -> None:
+    gating = _example("gating")
+    task = AgentEvalTask(id="task-1", intent="Answer.", inputs={})
+    trial = AgentEvalTrial(
+        id="task-1:fabric",
+        task_id=task.id,
+        status=AgentEvalTrialStatus.PARTIAL,
+        measurements=TrialMeasurements(prompt_tokens=8, completion_tokens=2, cost_usd=0.25),
+        metadata={"adapter_id": "nvidia.fabric.codex"},
+    )
+    result = AgentEvalResult(
+        run_id="run-1",
+        tasks=[task],
+        trials=[trial],
+        scores=[],
+        summary=AgentEvalSummary(),
+    )
+
+    summary = gating.summarize_run(result)
+
+    assert summary["total_tokens_sum"] == 10
+    assert summary["runtime_sec_sum"] is None
+    assert summary["avg_runtime_sec"] is None
+    assert summary["runtime_metrics_coverage"] == 0.0
+    assert summary["runtime_metrics_available_tasks"] == 0
+    assert summary["runtime_metrics_unavailable_tasks"] == ["task-1"]
+
+
+@pytest.mark.parametrize("filename", ["trial.json", "trials.jsonl"])
+@pytest.mark.parametrize(
+    ("payload", "expected_measurements"),
+    [
+        pytest.param(
+            {
+                "measurements": {
+                    "prompt_tokens": 8,
+                    "completion_tokens": 2,
+                    "runtime_sec": 0,
+                    "cost_usd": 0,
+                },
+                "metadata": {"reward": 0.8},
+            },
+            TrialMeasurements(prompt_tokens=8, completion_tokens=2, runtime_sec=0, cost_usd=0),
+            id="typed",
+        ),
+        pytest.param(
+            {"metadata": {"prompt_tokens": 8, "completion_tokens": 2, "duration_ms": 1500}},
+            TrialMeasurements(),
+            id="metadata-only",
+        ),
+        pytest.param(
+            {
+                "measurements": {"prompt_tokens": 8, "completion_tokens": 2},
+                "metadata": {"prompt_tokens": 999, "completion_tokens": 999, "duration_ms": 1500},
+            },
+            TrialMeasurements(prompt_tokens=8, completion_tokens=2),
+            id="conflicting-metadata",
+        ),
+    ],
+)
+def test_example_stored_trial_loaders_preserve_typed_measurements_and_opaque_metadata(
+    tmp_path: Path,
+    filename: str,
+    payload: dict[str, object],
+    expected_measurements: TrialMeasurements,
+) -> None:
+    workflow = _example("workflow_runtime")
+    row = {"id": "stored-trial", "task_id": "task-1", "status": "partial", **payload}
+    serialized = json.dumps(row)
+    (tmp_path / filename).write_text(serialized + ("\n" if filename.endswith("jsonl") else ""), encoding="utf-8")
+
+    [trial] = workflow.load_stored_trials(tmp_path)
+
+    assert trial.measurements == expected_measurements
+    assert trial.metadata == payload.get("metadata", {})
+
+
+@pytest.mark.parametrize("filename", ["trial.json", "trials.jsonl"])
+@pytest.mark.parametrize("measurements", [None, {"prompt_tokens": -1}])
+def test_example_stored_trial_loaders_reject_invalid_typed_measurements(
+    tmp_path: Path,
+    filename: str,
+    measurements: object,
+) -> None:
+    workflow = _example("workflow_runtime")
+    serialized = json.dumps(
+        {
+            "id": "stored-trial",
+            "task_id": "task-1",
+            "status": "partial",
+            "measurements": measurements,
+            "metadata": {"prompt_tokens": 8, "duration_ms": 1500},
+        }
+    )
+    (tmp_path / filename).write_text(serialized + ("\n" if filename.endswith("jsonl") else ""), encoding="utf-8")
+
+    with pytest.raises(ValidationError):
+        workflow.load_stored_trials(tmp_path)

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_run_agent_eval_measurements.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_run_agent_eval_measurements.py
@@ -134,6 +134,54 @@ def test_example_usage_handles_inclusive_ambiguous_and_invalid_cache_shapes(
     assert "cache_read_input_tokens='bad'" in caplog.text
 
 
+@pytest.mark.parametrize(
+    ("usage_payload", "expected"),
+    [
+        pytest.param(
+            {
+                "input_tokens": 5,
+                "output_tokens": 2,
+                "cached_input_tokens": None,
+                "cache_read_input_tokens": 4,
+            },
+            {
+                "prompt_tokens": 9,
+                "completion_tokens": 2,
+                "total_tokens": 11,
+                "cache_creation_tokens": None,
+                "cache_read_tokens": 4,
+                "duration_ms": None,
+            },
+            id="null-inclusive-placeholder",
+        ),
+        pytest.param(
+            {
+                "input_tokens": 5,
+                "output_tokens": 2,
+                "cached_input_tokens": 4,
+                "cache_read_input_tokens": None,
+            },
+            {
+                "prompt_tokens": 5,
+                "completion_tokens": 2,
+                "total_tokens": 7,
+                "cache_creation_tokens": None,
+                "cache_read_tokens": 4,
+                "duration_ms": None,
+            },
+            id="null-separate-placeholder",
+        ),
+    ],
+)
+def test_example_usage_ignores_null_cache_format_placeholders(
+    usage_payload: dict,
+    expected: dict,
+) -> None:
+    usage = _example("usage")
+
+    assert usage.extract_usage_metrics(json.dumps({"usage": usage_payload})) == expected
+
+
 def test_example_usage_ambiguous_message_invalidates_trial_wide_prompt_and_cache() -> None:
     usage = _example("usage")
 

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_trials.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_trials.py
@@ -9,11 +9,168 @@ from nemo_evaluator_sdk.agent_eval.trials import (
     AgentEvalTrial,
     AgentEvalTrialStatus,
     TrialError,
+    TrialMeasurements,
     resolve_trial_status,
     standard_evidence_descriptors,
 )
 from nemo_evaluator_sdk.values.evidence import CandidateEvidence, EvidenceDescriptor
 from pydantic import ValidationError
+
+
+def test_trial_measurements_default_empty_and_serialize_on_trial() -> None:
+    trial = AgentEvalTrial(id="trial-1", task_id="task-1", status=AgentEvalTrialStatus.PARTIAL)
+
+    assert trial.measurements == TrialMeasurements()
+    assert trial.model_dump(mode="json")["measurements"] == {
+        "prompt_tokens": None,
+        "completion_tokens": None,
+        "total_tokens": None,
+        "cache_creation_tokens": None,
+        "cache_read_tokens": None,
+        "runtime_sec": None,
+        "cost_usd": None,
+    }
+
+
+def test_trial_measurements_derive_and_validate_total_tokens() -> None:
+    measurements = TrialMeasurements(prompt_tokens=80, completion_tokens=10)
+
+    assert measurements.total_tokens == 90
+    assert TrialMeasurements(prompt_tokens=80, completion_tokens=10, total_tokens=90) == measurements
+
+    with pytest.raises(ValidationError, match="requires prompt_tokens and completion_tokens"):
+        TrialMeasurements(total_tokens=90)
+    with pytest.raises(ValidationError, match=r"must equal prompt_tokens \+ completion_tokens"):
+        TrialMeasurements(prompt_tokens=80, completion_tokens=10, total_tokens=91)
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "prompt_tokens",
+        "completion_tokens",
+        "total_tokens",
+        "cache_creation_tokens",
+        "cache_read_tokens",
+    ],
+)
+@pytest.mark.parametrize("bad", [True, "1", -1, 1.5])
+def test_trial_measurements_require_strict_nonnegative_token_counts(field: str, bad: object) -> None:
+    with pytest.raises(ValidationError):
+        TrialMeasurements.model_validate({field: bad})
+
+
+@pytest.mark.parametrize("field", ["runtime_sec", "cost_usd"])
+@pytest.mark.parametrize("bad", [True, "1.5", -0.1, float("nan"), float("inf"), float("-inf"), 10**1000])
+def test_trial_measurements_require_finite_nonnegative_real_values(field: str, bad: object) -> None:
+    with pytest.raises(ValidationError):
+        TrialMeasurements.model_validate({field: bad})
+
+
+def test_trial_measurements_normalize_integer_runtime_and_cost_to_float() -> None:
+    measurements = TrialMeasurements(runtime_sec=2, cost_usd=0)
+
+    assert measurements.runtime_sec == 2.0
+    assert type(measurements.runtime_sec) is float
+    assert measurements.cost_usd == 0.0
+    assert type(measurements.cost_usd) is float
+
+
+def test_trial_measurements_reject_direct_mutation() -> None:
+    measurements = TrialMeasurements(prompt_tokens=8, completion_tokens=2)
+
+    with pytest.raises(ValidationError, match="Instance is frozen"):
+        measurements.prompt_tokens = -1
+
+
+@pytest.mark.parametrize(
+    "corrupted_update",
+    [
+        {"prompt_tokens": -1},
+        {"runtime_sec": float("nan")},
+        {"total_tokens": 999},
+    ],
+)
+def test_trial_measurements_can_only_be_replaced_with_a_valid_complete_value(
+    corrupted_update: dict[str, object],
+) -> None:
+    trial = AgentEvalTrial(id="trial-1", task_id="task-1", status=AgentEvalTrialStatus.PARTIAL)
+    replacement = TrialMeasurements(prompt_tokens=8, completion_tokens=2)
+
+    trial.measurements = replacement
+
+    assert trial.measurements == replacement
+    corrupted = replacement.model_copy(update=corrupted_update)
+    with pytest.raises(ValidationError):
+        trial.measurements = corrupted
+    assert trial.measurements == replacement
+
+
+def test_trial_measurements_compatibility_import_is_same_class() -> None:
+    from nemo_evaluator_sdk.agent_eval.metrics import TrialMeasurements as CompatibilityTrialMeasurements
+
+    assert CompatibilityTrialMeasurements is TrialMeasurements
+
+
+def test_trial_validation_keeps_measurement_named_metadata_opaque() -> None:
+    trial = AgentEvalTrial.model_validate(
+        {
+            "id": "trial-1",
+            "task_id": "task-1",
+            "status": "partial",
+            "metadata": {"prompt_tokens": 80, "completion_tokens": 10, "duration_ms": 2500},
+        }
+    )
+
+    assert trial.measurements == TrialMeasurements()
+    assert trial.metadata == {"prompt_tokens": 80, "completion_tokens": 10, "duration_ms": 2500}
+
+
+def test_trial_validation_keeps_typed_measurements_authoritative_and_metadata_unchanged() -> None:
+    trial = AgentEvalTrial.model_validate(
+        {
+            "id": "trial-1",
+            "task_id": "task-1",
+            "status": "partial",
+            "measurements": {"prompt_tokens": 8, "completion_tokens": 2, "runtime_sec": 0},
+            "metadata": {
+                "prompt_tokens": 999,
+                "completion_tokens": 999,
+                "duration_ms": 999_000,
+            },
+        }
+    )
+
+    assert trial.measurements == TrialMeasurements(prompt_tokens=8, completion_tokens=2, runtime_sec=0)
+    assert trial.metadata == {"prompt_tokens": 999, "completion_tokens": 999, "duration_ms": 999_000}
+
+
+@pytest.mark.parametrize("measurements", [None, {"prompt_tokens": -1}])
+def test_invalid_typed_measurements_do_not_fall_back_to_metadata(measurements: object) -> None:
+    with pytest.raises(ValidationError):
+        AgentEvalTrial.model_validate(
+            {
+                "id": "trial-1",
+                "task_id": "task-1",
+                "status": "partial",
+                "measurements": measurements,
+                "metadata": {"prompt_tokens": 8, "duration_ms": 2500},
+            }
+        )
+
+
+def test_trial_measurement_metadata_survives_round_trip() -> None:
+    trial = AgentEvalTrial.model_validate(
+        {
+            "id": "trial-1",
+            "task_id": "task-1",
+            "status": "partial",
+            "measurements": {"prompt_tokens": 0, "completion_tokens": 0, "cost_usd": 0},
+            "metadata": {"prompt_tokens": 999, "duration_ms": 2500, "provenance": "kept"},
+        }
+    )
+
+    assert AgentEvalTrial.model_validate_json(trial.model_dump_json()) == trial
 
 
 def test_trial_accepts_mapping_shaped_evidence_and_serializes_descriptors() -> None:

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_usage_keys.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_usage_keys.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from nemo_evaluator_sdk.agent_eval.usage_keys import (
+    COMPLETION_TOKEN_KEYS,
+    PROMPT_TOKEN_KEYS,
+    SEPARATE_CACHE_KEYS,
+    USAGE_COUNT_KEYS,
+    USAGE_DETAILS_KEYS,
+    _first_nonnegative_int,
+    _first_usage_details,
+)
+
+
+def test_usage_count_keys_match_warn_loop_order() -> None:
+    assert USAGE_COUNT_KEYS == PROMPT_TOKEN_KEYS + COMPLETION_TOKEN_KEYS + SEPARATE_CACHE_KEYS
+    assert USAGE_COUNT_KEYS == (
+        "prompt_tokens",
+        "input_tokens",
+        "completion_tokens",
+        "output_tokens",
+        "cache_read_input_tokens",
+        "cache_creation_input_tokens",
+    )
+    assert USAGE_DETAILS_KEYS == ("prompt_tokens_details", "input_tokens_details")
+
+
+@pytest.mark.parametrize(
+    ("values", "keys", "expected"),
+    [
+        ({"prompt_tokens": 8, "input_tokens": 3}, ("prompt_tokens", "input_tokens"), 8),
+        ({"input_tokens": 3}, ("prompt_tokens", "input_tokens"), 3),
+        ({"prompt_tokens": None, "input_tokens": 3}, ("prompt_tokens", "input_tokens"), 3),
+        ({"prompt_tokens": True, "input_tokens": 0}, ("prompt_tokens", "input_tokens"), 0),
+        ({"prompt_tokens": False, "input_tokens": 1}, ("prompt_tokens", "input_tokens"), 1),
+        ({"prompt_tokens": "8", "input_tokens": 2}, ("prompt_tokens", "input_tokens"), 2),
+        ({"prompt_tokens": 1.5, "input_tokens": 2}, ("prompt_tokens", "input_tokens"), 2),
+        ({"prompt_tokens": -1, "input_tokens": 2}, ("prompt_tokens", "input_tokens"), 2),
+        ({}, ("prompt_tokens", "input_tokens"), None),
+        ({"prompt_tokens": None}, ("prompt_tokens",), None),
+    ],
+)
+def test_first_nonnegative_int_skips_unusable_aliases(
+    values: dict[str, object],
+    keys: tuple[str, ...],
+    expected: int | None,
+) -> None:
+    assert _first_nonnegative_int(values, *keys) == expected
+
+
+def test_first_usage_details_skips_unusable_preferred_alias() -> None:
+    details = {"cached_tokens": 3}
+
+    assert _first_usage_details({"prompt_tokens_details": "invalid", "input_tokens_details": details}) is details
+    assert _first_usage_details({"prompt_tokens_details": None}) is None

--- a/plugins/nemo-evaluator/openapi/openapi.yaml
+++ b/plugins/nemo-evaluator/openapi/openapi.yaml
@@ -2865,6 +2865,11 @@ components:
           - $ref: '#/components/schemas/TrialError'
           description: What went wrong producing this trial, when the producer reported
             a failure. Populated by a runner runtime. Drives AgentEvalSummary.error_trial_ids.
+        measurements:
+          allOf:
+          - $ref: '#/components/schemas/TrialMeasurements'
+          description: Validated token usage, agent runtime, and cost measurements
+            for the trial.
         metadata:
           additionalProperties: true
           type: object
@@ -2877,8 +2882,8 @@ components:
       - task_id
       - status
       title: AgentEvalTrial
-      description: 'Durable trial artifact for one task: output, evidence, status,
-        error, and metadata.'
+      description: 'Durable trial artifact: output, evidence, status, error, measurements,
+        and metadata.'
     AgentEvalTrialStatus:
       type: string
       enum:
@@ -6503,6 +6508,40 @@ components:
         the trial reports
 
         a new one.'
+    TrialMeasurements:
+      properties:
+        prompt_tokens:
+          title: Prompt Tokens
+          type: integer
+          minimum: 0.0
+        completion_tokens:
+          title: Completion Tokens
+          type: integer
+          minimum: 0.0
+        total_tokens:
+          title: Total Tokens
+          type: integer
+          minimum: 0.0
+        cache_creation_tokens:
+          title: Cache Creation Tokens
+          type: integer
+          minimum: 0.0
+        cache_read_tokens:
+          title: Cache Read Tokens
+          type: integer
+          minimum: 0.0
+        runtime_sec:
+          title: Runtime Sec
+          type: number
+          minimum: 0.0
+        cost_usd:
+          title: Cost Usd
+          type: number
+          minimum: 0.0
+      additionalProperties: false
+      type: object
+      title: TrialMeasurements
+      description: Validated usage, runtime, and cost measurements for one trial.
     ValidationError:
       properties:
         loc:

--- a/plugins/nemo-evaluator/src/nemo_evaluator/intake/mapping.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/intake/mapping.py
@@ -36,9 +36,8 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Literal
 
-from nemo_evaluator_sdk.agent_eval.metrics import TrialMeasurements
 from nemo_evaluator_sdk.agent_eval.scores import AgentEvalScoreStatus, AgentEvalTaskScore
-from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial
+from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial, TrialMeasurements
 from nemo_evaluator_sdk.values.evidence import EVIDENCE_FORMAT_ATIF, EVIDENCE_FORMAT_OTLP, EVIDENCE_TRACE
 from nemo_evaluator_sdk.values.otlp import (
     fill_missing_start_times,

--- a/plugins/nemo-evaluator/src/nemo_evaluator/intake/publish.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/intake/publish.py
@@ -25,10 +25,9 @@ from datetime import timedelta
 from typing import cast
 
 from nemo_evaluator.intake import mapping
-from nemo_evaluator_sdk.agent_eval.metrics import TrialMeasurements
 from nemo_evaluator_sdk.agent_eval.results import AgentEvalResult
 from nemo_evaluator_sdk.agent_eval.scores import AgentEvalTaskScore
-from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial
+from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial, TrialMeasurements
 from nemo_platform_plugin.client.errors import NotFoundError, UnprocessableEntityError
 from nemo_platform_plugin.intake.client import AsyncIntakeClient
 from nemo_platform_plugin.intake.types import (
@@ -179,6 +178,7 @@ async def publish_to_intake(
     arguments because it lives on the run *target*, which ``AgentEvalResult`` does
     not carry (design §3.9 #6).
     """
+    validated_trials = [AgentEvalTrial.model_validate(trial) for trial in result.trials]
     intake = client
     resolved_workspace = intake.require_workspace(workspace)
 
@@ -285,7 +285,7 @@ async def publish_to_intake(
 
     async def _publish_trial(trial: AgentEvalTrial) -> PublishedTrial:
         async with semaphore:
-            measurements = TrialMeasurements.from_metadata(trial.metadata)
+            measurements = trial.measurements
             session_id = mapping.session_id_for(result.run_id, trial.id)
             span_id = await _publish_otlp(trial, measurements=measurements, session_id=session_id)
             if span_id is None:
@@ -312,11 +312,11 @@ async def publish_to_intake(
             evaluator_result_count=written,
         )
 
-    outcomes = await asyncio.gather(*(_publish_trial(trial) for trial in result.trials), return_exceptions=True)
+    outcomes = await asyncio.gather(*(_publish_trial(trial) for trial in validated_trials), return_exceptions=True)
 
     published: list[PublishedTrial] = []
     failures: list[tuple[str, BaseException]] = []
-    for trial, outcome in zip(result.trials, outcomes, strict=True):
+    for trial, outcome in zip(validated_trials, outcomes, strict=True):
         if isinstance(outcome, PublishedTrial):
             published.append(outcome)
         else:

--- a/plugins/nemo-evaluator/src/nemo_evaluator/intake/row_adapter.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/intake/row_adapter.py
@@ -30,7 +30,19 @@ from nemo_evaluator_sdk.agent_eval.scores import (
     AgentEvalScoreStatus,
     AgentEvalTaskScore,
 )
-from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial, AgentEvalTrialStatus, AgentOutput
+from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial, AgentEvalTrialStatus, AgentOutput, TrialMeasurements
+from nemo_evaluator_sdk.agent_eval.usage_keys import (
+    CACHE_CREATION_INPUT_TOKENS_KEY,
+    CACHE_READ_INPUT_TOKENS_KEY,
+    CACHED_TOKENS_KEY,
+    COMPLETION_TOKEN_KEYS,
+    PROMPT_TOKEN_KEYS,
+    SEPARATE_CACHE_KEYS,
+    USAGE_COUNT_KEYS,
+    USAGE_DETAILS_KEYS,
+    _first_nonnegative_int,
+    _first_usage_details,
+)
 from nemo_evaluator_sdk.values.dataset_schemas import _KNOWN_BINDING_FIELDS
 from nemo_evaluator_sdk.values.multi_metric_results import BenchmarkEvaluationResult
 from nemo_evaluator_sdk.values.results import EvaluationResult, RowScore
@@ -85,33 +97,15 @@ def _output(row: RowScore) -> AgentOutput | None:
     return AgentOutput(output_text=output_text, response=response)
 
 
-def _first_int(usage: Mapping[str, Any], *keys: str) -> int | None:
-    """First key in ``keys`` holding a token count, or ``None``.
-
-    A count is a non-negative int that is not a bool. Negatives are rejected because they are used
-    as an unknown-value sentinel rather than a measurement, and nothing downstream would catch one:
-    Intake's ``total_prompt_tokens`` is an unconstrained ``int | None``, so a negative would be
-    summed into the evaluation rollup and shown as a real total.
-    """
-    for key in keys:
-        value = usage.get(key)
-        if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
-            return value
-    return None
-
-
-def _token_metadata(row: RowScore) -> dict[str, int]:
-    """Project the generation response's ``usage`` block onto the trial-metadata token keys.
+def _token_measurements(row: RowScore) -> TrialMeasurements:
+    """Normalize the generation response's ``usage`` block into typed measurements.
 
     A row's generation response is the only place its token usage survives: ``row.requests`` mixes
     the generation call with each metric's judge calls, so summing that would credit judge tokens to
-    the agent. ``total_tokens`` is left unset — Intake recomputes it from the parts.
+    the agent. ``TrialMeasurements`` derives the canonical total from the parts.
 
-    Both usage schemas a target can return are read, OpenAI's first: a ``GenericAgent`` points at an
-    arbitrary URL, so the response is whatever that endpoint emits, and an Anthropic-shaped block
-    would otherwise be dropped whole. Note the two disagree on whether cache reads are already
-    counted in the prompt total (OpenAI includes them, Anthropic does not); the values are recorded
-    as reported rather than reconciled, since nothing downstream adds them together.
+    OpenAI's cache detail is already included in prompt tokens. Anthropic's cache
+    creation/read fields are separate and are added to input tokens exactly once.
 
     No key list covers every provider, and a renamed key would fail the same silent way this
     function exists to fix, so a usage block that yields nothing is logged with the keys it actually
@@ -120,24 +114,73 @@ def _token_metadata(row: RowScore) -> dict[str, int]:
     response = row.sample.get("response")
     usage = response.get("usage") if isinstance(response, Mapping) else None
     if not isinstance(usage, Mapping):
-        return {}
-    details = usage.get("prompt_tokens_details")
-    cache_read = _first_int(details, "cached_tokens") if isinstance(details, Mapping) else None
-    if cache_read is None:
-        cache_read = _first_int(usage, "cache_read_input_tokens")
+        return TrialMeasurements()
+    _warn_invalid_usage_counts(usage, row_index=row.row_index)
+
+    separate_cache = any(key in usage for key in SEPARATE_CACHE_KEYS)
+    details = _first_usage_details(usage)
+    inclusive_cache = details is not None and CACHED_TOKENS_KEY in details
+    completion = _first_nonnegative_int(usage, *COMPLETION_TOKEN_KEYS)
+
+    if separate_cache and inclusive_cache:
+        logger.warning(
+            "Row %r generation usage contains both inclusive cache details and separate cache fields; "
+            "omitting ambiguous prompt/cache measurements",
+            row.row_index,
+        )
+        return TrialMeasurements(completion_tokens=completion)
+
+    cache_read = _first_nonnegative_int(usage, CACHE_READ_INPUT_TOKENS_KEY) if separate_cache else None
+    cache_creation = _first_nonnegative_int(usage, CACHE_CREATION_INPUT_TOKENS_KEY) if separate_cache else None
+    invalid_separate_cache = any(
+        key in usage and usage[key] is not None and _first_nonnegative_int(usage, key) is None
+        for key in SEPARATE_CACHE_KEYS
+    )
+    prompt = _first_nonnegative_int(usage, *PROMPT_TOKEN_KEYS)
+    if separate_cache and prompt is not None:
+        prompt = None if invalid_separate_cache else prompt + (cache_creation or 0) + (cache_read or 0)
+    elif details is not None and CACHED_TOKENS_KEY in details:
+        cache_read = _first_nonnegative_int(details, CACHED_TOKENS_KEY)
+
     captured = {
-        "prompt_tokens": _first_int(usage, "prompt_tokens", "input_tokens"),
-        "completion_tokens": _first_int(usage, "completion_tokens", "output_tokens"),
+        "prompt_tokens": prompt,
+        "completion_tokens": completion,
         "cache_read_tokens": cache_read,
-        "cache_creation_tokens": _first_int(usage, "cache_creation_input_tokens"),
+        "cache_creation_tokens": cache_creation,
     }
     recorded = {key: value for key, value in captured.items() if value is not None}
     if not recorded:
         logger.warning(
-            "No token counts recognized in the generation response's usage block; keys present: %s",
+            "Row %r has no recognized token counts in the generation response's usage block; keys present: %s",
+            row.row_index,
             sorted(str(key) for key in usage),
         )
-    return recorded
+    return TrialMeasurements(**recorded)
+
+
+def _warn_invalid_usage_counts(usage: Mapping[str, Any], *, row_index: int | None) -> None:
+    for key in USAGE_COUNT_KEYS:
+        if key in usage and usage[key] is not None and _first_nonnegative_int(usage, key) is None:
+            logger.warning(
+                "Row %r has invalid generation usage %s=%r; expected a non-negative integer and omitted it",
+                row_index,
+                key,
+                usage[key],
+            )
+    for details_key in USAGE_DETAILS_KEYS:
+        details = usage.get(details_key)
+        if (
+            isinstance(details, Mapping)
+            and CACHED_TOKENS_KEY in details
+            and details[CACHED_TOKENS_KEY] is not None
+            and _first_nonnegative_int(details, CACHED_TOKENS_KEY) is None
+        ):
+            logger.warning(
+                "Row %r has invalid generation usage %s.cached_tokens=%r; expected a non-negative integer and omitted it",
+                row_index,
+                details_key,
+                details[CACHED_TOKENS_KEY],
+            )
 
 
 def _scores(row: RowScore, *, run_id: str, task_id: str, trial_id: str) -> list[AgentEvalTaskScore]:
@@ -216,7 +259,7 @@ def row_result_to_agent_eval_result(
                 task_id=task_id,
                 status=AgentEvalTrialStatus.COMPLETED if output is not None else AgentEvalTrialStatus.FAILED,
                 output=output,
-                metadata=_token_metadata(row),
+                measurements=_token_measurements(row),
             )
         )
         scores.extend(_scores(row, run_id=run_id, task_id=task_id, trial_id=trial_id))

--- a/plugins/nemo-evaluator/tests/intake/test_publish.py
+++ b/plugins/nemo-evaluator/tests/intake/test_publish.py
@@ -16,10 +16,15 @@ from typing import Any
 import httpx
 import pytest
 from nemo_evaluator.intake.publish import PublishError, _token_final_metrics, publish_to_intake
-from nemo_evaluator_sdk.agent_eval.metrics import TrialMeasurements
 from nemo_evaluator_sdk.agent_eval.results import AgentEvalResult, AgentEvalSummary, RunMetadata
 from nemo_evaluator_sdk.agent_eval.scores import AgentEvalScoreStatus, AgentEvalTaskScore
-from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial, AgentEvalTrialStatus, AgentOutput, TrialError
+from nemo_evaluator_sdk.agent_eval.trials import (
+    AgentEvalTrial,
+    AgentEvalTrialStatus,
+    AgentOutput,
+    TrialError,
+    TrialMeasurements,
+)
 from nemo_evaluator_sdk.metrics.protocol import MetricOutput
 from nemo_evaluator_sdk.values.evidence import CandidateEvidence, EvidenceDescriptor
 from nemo_platform_plugin.client.errors import NotFoundError, UnprocessableEntityError
@@ -30,6 +35,7 @@ from nemo_platform_plugin.intake.types import (
     IngestResponse,
     ListTracesQueryParams,
 )
+from pydantic import ValidationError
 
 # --- fakes ------------------------------------------------------------------
 
@@ -268,6 +274,25 @@ async def test_publishes_trajectory_and_scores() -> None:
         "span:run-1:t-1",
         3,
     )
+
+
+async def test_publish_revalidates_model_copy_corrupted_measurements_before_network_calls() -> None:
+    trial = _trial("t-1").model_copy(update={"measurements": TrialMeasurements(prompt_tokens=8, completion_tokens=2)})
+    result = _result([trial], [])
+    corrupted_measurements = trial.measurements.model_copy(update={"prompt_tokens": -1})
+    corrupted_trial = trial.model_copy(update={"measurements": corrupted_measurements})
+    corrupted_result = result.model_copy(update={"trials": [corrupted_trial]})
+    client = _FakeClient()
+
+    with pytest.raises(ValidationError):
+        await publish_to_intake(
+            corrupted_result,
+            client=client,
+            experiment_id="exp-1",
+        )
+
+    assert client.evaluation_calls == []
+    assert (client.otlp_calls, client.atif_calls, client.eval_calls) == ([], [], [])
 
 
 async def test_an_unknown_evaluation_fails_the_run_before_any_trial_is_written() -> None:
@@ -550,7 +575,12 @@ async def test_trial_totals_land_on_the_root_span_only() -> None:
     child = {"traceId": _OTLP_TRACE_ID, "spanId": "aabbccddeeff0011", "parentSpanId": _OTLP_SPAN_ID, "name": "child"}
     trial = _otlp_trial(extra_spans=[child]).model_copy(
         update={
-            "metadata": {"prompt_tokens": 120, "completion_tokens": 45, "cache_read_tokens": 30, "cost_usd": 0.134},
+            "measurements": TrialMeasurements(
+                prompt_tokens=120,
+                completion_tokens=45,
+                cache_read_tokens=30,
+                cost_usd=0.134,
+            ),
             "error": TrialError(type="Timeout", message="agent exceeded its budget"),
         }
     )

--- a/plugins/nemo-evaluator/tests/intake/test_row_adapter.py
+++ b/plugins/nemo-evaluator/tests/intake/test_row_adapter.py
@@ -259,14 +259,15 @@ def test_a_metric_error_does_not_fail_the_trial_itself() -> None:
 # --- token usage ------------------------------------------------------------
 
 
-def _usage_metadata(usage: object) -> dict[str, Any]:
-    return _adapt([_row(sample={"output_text": "4", "response": {"usage": usage}})]).trials[0].metadata
+def _usage_measurements(usage: object) -> dict[str, Any]:
+    trial = _adapt([_row(sample={"output_text": "4", "response": {"usage": usage}})]).trials[0]
+    assert trial.metadata == {}
+    return trial.measurements.model_dump(exclude_none=True)
 
 
 def test_openai_usage_becomes_trial_token_measurements() -> None:
-    # Publishing reads these keys off trial metadata, so the names are the contract with
-    # TrialMeasurements.from_metadata; total_tokens is deliberately absent (Intake recomputes it).
-    metadata = _usage_metadata(
+    # OpenAI prompt usage already includes cached tokens; the typed model derives total_tokens.
+    measurements = _usage_measurements(
         {
             "prompt_tokens": 22635,
             "completion_tokens": 2949,
@@ -274,12 +275,17 @@ def test_openai_usage_becomes_trial_token_measurements() -> None:
             "prompt_tokens_details": {"cached_tokens": 1200},
         }
     )
-    assert metadata == {"prompt_tokens": 22635, "completion_tokens": 2949, "cache_read_tokens": 1200}
+    assert measurements == {
+        "prompt_tokens": 22635,
+        "completion_tokens": 2949,
+        "total_tokens": 25584,
+        "cache_read_tokens": 1200,
+    }
 
 
 def test_anthropic_usage_is_read_under_its_own_key_names() -> None:
     # A GenericAgent can target any endpoint, so an Anthropic-shaped block must not be dropped whole.
-    metadata = _usage_metadata(
+    measurements = _usage_measurements(
         {
             "input_tokens": 358,
             "output_tokens": 19324,
@@ -287,45 +293,47 @@ def test_anthropic_usage_is_read_under_its_own_key_names() -> None:
             "cache_creation_input_tokens": 512,
         }
     )
-    assert metadata == {
-        "prompt_tokens": 358,
+    assert measurements == {
+        "prompt_tokens": 3985491,
         "completion_tokens": 19324,
+        "total_tokens": 4004815,
         "cache_read_tokens": 3984621,
         "cache_creation_tokens": 512,
     }
 
 
 def test_openai_keys_win_when_a_response_carries_both_schemas() -> None:
-    metadata = _usage_metadata({"prompt_tokens": 10, "input_tokens": 999, "completion_tokens": 20})
-    assert metadata["prompt_tokens"] == 10
+    measurements = _usage_measurements({"prompt_tokens": 10, "input_tokens": 999, "completion_tokens": 20})
+    assert measurements["prompt_tokens"] == 10
 
 
 @pytest.mark.parametrize("usage", [None, {}, "1000", {"prompt_tokens": None}, {"prompt_tokens": "22635"}])
 def test_unusable_usage_records_no_tokens(usage: object) -> None:
     # A missing count must stay missing rather than land as a wrong number.
-    assert _usage_metadata(usage) == {}
+    assert _usage_measurements(usage) == {}
 
 
 def test_zero_counts_are_recorded_rather_than_dropped() -> None:
     # NAT reports prompt_tokens=0; 0 is a reported measurement and must survive a truthiness filter.
-    assert _usage_metadata({"prompt_tokens": 0, "completion_tokens": 38}) == {
+    assert _usage_measurements({"prompt_tokens": 0, "completion_tokens": 38}) == {
         "prompt_tokens": 0,
         "completion_tokens": 38,
+        "total_tokens": 38,
     }
 
 
 def test_booleans_are_not_counted_as_token_counts() -> None:
-    assert _usage_metadata({"prompt_tokens": True, "completion_tokens": 38}) == {"completion_tokens": 38}
+    assert _usage_measurements({"prompt_tokens": True, "completion_tokens": 38}) == {"completion_tokens": 38}
 
 
 def test_negative_counts_are_rejected_rather_than_summed_into_a_total() -> None:
     # -1 is an unknown-value sentinel, not a measurement, and Intake's token fields carry no ge=0
     # constraint — so publishing one would deflate the evaluation rollup with no error anywhere.
-    assert _usage_metadata({"prompt_tokens": -1, "completion_tokens": 38}) == {"completion_tokens": 38}
+    assert _usage_measurements({"prompt_tokens": -1, "completion_tokens": 38}) == {"completion_tokens": 38}
 
 
 def test_a_negative_falls_through_to_the_next_known_key() -> None:
-    assert _usage_metadata({"prompt_tokens": -1, "input_tokens": 500})["prompt_tokens"] == 500
+    assert _usage_measurements({"prompt_tokens": -1, "input_tokens": 500})["prompt_tokens"] == 500
 
 
 def test_a_row_without_a_response_records_no_tokens() -> None:
@@ -336,12 +344,27 @@ def test_an_unrecognized_usage_schema_is_logged_with_its_keys(caplog: pytest.Log
     # No key list covers every provider, so the one thing that must not happen is a silent blank:
     # the log has to name the real keys, which is what tells us what to add.
     with caplog.at_level(logging.WARNING, logger="nemo_evaluator.intake.row_adapter"):
-        assert _usage_metadata({"promptTokenCount": 12, "candidatesTokenCount": 34}) == {}
+        assert _usage_measurements({"promptTokenCount": 12, "candidatesTokenCount": 34}) == {}
     assert "promptTokenCount" in caplog.text
     assert "candidatesTokenCount" in caplog.text
 
 
 def test_a_recognized_usage_block_logs_nothing(caplog: pytest.LogCaptureFixture) -> None:
     with caplog.at_level(logging.WARNING, logger="nemo_evaluator.intake.row_adapter"):
-        _usage_metadata({"prompt_tokens": 1, "completion_tokens": 2})
+        _usage_measurements({"prompt_tokens": 1, "completion_tokens": 2})
     assert caplog.text == ""
+
+
+def test_mixed_cache_conventions_omit_ambiguous_prompt_and_cache(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.WARNING, logger="nemo_evaluator.intake.row_adapter"):
+        measurements = _usage_measurements(
+            {
+                "input_tokens": 10,
+                "output_tokens": 2,
+                "input_tokens_details": {"cached_tokens": 3},
+                "cache_read_input_tokens": 4,
+            }
+        )
+
+    assert measurements == {"completion_tokens": 2}
+    assert "both inclusive cache details and separate cache fields" in caplog.text

--- a/plugins/nemo-evaluator/tests/test_agent_evaluate.py
+++ b/plugins/nemo-evaluator/tests/test_agent_evaluate.py
@@ -59,6 +59,7 @@ from nemo_evaluator_sdk.agent_eval.trials import (
     AgentEvalTrial,
     AgentEvalTrialStatus,
     AgentOutput,
+    TrialMeasurements,
 )
 from nemo_evaluator_sdk.enums import AgentFormat
 from nemo_evaluator_sdk.metrics.exact_match import ExactMatchMetric
@@ -85,6 +86,7 @@ from nemo_platform_plugin.jobs.execution_profiles import (
 from nemo_platform_plugin.jobs.providers import SubprocessExecutionProvider
 from nemo_platform_plugin.jobs.spec import BaseExecutionProfile, PlatformJobSpec
 from nemo_platform_plugin.scheduler import NemoJobScheduler
+from pydantic import ValidationError
 from pytest_mock import MockerFixture
 from typer.testing import CliRunner
 
@@ -1584,6 +1586,80 @@ async def test_trial_error_survives_the_job_spec_wire_contract() -> None:
     round_tripped = AgentEvalSpec.model_validate(json.loads(json.dumps(spec.model_dump(mode="json"))))
     assert round_tripped.trials is not None
     assert round_tripped.trials[0].error == error
+
+
+@pytest.mark.parametrize("spec_type", [AgentEvalInputSpec, AgentEvalSpec])
+@pytest.mark.parametrize(
+    ("payload", "expected_measurements"),
+    [
+        pytest.param(
+            {
+                "measurements": {
+                    "prompt_tokens": 8,
+                    "completion_tokens": 2,
+                    "runtime_sec": 0,
+                    "cost_usd": 0,
+                },
+                "metadata": {"reward": 0.8},
+            },
+            TrialMeasurements(prompt_tokens=8, completion_tokens=2, runtime_sec=0, cost_usd=0),
+            id="typed",
+        ),
+        pytest.param(
+            {"metadata": {"prompt_tokens": 8, "completion_tokens": 2, "duration_ms": 1500}},
+            TrialMeasurements(),
+            id="metadata-only",
+        ),
+        pytest.param(
+            {
+                "measurements": {"prompt_tokens": 8, "completion_tokens": 2},
+                "metadata": {"prompt_tokens": 999, "completion_tokens": 999, "duration_ms": 1500},
+            },
+            TrialMeasurements(prompt_tokens=8, completion_tokens=2),
+            id="conflicting-metadata",
+        ),
+    ],
+)
+def test_precomputed_trial_measurements_validate_across_both_job_specs(
+    spec_type: type[AgentEvalInputSpec] | type[AgentEvalSpec],
+    payload: dict[str, object],
+    expected_measurements: TrialMeasurements,
+) -> None:
+    row = {"id": "stored-trial", "task_id": "task-1", "status": "partial", **payload}
+
+    spec = spec_type.model_validate(
+        {
+            "trials": [row],
+            "tasks": [_task_spec().model_dump(mode="json")],
+        }
+    )
+
+    assert spec.trials is not None
+    assert spec.trials[0].measurements == expected_measurements
+    assert spec.trials[0].metadata == payload.get("metadata", {})
+
+
+@pytest.mark.parametrize("spec_type", [AgentEvalInputSpec, AgentEvalSpec])
+@pytest.mark.parametrize("measurements", [None, {"prompt_tokens": -1}])
+def test_job_specs_reject_invalid_typed_measurements_without_metadata_fallback(
+    spec_type: type[AgentEvalInputSpec] | type[AgentEvalSpec],
+    measurements: object,
+) -> None:
+    with pytest.raises(ValidationError):
+        spec_type.model_validate(
+            {
+                "trials": [
+                    {
+                        "id": "stored-trial",
+                        "task_id": "task-1",
+                        "status": "partial",
+                        "measurements": measurements,
+                        "metadata": {"prompt_tokens": 8, "duration_ms": 1500},
+                    }
+                ],
+                "tasks": [_task_spec().model_dump(mode="json")],
+            }
+        )
 
 
 async def test_compile_resolves_gym_runner_env_secrets() -> None:


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
<!-- In 1-3 plain sentences, explain what changes and why. Describe before-and-after behavior when it applies. -->

### What
- Moves token, runtime, and cost measurements from loose `AgentEvalTrial.metadata` unstrctured dict keys into a validated `TrialMeasurements` value owned by each trial.
- Keeps historical persisted trials readable through one legacy hydration seam and projects typed values ephemerally for existing custom metrics, without maintaining two durable sources of truth.
- Normalizes measurements from live inference, Callable, Gym, Fabric, and Harbor runtimes through persistence and Intake publication.

### Why

Experimentalist would be migrated from its plugin-specific `EvaluationResult` and `TrialResult` models to the shared SDK `AgentEvalResult` contract ([AALGO-515](https://linear.app/nvidia/issue/AALGO-515/return-agentevalresult-from-experimentalist-evaluators-p41b), [AALGO-516](https://linear.app/nvidia/issue/AALGO-516/migrate-experimentalist-result-consumers-to-agentevalresult-p43)).

Before this change, `AgentEvalResult` had no self-contained, typed contract for operational measurements such as token usage, runtime, and cost. Producers stored these values using runtime-specific metadata conventions, requiring downstream consumers to understand those conventions or reopen native result artifacts.

Experimentalist demonstrates this gap today:

- Its [`TrialResult`](plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/entities.py#L318) has metrics and generic metadata, but no typed measurements.
- Benchmark reporting [reopens each Harbor `result.json`](plugins/nemo-experimentalist/benchmarks/run.py#L251) to recover usage and cost.
- It then [parses Harbor-specific keys](plugins/nemo-experimentalist/benchmarks/run.py#L300) such as `n_input_tokens`, `n_cache_tokens`, and `cost_usd`.

This change adds validated `trial.measurements` to the shared result contract and normalizes measurements at their source. When Experimentalist adopts `AgentEvalResult`, benchmark accounting can consume these values directly without retaining Harbor-specific parsing or reopening the Harbor job tree, as required by AALGO-516.


## Related Issue
<!-- Use Fixes #NNN or Closes #NNN for a related issue. Remove this section if there is none. -->

- [AALGO-513](https://linear.app/nvidia/issue/AALGO-513)

## Changes
<!-- List the concrete changes included in this pull request. -->

- Adds a frozen, validated `TrialMeasurements` model to `AgentEvalTrial`, including canonical `total_tokens` derivation and finite, non-negative measurement constraints.
- Hydrates legacy metadata-backed measurements only while loading historical persisted trials, then strips the migrated keys.
- Captures provider-specific token/cache usage and runtime/cost measurements across live inference and all supported agent runtimes.
- Revalidates trials at evaluation, persistence, and Intake publication boundaries so unchecked `model_copy(update=...)` values cannot escape.
- Preserves legacy custom-metric behavior with an in-memory measurement projection while keeping durable trial metadata measurement-free.
- Updates persistence, Intake mapping, OpenAPI, examples, documentation, and focused contract tests.

## Review this first

The user-visible contract is: **trial measurements have one durable, typed home; compatibility happens only at explicit read or scoring boundaries.** Rewards, pass/fail, errors, and provenance remain separate scoring or metadata concepts.

Skip OpenAPI, Intake plumbing, and example call-site migrations on the first pass. They carry the same model through downstream surfaces; they do not define the ownership or normalization rules.

Read these in order:

1. [`trials.py`](https://github.com/NVIDIA-NeMo/nemo-platform/blob/aalgo-513-trial-measurements/ngoncharenko/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/trials.py) — the `TrialMeasurements` model, invariants, `AgentEvalTrial.measurements`, and legacy hydration boundary.
2. [`evaluator.py`](https://github.com/NVIDIA-NeMo/nemo-platform/blob/aalgo-513-trial-measurements/ngoncharenko/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/evaluator.py) — live-response normalization, runtime revalidation, and ephemeral metric compatibility projection.
3. [`usage.py`](https://github.com/NVIDIA-NeMo/nemo-platform/blob/aalgo-513-trial-measurements/ngoncharenko/packages/nemo_evaluator_sdk/examples/run_agent_eval/usage.py) — multi-message aggregation and cache-convention ambiguity handling.
4. [`harbor_trial_adapter.py`](https://github.com/NVIDIA-NeMo/nemo-platform/blob/aalgo-513-trial-measurements/ngoncharenko/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/harbor_trial_adapter.py) and [`fabric/runtime.py`](https://github.com/NVIDIA-NeMo/nemo-platform/blob/aalgo-513-trial-measurements/ngoncharenko/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/fabric/runtime.py) — producer precedence, per-field fallback, and invalid-aggregate handling.
5. [`test_measurement_contract.py`](https://github.com/NVIDIA-NeMo/nemo-platform/blob/aalgo-513-trial-measurements/ngoncharenko/packages/nemo_evaluator_sdk/tests/agent_eval/test_measurement_contract.py) — the source-of-truth tripwire preventing production code from drifting back to durable metadata reads.

### Before / after: one durable source

**Before.** Producers stamped loosely typed values into metadata, so every consumer had to rediscover validation and fallback rules:

```python
AgentEvalTrial(
    ...,
    metadata={"prompt_tokens": 80, "completion_tokens": 20, "runtime_sec": 4.5},
)
```

**After.** Producers construct one validated value and consumers read it directly:

```python
AgentEvalTrial(
    ...,
    measurements=TrialMeasurements(
        prompt_tokens=80,
        completion_tokens=20,
        runtime_sec=4.5,
    ),
)
```

| Boundary | Behavior |
|---|---|
| New trials | Write only `trial.measurements`; measurement keys are absent from durable metadata. |
| Historical JSONL/job payloads | Hydrate recognized legacy keys once; a valid `runtime_sec` wins, otherwise valid `duration_ms` falls back to seconds. |
| Existing custom metrics | Receive a temporary projection in metric input metadata; the stored trial is not mutated. |
| Persistence and publication | Revalidate the full trial before writing or sending it. |

Invariant to check: after hydration, `trial.measurements` is authoritative and the migrated metadata keys are gone.

### Before / after: token totals and cache conventions

**Before.** Independent adapters could trust provider totals, double-count cached input, or publish earlier partial prompt totals after a later message made the cache representation ambiguous.

**After.** Every adapter uses the same canonical rules:

| Provider shape | Prompt treatment | Cache fields |
|---|---|---|
| Inclusive cache details | Prompt already includes cached input; do not add it again. | Record `cache_read_tokens` as the subset. |
| Separate cache creation/read fields | Add valid cache creation and read counts to the uncached input count. | Preserve both typed cache fields. |
| Both conventions in one contribution | Omit ambiguous prompt/cache measurements. | Preserve independently valid completion tokens. |
| Multi-message aggregate with any ambiguous contribution | Poison prompt/cache for the whole trial rather than publishing a partial total. | Preserve independently valid completion tokens. |

`total_tokens` is never trusted from a provider. It is derived only when both canonical prompt and completion counts are available, including valid zero counts.

### Runtime-specific precedence

| Runtime | Measurement source and precedence |
|---|---|
| Live inference / Gym | Normalize response `usage`, including chat/Responses aliases and cache conventions. |
| Callable | Forward the producer-supplied typed measurements unchanged. |
| Fabric | Resolve each ATIF final metric independently; fall back to step sums only when that field is absent. |
| Harbor | Prefer a mapping-valued top-level `agent_result`, otherwise aggregate steps; prefer top-level agent execution time, otherwise sum valid step windows. |

An explicitly malformed contributor poisons only its affected aggregate. Missing data remains omitted; it is never converted to zero.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `flox -q activate -- uv run pre-commit run -a` — passed, including repository-wide Ruff and `ty` checks, generated-doc checks, lock checks, and merge-conflict detection.
- `uv run --frozen pytest packages/nemo_evaluator_sdk/tests/agent_eval/test_trials.py packages/nemo_evaluator_sdk/tests/agent_eval/test_evaluator.py packages/nemo_evaluator_sdk/tests/agent_eval/test_persistence.py packages/nemo_evaluator_sdk/tests/agent_eval/test_callable_runtime.py packages/nemo_evaluator_sdk/tests/agent_eval/test_fabric_runtime.py packages/nemo_evaluator_sdk/tests/agent_eval/test_gym_runtime.py packages/nemo_evaluator_sdk/tests/agent_eval/test_harbor_runtime.py packages/nemo_evaluator_sdk/tests/agent_eval/test_harbor_resume_reconciliation.py packages/nemo_evaluator_sdk/tests/agent_eval/test_measurement_contract.py packages/nemo_evaluator_sdk/tests/agent_eval/test_run_agent_eval_measurements.py packages/nemo_evaluator_sdk/tests/agent_eval/test_usage_keys.py plugins/nemo-evaluator/tests/intake/test_row_adapter.py plugins/nemo-evaluator/tests/intake/test_publish.py plugins/nemo-evaluator/tests/test_agent_evaluate.py -q` — 684 passed.
- Targeted Ruff lint/format and conflict-focused `ty check` — passed.
- `make docs-check` — passed; 224 MDX files parsed cleanly.
- `make docs-check-python-snippets DOCS_PATH=docs/evaluator/agent-eval/writing-metrics.mdx` — 6 snippets passed syntax and type checks.
- `make docs-broken-links` — reports three existing `/documentation/studio/customization` links in `docs/studio/index.mdx` and `docs/studio/model-evaluations.mdx`, outside this PR's changed files.
- Direct host `uv run pre-commit run -a` was blocked only by missing `helm-docs` and host uv 0.9.30 versus the required 0.9.14; the same full gate passed in the pinned Flox environment above.
- A direct changed-file `ty check` in the host optional-dependency environment reported existing diagnostics on unchanged example/Fabric lines; the repository-pinned full `ty` hook passed in Flox above.

<!-- List each command and result. Explain skipped, blocked, or non-successful checks without marking them as passed. -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added structured trial measurements for token usage, runtime, and cost.
  - Added support for usage data from multiple provider formats, including cache-token details.
  - Exposed measurements in persisted trials, metrics, publishing, and API schemas.

- **Bug Fixes**
  - Invalid, ambiguous, or incomplete usage data is safely excluded with warnings.
  - Trial validation now occurs before scoring, persistence, and publishing.
  - Gating reports tasks without completed rewards as unscored.

- **Documentation**
  - Expanded guidance on measurement fields, metadata precedence, and reading measurements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->