### PR TITLE
feat(sandboxed-gym): let a caller choose where the episode broker runs

### DIFF
--- a/packages/sandboxed_gym/src/sandboxed_gym/orchestrator.py
+++ b/packages/sandboxed_gym/src/sandboxed_gym/orchestrator.py
@@ -19,7 +19,7 @@ import urllib.error
 import urllib.request
 from collections.abc import Callable, Coroutine, Mapping
 from types import FrameType
-from typing import Any, TypeVar
+from typing import Any, Protocol, TypeVar
 from urllib.parse import urlparse
 
 from sandboxed_gym.broker import EpisodeBrokerServer
@@ -339,7 +339,7 @@ class SandboxedGymSession:
         self,
         *,
         cfg: SandboxedGymServeConfig,
-        broker_server: EpisodeBrokerServer,
+        broker_server: EpisodeBroker,
         broker: BrokerEndpoint,
         host_provider: SandboxedGymHostProvider,
         host: GymHostHandle,
@@ -646,40 +646,76 @@ class SandboxedGymSession:
             LOGGER.exception("Failed to shut down episode broker")
 
 
+class EpisodeBroker(Protocol):
+    """All the orchestrator needs of a broker: somewhere to start it, and a way to stop it.
+
+    Narrow on purpose -- anything added here couples the orchestrator to how a broker is hosted,
+    which is the caller's choice to make.
+    """
+
+    def start(self) -> BrokerEndpoint: ...
+
+    def shutdown(self) -> None: ...
+
+
 class SandboxedGymOrchestrator:
     """Start episode broker, provision Gym host, return a live session."""
 
-    def start(self, cfg: SandboxedGymServeConfig | Mapping[str, Any]) -> SandboxedGymSession:
+    def start(
+        self,
+        cfg: SandboxedGymServeConfig | Mapping[str, Any],
+        *,
+        broker: EpisodeBroker | None = None,
+    ) -> SandboxedGymSession:
+        """Bring up a session, hosting the broker in this process unless given one.
+
+        The default hosts it on a background thread here, which suits a caller that rarely
+        creates episodes -- an ordinary evaluation creates none. Pass a broker that runs
+        elsewhere when they are created heavily: a SWE rollout crosses the broker on every
+        ``exec``, and that traffic would otherwise contend for this process's GIL.
+
+        A supplied broker is configured by its owner; ``cfg.episode_broker`` is not applied to it.
+        """
         if not isinstance(cfg, SandboxedGymServeConfig):
             cfg = SandboxedGymServeConfig.model_validate(cfg)
 
-        broker_cfg = cfg.broker_config()
-        broker_server = EpisodeBrokerServer(broker_cfg)
-        broker = broker_server.start()
+        broker_server: EpisodeBroker = broker if broker is not None else EpisodeBrokerServer(cfg.broker_config())
+        broker_endpoint = broker_server.start()
 
-        host_spec = build_gym_host_spec(cfg, broker)
-        host_provider = get_host_provider(cfg.host_provider, cfg.sandbox.host_provider_options)
-        # Use one loop for create, wait-ready, and destroy. A new asyncio.run() for
-        # each call closes the SDK client that create_host just built.
-        async_runner = _SessionAsyncRunner()
-        host: GymHostHandle | None = None
+        # The broker is serving from here on, so every later failure has to release it --
+        # including provider selection, which rejects an unknown name or a bad option. An
+        # injected broker can be a Ray actor, which would otherwise outlive this process.
         try:
-            host = async_runner.run(host_provider.create_host(host_spec))
-            async_runner.run(host_provider.wait_ready(host, cfg.sandbox.ready_timeout_s))
+            host_spec = build_gym_host_spec(cfg, broker_endpoint)
+            host_provider = get_host_provider(cfg.host_provider, cfg.sandbox.host_provider_options)
+            # Use one loop for create, wait-ready, and destroy. A new asyncio.run() for
+            # each call closes the SDK client that create_host just built.
+            async_runner = _SessionAsyncRunner()
+            host: GymHostHandle | None = None
+            try:
+                host = async_runner.run(host_provider.create_host(host_spec))
+                async_runner.run(host_provider.wait_ready(host, cfg.sandbox.ready_timeout_s))
+            except Exception:
+                if host is not None:
+                    try:
+                        async_runner.run(host_provider.destroy_host(host))
+                    except Exception:
+                        LOGGER.exception("Failed to destroy sandboxed Gym host after startup failure")
+                async_runner.close()
+                raise
         except Exception:
-            if host is not None:
-                try:
-                    async_runner.run(host_provider.destroy_host(host))
-                except Exception:
-                    LOGGER.exception("Failed to destroy sandboxed Gym host after startup failure")
-            broker_server.shutdown()
-            async_runner.close()
+            # A supplied broker is the caller's code. Let its failure be logged rather than
+            # replace the startup error that is the reason we are here.
+            try:
+                broker_server.shutdown()
+            except Exception:
+                LOGGER.exception("Failed to shut down episode broker after startup failure")
             raise
 
         return SandboxedGymSession(
             cfg=cfg,
             broker_server=broker_server,
-            broker=broker,
+            broker=broker_endpoint,
             host_provider=host_provider,
             host=host,
             async_runner=async_runner,

--- a/packages/sandboxed_gym/src/sandboxed_gym/ray/broker_actor.py
+++ b/packages/sandboxed_gym/src/sandboxed_gym/ray/broker_actor.py
@@ -5,12 +5,15 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 import ray
 
 from sandboxed_gym.broker import EpisodeBrokerServer
 from sandboxed_gym.config import BrokerEndpoint, EpisodeBrokerConfig
+
+LOGGER = logging.getLogger(__name__)
 
 BROKER_ACTOR_FQN = "sandboxed_gym.ray.broker_actor.SandboxEpisodeBrokerActor"
 
@@ -51,3 +54,44 @@ def start_episode_broker(
     actor = SandboxEpisodeBrokerActor.options(**options).remote(config)
     endpoint = ray.get(actor.start.remote())
     return actor, endpoint
+
+
+class RayEpisodeBroker:
+    """Runs the broker in its own Ray actor, for :meth:`SandboxedGymOrchestrator.start`.
+
+    Worth choosing when a job's environments open episodes often: the broker serves every episode
+    ``exec``, and hosting it here keeps that traffic off the calling process's GIL.
+
+    Ray supplies placement and lifecycle only. The HTTP server still runs on a background thread
+    inside the actor, so requests never serialize through Ray actor dispatch -- which is what
+    makes this a placement decision rather than a throughput one.
+    """
+
+    def __init__(
+        self,
+        config: EpisodeBrokerConfig | dict[str, Any],
+        *,
+        node_id: str | None = None,
+        extra_ray_options: dict[str, Any] | None = None,
+    ) -> None:
+        self._config = config
+        self._node_id = node_id
+        self._extra_ray_options = extra_ray_options
+        self._actor: Any | None = None
+
+    def start(self) -> BrokerEndpoint:
+        self._actor, endpoint = start_episode_broker(
+            self._config, node_id=self._node_id, extra_ray_options=self._extra_ray_options
+        )
+        return endpoint
+
+    def shutdown(self) -> None:
+        """Stop the actor. Logged rather than raised: a caller is already tearing down."""
+        if self._actor is None:
+            return
+        try:
+            ray.get(self._actor.shutdown.remote())
+        except Exception:
+            LOGGER.exception("Failed to shut down the episode broker actor")
+        finally:
+            self._actor = None

--- a/packages/sandboxed_gym/tests/test_session_and_advertise.py
+++ b/packages/sandboxed_gym/tests/test_session_and_advertise.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import asyncio
 from unittest.mock import MagicMock
 
+import pytest
 import sandboxed_gym.orchestrator as orchestrator_module
 from sandboxed_gym.broker import EpisodeBrokerServer
 from sandboxed_gym.config import BrokerEndpoint, EpisodeBrokerConfig
@@ -128,3 +129,134 @@ def test_host_sdk_lifecycle_uses_one_event_loop(monkeypatch):
 
     assert len(loops) == 3
     assert loops[0] is loops[1] is loops[2]
+
+
+# --------------------------------------------------------------------------------------------
+# Choosing where the broker runs
+# --------------------------------------------------------------------------------------------
+
+
+def _minimal_cfg() -> SandboxedGymServeConfig:
+    return SandboxedGymServeConfig.model_validate(
+        {
+            "job_id": "job-1",
+            "sandbox": {
+                "image": "runtime:dev",
+                "network_policy": {"egress_allow": []},
+                "environment_pvc_claim": "env",
+                "workspace_pvc_claim": "work",
+            },
+        }
+    )
+
+
+def _stub_host_provider(monkeypatch, *, ready_fails: bool = False):
+    """Patch out host provisioning so only broker selection is under test."""
+    host = GymHostHandle(host_id="h1", health_url="http://host/health", rollout_url="http://host/rollouts/run")
+    destroyed: list[str] = []
+
+    class HostProvider:
+        async def create_host(self, spec):
+            return host
+
+        async def wait_ready(self, handle, timeout_s):
+            if ready_fails:
+                raise RuntimeError("host never came up")
+
+        async def destroy_host(self, handle):
+            destroyed.append(handle.host_id)
+
+    monkeypatch.setattr(orchestrator_module, "get_host_provider", lambda name, options: HostProvider())
+    return destroyed
+
+
+def _fake_broker() -> MagicMock:
+    broker = MagicMock()
+    broker.start.return_value = BrokerEndpoint(url="http://injected:9000", host="injected", port=9000, token="itok")
+    return broker
+
+
+def test_a_supplied_broker_is_used_instead_of_starting_one_here(monkeypatch):
+    """The whole point: the caller decides where the broker runs."""
+    _stub_host_provider(monkeypatch)
+    in_process = MagicMock()
+    monkeypatch.setattr(orchestrator_module, "EpisodeBrokerServer", lambda config: in_process)
+    injected = _fake_broker()
+
+    session = SandboxedGymOrchestrator().start(_minimal_cfg(), broker=injected)
+    try:
+        injected.start.assert_called_once()
+        # Not merely "ours was used" -- nothing may start a second broker holding the same
+        # credential.
+        in_process.start.assert_not_called()
+        assert session.broker.url == "http://injected:9000"
+    finally:
+        # The only test here that reaches a live session; closing it releases the runner thread.
+        session.shutdown()
+
+
+def test_a_supplied_broker_is_shut_down_with_the_session(monkeypatch):
+    _stub_host_provider(monkeypatch)
+    injected = _fake_broker()
+
+    SandboxedGymOrchestrator().start(_minimal_cfg(), broker=injected).shutdown()
+
+    injected.shutdown.assert_called_once()
+
+
+def test_a_supplied_broker_is_shut_down_when_the_host_never_becomes_ready(monkeypatch):
+    """A broker left running past a failed spinup holds its port and its credential."""
+    destroyed = _stub_host_provider(monkeypatch, ready_fails=True)
+    injected = _fake_broker()
+
+    with pytest.raises(RuntimeError, match="never came up"):
+        SandboxedGymOrchestrator().start(_minimal_cfg(), broker=injected)
+
+    injected.shutdown.assert_called_once()
+    assert destroyed == ["h1"]
+
+
+def test_a_supplied_broker_is_shut_down_when_the_host_provider_is_unknown(monkeypatch):
+    """Provisioning is not the only step that can fail after the broker is already serving.
+
+    `get_host_provider` rejects an unknown name and a bad option -- ordinary config mistakes,
+    reached before any host exists.
+    """
+    monkeypatch.setattr(
+        orchestrator_module,
+        "get_host_provider",
+        lambda name, options: (_ for _ in ()).throw(ValueError("Unknown sandboxed gym host provider: 'nope'")),
+    )
+    injected = _fake_broker()
+
+    with pytest.raises(ValueError, match="Unknown sandboxed gym host provider"):
+        SandboxedGymOrchestrator().start(_minimal_cfg(), broker=injected)
+
+    injected.shutdown.assert_called_once()
+
+
+def test_a_broker_that_fails_to_shut_down_does_not_hide_why_startup_failed(monkeypatch):
+    """The startup error is the diagnosis; a failed cleanup of caller code must not replace it."""
+    _stub_host_provider(monkeypatch, ready_fails=True)
+    injected = _fake_broker()
+    injected.shutdown.side_effect = RuntimeError("broker actor already dead")
+
+    closed: list[bool] = []
+    real_runner = orchestrator_module._SessionAsyncRunner
+
+    class RecordingRunner(real_runner):
+        def close(self) -> None:
+            closed.append(True)
+            super().close()
+
+    monkeypatch.setattr(orchestrator_module, "_SessionAsyncRunner", RecordingRunner)
+
+    with pytest.raises(RuntimeError, match="never came up"):
+        SandboxedGymOrchestrator().start(_minimal_cfg(), broker=injected)
+
+    # Without this the test would also pass if cleanup skipped the broker entirely: the raising
+    # shutdown is only interesting once we know it was reached.
+    injected.shutdown.assert_called_once()
+    # The loop thread is released before the broker is asked to stop, so a broker that raises
+    # cannot strand it.
+    assert closed == [True]


### PR DESCRIPTION
## Summary

`SandboxedGymOrchestrator.start` always hosted the episode broker in its own process. That is right for a caller that rarely opens episodes — an ordinary evaluation opens none — and wrong for NeMo-RL, where a SWE rollout crosses the broker on every episode `exec` while the same process is postprocessing results (tokenizer-bound). The NeMo-RL fork avoided that GIL sharing by giving the broker its own Ray actor; adopting the wheel would have silently given it up.

Before: the process is fixed. After: `start(cfg, broker=...)` takes one, defaulting to today's behaviour.

## Related Issue

Part of [AALGO-583](https://linear.app/nvidia/issue/AALGO-583/share-the-sandboxed-gym-implementation-as-a-sandboxed-gym-wheel). Prerequisite for the NeMo-RL branch, which will pass `RayEpisodeBroker`.

## Changes

- `orchestrator.py`: `EpisodeBroker`, a two-method `Protocol` (`start() -> BrokerEndpoint`, `shutdown()`); `start()` gains a keyword-only `broker` argument defaulting to `EpisodeBrokerServer`, which already satisfies it.
- `ray/broker_actor.py`: `RayEpisodeBroker` satisfies the same protocol over `start_episode_broker`, with optional `node_id` pinning.
- Three tests: a supplied broker is used *and* no second one is started; it is shut down with the session; it is shut down when the host never becomes ready.

### Design notes

**Injection rather than a config flag.** A `episode_broker.host: ray` field would be selectable from `serve.yaml`, but it would put Ray in the core orchestrator's vocabulary for a mode that only means anything inside a Ray cluster. Injection keeps `ray` a genuine extra — the orchestrator names no Ray type, and a caller that never imports `sandboxed_gym.ray` is unaffected.

**Ray is placement and lifecycle only, not the request path.** `RayEpisodeBroker` does not change how requests are served: the HTTP server still runs on a background thread inside the actor, exactly as `EpisodeBrokerServer` does in-process, so nothing serializes through Ray actor dispatch. The difference is which process — and therefore which GIL — serves episode traffic. The Gym host reaches the broker over HTTP either way and is never handed a Ray handle.

**Default unchanged.** Evaluator and `sandboxed-gym serve` keep the process they have today; `serve.py` needed no change.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: the choice and its rationale are documented on `EpisodeBroker`, `start()` and `RayEpisodeBroker`, where a caller meets them. The package README describes the trust boundary, which is unchanged.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `uv run --frozen pytest packages/sandboxed_gym/tests -q` → **301 passed, 5 skipped** (298 before)
- hooks on the changed files: `ruff`, `ruff format`, `ty`, copyright, merge-conflict — all pass
- Mutation-checked the new tests: making `start()` ignore the supplied broker fails all three.

`RayEpisodeBroker` is not exercised against a live Ray cluster here — it is a thin wrapper over the existing `start_episode_broker`, and the package's Ray surface is covered by `test_ray_actors.py` (import/shape only, no cluster). The NeMo-RL branch is where it gets a real run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for externally managed episode brokers during sandboxed session startup.
  * Added Ray-based broker support with optional node placement and configuration options.
  * Broker endpoints are obtained automatically during session setup.

* **Reliability**
  * Improved broker lifecycle management, including cleanup after startup and host-readiness failures.
  * Broker shutdown failures are logged without replacing the original startup error.
  * Improved support for reusing brokers across sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->