### PR TITLE
feat(eval-author): harden trace environment generation

### DIFF
--- a/plugins/nemo-eval-author/skills/eval-author-trace-environment/SKILL.md
+++ b/plugins/nemo-eval-author/skills/eval-author-trace-environment/SKILL.md
@@ -20,7 +20,9 @@ not-for:
 compatibility: >-
   Python 3.11 or later for the standalone helper. MLflow normalization uses the
   sibling mlflow-to-atif skill. Intake reads require the nemo CLI. Candidate
-  verification requires an existing Harbor installation and Docker. No model,
+  verification requires an existing Harbor installation and Docker.
+  Proof-input recording and proof checks use Harbor's Task API;
+  run those commands in the existing Harbor Python environment. No model,
   provider, or agent-framework configuration is required.
 maturity: alpha
 license: Apache-2.0
@@ -36,9 +38,10 @@ reproducible Harbor task. It does not require a particular coding agent, model,
 or framework.
 
 ```text
-bounded source → canonical ATIF → private text scrub → candidate decision
-                                                     ├─ no_candidate → summary
-                                                     └─ candidate → Harbor task → summary
+bounded source → canonical ATIF → private text scrub → contextual audit
+                                                        └─ candidate decision
+                                                           ├─ no_candidate → summary
+                                                           └─ candidate → isolated Harbor proof → review → summary
 ```
 
 The ATIF file is the only handoff into candidate analysis. Keep exact source
@@ -54,15 +57,22 @@ Use one workspace per task:
   .gitignore
   <task-id>/
     private/source.atif.json
+    private/canonical.atif.json
+    private/privacy-audit.json
     private/ground-truth/
     safe/trace.atif.json
     safe/privacy.json
     candidate.json
     task/
+    reproducibility.json
     validation.json
     summary.json
     summary.md
 ```
+
+The original bytes, normalized canonical ATIF, safe ATIF, privacy report, audit,
+ground truth, and Harbor jobs stay ignored. The declassified reproducibility
+manifest is published only through the helper's whitelist-only `export` command.
 
 `scripts/trace_environment.py init` writes the parent `.gitignore` so every
 task directory is ignored, makes directories owner-only, and refuses to replace
@@ -127,6 +137,17 @@ no_candidate instead of guessing.
 
 Before continuing, verify the canonical file has one ATIF v1.0-v1.7 object, one-based
 sequential step IDs, at least one user step, and resolvable tool-call references.
+The helper accepts at most 128 MiB of exact source bytes and produces canonical
+and safe files of at most 25 MiB. It may make only two bounded normalizations:
+
+- insert a missing JSON escape when the parser-implicated quote immediately
+  follows a provider-redaction placeholder; and
+- convert string-encoded ATIF image objects into image parts while omitting
+  encoded binary data and oversized image metadata.
+
+Every operation, offset, count, and loss is recorded in the canonical ATIF and
+summary. Exact source bytes remain unchanged and hashed. Reject unrelated JSON
+damage instead of repairing it heuristically.
 
 ## Step 3: make a text-only safe copy
 
@@ -137,16 +158,29 @@ python <skill_dir>/scripts/trace_environment.py prepare \
   --source-kind <atif|mlflow|intake|otel>
 ```
 
-The helper retains an exact owner-private original, writes a scrubbed safe copy,
-replaces image parts with omission markers, and records only redaction counts.
+The helper retains an exact owner-private original, writes the bounded canonical
+ATIF and a scrubbed safe copy, replaces image parts with omission markers, and
+records only redaction counts in the safe report.
 It recognizes common secret fields, bearer tokens, private keys, email addresses,
-phone numbers, social-security numbers, IP addresses, and user home paths.
+phone numbers, social-security numbers, IP addresses, internal Kubernetes hostnames,
+and user home paths.
 
-This deliberately small scanner cannot recognize names, organizations, street
-addresses, proprietary code, or every credential format. Review every text field
-in `safe/trace.atif.json` and the generalized task files before passing
-`--privacy-reviewed`. Never copy a redacted value into a verifier. An image-only
-user instruction is a blocking reason and must remain no_candidate.
+The helper also writes `private/privacy-audit.json`: a complete string-field and
+character denominator, URL hosts, and candidate name, organization, and street
+address findings. These are contextual leads, not automatic claims. Review every
+text field in `safe/trace.atif.json`, every audit finding and host, and the
+generalized task files, then record who performed the review:
+
+```bash
+python <skill_dir>/scripts/trace_environment.py review-privacy \
+  --task-dir <task-dir> \
+  --reviewer-kind <agent|human> \
+  --note "<what was reviewed and any disposition>"
+```
+
+Never copy a redacted value into a verifier. An image-only user instruction is a
+blocking reason and must remain no_candidate. The scanner cannot establish that
+proprietary code is safe; the contextual reviewer owns that judgment.
 
 ## Step 4: inventory ground truth and software requirements
 
@@ -161,15 +195,28 @@ agent's observed answer:
 An agent answer is not ground truth merely because the trace succeeded. Record
 ground truth as `available`, `partial`, `absent`, or `unknown`. Retain available
 artifacts under `private/ground-truth/`, make them owner-only, record their
-SHA-256 digests, and cite the ATIF steps that establish their relationship to
-the task. Do not copy private ground-truth values into the generated task;
-generalize only what the verifier needs.
+SHA-256 digests, and declare whether each artifact came from an ATIF step or an
+external source. ATIF provenance requires real step IDs and no external locator.
+External provenance requires an empty step list and at least one immutable URI,
+revision, or source ID. Never cite an instruction step as evidence for a public
+benchmark fixture merely because both describe the same task. Record whether
+ground truth is used for `comparison_only` or `verification`; use `none` when it
+is absent or unknown. Do not copy private ground-truth values into the generated
+task; generalize only what the verifier needs.
 
 Also inventory software needed to reproduce the work or verify the outcome.
 Include libraries and CLIs, desktop applications such as CAD tools, services,
 hardware, and proprietary or commercially licensed software. For each item,
 record whether it is actually required, its version when known, license class,
 local availability, redistributability, evidence steps, and a short note.
+Use the same explicit ATIF-or-external provenance object for software facts.
+
+Inventory the complete build, runtime, solution, and verifier dependency
+closure. Pin images, packages, repositories, and tools where reproducibility
+depends on them. The grading path must not download dependencies or contact a
+live service. A dependency needed only by the verifier still belongs in the
+inventory; common misses include fonts, compiler headers, package indexes, and
+language registries.
 
 Do not silently replace required software with a different application or mock
 when the requested behavior depends on the real product. Required unavailable
@@ -186,22 +233,32 @@ this shape:
 
 ```json
 {
-  "schema": "nemo.eval_author.trace_environment_candidate.v1",
+  "schema": "nemo.eval_author.trace_environment_candidate.v2",
   "status": "candidate",
+  "decision_basis": "safe_atif_only",
   "instruction": "Observable task instruction without private values",
-  "requirements": ["Objectively testable requirement"],
+  "requirements": [
+    {"description": "Objectively testable requirement", "evidence_steps": [1, 2]}
+  ],
   "verification_mode": "execution",
   "evidence_steps": [1, 2],
   "uncertainties": [],
   "reason_codes": [],
   "ground_truth": {
     "availability": "available",
+    "use": "comparison_only",
     "artifacts": [
       {
         "kind": "expected_output",
         "path": "private/ground-truth/expected.json",
         "sha256": "sha256:<64-hex-digest>",
-        "evidence_steps": [2],
+        "provenance": {
+          "kind": "external",
+          "step_ids": [],
+          "uri": "https://example.test/fixture.json",
+          "revision": "<immutable-revision>",
+          "source_id": null
+        },
         "notes": "Expected output attached to the recorded task."
       }
     ],
@@ -216,7 +273,13 @@ this shape:
       "license": "proprietary",
       "availability": "unknown",
       "redistributable": false,
-      "evidence_steps": [1, 2],
+      "provenance": {
+        "kind": "atif_step",
+        "step_ids": [1, 2],
+        "uri": null,
+        "revision": null,
+        "source_id": null
+      },
       "notes": "The requested edit and verifier depend on native CAD behavior."
     }
   ]
@@ -241,6 +304,13 @@ Typical reasons are `missing_instruction`,
 reproducible task. Ground truth may be absent without blocking a task, but its
 absence must be explicit.
 
+For batch reporting, distinguish source and construction failures rather than
+folding them into `insufficient_trace_evidence`: use `malformed_atif`,
+`source_too_large`, `build_dependency_unavailable`,
+`verifier_dependency_unavailable`, `network_dependency_required`, and
+`verifier_not_isolated` where applicable. Record the concrete failed command or
+contract check in `did_not_work`; keep `reason_codes` stable and aggregateable.
+
 ## Step 6: author and prove a candidate environment
 
 Skip this step for no_candidate. Under `<task-dir>/task/`, create the smallest
@@ -254,6 +324,51 @@ generalized outcome:
 - `solution/solve.sh` with the reference solution; and
 - `README.md` containing reviewer-facing development context, not a copy of the
   agent instruction.
+
+`task.toml` must explicitly set `[verifier].environment_mode = "separate"`,
+`[verifier].network_mode = "no-network"`, and a
+`[verifier.environment]` table whose `network_mode` is also `"no-network"`.
+The helper rejects shared verification because it lets the grader observe or
+alter the agent container and can expose hidden tests to the agent. When the
+grader needs a different image, provide a verifier-owned `tests/Dockerfile` or
+a pinned verifier image through `[verifier.environment]`; include its complete
+grading dependency closure and `/tests` tree.
+
+For a multi-step task, every step inherits the top-level separate verifier.
+An explicit `[steps.verifier]` override must not select `shared`. When a step
+defines `[steps.verifier.environment]`, that environment must also set
+`network_mode = "no-network"`. Transfer only the declared agent-produced
+artifacts into the verifier environment; do not mount or copy the agent
+workspace wholesale.
+
+Read and follow `references/environment-integrity.md` for agent-network,
+contamination, portability, repeat-run, and negative-control requirements.
+
+```toml
+[verifier]
+environment_mode = "separate"
+network_mode = "no-network"
+
+[verifier.environment]
+network_mode = "no-network"
+
+[environment]
+network_mode = "no-network"
+```
+
+Add a step-local environment only when that step needs a different verifier
+image or resource configuration:
+
+```toml
+[[steps]]
+name = "grade"
+
+[steps.verifier]
+environment_mode = "separate"
+
+[steps.verifier.environment]
+network_mode = "no-network"
+```
 
 The task README is not passed to the agent. Give it a level-one task title and
 these substantive level-two sections:
@@ -279,31 +394,37 @@ Do not copy private trace payloads into the task. Include only the minimal files
 needed to reproduce the starting state. Pin external source to an exact public
 commit when it is truly required; otherwise prefer a small local fixture.
 
-Run both deterministic arms:
+Before Harbor, record the exact task tree and its static integrity scan:
 
 ```bash
-harbor run -p <task-dir>/task -a nop
-harbor run -p <task-dir>/task -a oracle
+python <skill_dir>/scripts/trace_environment.py record-reproducibility \
+  --task-dir <task-dir>
 ```
 
-NOP must finish without an exception and receive reward `0`; Oracle must finish
-without an exception and receive reward `1`. Do not weaken the verifier to make
-Oracle pass. Write their exact evidence to `validation.json`:
+Run at least two independent NOP jobs, two Oracle jobs, and one task-specific
+negative-control job. Record each run's inputs before Harbor creates its job
+directory. Each invocation must create fresh task containers. For example:
 
-```json
-{
-  "schema": "nemo.eval_author.trace_environment_validation.v1",
-  "nop": {"reward": 0, "exception": null, "job_dir": "private/jobs/nop"},
-  "oracle": {"reward": 1, "exception": null, "job_dir": "private/jobs/oracle"}
-}
+```bash
+python <skill_dir>/scripts/trace_environment.py record-run-inputs \
+  --task-dir <task-dir> --arm nop --job-dir private/jobs/nop-1
+harbor run -p <task-dir>/task -a nop \
+  --jobs-dir <task-dir>/private/jobs --job-name nop-1
 ```
 
-Retain each exact Harbor job directory at the relative path recorded above.
-These evidence directories must stay inside the ignored task workspace.
+Repeat with `nop-2`, `oracle-1`, and `oracle-2`, selecting the matching arm and
+agent. Follow the integrity reference to declare and run the negative control.
+Retain every exact Harbor job and use the reference's `record-validation`
+command. Never hand-write rewards, job IDs, exceptions, or checksums. Do not
+weaken the verifier to make Oracle pass. Failed proof remains technical evidence.
 
-If Harbor or Docker is missing, the environment is `unproven`; do not describe
-it as ready. If either arm fails, record `failed` and retain the useful failure
-summary in the task workspace.
+If Harbor or Docker is missing, technical status is `not_run` and the environment
+is `unproven`; do not describe it as ready. Two NOP=0 runs, two Oracle=1 runs,
+and a task-specific negative-control=0 run without exceptions establish technical
+status `passed` only when their recorded agents and task snapshots match. They
+do not establish human review. The
+helper independently requires the task configuration and every retained Harbor
+result to report separate verification.
 
 ## Step 7: finalize and verify the summary
 
@@ -316,8 +437,7 @@ For a ready candidate:
 python <skill_dir>/scripts/trace_environment.py finalize \
   --task-dir <task-dir> \
   --status candidate \
-  --environment-status ready \
-  --privacy-reviewed \
+  --human-reviewed \
   --worked-well "<evidence-backed success>" \
   --did-not-work "<evidence-backed limitation>"
 ```
@@ -338,9 +458,59 @@ python <skill_dir>/scripts/trace_environment.py check \
   --task-dir <task-dir>
 ```
 
+The helper derives environment status rather than accepting a claimed status:
+failed technical proof becomes `failed`; passed proof with the required separate
+no-network verification and `--human-reviewed` becomes `ready`; every other
+candidate is `unproven`. A shared verifier is a contract error rather than an
+unproven candidate. The human-review flag means a human supplied or reviewed
+Relevant experience and the generalized task. It is distinct from the earlier
+contextual privacy review, which records either an agent or human reviewer.
+
+## Batch and publication
+
+For a multi-task run, write a checked-in manifest with stable task IDs and
+source paths. This makes the denominator explicit and reruns idempotent:
+
+```json
+{
+  "schema": "nemo.eval_author.trace_environment_batch.v1",
+  "members": [
+    {"task_id": "stable-id", "atif": "private-source.atif.json", "source_kind": "atif"}
+  ]
+}
+```
+
+Keep a real manifest's source paths private if they reveal internal layout.
+Prepare missing members, safely resume existing ones, and report every member:
+
+```bash
+python <skill_dir>/scripts/trace_environment.py batch-prepare \
+  --manifest <manifest.json>
+python <skill_dir>/scripts/trace_environment.py batch-status \
+  --manifest <manifest.json>
+```
+
+`denominator` must equal the selected source set. Never report only candidates
+or successes. A malformed workspace remains in the `batch-status` report with
+status `invalid` and makes the report invalid without hiding other member rows.
+For publication, export each finalized workspace to a new,
+nonexistent destination:
+
+```bash
+python <skill_dir>/scripts/trace_environment.py export \
+  --task-dir <task-dir> \
+  --output-dir <dataset-product-dir>
+```
+
+The command runs `check` and copies only `candidate.json`, the generalized
+`task/` and `reproducibility.json` when present, and a declassified `result.json`.
+It never copies source, canonical, safe, privacy-audit, ground-truth, validation,
+or Harbor job files.
+
 Report the task ID, `candidate` or `no_candidate`, ground-truth availability and
 artifact count, required software and licensing constraints, environment
-status, privacy review status, NOP and Oracle rewards when run, and paths to
+status, technical status, review status, verifier isolation, privacy review
+status, NOP and Oracle rewards when run, and paths to
 `summary.md` and the generated task. A `valid: true` check proves the recorded
 files are internally consistent; Harbor is the authority for whether the task
 actually runs.

--- a/plugins/nemo-eval-author/skills/eval-author-trace-environment/SKILL.md
+++ b/plugins/nemo-eval-author/skills/eval-author-trace-environment/SKILL.md
@@ -422,7 +422,8 @@ If Harbor or Docker is missing, technical status is `not_run` and the environmen
 is `unproven`; do not describe it as ready. Two NOP=0 runs, two Oracle=1 runs,
 and a task-specific negative-control=0 run without exceptions establish technical
 status `passed` only when their recorded agents and task snapshots match. They
-do not establish human review. The
+do not establish human review or container freshness. Reports distinguish
+verified distinct job IDs/paths from `container_freshness: "unverified"`. The
 helper independently requires the task configuration and every retained Harbor
 result to report separate verification.
 
@@ -505,7 +506,10 @@ python <skill_dir>/scripts/trace_environment.py export \
 The command runs `check` and copies only `candidate.json`, the generalized
 `task/` and `reproducibility.json` when present, and a declassified `result.json`.
 It never copies source, canonical, safe, privacy-audit, ground-truth, validation,
-or Harbor job files.
+or Harbor job files. It preserves task-file executable bits while making the
+export readable, so the published task matches its task-tree digest.
+Public results report image pinning separately from unverified dependency
+closure and distinguish distinct jobs from unverified container freshness.
 
 Report the task ID, `candidate` or `no_candidate`, ground-truth availability and
 artifact count, required software and licensing constraints, environment

--- a/plugins/nemo-eval-author/skills/eval-author-trace-environment/references/environment-integrity.md
+++ b/plugins/nemo-eval-author/skills/eval-author-trace-environment/references/environment-integrity.md
@@ -12,6 +12,8 @@ environment to set `[environment].network_mode = "no-network"`. A step-local
 agent environment may inherit that setting or repeat `network_mode =
 "no-network"`; it must never enable public networking. Resolve and vendor the
 complete build and runtime dependency closure before grading.
+This is an authoring requirement, not a claim that the static helper verifies
+the complete dependency closure.
 
 ## Reproducibility manifest
 
@@ -26,15 +28,17 @@ The manifest hashes every task path, file byte, directory, and executable bit.
 It records a declared source revision, Dockerfile base images, external
 `COPY --from` and `RUN --mount=from=...` image dependencies, configured agent,
 verifier and step `docker_image` references, network modes,
-and one portability state: `local_only`, `recipe_rebuildable`, or
-`immutable_image`. A recipe is rebuildable only when the agent Dockerfile exists
+and one image-reference state: `local_only`, `image_pinned_recipe`, or
+`immutable_image`. `image_pinned_recipe` means the agent Dockerfile exists
 and every inventoried external image is pinned by digest. Local named or numeric
 build stages are distinguished from external images. Unresolved variable-based
 references keep the task `local_only`. A configured agent image is immutable
 only when its reference contains a SHA-256 digest and all inventoried image
 dependencies are immutable. Use Harbor's `docker_image` field, not `image`.
-These states describe image pinning; they do not prove that arbitrary package
-downloads in a Dockerfile are reproducible.
+These states describe image pinning only. The manifest and public result
+explicitly report `dependency_closure: "unverified"`: arbitrary package
+downloads, tool installations, and external build inputs are not proven
+reproducible. Do not describe `image_pinned_recipe` as a rebuildability verdict.
 
 The scan fails closed on Git metadata in `task/environment`, exact solution or
 hidden-test files copied into the agent build context, private keys, bearer
@@ -44,8 +48,8 @@ transcripts private and inspect pre-existing opaque images separately.
 
 ## Repeat and negative-control proof
 
-Run every arm as an independent Harbor invocation so each result records a
-distinct job ID and fresh task containers. Require at least two NOP runs, two
+Run every arm as an independent Harbor invocation with new task containers.
+Require at least two NOP runs, two
 Oracle runs, and one negative control. NOP must receive reward `0`, Oracle must
 receive reward `1`, and every run must finish without an exception.
 
@@ -100,12 +104,21 @@ The helper requires unique Harbor job IDs, each result's task checksum matching
 the current task and its pre-run receipt, separate verifier mode in every
 result, and matching pre-run/current/reproducibility task-tree digests. Old
 results cannot be attached to a changed task by regenerating its manifest.
-These checks establish consistency of retained evidence, not cryptographic
-attestation of container freshness. Failed rewards remain technical evidence:
-retain them and report the candidate as failed.
+The report records `distinct_jobs: true` only after checking unique job paths
+and IDs. It explicitly reports `container_freshness: "unverified"`, including
+in exported results. Neither job identity nor the pre-run task receipt proves
+container identity or absence of reused container state. Fresh containers remain
+an execution requirement, not a property established by this helper. A passing
+report means the retained rewards and evidence are consistent, not that container
+freshness has been verified. Failed rewards remain technical evidence: retain
+them and report the candidate as failed.
 
-Validation v4 and reproducibility v2 replace the previous contracts. Historical
-proof without pre-run receipts must be rerun; do not fabricate receipts for
-completed jobs. Keep historical fixture results labeled with their original
-contract rather than implying that they passed the upgraded gate. Run receipts
-and negative-control source/rationale stay private and are never exported.
+Validation v5, reproducibility v3, and public product v3 replace the previous
+contracts and their broader claim names. Preserve previous reports privately
+before regenerating them from the unchanged task and retained evidence; do not
+edit schema strings or claims in place. Jobs with genuine matching pre-run
+receipts can be rechecked without claiming a new execution. Historical proof
+without those receipts must be rerun; do not fabricate receipts for completed
+jobs. Keep historical fixture results labeled with their original contract.
+Run receipts and negative-control source/rationale stay private and are never
+exported.

--- a/plugins/nemo-eval-author/skills/eval-author-trace-environment/references/environment-integrity.md
+++ b/plugins/nemo-eval-author/skills/eval-author-trace-environment/references/environment-integrity.md
@@ -1,0 +1,111 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Environment integrity protocol
+
+Apply this protocol to every candidate before finalization.
+
+## Network isolation
+
+In addition to the separate no-network verifier contract, require the agent
+environment to set `[environment].network_mode = "no-network"`. A step-local
+agent environment may inherit that setting or repeat `network_mode =
+"no-network"`; it must never enable public networking. Resolve and vendor the
+complete build and runtime dependency closure before grading.
+
+## Reproducibility manifest
+
+Record the exact task tree before running Harbor:
+
+```bash
+python <skill_dir>/scripts/trace_environment.py record-reproducibility \
+  --task-dir <task-dir>
+```
+
+The manifest hashes every task path, file byte, directory, and executable bit.
+It records a declared source revision, Dockerfile base images, external
+`COPY --from` and `RUN --mount=from=...` image dependencies, configured agent,
+verifier and step `docker_image` references, network modes,
+and one portability state: `local_only`, `recipe_rebuildable`, or
+`immutable_image`. A recipe is rebuildable only when the agent Dockerfile exists
+and every inventoried external image is pinned by digest. Local named or numeric
+build stages are distinguished from external images. Unresolved variable-based
+references keep the task `local_only`. A configured agent image is immutable
+only when its reference contains a SHA-256 digest and all inventoried image
+dependencies are immutable. Use Harbor's `docker_image` field, not `image`.
+These states describe image pinning; they do not prove that arbitrary package
+downloads in a Dockerfile are reproducible.
+
+The scan fails closed on Git metadata in `task/environment`, exact solution or
+hidden-test files copied into the agent build context, private keys, bearer
+credentials, credential-bearing URLs, and symlinks. It is a static task-tree
+gate, not an inspection of opaque image layers. Keep image-construction
+transcripts private and inspect pre-existing opaque images separately.
+
+## Repeat and negative-control proof
+
+Run every arm as an independent Harbor invocation so each result records a
+distinct job ID and fresh task containers. Require at least two NOP runs, two
+Oracle runs, and one negative control. NOP must receive reward `0`, Oracle must
+receive reward `1`, and every run must finish without an exception.
+
+The negative control must be a deliberately incomplete or subtly incorrect,
+non-crashing solution relevant to the task and must receive reward `0`. Do not
+reuse NOP as the negative control. Record the mutation in private construction
+notes without exposing verifier logic.
+
+Before **every** invocation, run `record-run-inputs` with its arm and future job
+directory (see the skill's NOP example). This writes an owner-private receipt
+under `private/run-inputs/` and refuses existing jobs or receipts. It binds the
+full task-tree digest, including executable bits, and Harbor's directory
+checksum to the future job. Proof commands use Harbor's `Task.checksum` API
+directly; use the existing Harbor Python environment.
+
+For the negative control, retain the custom agent source and supply its exact
+`module:Class` identity and task-specific mutation rationale before execution:
+
+```bash
+python <skill_dir>/scripts/trace_environment.py record-run-inputs \
+  --task-dir <task-dir> --arm negative --job-dir private/jobs/negative-1 \
+  --negative-agent negative_agent:IncompleteSolution \
+  --negative-source private/negative_agent.py \
+  --negative-rationale "<specific incomplete behavior this control exercises>"
+PYTHONPATH=<task-dir>/private harbor run -p <task-dir>/task \
+  -a negative_agent:IncompleteSolution \
+  --jobs-dir <task-dir>/private/jobs --job-name negative-1
+```
+
+Ensure that the import resolves to that retained source and retain any local
+dependencies as construction evidence. The helper compares the declared source
+digest and recorded agent identity; it does not import or execute the control
+to infer its semantics. Both `config.agent.name` and `config.agent.import_path`
+representations are supported, but conflicting nonempty fields are rejected.
+Built-in NOP/Oracle import paths are recognized and cannot serve as the negative
+control. NOP and Oracle proof arms must identify their respective built-in agent.
+
+Retain each exact Harbor job directory. Repeat each job option once per result:
+
+```bash
+python <skill_dir>/scripts/trace_environment.py record-validation \
+  --task-dir <task-dir> \
+  --nop-job-dir private/jobs/nop-1 \
+  --nop-job-dir private/jobs/nop-2 \
+  --oracle-job-dir private/jobs/oracle-1 \
+  --oracle-job-dir private/jobs/oracle-2 \
+  --negative-job-dir private/jobs/negative-1 \
+  --harbor-version "$(harbor --version)"
+```
+
+The helper requires unique Harbor job IDs, each result's task checksum matching
+the current task and its pre-run receipt, separate verifier mode in every
+result, and matching pre-run/current/reproducibility task-tree digests. Old
+results cannot be attached to a changed task by regenerating its manifest.
+These checks establish consistency of retained evidence, not cryptographic
+attestation of container freshness. Failed rewards remain technical evidence:
+retain them and report the candidate as failed.
+
+Validation v4 and reproducibility v2 replace the previous contracts. Historical
+proof without pre-run receipts must be rerun; do not fabricate receipts for
+completed jobs. Keep historical fixture results labeled with their original
+contract rather than implying that they passed the upgraded gate. Run receipts
+and negative-control source/rationale stay private and are never exported.

--- a/plugins/nemo-eval-author/skills/eval-author-trace-environment/scripts/trace_environment.py
+++ b/plugins/nemo-eval-author/skills/eval-author-trace-environment/scripts/trace_environment.py
@@ -23,11 +23,11 @@ from urllib.parse import urlsplit
 
 SCHEMA = "nemo.eval_author.trace_environment_summary.v2"
 CANDIDATE_SCHEMA = "nemo.eval_author.trace_environment_candidate.v2"
-VALIDATION_SCHEMA = "nemo.eval_author.trace_environment_validation.v4"
+VALIDATION_SCHEMA = "nemo.eval_author.trace_environment_validation.v5"
 RUN_INPUT_SCHEMA = "nemo.eval_author.trace_environment_run_input.v1"
 PRIVACY_AUDIT_SCHEMA = "nemo.eval_author.trace_environment_privacy_audit.v1"
-REPRODUCIBILITY_SCHEMA = "nemo.eval_author.trace_environment_reproducibility.v2"
-EXPORT_SCHEMA = "nemo.eval_author.trace_environment_product.v2"
+REPRODUCIBILITY_SCHEMA = "nemo.eval_author.trace_environment_reproducibility.v3"
+EXPORT_SCHEMA = "nemo.eval_author.trace_environment_product.v3"
 BATCH_SCHEMA = "nemo.eval_author.trace_environment_batch.v1"
 MAX_RAW_SOURCE_BYTES = 128 * 1024 * 1024
 MAX_CANONICAL_BYTES = 25 * 1024 * 1024
@@ -1310,7 +1310,7 @@ def _derive_reproducibility(task_dir: Path) -> dict[str, Any]:
     if all_immutable and isinstance(configured_image, str) and _IMAGE_DIGEST.fullmatch(configured_image):
         portability_state = "immutable_image"
     elif has_agent_recipe and all_immutable:
-        portability_state = "recipe_rebuildable"
+        portability_state = "image_pinned_recipe"
     else:
         portability_state = "local_only"
     findings, scanned_files = _contamination_findings(task_dir)
@@ -1320,6 +1320,7 @@ def _derive_reproducibility(task_dir: Path) -> dict[str, Any]:
         "source_revision": source_revision,
         "portability": {
             "state": portability_state,
+            "dependency_closure": "unverified",
             "configured_image": configured_image,
             "container_images": images,
             "configured_images": configured_images,
@@ -1681,7 +1682,8 @@ def _validation_from_jobs(
         "task_checksum": next(iter(checksums)),
         "task_tree_sha256": reproducibility["task_tree_sha256"],
         "verifier_environment_mode": mode,
-        "fresh_jobs": True,
+        "distinct_jobs": True,
+        "container_freshness": "unverified",
         "minimum_runs": _MIN_VALIDATION_RUNS,
         "passed": passed,
         "runs": runs,
@@ -1719,7 +1721,8 @@ def _validate_validation(task_dir: Path) -> dict[str, Any]:
         "task_checksum",
         "task_tree_sha256",
         "verifier_environment_mode",
-        "fresh_jobs",
+        "distinct_jobs",
+        "container_freshness",
         "minimum_runs",
         "passed",
         "runs",
@@ -1728,8 +1731,12 @@ def _validate_validation(task_dir: Path) -> dict[str, Any]:
         raise ContractError("validation fields do not match the versioned contract")
     if not isinstance(recorded.get("harbor_version"), str) or not recorded["harbor_version"].strip():
         raise ContractError("validation.harbor_version must be nonempty text")
-    if recorded.get("minimum_runs") != _MIN_VALIDATION_RUNS or recorded.get("fresh_jobs") is not True:
-        raise ContractError("validation repeat and fresh-job policy does not match the versioned contract")
+    if (
+        recorded.get("minimum_runs") != _MIN_VALIDATION_RUNS
+        or recorded.get("distinct_jobs") is not True
+        or recorded.get("container_freshness") != "unverified"
+    ):
+        raise ContractError("validation repeat and job-evidence policy does not match the versioned contract")
     runs = recorded.get("runs")
     if not isinstance(runs, dict) or set(runs) != set(_MIN_VALIDATION_RUNS):
         raise ContractError("validation.runs fields do not match the versioned contract")
@@ -2117,6 +2124,7 @@ def _export(args: argparse.Namespace) -> dict[str, Any]:
             "total_bytes": reproducibility["total_bytes"],
             "source_revision": reproducibility["source_revision"],
             "portability_state": reproducibility["portability"]["state"],
+            "dependency_closure": reproducibility["portability"]["dependency_closure"],
             "agent_network_mode": reproducibility["network"]["agent"],
             "contamination_passed": reproducibility["contamination"]["passed"],
         }
@@ -2128,7 +2136,8 @@ def _export(args: argparse.Namespace) -> dict[str, Any]:
             "task_checksum": validation["task_checksum"],
             "task_tree_sha256": validation["task_tree_sha256"],
             "verifier_environment_mode": validation["verifier_environment_mode"],
-            "fresh_jobs": validation["fresh_jobs"],
+            "distinct_jobs": validation["distinct_jobs"],
+            "container_freshness": validation["container_freshness"],
             "minimum_runs": validation["minimum_runs"],
             "passed": validation["passed"],
             "runs": {
@@ -2172,7 +2181,7 @@ def _export(args: argparse.Namespace) -> dict[str, Any]:
     _write_json(output_dir / "result.json", product)
     for path in output_dir.rglob("*"):
         if path.is_file():
-            path.chmod(0o644)
+            path.chmod(0o644 | (stat.S_IMODE(path.stat().st_mode) & 0o111))
         elif path.is_dir():
             path.chmod(0o755)
     output_dir.chmod(0o755)

--- a/plugins/nemo-eval-author/skills/eval-author-trace-environment/scripts/trace_environment.py
+++ b/plugins/nemo-eval-author/skills/eval-author-trace-environment/scripts/trace_environment.py
@@ -11,16 +11,26 @@ import ipaddress
 import json
 import os
 import re
+import shlex
+import shutil
 import stat
 import sys
 import tempfile
+import tomllib
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
-SCHEMA = "nemo.eval_author.trace_environment_summary.v1"
-CANDIDATE_SCHEMA = "nemo.eval_author.trace_environment_candidate.v1"
-VALIDATION_SCHEMA = "nemo.eval_author.trace_environment_validation.v1"
-MAX_SOURCE_BYTES = 25 * 1024 * 1024
+SCHEMA = "nemo.eval_author.trace_environment_summary.v2"
+CANDIDATE_SCHEMA = "nemo.eval_author.trace_environment_candidate.v2"
+VALIDATION_SCHEMA = "nemo.eval_author.trace_environment_validation.v4"
+RUN_INPUT_SCHEMA = "nemo.eval_author.trace_environment_run_input.v1"
+PRIVACY_AUDIT_SCHEMA = "nemo.eval_author.trace_environment_privacy_audit.v1"
+REPRODUCIBILITY_SCHEMA = "nemo.eval_author.trace_environment_reproducibility.v2"
+EXPORT_SCHEMA = "nemo.eval_author.trace_environment_product.v2"
+BATCH_SCHEMA = "nemo.eval_author.trace_environment_batch.v1"
+MAX_RAW_SOURCE_BYTES = 128 * 1024 * 1024
+MAX_CANONICAL_BYTES = 25 * 1024 * 1024
 TASK_ID = re.compile(r"[a-z0-9]+(?:-[a-z0-9]+)*")
 ATIF_VERSION = re.compile(r"ATIF-v1\.[0-7]")
 
@@ -35,6 +45,19 @@ _PRIVATE_KEY = re.compile(
     re.DOTALL,
 )
 _SECRET_KEY = re.compile(r"(?i)(?:password|passwd|secret|token|api[_-]?key|access[_-]?key|authorization)")
+_INTERNAL_HOST = re.compile(r"(?i)\b[a-z0-9.-]+\.svc\.cluster\.local\b")
+_URL = re.compile(r"https?://[^\s\"'<>]+", re.IGNORECASE)
+_STREET = re.compile(
+    r"(?i)\b\d{1,6}\s+[A-Z][A-Za-z.'-]*(?:\s+[A-Z][A-Za-z.'-]*){0,4}\s+"
+    r"(?:street|st|avenue|ave|road|rd|boulevard|blvd|lane|ln|drive|dr)\b"
+)
+_ORGANIZATION = re.compile(
+    r"\b[A-Z][A-Za-z0-9&.'-]*(?:\s+[A-Z][A-Za-z0-9&.'-]*){0,5}\s+"
+    r"(?:Corporation|Corp|Company|Inc|LLC|Ltd|University|Laboratories|Labs)\b"
+)
+_PERSON = re.compile(r"\b[A-Z][a-z]{2,20}\s+[A-Z][a-z]{2,20}\b")
+_REDACTION_QUOTE = '<redacted>"'
+_IMAGE_OBJECT_START = re.compile(r'\{\s*"type"\s*:\s*"image"')
 _IDENTIFIER_KEYS = frozenset(
     {
         "parent_span_id",
@@ -64,6 +87,7 @@ _CANDIDATE_KEYS = frozenset(
     {
         "schema",
         "status",
+        "decision_basis",
         "instruction",
         "requirements",
         "verification_mode",
@@ -74,8 +98,10 @@ _CANDIDATE_KEYS = frozenset(
         "software_requirements",
     }
 )
-_GROUND_TRUTH_KEYS = frozenset({"availability", "artifacts", "absence_reason"})
-_GROUND_TRUTH_ARTIFACT_KEYS = frozenset({"kind", "path", "sha256", "evidence_steps", "notes"})
+_REQUIREMENT_KEYS = frozenset({"description", "evidence_steps"})
+_GROUND_TRUTH_KEYS = frozenset({"availability", "use", "artifacts", "absence_reason"})
+_GROUND_TRUTH_ARTIFACT_KEYS = frozenset({"kind", "path", "sha256", "provenance", "notes"})
+_PROVENANCE_KEYS = frozenset({"kind", "step_ids", "uri", "revision", "source_id"})
 _SOFTWARE_REQUIREMENT_KEYS = frozenset(
     {
         "name",
@@ -85,22 +111,49 @@ _SOFTWARE_REQUIREMENT_KEYS = frozenset(
         "license",
         "availability",
         "redistributable",
-        "evidence_steps",
+        "provenance",
         "notes",
     }
 )
-_SOURCE_KEYS = frozenset({"kind", "private_path", "private_sha256", "safe_path", "safe_sha256"})
+_SOURCE_KEYS = frozenset(
+    {
+        "kind",
+        "original_path",
+        "original_sha256",
+        "original_size_bytes",
+        "canonical_path",
+        "canonical_sha256",
+        "canonical_size_bytes",
+        "safe_path",
+        "safe_sha256",
+        "safe_size_bytes",
+        "normalizations",
+    }
+)
 _PRIVACY_KEYS = frozenset(
     {
         "path",
+        "audit_path",
         "deterministic_redactions",
         "images_omitted",
-        "manual_review_required",
-        "manual_review_complete",
+        "contextual_review_required",
+        "contextual_review_complete",
+        "reviewer_kind",
         "blocking_reasons",
     }
 )
-_ENVIRONMENT_KEYS = frozenset({"path", "status", "validation"})
+_PRIVACY_REPORT_KEYS = _PRIVACY_KEYS - {"path", "audit_path"}
+_ENVIRONMENT_KEYS = frozenset(
+    {
+        "path",
+        "status",
+        "technical_status",
+        "review_status",
+        "validation",
+        "verifier_environment_mode",
+        "isolation_status",
+    }
+)
 _TASK_README_SECTIONS = (
     "Difficulty explanation",
     "Environment and software requirements",
@@ -110,6 +163,13 @@ _TASK_README_SECTIONS = (
     "Relevant experience",
 )
 _DIGEST = re.compile(r"sha256:[0-9a-f]{64}")
+_TASK_CHECKSUM = re.compile(r"[0-9a-f]{64}")
+_IMAGE_DIGEST = re.compile(r".+@sha256:[0-9a-f]{64}$")
+_PRIVATE_KEY_BYTES = re.compile(rb"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----")
+_BEARER_BYTES = re.compile(rb"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]{12,}")
+_CREDENTIALED_URL_BYTES = re.compile(rb"(?i)https?://[^\s/:@]+:[^\s/@]+@")
+_BATCH_MEMBER_KEYS = frozenset({"task_id", "atif", "source_kind"})
+_MIN_VALIDATION_RUNS = {"nop": 2, "oracle": 2, "negative": 1}
 
 
 class ContractError(ValueError):
@@ -118,6 +178,11 @@ class ContractError(ValueError):
 
 def _sha256(data: bytes) -> str:
     return f"sha256:{hashlib.sha256(data).hexdigest()}"
+
+
+def _sha256_file(path: Path) -> str:
+    with path.open("rb") as stream:
+        return f"sha256:{hashlib.file_digest(stream, 'sha256').hexdigest()}"
 
 
 def _chmod_private(path: Path, *, directory: bool = False) -> None:
@@ -160,12 +225,12 @@ def _write_text(path: Path, text: str) -> None:
         temporary.unlink(missing_ok=True)
 
 
-def _load_json(path: Path, *, label: str) -> Any:
+def _load_json(path: Path, *, label: str, max_bytes: int = MAX_CANONICAL_BYTES) -> Any:
     if path.is_symlink() or not path.is_file():
         raise ContractError(f"{label} must be a regular file: {path}")
     size = path.stat().st_size
-    if size > MAX_SOURCE_BYTES:
-        raise ContractError(f"{label} exceeds the {MAX_SOURCE_BYTES}-byte limit")
+    if size > max_bytes:
+        raise ContractError(f"{label} exceeds the {max_bytes}-byte limit")
     try:
         return json.loads(path.read_text(encoding="utf-8"))
     except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
@@ -191,7 +256,7 @@ def _load_summary(task_dir: Path) -> dict[str, Any]:
         raise ContractError(f"summary.schema must be {SCHEMA!r}")
     if summary.get("task_id") != task_dir.name:
         raise ContractError("summary task_id does not match its directory")
-    if summary.get("status") not in {"pending", "candidate", "no_candidate"}:
+    if summary.get("status") not in ("pending", "candidate", "no_candidate"):
         raise ContractError("summary status is not recognized")
     for name in ("worked_well", "did_not_work", "reasons"):
         value = summary.get(name)
@@ -201,13 +266,20 @@ def _load_summary(task_dir: Path) -> dict[str, Any]:
     if source is not None and (
         not isinstance(source, dict)
         or set(source) != _SOURCE_KEYS
-        or source.get("kind") not in {"atif", "intake", "mlflow", "otel"}
-        or source.get("private_path") != "private/source.atif.json"
+        or source.get("kind") not in ("atif", "intake", "mlflow", "otel")
+        or source.get("original_path") != "private/source.atif.json"
+        or source.get("canonical_path") != "private/canonical.atif.json"
         or source.get("safe_path") != "safe/trace.atif.json"
-        or not isinstance(source.get("private_sha256"), str)
-        or _DIGEST.fullmatch(source["private_sha256"]) is None
-        or not isinstance(source.get("safe_sha256"), str)
-        or _DIGEST.fullmatch(source["safe_sha256"]) is None
+        or any(
+            not isinstance(source.get(name), str) or _DIGEST.fullmatch(source[name]) is None
+            for name in ("original_sha256", "canonical_sha256", "safe_sha256")
+        )
+        or any(
+            type(source.get(name)) is not int or source[name] < 0
+            for name in ("original_size_bytes", "canonical_size_bytes", "safe_size_bytes")
+        )
+        or not isinstance(source.get("normalizations"), list)
+        or any(not isinstance(item, dict) for item in source["normalizations"])
     ):
         raise ContractError("summary source does not match the versioned task workspace contract")
     privacy = summary.get("privacy")
@@ -215,10 +287,12 @@ def _load_summary(task_dir: Path) -> dict[str, Any]:
         not isinstance(privacy, dict)
         or set(privacy) != _PRIVACY_KEYS
         or privacy.get("path") != "safe/privacy.json"
+        or privacy.get("audit_path") != "private/privacy-audit.json"
         or not isinstance(privacy.get("deterministic_redactions"), dict)
         or not isinstance(privacy.get("images_omitted"), int)
-        or privacy.get("manual_review_required") is not True
-        or not isinstance(privacy.get("manual_review_complete"), bool)
+        or privacy.get("contextual_review_required") is not True
+        or not isinstance(privacy.get("contextual_review_complete"), bool)
+        or privacy.get("reviewer_kind") not in (None, "agent", "human")
         or not isinstance(privacy.get("blocking_reasons"), list)
     ):
         raise ContractError("summary privacy data does not match the versioned task workspace contract")
@@ -227,10 +301,16 @@ def _load_summary(task_dir: Path) -> dict[str, Any]:
         not isinstance(environment, dict)
         or set(environment) != _ENVIRONMENT_KEYS
         or environment.get("path") != "task"
-        or environment.get("status") not in {"ready", "failed", "unproven", "not_attempted"}
-        or environment.get("validation") not in {None, "validation.json"}
+        or environment.get("status") not in ("ready", "failed", "unproven", "not_attempted")
+        or environment.get("technical_status") not in ("passed", "failed", "not_run")
+        or environment.get("review_status") not in ("human_reviewed", "unreviewed")
+        or environment.get("validation") not in (None, "validation.json")
+        or environment.get("verifier_environment_mode") not in (None, "separate")
+        or environment.get("isolation_status") not in ("isolated", "not_run")
     ):
         raise ContractError("summary environment does not match the versioned task workspace contract")
+    if privacy is not None and source is None:
+        raise ContractError("summary privacy data requires prepared source evidence")
     return summary
 
 
@@ -245,7 +325,7 @@ def _ensure_task_dir(path: Path) -> Path:
         raise ContractError(f"task directory must be a regular directory: {path}")
     if TASK_ID.fullmatch(path.name) is None:
         raise ContractError("task directory name must be lowercase kebab-case")
-    return path
+    return path.resolve()
 
 
 def _init(args: argparse.Namespace) -> dict[str, Any]:
@@ -275,7 +355,15 @@ def _init(args: argparse.Namespace) -> dict[str, Any]:
         "source": None,
         "privacy": None,
         "candidate": None,
-        "environment": {"path": "task", "status": "not_attempted", "validation": None},
+        "environment": {
+            "path": "task",
+            "status": "not_attempted",
+            "technical_status": "not_run",
+            "review_status": "unreviewed",
+            "validation": None,
+            "verifier_environment_mode": None,
+            "isolation_status": "not_run",
+        },
         "worked_well": [],
         "did_not_work": [],
         "reasons": [],
@@ -416,6 +504,7 @@ def _redact_text(value: str, counts: dict[str, int]) -> str:
     value = _replace(_EMAIL, value, "<redacted:email>", counts, "email")
     value = _replace(_SSN, value, "<redacted:ssn>", counts, "ssn")
     value = _replace(_HOME_PATH, value, "/home/<redacted:user>", counts, "home_path")
+    value = _replace(_INTERNAL_HOST, value, "<redacted:internal-host>", counts, "internal_host")
     value = _redact_ipv4(value, counts)
     return _redact_phone(value, counts)
 
@@ -441,60 +530,299 @@ def _scrub(value: Any, counts: dict[str, int], *, key: str | None = None) -> Any
     return value
 
 
+def _parse_or_repair(raw: str) -> tuple[dict[str, Any], list[int]]:
+    repaired = raw
+    inserted_offsets: list[int] = []
+    while True:
+        try:
+            payload = json.loads(repaired)
+            if not isinstance(payload, dict):
+                raise ContractError("ATIF root must be a JSON object")
+            return payload, inserted_offsets
+        except json.JSONDecodeError as error:
+            candidates = [
+                index + len(_REDACTION_QUOTE) - 1
+                for index in range(len(repaired))
+                if repaired.startswith(_REDACTION_QUOTE, index) and index + len(_REDACTION_QUOTE) - 1 < error.pos
+            ]
+            if not candidates:
+                raise ContractError(
+                    "invalid JSON is not attributable to a provider-redaction placeholder quote"
+                ) from error
+            quote_offset = candidates[-1]
+            original_offset = quote_offset - len(inserted_offsets)
+            repaired = repaired[:quote_offset] + "\\" + repaired[quote_offset:]
+            inserted_offsets.append(original_offset)
+
+
+def _bound_stringified_images(payload: dict[str, Any]) -> dict[str, int]:
+    counts = {
+        "count": 0,
+        "omitted_encoded_characters": 0,
+        "metadata_field_count": 0,
+        "metadata_omitted_characters": 0,
+    }
+
+    def convert(content: str) -> tuple[list[dict[str, Any]] | None, int, int]:
+        decoder = json.JSONDecoder()
+        parts: list[dict[str, Any]] = []
+        search_cursor = 0
+        emitted_cursor = 0
+        converted_count = 0
+        converted_characters = 0
+        while match := _IMAGE_OBJECT_START.search(content, search_cursor):
+            start = match.start()
+            try:
+                part, end = decoder.raw_decode(content, start)
+            except json.JSONDecodeError:
+                search_cursor = match.end()
+                continue
+            source = part.get("source") if isinstance(part, dict) else None
+            if part.get("type") != "image" or not isinstance(source, dict) or not isinstance(source.get("data"), str):
+                search_cursor = end
+                continue
+            if start > emitted_cursor:
+                parts.append({"type": "text", "text": content[emitted_cursor:start]})
+            bounded_source = dict(source)
+            encoded = bounded_source["data"]
+            bounded_source["data"] = ""
+            parts.append({"type": "image", "source": bounded_source})
+            converted_count += 1
+            converted_characters += len(encoded)
+            search_cursor = end
+            emitted_cursor = end
+        if converted_count == 0:
+            return None, 0, 0
+        if emitted_cursor < len(content):
+            parts.append({"type": "text", "text": content[emitted_cursor:]})
+        return parts, converted_count, converted_characters
+
+    def bound_metadata(value: Any) -> None:
+        if isinstance(value, dict):
+            image_like = value.get("type") in {"image", "base64"} or (
+                isinstance(value.get("media_type"), str) and value["media_type"].startswith("image/")
+            )
+            for key, nested in value.items():
+                if (
+                    isinstance(nested, str)
+                    and len(nested) > 100_000
+                    and (key == "base64" or (key == "data" and image_like))
+                ):
+                    counts["metadata_field_count"] += 1
+                    counts["metadata_omitted_characters"] += len(nested)
+                    value[key] = ""
+                else:
+                    bound_metadata(nested)
+        elif isinstance(value, list):
+            for nested in value:
+                bound_metadata(nested)
+
+    def bound_image_parts(value: Any) -> None:
+        if isinstance(value, dict):
+            source = value.get("source")
+            if value.get("type") == "image" and isinstance(source, dict):
+                encoded = source.get("data")
+                if isinstance(encoded, str) and encoded:
+                    counts["count"] += 1
+                    counts["omitted_encoded_characters"] += len(encoded)
+                    source["data"] = ""
+            for nested in value.values():
+                bound_image_parts(nested)
+        elif isinstance(value, list):
+            for nested in value:
+                bound_image_parts(nested)
+
+    def visit(trajectory: dict[str, Any]) -> None:
+        steps = trajectory.get("steps")
+        if isinstance(steps, list):
+            for step in steps:
+                observation = step.get("observation") if isinstance(step, dict) else None
+                results = observation.get("results") if isinstance(observation, dict) else None
+                if not isinstance(results, list):
+                    continue
+                for result in results:
+                    if not isinstance(result, dict):
+                        continue
+                    content = result.get("content")
+                    if isinstance(content, str):
+                        parts, converted_count, converted_characters = convert(content)
+                        if parts is not None:
+                            result["content"] = parts
+                            counts["count"] += converted_count
+                            counts["omitted_encoded_characters"] += converted_characters
+                    bound_metadata(result.get("extra"))
+        subagents = trajectory.get("subagent_trajectories")
+        if isinstance(subagents, list):
+            for subagent in subagents:
+                if isinstance(subagent, dict):
+                    visit(subagent)
+
+    visit(payload)
+    bound_image_parts(payload)
+    bound_metadata(payload)
+    return counts
+
+
+def _record_normalization(
+    payload: dict[str, Any], source_sha256: str, offsets: list[int], image_counts: dict[str, int]
+) -> list[dict[str, Any]]:
+    normalizations: list[dict[str, Any]] = []
+    if offsets:
+        normalizations.append(
+            {
+                "kind": "escape_provider_redaction_placeholder_quote",
+                "count": len(offsets),
+                "source_character_offsets": offsets,
+            }
+        )
+    if image_counts["count"] or image_counts["metadata_field_count"]:
+        normalizations.append({"kind": "bound_stringified_image_observations", **image_counts})
+    extra = payload.setdefault("extra", {})
+    if not isinstance(extra, dict):
+        raise ContractError("ATIF extra field must be an object when present")
+    normalization = extra.setdefault("normalization", {})
+    if not isinstance(normalization, dict):
+        raise ContractError("ATIF extra.normalization field must be an object when present")
+    uncertainties = normalization.setdefault("uncertainties", [])
+    losses = normalization.setdefault("losses", [])
+    if not isinstance(uncertainties, list) or any(not isinstance(item, str) for item in uncertainties):
+        raise ContractError("ATIF normalization uncertainties must be a string list")
+    if not isinstance(losses, list) or any(not isinstance(item, str) for item in losses):
+        raise ContractError("ATIF normalization losses must be a string list")
+    if offsets:
+        uncertainties.append(
+            "A missing JSON escape immediately after a provider-redaction placeholder was inserted only where the parser implicated that quote."
+        )
+    if image_counts["count"] or image_counts["metadata_field_count"]:
+        losses.append(
+            "String-encoded image data was omitted from the bounded canonical ATIF; exact source bytes remain preserved and hashed."
+        )
+    normalization["source_sha256"] = source_sha256
+    normalization["operations"] = normalizations
+    return normalizations
+
+
+def _walk_strings(value: Any, path: str = "$") -> list[tuple[str, str]]:
+    if isinstance(value, dict):
+        strings: list[tuple[str, str]] = []
+        for key, nested in value.items():
+            strings.extend(_walk_strings(nested, f"{path}.{key}"))
+        return strings
+    if isinstance(value, list):
+        strings = []
+        for index, nested in enumerate(value):
+            strings.extend(_walk_strings(nested, f"{path}[{index}]"))
+        return strings
+    return [(path, value)] if isinstance(value, str) else []
+
+
+def _privacy_audit(payload: dict[str, Any], safe_sha256: str) -> dict[str, Any]:
+    strings = _walk_strings(payload)
+    findings: list[dict[str, str]] = []
+    url_hosts: set[str] = set()
+    patterns = (("street_address", _STREET), ("organization", _ORGANIZATION), ("person_name", _PERSON))
+    for path, value in strings:
+        for url in _URL.findall(value):
+            hostname = urlsplit(url).hostname
+            if hostname:
+                url_hosts.add(hostname)
+        for kind, pattern in patterns:
+            for match in pattern.finditer(value):
+                findings.append({"kind": kind, "path": path, "value": match.group(0)})
+    return {
+        "schema": PRIVACY_AUDIT_SCHEMA,
+        "safe_sha256": safe_sha256,
+        "string_field_count": len(strings),
+        "unique_string_count": len({value for _, value in strings}),
+        "character_count": sum(len(value) for _, value in strings),
+        "url_hosts": sorted(url_hosts),
+        "candidate_findings": findings,
+        "review": {"complete": False, "reviewer_kind": None, "note": None},
+    }
+
+
 def _prepare(args: argparse.Namespace) -> dict[str, Any]:
-    task_dir = _ensure_task_dir(args.task_dir.resolve())
+    task_dir = _ensure_task_dir(args.task_dir)
     summary = _load_summary(task_dir)
     if summary["source"] is not None:
         raise ContractError("this task workspace already has prepared source evidence")
 
-    source_path = args.atif.resolve()
+    source_path = args.atif
     if source_path.is_symlink() or not source_path.is_file():
         raise ContractError(f"ATIF source must be a regular file: {source_path}")
+    source_path = source_path.resolve()
     source_bytes = source_path.read_bytes()
-    if len(source_bytes) > MAX_SOURCE_BYTES:
-        raise ContractError(f"ATIF source exceeds the {MAX_SOURCE_BYTES}-byte limit")
+    if len(source_bytes) > MAX_RAW_SOURCE_BYTES:
+        raise ContractError(f"ATIF source exceeds the {MAX_RAW_SOURCE_BYTES}-byte raw-source limit")
     try:
-        payload = json.loads(source_bytes.decode("utf-8"))
-    except (UnicodeDecodeError, json.JSONDecodeError) as error:
-        raise ContractError(f"could not read ATIF source as UTF-8 JSON: {error}") from error
+        source_text = source_bytes.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise ContractError(f"could not read ATIF source as UTF-8: {error}") from error
+    payload, repaired_offsets = _parse_or_repair(source_text)
+    image_counts = _bound_stringified_images(payload)
+    normalizations = _record_normalization(payload, _sha256(source_bytes), repaired_offsets, image_counts)
     validation = _validate_trajectory(payload)
 
-    private_path = task_dir / "private" / "source.atif.json"
+    original_path = task_dir / "private" / "source.atif.json"
+    canonical_path = task_dir / "private" / "canonical.atif.json"
     safe_path = task_dir / "safe" / "trace.atif.json"
     privacy_path = task_dir / "safe" / "privacy.json"
-    if any(path.exists() for path in (private_path, safe_path, privacy_path)):
+    audit_path = task_dir / "private" / "privacy-audit.json"
+    if any(path.exists() for path in (original_path, canonical_path, safe_path, privacy_path, audit_path)):
         raise ContractError("refusing to replace an existing prepared artifact")
+    canonical_bytes = (json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n").encode()
+    if len(canonical_bytes) > MAX_CANONICAL_BYTES:
+        raise ContractError(f"canonical ATIF exceeds the {MAX_CANONICAL_BYTES}-byte limit after bounded normalization")
     counts: dict[str, int] = {}
     scrubbed = _scrub(payload, counts)
     _validate_trajectory(scrubbed)
     safe_bytes = (json.dumps(scrubbed, ensure_ascii=False, indent=2, sort_keys=True) + "\n").encode()
+    if len(safe_bytes) > MAX_CANONICAL_BYTES:
+        raise ContractError(f"safe ATIF exceeds the {MAX_CANONICAL_BYTES}-byte limit")
     blocking_reasons = [
         f"image_only_user_instruction:step-{step_id}" for step_id in validation["image_only_user_steps"]
     ]
     privacy = {
         "deterministic_redactions": dict(sorted(counts.items())),
         "images_omitted": counts.get("image", 0),
-        "manual_review_required": True,
-        "manual_review_complete": False,
+        "contextual_review_required": True,
+        "contextual_review_complete": False,
+        "reviewer_kind": None,
         "blocking_reasons": blocking_reasons,
     }
+    audit = _privacy_audit(scrubbed, _sha256(safe_bytes))
     summary["source"] = {
         "kind": args.source_kind,
-        "private_path": "private/source.atif.json",
-        "private_sha256": _sha256(source_bytes),
+        "original_path": "private/source.atif.json",
+        "original_sha256": _sha256(source_bytes),
+        "original_size_bytes": len(source_bytes),
+        "canonical_path": "private/canonical.atif.json",
+        "canonical_sha256": _sha256(canonical_bytes),
+        "canonical_size_bytes": len(canonical_bytes),
         "safe_path": "safe/trace.atif.json",
         "safe_sha256": _sha256(safe_bytes),
+        "safe_size_bytes": len(safe_bytes),
+        "normalizations": normalizations,
     }
-    summary["privacy"] = {"path": "safe/privacy.json", **privacy}
+    summary["privacy"] = {
+        "path": "safe/privacy.json",
+        "audit_path": "private/privacy-audit.json",
+        **privacy,
+    }
     privacy_bytes = (json.dumps(privacy, ensure_ascii=False, indent=2, sort_keys=True) + "\n").encode()
+    audit_bytes = (json.dumps(audit, ensure_ascii=False, indent=2, sort_keys=True) + "\n").encode()
     written: list[Path] = []
     try:
-        _write_bytes_once(private_path, source_bytes)
-        written.append(private_path)
+        _write_bytes_once(original_path, source_bytes)
+        written.append(original_path)
+        _write_bytes_once(canonical_path, canonical_bytes)
+        written.append(canonical_path)
         _write_bytes_once(safe_path, safe_bytes)
         written.append(safe_path)
         _write_bytes_once(privacy_path, privacy_bytes)
         written.append(privacy_path)
+        _write_bytes_once(audit_path, audit_bytes)
+        written.append(audit_path)
         _write_json(_summary_path(task_dir), summary)
     except BaseException:
         for path in written:
@@ -506,6 +834,8 @@ def _prepare(args: argparse.Namespace) -> dict[str, Any]:
         "redaction_count": sum(counts.values()),
         "images_omitted": privacy["images_omitted"],
         "blocking_reason_count": len(blocking_reasons),
+        "normalization_count": len(normalizations),
+        "privacy_candidate_count": len(audit["candidate_findings"]),
     }
 
 
@@ -516,6 +846,42 @@ def _string_list(payload: dict[str, Any], name: str, *, nonempty: bool = False) 
     if nonempty and not value:
         raise ContractError(f"candidate.{name} must not be empty")
     return value
+
+
+def _review_privacy(args: argparse.Namespace) -> dict[str, Any]:
+    task_dir = _ensure_task_dir(args.task_dir)
+    summary = _load_summary(task_dir)
+    privacy = summary.get("privacy")
+    if not isinstance(privacy, dict):
+        raise ContractError("prepare ATIF evidence before reviewing privacy")
+    safe_path = task_dir / summary["source"]["safe_path"]
+    audit_path = task_dir / privacy["audit_path"]
+    report_path = task_dir / privacy["path"]
+    audit = _load_object(audit_path, label="privacy audit")
+    if audit.get("schema") != PRIVACY_AUDIT_SCHEMA or audit.get("safe_sha256") != _sha256(safe_path.read_bytes()):
+        raise ContractError("privacy audit does not match the current safe ATIF")
+    review = audit.get("review")
+    if not isinstance(review, dict) or set(review) != {"complete", "reviewer_kind", "note"}:
+        raise ContractError("privacy audit review fields do not match the versioned contract")
+    if review["complete"]:
+        raise ContractError("contextual privacy review has already been recorded")
+    audit["review"] = {"complete": True, "reviewer_kind": args.reviewer_kind, "note": args.note}
+    report = _load_object(report_path, label="privacy report")
+    if set(report) != _PRIVACY_REPORT_KEYS:
+        raise ContractError("privacy report fields do not match the versioned contract")
+    report["contextual_review_complete"] = True
+    report["reviewer_kind"] = args.reviewer_kind
+    privacy.update(report)
+    _write_json(audit_path, audit)
+    _write_json(report_path, report)
+    _write_json(_summary_path(task_dir), summary)
+    return {
+        "task_dir": str(task_dir),
+        "contextual_review_complete": True,
+        "reviewer_kind": args.reviewer_kind,
+        "candidate_findings_reviewed": len(audit.get("candidate_findings", [])),
+        "url_hosts_reviewed": len(audit.get("url_hosts", [])),
+    }
 
 
 def _evidence_steps(value: Any, step_ids: set[int], *, label: str) -> list[int]:
@@ -532,6 +898,42 @@ def _evidence_steps(value: Any, step_ids: set[int], *, label: str) -> list[int]:
     return value
 
 
+def _validate_provenance(value: Any, step_ids: set[int], *, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict) or set(value) != _PROVENANCE_KEYS:
+        raise ContractError(f"{label} fields do not match the versioned contract")
+    kind = value.get("kind")
+    provenance_steps = value.get("step_ids")
+    if kind == "atif_step":
+        _evidence_steps(provenance_steps, step_ids, label=f"{label}.step_ids")
+        if any(value.get(name) is not None for name in ("uri", "revision", "source_id")):
+            raise ContractError(f"{label} ATIF provenance must not include external identifiers")
+    elif kind == "external":
+        if provenance_steps != []:
+            raise ContractError(f"{label}.step_ids must be empty for external provenance")
+        for name in ("uri", "revision", "source_id"):
+            item = value.get(name)
+            if item is not None and (not isinstance(item, str) or not item.strip()):
+                raise ContractError(f"{label}.{name} must be null or nonempty text")
+        if not any(value.get(name) for name in ("uri", "revision", "source_id")):
+            raise ContractError(f"{label} external provenance needs a URI, revision, or source ID")
+    else:
+        raise ContractError(f"{label}.kind must be atif_step or external")
+    return value
+
+
+def _validate_requirements(value: Any, step_ids: set[int]) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        raise ContractError("candidate.requirements must be a list")
+    for index, requirement in enumerate(value):
+        label = f"candidate.requirements[{index}]"
+        if not isinstance(requirement, dict) or set(requirement) != _REQUIREMENT_KEYS:
+            raise ContractError(f"{label} fields do not match the versioned contract")
+        if not isinstance(requirement.get("description"), str) or not requirement["description"].strip():
+            raise ContractError(f"{label}.description must be nonempty text")
+        _evidence_steps(requirement.get("evidence_steps"), step_ids, label=f"{label}.evidence_steps")
+    return value
+
+
 def _validate_ground_truth(task_dir: Path, value: Any, step_ids: set[int]) -> dict[str, Any]:
     if not isinstance(value, dict) or set(value) != _GROUND_TRUTH_KEYS:
         raise ContractError("candidate.ground_truth fields do not match the versioned contract")
@@ -542,6 +944,9 @@ def _validate_ground_truth(task_dir: Path, value: Any, step_ids: set[int]) -> di
     if not isinstance(artifacts, list):
         raise ContractError("candidate.ground_truth.artifacts must be a list")
     absence_reason = value.get("absence_reason")
+    use = value.get("use")
+    if use not in {"none", "comparison_only", "verification"}:
+        raise ContractError("candidate.ground_truth.use is not recognized")
     if absence_reason is not None and (not isinstance(absence_reason, str) or not absence_reason.strip()):
         raise ContractError("candidate.ground_truth.absence_reason must be null or nonempty text")
     if availability in {"available", "partial"} and not artifacts:
@@ -552,6 +957,10 @@ def _validate_ground_truth(task_dir: Path, value: Any, step_ids: set[int]) -> di
         raise ContractError("available ground truth must set absence_reason to null")
     if availability == "partial" and absence_reason is None:
         raise ContractError("partial ground truth must explain what is missing")
+    if availability in {"absent", "unknown"} and use != "none":
+        raise ContractError("absent or unknown ground truth must set use to none")
+    if availability in {"available", "partial"} and use == "none":
+        raise ContractError("available or partial ground truth must declare comparison_only or verification use")
 
     allowed_kinds = {
         "reference_trace",
@@ -584,7 +993,7 @@ def _validate_ground_truth(task_dir: Path, value: Any, step_ids: set[int]) -> di
             raise ContractError(f"{label}.sha256 does not match the retained artifact")
         if os.name == "posix" and stat.S_IMODE(artifact_path.stat().st_mode) & 0o077:
             raise ContractError(f"{label}.path is not owner-private")
-        _evidence_steps(artifact.get("evidence_steps"), step_ids, label=f"{label}.evidence_steps")
+        _validate_provenance(artifact.get("provenance"), step_ids, label=f"{label}.provenance")
         notes = artifact.get("notes")
         if not isinstance(notes, str) or not notes.strip():
             raise ContractError(f"{label}.notes must be nonempty text")
@@ -620,7 +1029,7 @@ def _validate_software_requirements(value: Any, step_ids: set[int]) -> list[dict
         redistributable = requirement.get("redistributable")
         if redistributable is not None and type(redistributable) is not bool:
             raise ContractError(f"{label}.redistributable must be true, false, or null")
-        _evidence_steps(requirement.get("evidence_steps"), step_ids, label=f"{label}.evidence_steps")
+        _validate_provenance(requirement.get("provenance"), step_ids, label=f"{label}.provenance")
         notes = requirement.get("notes")
         if not isinstance(notes, str) or not notes.strip():
             raise ContractError(f"{label}.notes must be nonempty text")
@@ -635,6 +1044,8 @@ def _validate_candidate(task_dir: Path, status: str, step_ids: set[int]) -> dict
         raise ContractError(f"candidate.schema must be {CANDIDATE_SCHEMA!r}")
     if candidate.get("status") != status:
         raise ContractError("candidate status does not match the requested summary status")
+    if candidate.get("decision_basis") != "safe_atif_only":
+        raise ContractError("candidate.decision_basis must be safe_atif_only")
     _evidence_steps(candidate.get("evidence_steps"), step_ids, label="candidate.evidence_steps")
     _string_list(candidate, "uncertainties")
     _string_list(candidate, "reason_codes", nonempty=status == "no_candidate")
@@ -643,7 +1054,9 @@ def _validate_candidate(task_dir: Path, status: str, step_ids: set[int]) -> dict
     if status == "candidate":
         if not isinstance(candidate.get("instruction"), str) or not candidate["instruction"].strip():
             raise ContractError("candidate.instruction must be nonempty text")
-        _string_list(candidate, "requirements", nonempty=True)
+        requirements = _validate_requirements(candidate.get("requirements"), step_ids)
+        if not requirements:
+            raise ContractError("candidate.requirements must not be empty")
         if candidate.get("verification_mode") != "execution":
             raise ContractError("the basic flow accepts only deterministic execution candidates")
         unavailable = [
@@ -661,7 +1074,296 @@ def _validate_candidate(task_dir: Path, status: str, step_ids: set[int]) -> dict
     return candidate
 
 
-def _validate_environment(task_dir: Path) -> dict[str, Any]:
+def _task_tree_info(root: Path) -> dict[str, Any]:
+    """Hash a task tree with unambiguous framing and executable-bit coverage."""
+
+    if root.is_symlink() or not root.is_dir():
+        raise ContractError("task must be a regular directory")
+    digest = hashlib.sha256()
+    file_count = 0
+    total_bytes = 0
+    for path in sorted(root.rglob("*"), key=lambda candidate: candidate.relative_to(root).as_posix()):
+        relative = path.relative_to(root).as_posix().encode()
+        if path.is_symlink():
+            raise ContractError(f"task tree refuses symlink: {path.relative_to(root)}")
+        if path.is_dir():
+            kind = b"directory"
+            executable = b"0"
+            payload_size = 0
+        elif path.is_file():
+            kind = b"file"
+            executable = b"1" if stat.S_IMODE(path.stat().st_mode) & 0o111 else b"0"
+            payload_size = path.stat().st_size
+            file_count += 1
+            total_bytes += payload_size
+        else:
+            raise ContractError(f"task tree contains an unsupported entry: {path.relative_to(root)}")
+        for field in (kind, relative, executable):
+            digest.update(len(field).to_bytes(8, "big"))
+            digest.update(field)
+        digest.update(payload_size.to_bytes(8, "big"))
+        if path.is_file():
+            with path.open("rb") as stream:
+                while chunk := stream.read(1024 * 1024):
+                    digest.update(chunk)
+    return {
+        "task_tree_sha256": f"sha256:{digest.hexdigest()}",
+        "file_count": file_count,
+        "total_bytes": total_bytes,
+    }
+
+
+def _dockerfile_images(task_dir: Path) -> list[dict[str, Any]]:
+    images: list[dict[str, Any]] = []
+    for path in sorted((task_dir / "task").rglob("Dockerfile")):
+        stages: set[str] = set()
+        stage_count = 0
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except UnicodeDecodeError as error:
+            raise ContractError(f"{path.relative_to(task_dir)} must be UTF-8 text") from error
+        logical_line = ""
+        first_line = 1
+        escape = "\\"
+        for line_number, line in enumerate(lines, start=1):
+            stripped = line.strip()
+            if stripped.lower().startswith("# escape="):
+                escape = stripped.split("=", 1)[1].strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            if not logical_line:
+                first_line = line_number
+            if escape and stripped.endswith(escape):
+                logical_line += stripped[: -len(escape)] + " "
+                continue
+            logical_line += stripped
+            instruction = logical_line.split(maxsplit=1)[0].casefold()
+            if instruction not in ("from", "copy", "run"):
+                logical_line = ""
+                continue
+            try:
+                parts = shlex.split(logical_line)
+            except ValueError as error:
+                raise ContractError(f"cannot inventory Dockerfile line {first_line}: {error}") from error
+            logical_line = ""
+            reference = None
+            if instruction == "from":
+                references = [part for part in parts[1:] if not part.startswith("--")]
+                if not references:
+                    raise ContractError(f"{path.relative_to(task_dir)}:{first_line} has an invalid FROM instruction")
+                reference = references[0]
+            else:
+                for index, part in enumerate(parts[1:], start=1):
+                    if part.startswith("--from="):
+                        reference = part.split("=", 1)[1]
+                    elif part == "--from" and index + 1 < len(parts):
+                        reference = parts[index + 1]
+                    elif instruction == "run" and part.startswith("--mount="):
+                        for option in part.split("=", 1)[1].split(","):
+                            if option.startswith("from="):
+                                images.append(
+                                    _image_reference(path, task_dir, first_line, "run_mount", option[5:], stages)
+                                )
+            if reference is None:
+                continue
+            images.append(_image_reference(path, task_dir, first_line, instruction, reference, stages))
+            if instruction == "from":
+                stages.add(str(stage_count))
+                stage_count += 1
+                lowered = [part.casefold() for part in parts]
+                if "as" in lowered:
+                    alias_index = lowered.index("as") + 1
+                    if alias_index >= len(parts):
+                        raise ContractError(f"{path.relative_to(task_dir)}:{first_line} has an invalid stage alias")
+                    stages.add(parts[alias_index].casefold())
+        if logical_line:
+            raise ContractError(f"{path.relative_to(task_dir)} has an unfinished continuation")
+    return images
+
+
+def _image_reference(
+    path: Path, task_dir: Path, line: int, instruction: str, reference: str, stages: set[str]
+) -> dict[str, Any]:
+    internal = reference.casefold() in stages
+    return {
+        "path": str(path.relative_to(task_dir)),
+        "line": line,
+        "instruction": instruction,
+        "reference": reference,
+        "internal_stage": internal,
+        "immutable": bool(
+            "$" not in reference and (internal or reference == "scratch" or _IMAGE_DIGEST.fullmatch(reference))
+        ),
+    }
+
+
+def _configured_images(config: dict[str, Any]) -> list[dict[str, Any]]:
+    environments = [("environment", config["environment"]), ("verifier.environment", config["verifier"]["environment"])]
+    for index, step in enumerate(config.get("steps", [])):
+        if isinstance(step.get("environment"), dict):
+            environments.append((f"steps[{index}].environment", step["environment"]))
+        verifier = step.get("verifier")
+        if isinstance(verifier, dict) and isinstance(verifier.get("environment"), dict):
+            environments.append((f"steps[{index}].verifier.environment", verifier["environment"]))
+    images = []
+    for location, environment in environments:
+        if "image" in environment:
+            raise ContractError(f"{location}.image is not a Harbor image field; use docker_image")
+        reference = environment.get("docker_image")
+        if reference is None:
+            continue
+        if not isinstance(reference, str) or not reference.strip():
+            raise ContractError(f"{location}.docker_image must be nonempty text")
+        images.append(
+            {
+                "path": "task/task.toml",
+                "field": f"{location}.docker_image",
+                "reference": reference,
+                "immutable": "$" not in reference and _IMAGE_DIGEST.fullmatch(reference) is not None,
+            }
+        )
+    return images
+
+
+def _contamination_findings(task_dir: Path) -> tuple[list[dict[str, str]], int]:
+    task = task_dir / "task"
+    environment = task / "environment"
+    findings: list[dict[str, str]] = []
+    scanned_files = 0
+
+    for path in sorted(environment.rglob("*")):
+        relative = path.relative_to(task)
+        if path.name == ".git":
+            findings.append(
+                {
+                    "code": "git_metadata_in_agent_context",
+                    "path": str(relative),
+                    "detail": "agent build context contains Git metadata or object history",
+                }
+            )
+
+    protected_digests: dict[str, str] = {}
+    for protected_dir, code in (
+        (task / "solution", "solution_in_agent_context"),
+        (task / "tests", "tests_in_agent_context"),
+    ):
+        for path in protected_dir.rglob("*") if protected_dir.is_dir() else ():
+            if path.name != "Dockerfile" and path.is_file() and not path.is_symlink() and path.stat().st_size:
+                protected_digests.setdefault(_sha256_file(path), code)
+    for path in environment.rglob("*"):
+        if not path.is_file() or path.is_symlink():
+            continue
+        code = protected_digests.get(_sha256_file(path)) if path.stat().st_size else None
+        if code is not None:
+            findings.append(
+                {
+                    "code": code,
+                    "path": str(path.relative_to(task)),
+                    "detail": "agent build context duplicates a protected task file",
+                }
+            )
+
+    for path in sorted(task.rglob("*")):
+        if not path.is_file() or path.is_symlink():
+            continue
+        scanned_files += 1
+        relative = str(path.relative_to(task))
+        matched_codes: set[str] = set()
+        overlap = b""
+        with path.open("rb") as stream:
+            while chunk := stream.read(1024 * 1024):
+                sample = overlap + chunk
+                for code, pattern, detail in (
+                    ("private_key_material", _PRIVATE_KEY_BYTES, "task contains private key material"),
+                    ("bearer_credential", _BEARER_BYTES, "task contains a bearer credential"),
+                    (
+                        "credentialed_url",
+                        _CREDENTIALED_URL_BYTES,
+                        "task contains credentials embedded in a URL",
+                    ),
+                ):
+                    if code not in matched_codes and pattern.search(sample):
+                        findings.append({"code": code, "path": relative, "detail": detail})
+                        matched_codes.add(code)
+                overlap = sample[-4096:]
+    findings.sort(key=lambda finding: (finding["code"], finding["path"]))
+    return findings, scanned_files
+
+
+def _derive_reproducibility(task_dir: Path) -> dict[str, Any]:
+    task_contract = _validate_task(task_dir)
+    task_info = _task_tree_info(task_dir / "task")
+    images = _dockerfile_images(task_dir)
+    config = task_contract["config"]
+    configured_images = _configured_images(config)
+    metadata = config.get("metadata")
+    source_revision = None
+    if isinstance(metadata, dict):
+        for key in ("source_commit", "source_revision"):
+            if isinstance(metadata.get(key), str) and metadata[key].strip():
+                source_revision = metadata[key]
+                break
+    environment = config.get("environment")
+    configured_image = environment.get("docker_image") if isinstance(environment, dict) else None
+    has_agent_recipe = any(image["path"] == "task/environment/Dockerfile" for image in images)
+    all_immutable = all(image["immutable"] for image in [*images, *configured_images])
+    if all_immutable and isinstance(configured_image, str) and _IMAGE_DIGEST.fullmatch(configured_image):
+        portability_state = "immutable_image"
+    elif has_agent_recipe and all_immutable:
+        portability_state = "recipe_rebuildable"
+    else:
+        portability_state = "local_only"
+    findings, scanned_files = _contamination_findings(task_dir)
+    return {
+        "schema": REPRODUCIBILITY_SCHEMA,
+        **task_info,
+        "source_revision": source_revision,
+        "portability": {
+            "state": portability_state,
+            "configured_image": configured_image,
+            "container_images": images,
+            "configured_images": configured_images,
+        },
+        "network": {
+            "agent": task_contract["agent_network_mode"],
+            "verifier": "no-network",
+        },
+        "contamination": {
+            "passed": not findings,
+            "scanned_files": scanned_files,
+            "findings": findings,
+        },
+    }
+
+
+def _record_reproducibility(args: argparse.Namespace) -> dict[str, Any]:
+    task_dir = _ensure_task_dir(args.task_dir)
+    output = task_dir / "reproducibility.json"
+    if output.exists():
+        raise ContractError("refusing to replace existing reproducibility.json")
+    report = _derive_reproducibility(task_dir)
+    _write_json(output, report)
+    return {
+        "task_dir": str(task_dir),
+        "valid": report["contamination"]["passed"],
+        "task_tree_sha256": report["task_tree_sha256"],
+        "portability_state": report["portability"]["state"],
+        "contamination_findings": len(report["contamination"]["findings"]),
+    }
+
+
+def _validate_reproducibility(task_dir: Path) -> dict[str, Any]:
+    recorded = _load_object(task_dir / "reproducibility.json", label="environment reproducibility")
+    derived = _derive_reproducibility(task_dir)
+    if recorded != derived:
+        raise ContractError("reproducibility.json differs from the current task tree or integrity scan")
+    if not recorded["contamination"]["passed"]:
+        codes = sorted({finding["code"] for finding in recorded["contamination"]["findings"]})
+        raise ContractError(f"task contamination scan failed: {', '.join(codes)}")
+    return recorded
+
+
+def _validate_task(task_dir: Path) -> dict[str, Any]:
     environment = task_dir / "task"
     required_files = (
         environment / "README.md",
@@ -693,27 +1395,371 @@ def _validate_environment(task_dir: Path) -> dict[str, Any]:
     missing_sections = [section for section in _TASK_README_SECTIONS if not sections.get(section)]
     if missing_sections:
         raise ContractError(f"task/README.md is missing substantive sections: {', '.join(missing_sections)}")
-    validation = _load_object(task_dir / "validation.json", label="environment validation")
-    if set(validation) != {"schema", "nop", "oracle"}:
+    try:
+        config = tomllib.loads((environment / "task.toml").read_text(encoding="utf-8"))
+    except (UnicodeDecodeError, tomllib.TOMLDecodeError) as error:
+        raise ContractError(f"task/task.toml must be valid UTF-8 TOML: {error}") from error
+    verifier = config.get("verifier")
+    if not isinstance(verifier, dict):
+        raise ContractError("task/task.toml must contain a [verifier] table")
+    mode = verifier.get("environment_mode")
+    if mode != "separate":
+        raise ContractError("task/task.toml must explicitly set [verifier].environment_mode to separate")
+    if verifier.get("network_mode") != "no-network":
+        raise ContractError("[verifier].network_mode must be no-network")
+    verifier_environment = verifier.get("environment")
+    if not isinstance(verifier_environment, dict):
+        raise ContractError("task/task.toml must contain an explicit [verifier.environment] table")
+    if verifier_environment.get("network_mode") != "no-network":
+        raise ContractError("[verifier.environment].network_mode must be no-network")
+    agent_environment = config.get("environment")
+    if not isinstance(agent_environment, dict) or agent_environment.get("network_mode") != "no-network":
+        raise ContractError("[environment].network_mode must be no-network")
+    steps = config.get("steps", [])
+    if not isinstance(steps, list):
+        raise ContractError("task/task.toml steps must be an array of tables")
+    for index, step in enumerate(steps, start=1):
+        if not isinstance(step, dict):
+            raise ContractError(f"task/task.toml step {index} must be a table")
+        step_agent_environment = step.get("environment")
+        if step_agent_environment is not None and (
+            not isinstance(step_agent_environment, dict)
+            or step_agent_environment.get("network_mode") not in {None, "no-network"}
+        ):
+            raise ContractError(f"task/task.toml step {index} agent environment network_mode must be no-network")
+        step_verifier = step.get("verifier")
+        if step_verifier is None:
+            continue
+        if not isinstance(step_verifier, dict):
+            raise ContractError(f"task/task.toml step {index} verifier must be a table")
+        step_mode = step_verifier.get("environment_mode")
+        if step_mode not in {None, "separate"}:
+            raise ContractError(f"task/task.toml step {index} verifier must not override separate mode")
+        step_network_mode = step_verifier.get("network_mode")
+        if step_network_mode not in {None, "no-network"}:
+            raise ContractError(f"task/task.toml step {index} verifier network_mode must be no-network")
+        step_environment = step_verifier.get("environment")
+        if step_environment is not None and (
+            not isinstance(step_environment, dict) or step_environment.get("network_mode") != "no-network"
+        ):
+            raise ContractError(f"[steps.verifier.environment] for step {index} must set network_mode to no-network")
+    return {
+        "verifier_environment_mode": mode,
+        "isolation_status": "isolated",
+        "agent_network_mode": "no-network",
+        "config": config,
+    }
+
+
+def _job_result(task_dir: Path, value: str | Path, *, arm: str) -> tuple[Path, Path, dict[str, Any]]:
+    job_dir = Path(value)
+    if not job_dir.is_absolute():
+        job_dir = task_dir / job_dir
+    if job_dir.is_symlink():
+        raise ContractError(f"{arm} Harbor job directory must not be a symlink")
+    job_dir = job_dir.resolve()
+    if not job_dir.is_relative_to(task_dir.resolve()):
+        raise ContractError(f"{arm} Harbor job directory must stay inside the task workspace")
+    if not job_dir.is_dir():
+        raise ContractError(f"{arm} Harbor job directory does not exist as a regular directory")
+    results = sorted(job_dir.glob("task__*/result.json"))
+    if len(results) != 1:
+        raise ContractError(f"{arm} Harbor job directory must contain exactly one task__*/result.json")
+    result_path = results[0]
+    result = _load_object(result_path, label=f"{arm} Harbor result")
+    return job_dir, result_path, result
+
+
+def _harbor_task_checksum(task_dir: Path) -> str:
+    # Let Harbor own task validation and checksum semantics. This is separate
+    # from our full-tree digest, which additionally covers executable bits.
+    try:
+        from harbor.models.task.task import Task
+    except ImportError as error:
+        raise ContractError("proof commands require Harbor; use the existing Harbor Python environment") from error
+    try:
+        return Task(task_dir / "task").checksum
+    except (ValueError, FileNotFoundError) as error:
+        raise ContractError(f"Harbor could not validate the proof task: {error}") from error
+
+
+def _run_input_path(task_dir: Path, job_dir: Path) -> Path:
+    relative = job_dir.relative_to(task_dir).as_posix()
+    return task_dir / "private" / "run-inputs" / f"{hashlib.sha256(relative.encode()).hexdigest()}.json"
+
+
+def _agent_identity(config: Any) -> str:
+    if not isinstance(config, dict):
+        raise ContractError("Harbor result must record config.agent")
+    name, import_path = config.get("name"), config.get("import_path")
+    for value in (name, import_path):
+        if value is not None and (not isinstance(value, str) or not value.strip()):
+            raise ContractError("Harbor agent name and import_path must be nonempty text or null")
+    # Fail closed on conflicting fields rather than interpreting a provider's
+    # precedence differently. No task-supplied module is imported to identify it.
+    if name and import_path:
+        raise ContractError("proof agents must declare only name or import_path, not both")
+    identity = import_path or name
+    if not identity:
+        raise ContractError("Harbor result must explicitly identify its agent")
+    aliases = {"harbor.agents.nop:NopAgent": "nop", "harbor.agents.oracle:OracleAgent": "oracle"}
+    return aliases.get(identity, identity)
+
+
+def _negative_control(task_dir: Path, agent: str, source: Path, rationale: str) -> dict[str, Any]:
+    identity = _agent_identity({"name": agent})
+    if identity in ("nop", "oracle") or re.fullmatch(r"[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*:[A-Za-z_]\w*", identity) is None:
+        raise ContractError("negative control must identify a custom module:Class agent distinct from NOP and Oracle")
+    if not isinstance(rationale, str) or not rationale.strip():
+        raise ContractError("negative control requires a task-specific mutation rationale")
+    source_path = source if source.is_absolute() else task_dir / source
+    if source_path.is_symlink() or not source_path.is_file():
+        raise ContractError("negative control source must be a retained regular file")
+    source_path = source_path.resolve()
+    if not source_path.is_relative_to(task_dir / "private") or not source_path.stat().st_size:
+        raise ContractError("negative control source must be nonempty and stay under private/")
+    return {
+        "agent": identity,
+        "source_path": source_path.relative_to(task_dir).as_posix(),
+        "source_sha256": _sha256_file(source_path),
+        "rationale": rationale,
+    }
+
+
+def _record_run_inputs(args: argparse.Namespace) -> dict[str, Any]:
+    task_dir = _ensure_task_dir(args.task_dir)
+    job_dir = args.job_dir if args.job_dir.is_absolute() else task_dir / args.job_dir
+    if job_dir.is_symlink():
+        raise ContractError("future Harbor job directory must not be a symlink")
+    job_dir = job_dir.resolve()
+    if not job_dir.is_relative_to(task_dir / "private") or job_dir == task_dir / "private":
+        raise ContractError("future Harbor job directory must stay under private/")
+    if job_dir.exists():
+        raise ContractError("record run inputs before Harbor creates the job directory; use a fresh job name")
+    output = _run_input_path(task_dir, job_dir)
+    if output.exists():
+        raise ContractError("run inputs already recorded; use a fresh job name")
+    reproducibility = _validate_reproducibility(task_dir)
+    control = None
+    if args.arm == "negative":
+        if not args.negative_agent or args.negative_source is None or not args.negative_rationale:
+            raise ContractError(
+                "negative run inputs require --negative-agent, --negative-source and --negative-rationale"
+            )
+        control = _negative_control(task_dir, args.negative_agent, args.negative_source, args.negative_rationale)
+    elif args.negative_agent or args.negative_source or args.negative_rationale:
+        raise ContractError("negative control options apply only to the negative arm")
+    receipt = {
+        "schema": RUN_INPUT_SCHEMA,
+        "arm": args.arm,
+        "job_dir": job_dir.relative_to(task_dir).as_posix(),
+        "task_tree_sha256": reproducibility["task_tree_sha256"],
+        "task_checksum": _harbor_task_checksum(task_dir),
+        "negative_control": control,
+    }
+    _mkdir_private(output.parent)
+    _write_bytes_once(output, (json.dumps(receipt, indent=2, sort_keys=True) + "\n").encode())
+    return {
+        "task_dir": str(task_dir),
+        "arm": args.arm,
+        "run_inputs": str(output),
+        "task_tree_sha256": receipt["task_tree_sha256"],
+    }
+
+
+def _validate_run_inputs(
+    task_dir: Path, job_dir: Path, arm: str, result: dict[str, Any], task_digest: str, checksum: str
+) -> dict[str, Any]:
+    path = _run_input_path(task_dir, job_dir)
+    receipt = _load_object(path, label="pre-run inputs (record-run-inputs is required before every Harbor job)")
+    if (
+        set(receipt) != {"schema", "arm", "job_dir", "task_tree_sha256", "task_checksum", "negative_control"}
+        or receipt.get("schema") != RUN_INPUT_SCHEMA
+    ):
+        raise ContractError("run inputs do not match the versioned contract")
+    if receipt["arm"] != arm or receipt["job_dir"] != job_dir.relative_to(task_dir).as_posix():
+        raise ContractError("run inputs identify a different Harbor job or proof arm")
+    if receipt["task_tree_sha256"] != task_digest or receipt["task_checksum"] != checksum:
+        raise ContractError("pre-run task snapshot differs from the current task; fresh Harbor jobs are required")
+    if result.get("task_checksum") != checksum:
+        raise ContractError("Harbor result task checksum differs from the current task")
+    config = result.get("config")
+    identity = _agent_identity(config.get("agent") if isinstance(config, dict) else None)
+    control = receipt["negative_control"]
+    if arm == "negative":
+        if not isinstance(control, dict) or set(control) != {"agent", "source_path", "source_sha256", "rationale"}:
+            raise ContractError("negative run inputs require retained control source and rationale")
+        if not isinstance(control["agent"], str) or not isinstance(control["source_path"], str):
+            raise ContractError("negative control agent and source_path must be strings")
+        expected = _negative_control(task_dir, control["agent"], Path(control["source_path"]), control["rationale"])
+        if expected != control or identity != control["agent"]:
+            raise ContractError("negative control source or recorded agent differs from its pre-run declaration")
+    elif control is not None or identity != arm:
+        raise ContractError(f"{arm} Harbor result must identify the {arm} agent")
+    return {
+        "agent": identity,
+        "run_inputs_path": path.relative_to(task_dir).as_posix(),
+        "run_inputs_sha256": _sha256_file(path),
+    }
+
+
+def _arm_from_result(task_dir: Path, job_dir: Path, result_path: Path, result: dict[str, Any]) -> dict[str, Any]:
+    verifier_result = result.get("verifier_result")
+    rewards = verifier_result.get("rewards") if isinstance(verifier_result, dict) else None
+    reward = rewards.get("reward") if isinstance(rewards, dict) else None
+    if reward is not None and (isinstance(reward, bool) or not isinstance(reward, (int, float))):
+        raise ContractError("Harbor result reward must be numeric or null")
+    config = result.get("config")
+    job_id = config.get("job_id") if isinstance(config, dict) else None
+    if not isinstance(job_id, str) or not job_id.strip():
+        raise ContractError("Harbor result must record a nonempty config.job_id")
+    return {
+        "job_id": job_id,
+        "job_dir": str(job_dir.relative_to(task_dir.resolve())),
+        "result_path": str(result_path.relative_to(task_dir.resolve())),
+        "result_sha256": _sha256(result_path.read_bytes()),
+        "reward": reward,
+        "exception_present": result.get("exception_info") is not None,
+    }
+
+
+def _validation_from_jobs(
+    task_dir: Path,
+    nop_job_dirs: list[str | Path],
+    oracle_job_dirs: list[str | Path],
+    negative_job_dirs: list[str | Path],
+    harbor_version: str,
+) -> dict[str, Any]:
+    if not isinstance(harbor_version, str) or not harbor_version.strip():
+        raise ContractError("Harbor version must be nonempty text")
+    task_contract = _validate_task(task_dir)
+    reproducibility = _validate_reproducibility(task_dir)
+    checksum = _harbor_task_checksum(task_dir)
+    inputs = {"nop": nop_job_dirs, "oracle": oracle_job_dirs, "negative": negative_job_dirs}
+    for arm, minimum in _MIN_VALIDATION_RUNS.items():
+        if len(inputs[arm]) < minimum:
+            raise ContractError(f"validation requires at least {minimum} independent {arm} Harbor jobs")
+    runs: dict[str, list[dict[str, Any]]] = {arm: [] for arm in inputs}
+    trials: list[dict[str, Any]] = []
+    for arm, values in inputs.items():
+        for index, value in enumerate(values, start=1):
+            label = f"{arm} run {index}"
+            job_dir, result_path, result = _job_result(task_dir, value, arm=label)
+            trials.append(result)
+            run_inputs = _validate_run_inputs(
+                task_dir, job_dir, arm, result, reproducibility["task_tree_sha256"], checksum
+            )
+            runs[arm].append({**_arm_from_result(task_dir, job_dir, result_path, result), **run_inputs})
+    job_dirs = [run["job_dir"] for arm_runs in runs.values() for run in arm_runs]
+    job_ids = [run["job_id"] for arm_runs in runs.values() for run in arm_runs]
+    if len(job_dirs) != len(set(job_dirs)):
+        raise ContractError("validation Harbor job directories must be distinct")
+    if len(job_ids) != len(set(job_ids)):
+        raise ContractError("validation Harbor config.job_id values must be distinct")
+    checksums = {trial.get("task_checksum") for trial in trials}
+    if (
+        len(checksums) != 1
+        or not isinstance(next(iter(checksums)), str)
+        or _TASK_CHECKSUM.fullmatch(next(iter(checksums))) is None
+    ):
+        raise ContractError("all validation Harbor results must have one matching task checksum")
+    modes = {trial.get("verifier_environment_mode") for trial in trials}
+    if modes != {"separate"}:
+        raise ContractError("all validation Harbor results must report separate verifier mode")
+    mode = next(iter(modes))
+    if mode != task_contract["verifier_environment_mode"]:
+        raise ContractError("Harbor verifier environment mode differs from task/task.toml")
+    expected_rewards = {"nop": 0, "oracle": 1, "negative": 0}
+    passed = all(
+        run["reward"] == expected_rewards[arm] and not run["exception_present"]
+        for arm, arm_runs in runs.items()
+        for run in arm_runs
+    )
+    return {
+        "schema": VALIDATION_SCHEMA,
+        "harbor_version": harbor_version,
+        "task_checksum": next(iter(checksums)),
+        "task_tree_sha256": reproducibility["task_tree_sha256"],
+        "verifier_environment_mode": mode,
+        "fresh_jobs": True,
+        "minimum_runs": _MIN_VALIDATION_RUNS,
+        "passed": passed,
+        "runs": runs,
+    }
+
+
+def _record_validation(args: argparse.Namespace) -> dict[str, Any]:
+    task_dir = _ensure_task_dir(args.task_dir)
+    validation_path = task_dir / "validation.json"
+    if validation_path.exists():
+        raise ContractError("refusing to replace existing validation.json")
+    validation = _validation_from_jobs(
+        task_dir,
+        args.nop_job_dir,
+        args.oracle_job_dir,
+        args.negative_job_dir,
+        args.harbor_version,
+    )
+    _write_json(validation_path, validation)
+    return {
+        "task_dir": str(task_dir),
+        "passed": validation["passed"],
+        "nop_rewards": [run["reward"] for run in validation["runs"]["nop"]],
+        "oracle_rewards": [run["reward"] for run in validation["runs"]["oracle"]],
+        "negative_rewards": [run["reward"] for run in validation["runs"]["negative"]],
+        "verifier_environment_mode": validation["verifier_environment_mode"],
+    }
+
+
+def _validate_validation(task_dir: Path) -> dict[str, Any]:
+    recorded = _load_object(task_dir / "validation.json", label="environment validation")
+    expected_keys = {
+        "schema",
+        "harbor_version",
+        "task_checksum",
+        "task_tree_sha256",
+        "verifier_environment_mode",
+        "fresh_jobs",
+        "minimum_runs",
+        "passed",
+        "runs",
+    }
+    if set(recorded) != expected_keys or recorded.get("schema") != VALIDATION_SCHEMA:
         raise ContractError("validation fields do not match the versioned contract")
-    if validation.get("schema") != VALIDATION_SCHEMA:
-        raise ContractError(f"validation.schema must be {VALIDATION_SCHEMA!r}")
-    for arm, reward in (("nop", 0), ("oracle", 1)):
-        result = validation.get(arm)
-        if not isinstance(result, dict) or set(result) != {"reward", "exception", "job_dir"}:
-            raise ContractError(f"validation.{arm} must be an object")
-        if result.get("reward") != reward or result.get("exception") is not None:
-            raise ContractError(f"validation.{arm} must have reward {reward} and no exception")
-        job_dir = result.get("job_dir")
-        if not isinstance(job_dir, str) or not job_dir.strip():
-            raise ContractError(f"validation.{arm}.job_dir must name the Harbor evidence directory")
-        job_path = task_dir / job_dir
-        resolved_job_path = job_path.resolve()
-        if not resolved_job_path.is_relative_to(task_dir.resolve()):
-            raise ContractError(f"validation.{arm}.job_dir must stay inside the task workspace")
-        if job_path.is_symlink() or not job_path.is_dir():
-            raise ContractError(f"validation.{arm}.job_dir does not exist as a regular directory")
-    return validation
+    if not isinstance(recorded.get("harbor_version"), str) or not recorded["harbor_version"].strip():
+        raise ContractError("validation.harbor_version must be nonempty text")
+    if recorded.get("minimum_runs") != _MIN_VALIDATION_RUNS or recorded.get("fresh_jobs") is not True:
+        raise ContractError("validation repeat and fresh-job policy does not match the versioned contract")
+    runs = recorded.get("runs")
+    if not isinstance(runs, dict) or set(runs) != set(_MIN_VALIDATION_RUNS):
+        raise ContractError("validation.runs fields do not match the versioned contract")
+    for arm, minimum in _MIN_VALIDATION_RUNS.items():
+        values = runs.get(arm)
+        if not isinstance(values, list) or len(values) < minimum:
+            raise ContractError(f"validation.runs.{arm} does not meet the minimum run count")
+        for value in values:
+            if not isinstance(value, dict) or set(value) != {
+                "job_id",
+                "job_dir",
+                "result_path",
+                "result_sha256",
+                "reward",
+                "exception_present",
+                "agent",
+                "run_inputs_path",
+                "run_inputs_sha256",
+            }:
+                raise ContractError(f"validation.runs.{arm} fields do not match the versioned contract")
+    derived = _validation_from_jobs(
+        task_dir,
+        [run["job_dir"] for run in runs["nop"]],
+        [run["job_dir"] for run in runs["oracle"]],
+        [run["job_dir"] for run in runs["negative"]],
+        recorded["harbor_version"],
+    )
+    if recorded != derived:
+        raise ContractError("validation.json differs from the retained Harbor result evidence")
+    return recorded
 
 
 def _summary_markdown(summary: dict[str, Any]) -> str:
@@ -738,7 +1784,10 @@ def _summary_markdown(summary: dict[str, Any]) -> str:
         f"## Evidence\n\n"
         f"- Safe ATIF: `{summary['source']['safe_path']}`\n"
         f"- Evidence steps: {candidate.get('evidence_steps', [])}\n"
-        f"- Environment: `{summary['environment']['status']}`\n\n"
+        f"- Environment: `{summary['environment']['status']}`\n"
+        f"- Technical proof: `{summary['environment']['technical_status']}`\n"
+        f"- Review: `{summary['environment']['review_status']}`\n"
+        f"- Verifier isolation: `{summary['environment']['isolation_status']}`\n\n"
         f"## Ground truth\n\n"
         f"- Availability: `{ground_truth['availability']}`\n"
         f"- Retained artifacts: {len(ground_truth['artifacts'])}\n"
@@ -752,7 +1801,7 @@ def _summary_markdown(summary: dict[str, Any]) -> str:
 
 
 def _finalize(args: argparse.Namespace) -> dict[str, Any]:
-    task_dir = _ensure_task_dir(args.task_dir.resolve())
+    task_dir = _ensure_task_dir(args.task_dir)
     summary = _load_summary(task_dir)
     if summary["source"] is None or summary["privacy"] is None:
         raise ContractError("prepare canonical ATIF evidence before finalizing")
@@ -766,25 +1815,37 @@ def _finalize(args: argparse.Namespace) -> dict[str, Any]:
     candidate = _validate_candidate(task_dir, args.status, step_ids)
 
     privacy = summary["privacy"]
-    privacy_review_complete = privacy["manual_review_complete"] or args.privacy_reviewed
-    if args.status == "candidate" and not privacy_review_complete:
-        raise ContractError("candidate finalization requires --privacy-reviewed after contextual review")
+    if args.status == "candidate" and not privacy["contextual_review_complete"]:
+        raise ContractError("candidate finalization requires the review-privacy command")
     if args.status == "candidate" and privacy["blocking_reasons"]:
         raise ContractError("candidate finalization is blocked by unresolved non-text evidence")
 
     validation: dict[str, Any] | None = None
-    environment_status = args.environment_status
     if args.status == "no_candidate":
-        if environment_status != "not_attempted":
-            raise ContractError("no_candidate must use environment status not_attempted")
-    elif environment_status == "ready":
-        validation = _validate_environment(task_dir)
-
-    if args.privacy_reviewed:
-        privacy["manual_review_complete"] = True
-        privacy_payload = _load_object(task_dir / privacy["path"], label="privacy report")
-        privacy_payload["manual_review_complete"] = True
-        _write_json(task_dir / privacy["path"], privacy_payload)
+        environment_status = "not_attempted"
+        technical_status = "not_run"
+        review_status = "unreviewed"
+        verifier_mode = None
+        isolation_status = "not_run"
+        if (task_dir / "validation.json").exists():
+            raise ContractError("no_candidate workspaces must not include validation.json")
+    else:
+        task_contract = _validate_task(task_dir)
+        _validate_reproducibility(task_dir)
+        verifier_mode = task_contract["verifier_environment_mode"]
+        isolation_status = task_contract["isolation_status"]
+        review_status = "human_reviewed" if args.human_reviewed else "unreviewed"
+        if (task_dir / "validation.json").exists():
+            validation = _validate_validation(task_dir)
+            technical_status = "passed" if validation["passed"] else "failed"
+        else:
+            technical_status = "not_run"
+        if technical_status == "failed":
+            environment_status = "failed"
+        elif technical_status == "passed" and isolation_status == "isolated" and args.human_reviewed:
+            environment_status = "ready"
+        else:
+            environment_status = "unproven"
 
     reasons = list(args.reason)
     if args.status == "no_candidate" and not reasons:
@@ -796,7 +1857,11 @@ def _finalize(args: argparse.Namespace) -> dict[str, Any]:
             "environment": {
                 "path": "task",
                 "status": environment_status,
+                "technical_status": technical_status,
+                "review_status": review_status,
                 "validation": "validation.json" if validation is not None else None,
+                "verifier_environment_mode": verifier_mode,
+                "isolation_status": isolation_status,
             },
             "worked_well": list(args.worked_well),
             "did_not_work": list(args.did_not_work),
@@ -814,14 +1879,22 @@ def _finalize(args: argparse.Namespace) -> dict[str, Any]:
 
 
 def _check(args: argparse.Namespace) -> dict[str, Any]:
-    task_dir = _ensure_task_dir(args.task_dir.resolve())
+    task_dir = _ensure_task_dir(args.task_dir)
     summary = _load_summary(task_dir)
     errors: list[str] = []
     source = summary.get("source")
     if isinstance(source, dict):
-        for path_key, digest_key in (("private_path", "private_sha256"), ("safe_path", "safe_sha256")):
+        for path_key, digest_key, size_key in (
+            ("original_path", "original_sha256", "original_size_bytes"),
+            ("canonical_path", "canonical_sha256", "canonical_size_bytes"),
+            ("safe_path", "safe_sha256", "safe_size_bytes"),
+        ):
             path = task_dir / source[path_key]
-            if not path.is_file() or _sha256(path.read_bytes()) != source[digest_key]:
+            if (
+                not path.is_file()
+                or _sha256(path.read_bytes()) != source[digest_key]
+                or path.stat().st_size != source[size_key]
+            ):
                 errors.append(f"{path_key} is missing or its digest changed")
             elif os.name == "posix" and stat.S_IMODE(path.stat().st_mode) & 0o077:
                 errors.append(f"{path_key} is not owner-private")
@@ -830,9 +1903,17 @@ def _check(args: argparse.Namespace) -> dict[str, Any]:
     privacy = summary.get("privacy")
     if isinstance(privacy, dict):
         try:
-            privacy_payload = _load_object(task_dir / "safe" / "privacy.json", label="privacy report")
-            if privacy != {"path": "safe/privacy.json", **privacy_payload}:
+            privacy_payload = _load_object(task_dir / privacy["path"], label="privacy report")
+            if privacy != {"path": privacy["path"], "audit_path": privacy["audit_path"], **privacy_payload}:
                 errors.append("privacy report does not match the summary")
+            audit = _load_object(task_dir / privacy["audit_path"], label="privacy audit")
+            if audit.get("schema") != PRIVACY_AUDIT_SCHEMA or audit.get("safe_sha256") != source["safe_sha256"]:
+                errors.append("privacy audit does not match the safe ATIF")
+            review = audit.get("review", {})
+            if review.get("complete") != privacy["contextual_review_complete"]:
+                errors.append("privacy audit review does not match the summary")
+            if review.get("reviewer_kind") != privacy["reviewer_kind"]:
+                errors.append("privacy audit reviewer kind does not match the summary")
         except ContractError as error:
             errors.append(str(error))
     elif source is not None:
@@ -844,14 +1925,262 @@ def _check(args: argparse.Namespace) -> dict[str, Any]:
             candidate = _validate_candidate(task_dir, summary["status"], step_ids)
             if summary.get("candidate") != {"path": "candidate.json", **candidate}:
                 errors.append("candidate record does not match the summary")
-            if summary.get("environment", {}).get("status") == "ready":
-                _validate_environment(task_dir)
+            environment = summary.get("environment", {})
+            if summary["status"] == "candidate":
+                if (
+                    not isinstance(privacy, dict)
+                    or not privacy["contextual_review_complete"]
+                    or privacy["blocking_reasons"]
+                ):
+                    errors.append("finalized candidate lacks a clear contextual privacy review")
+                task_contract = _validate_task(task_dir)
+                _validate_reproducibility(task_dir)
+                if environment.get("verifier_environment_mode") != task_contract["verifier_environment_mode"]:
+                    errors.append("summary verifier mode does not match task/task.toml")
+                if environment.get("isolation_status") != task_contract["isolation_status"]:
+                    errors.append("summary isolation status does not match task/task.toml")
+                validation_path = task_dir / "validation.json"
+                if validation_path.exists():
+                    validation = _validate_validation(task_dir)
+                    expected_technical = "passed" if validation["passed"] else "failed"
+                    if environment.get("technical_status") != expected_technical:
+                        errors.append("summary technical status does not match Harbor evidence")
+                    expected_status = "failed"
+                    if validation["passed"]:
+                        expected_status = (
+                            "ready"
+                            if task_contract["isolation_status"] == "isolated"
+                            and environment.get("review_status") == "human_reviewed"
+                            else "unproven"
+                        )
+                    if environment.get("status") != expected_status:
+                        errors.append("summary environment status does not match proof, review, and isolation")
+                    if environment.get("validation") != "validation.json":
+                        errors.append("summary omits retained Harbor validation")
+                elif environment.get("technical_status") != "not_run":
+                    errors.append("summary claims technical proof without validation.json")
+                elif environment.get("status") != "unproven" or environment.get("validation") is not None:
+                    errors.append("unrun candidate must remain unproven without validation")
+            elif environment != {
+                "path": "task",
+                "status": "not_attempted",
+                "technical_status": "not_run",
+                "review_status": "unreviewed",
+                "validation": None,
+                "verifier_environment_mode": None,
+                "isolation_status": "not_run",
+            }:
+                errors.append("no_candidate environment status must remain not_attempted")
             markdown_path = task_dir / "summary.md"
             if not markdown_path.is_file() or markdown_path.read_text(encoding="utf-8") != _summary_markdown(summary):
                 errors.append("summary.md is missing or does not match summary.json")
         except ContractError as error:
             errors.append(str(error))
     return {"task_dir": str(task_dir), "valid": not errors, "errors": errors}
+
+
+def _load_batch_manifest(path: Path) -> list[dict[str, Any]]:
+    manifest = _load_object(path, label="batch manifest")
+    if set(manifest) != {"schema", "members"} or manifest.get("schema") != BATCH_SCHEMA:
+        raise ContractError("batch manifest fields do not match the versioned contract")
+    members = manifest.get("members")
+    if not isinstance(members, list) or not members:
+        raise ContractError("batch manifest members must be a nonempty list")
+    task_ids: set[str] = set()
+    for index, member in enumerate(members):
+        if not isinstance(member, dict) or set(member) != _BATCH_MEMBER_KEYS:
+            raise ContractError(f"batch manifest member {index} fields do not match the versioned contract")
+        task_id = member.get("task_id")
+        if not isinstance(task_id, str) or len(task_id) > 80 or TASK_ID.fullmatch(task_id) is None:
+            raise ContractError(f"batch manifest member {index} has an invalid task_id")
+        if task_id in task_ids:
+            raise ContractError(f"batch manifest contains duplicate task_id {task_id!r}")
+        task_ids.add(task_id)
+        atif = member.get("atif")
+        if not isinstance(atif, str) or not atif.strip():
+            raise ContractError(f"batch manifest member {index}.atif must be nonempty text")
+        if member.get("source_kind") not in {"atif", "intake", "mlflow", "otel"}:
+            raise ContractError(f"batch manifest member {index}.source_kind is not recognized")
+    return members
+
+
+def _batch_prepare(args: argparse.Namespace) -> dict[str, Any]:
+    manifest_path = args.manifest.resolve()
+    members = _load_batch_manifest(manifest_path)
+    root = args.root.resolve()
+    results: list[dict[str, Any]] = []
+    counts: dict[str, int] = {}
+    for member in members:
+        task_id = member["task_id"]
+        task_dir = root / task_id
+        source_path = Path(member["atif"])
+        if not source_path.is_absolute():
+            source_path = manifest_path.parent / source_path
+        try:
+            if not task_dir.exists():
+                _init(argparse.Namespace(root=root, task_id=task_id))
+            summary = _load_summary(task_dir)
+            if summary["source"] is None:
+                _prepare(
+                    argparse.Namespace(
+                        task_dir=task_dir,
+                        atif=source_path,
+                        source_kind=member["source_kind"],
+                    )
+                )
+                outcome = "prepared"
+            else:
+                source_bytes = source_path.resolve().read_bytes()
+                if summary["source"]["original_sha256"] != _sha256(source_bytes):
+                    raise ContractError("existing workspace source digest differs from the batch manifest source")
+                outcome = "existing"
+            results.append({"task_id": task_id, "outcome": outcome})
+        except (ContractError, OSError) as error:
+            outcome = "failed"
+            results.append({"task_id": task_id, "outcome": outcome, "error": str(error)})
+        counts[outcome] = counts.get(outcome, 0) + 1
+    return {
+        "schema": BATCH_SCHEMA,
+        "denominator": len(members),
+        "counts": dict(sorted(counts.items())),
+        "members": results,
+        "valid": counts.get("failed", 0) == 0,
+    }
+
+
+def _batch_status(args: argparse.Namespace) -> dict[str, Any]:
+    members = _load_batch_manifest(args.manifest.resolve())
+    root = args.root.resolve()
+    results: list[dict[str, str]] = []
+    counts: dict[str, int] = {}
+    for member in members:
+        task_dir = root / member["task_id"]
+        if not task_dir.is_dir():
+            status = "missing"
+        else:
+            try:
+                summary = _load_summary(task_dir)
+                if summary["status"] == "pending":
+                    status = "pending_prepared" if summary["source"] is not None else "pending_unprepared"
+                elif summary["status"] == "candidate":
+                    status = f"candidate_{summary['environment']['status']}"
+                else:
+                    status = "no_candidate"
+            except (ContractError, OSError) as error:
+                status = "invalid"
+                results.append({"task_id": member["task_id"], "status": status, "error": str(error)})
+                counts[status] = counts.get(status, 0) + 1
+                continue
+        counts[status] = counts.get(status, 0) + 1
+        results.append({"task_id": member["task_id"], "status": status})
+    return {
+        "schema": BATCH_SCHEMA,
+        "denominator": len(members),
+        "counts": dict(sorted(counts.items())),
+        "members": results,
+        "valid": counts.get("invalid", 0) == 0,
+    }
+
+
+def _reject_symlinks(root: Path) -> None:
+    for path in (root, *root.rglob("*")):
+        if path.is_symlink():
+            raise ContractError(f"safe export refuses symlink: {path.relative_to(root.parent)}")
+
+
+def _export(args: argparse.Namespace) -> dict[str, Any]:
+    task_dir = _ensure_task_dir(args.task_dir)
+    summary = _load_summary(task_dir)
+    if summary["status"] == "pending":
+        raise ContractError("finalize the task workspace before export")
+    checked = _check(argparse.Namespace(task_dir=task_dir))
+    if not checked["valid"]:
+        raise ContractError(f"task workspace check failed: {'; '.join(checked['errors'])}")
+    output_dir = args.output_dir.resolve()
+    if output_dir.is_relative_to(task_dir) or ".eval-author" in output_dir.parts:
+        raise ContractError("export directory must be outside every private .eval-author workspace")
+    if output_dir.exists():
+        raise ContractError(f"refusing to replace existing export directory: {output_dir}")
+    output_dir.mkdir(parents=True)
+    candidate = _load_object(task_dir / "candidate.json", label="candidate")
+    shutil.copy2(task_dir / "candidate.json", output_dir / "candidate.json")
+    if summary["status"] == "candidate":
+        _reject_symlinks(task_dir / "task")
+        shutil.copytree(task_dir / "task", output_dir / "task")
+        shutil.copy2(task_dir / "reproducibility.json", output_dir / "reproducibility.json")
+    reproducibility_summary = None
+    if summary["status"] == "candidate":
+        reproducibility = _validate_reproducibility(task_dir)
+        reproducibility_summary = {
+            "task_tree_sha256": reproducibility["task_tree_sha256"],
+            "file_count": reproducibility["file_count"],
+            "total_bytes": reproducibility["total_bytes"],
+            "source_revision": reproducibility["source_revision"],
+            "portability_state": reproducibility["portability"]["state"],
+            "agent_network_mode": reproducibility["network"]["agent"],
+            "contamination_passed": reproducibility["contamination"]["passed"],
+        }
+    validation_summary = None
+    if summary["environment"]["validation"] is not None:
+        validation = _validate_validation(task_dir)
+        validation_summary = {
+            "harbor_version": validation["harbor_version"],
+            "task_checksum": validation["task_checksum"],
+            "task_tree_sha256": validation["task_tree_sha256"],
+            "verifier_environment_mode": validation["verifier_environment_mode"],
+            "fresh_jobs": validation["fresh_jobs"],
+            "minimum_runs": validation["minimum_runs"],
+            "passed": validation["passed"],
+            "runs": {
+                arm: [
+                    {"reward": run["reward"], "exception_present": run["exception_present"]}
+                    for run in validation["runs"][arm]
+                ]
+                for arm in _MIN_VALIDATION_RUNS
+            },
+        }
+    product = {
+        "schema": EXPORT_SCHEMA,
+        "task_id": summary["task_id"],
+        "status": summary["status"],
+        "reason_codes": candidate["reason_codes"],
+        "candidate_evidence_steps": candidate["evidence_steps"],
+        "ground_truth": {
+            "availability": candidate["ground_truth"]["availability"],
+            "use": candidate["ground_truth"]["use"],
+            "artifact_count": len(candidate["ground_truth"]["artifacts"]),
+        },
+        "privacy": {
+            "redaction_count": sum(summary["privacy"]["deterministic_redactions"].values()),
+            "images_omitted": summary["privacy"]["images_omitted"],
+            "contextual_review_complete": summary["privacy"]["contextual_review_complete"],
+            "reviewer_kind": summary["privacy"]["reviewer_kind"],
+        },
+        "environment": {
+            name: summary["environment"][name]
+            for name in (
+                "status",
+                "technical_status",
+                "review_status",
+                "verifier_environment_mode",
+                "isolation_status",
+            )
+        },
+        "reproducibility": reproducibility_summary,
+        "technical_validation": validation_summary,
+    }
+    _write_json(output_dir / "result.json", product)
+    for path in output_dir.rglob("*"):
+        if path.is_file():
+            path.chmod(0o644)
+        elif path.is_dir():
+            path.chmod(0o755)
+    output_dir.chmod(0o755)
+    return {
+        "task_id": summary["task_id"],
+        "output_dir": str(output_dir),
+        "files": sorted(str(path.relative_to(output_dir)) for path in output_dir.rglob("*") if path.is_file()),
+    }
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -869,15 +2198,41 @@ def _parser() -> argparse.ArgumentParser:
     prepare.add_argument("--source-kind", choices=("atif", "intake", "mlflow", "otel"), required=True)
     prepare.set_defaults(run=_prepare)
 
+    review = subparsers.add_parser("review-privacy", help="record contextual review of every safe ATIF string")
+    review.add_argument("--task-dir", required=True, type=Path)
+    review.add_argument("--reviewer-kind", choices=("agent", "human"), required=True)
+    review.add_argument("--note", required=True)
+    review.set_defaults(run=_review_privacy)
+
+    reproducibility = subparsers.add_parser(
+        "record-reproducibility", help="hash the task tree and record portability and contamination evidence"
+    )
+    reproducibility.add_argument("--task-dir", required=True, type=Path)
+    reproducibility.set_defaults(run=_record_reproducibility)
+
+    run_inputs = subparsers.add_parser(
+        "record-run-inputs", help="bind a future Harbor job to the current task and proof arm"
+    )
+    run_inputs.add_argument("--task-dir", required=True, type=Path)
+    run_inputs.add_argument("--job-dir", required=True, type=Path)
+    run_inputs.add_argument("--arm", required=True, choices=("nop", "oracle", "negative"))
+    run_inputs.add_argument("--negative-agent")
+    run_inputs.add_argument("--negative-source", type=Path)
+    run_inputs.add_argument("--negative-rationale")
+    run_inputs.set_defaults(run=_record_run_inputs)
+
+    record = subparsers.add_parser("record-validation", help="derive proof only from retained Harbor results")
+    record.add_argument("--task-dir", required=True, type=Path)
+    record.add_argument("--nop-job-dir", required=True, action="append", type=Path)
+    record.add_argument("--oracle-job-dir", required=True, action="append", type=Path)
+    record.add_argument("--negative-job-dir", required=True, action="append", type=Path)
+    record.add_argument("--harbor-version", required=True)
+    record.set_defaults(run=_record_validation)
+
     finalize = subparsers.add_parser("finalize", help="write the candidate decision and task summary")
     finalize.add_argument("--task-dir", required=True, type=Path)
     finalize.add_argument("--status", choices=("candidate", "no_candidate"), required=True)
-    finalize.add_argument(
-        "--environment-status",
-        choices=("ready", "failed", "unproven", "not_attempted"),
-        default="not_attempted",
-    )
-    finalize.add_argument("--privacy-reviewed", action="store_true")
+    finalize.add_argument("--human-reviewed", action="store_true")
     finalize.add_argument("--worked-well", action="append", default=[])
     finalize.add_argument("--did-not-work", action="append", default=[])
     finalize.add_argument("--reason", action="append", default=[])
@@ -886,6 +2241,21 @@ def _parser() -> argparse.ArgumentParser:
     check = subparsers.add_parser("check", help="verify recorded digests and generated artifacts")
     check.add_argument("--task-dir", required=True, type=Path)
     check.set_defaults(run=_check)
+
+    batch_prepare = subparsers.add_parser("batch-prepare", help="idempotently prepare every manifest member")
+    batch_prepare.add_argument("--root", type=Path, default=Path(".eval-author/trace-environments"))
+    batch_prepare.add_argument("--manifest", required=True, type=Path)
+    batch_prepare.set_defaults(run=_batch_prepare)
+
+    batch_status = subparsers.add_parser("batch-status", help="report the complete manifest denominator")
+    batch_status.add_argument("--root", type=Path, default=Path(".eval-author/trace-environments"))
+    batch_status.add_argument("--manifest", required=True, type=Path)
+    batch_status.set_defaults(run=_batch_status)
+
+    export = subparsers.add_parser("export", help="publish only the reviewed candidate, task, and result summary")
+    export.add_argument("--task-dir", required=True, type=Path)
+    export.add_argument("--output-dir", required=True, type=Path)
+    export.set_defaults(run=_export)
     return parser
 
 

--- a/plugins/nemo-eval-author/tests/test_trace_environment.py
+++ b/plugins/nemo-eval-author/tests/test_trace_environment.py
@@ -6,18 +6,20 @@
 import hashlib
 import json
 import os
+import stat
 import subprocess
 import sys
 from pathlib import Path
 from typing import Any
 
 import pytest
+from dirhash import dirhash
 
 _PLUGIN = Path(__file__).resolve().parents[1]
 _SCRIPT = _PLUGIN / "skills" / "eval-author-trace-environment" / "scripts" / "trace_environment.py"
-_SUMMARY_SCHEMA = "nemo.eval_author.trace_environment_summary.v1"
-_CANDIDATE_SCHEMA = "nemo.eval_author.trace_environment_candidate.v1"
-_VALIDATION_SCHEMA = "nemo.eval_author.trace_environment_validation.v1"
+_SUMMARY_SCHEMA = "nemo.eval_author.trace_environment_summary.v2"
+_CANDIDATE_SCHEMA = "nemo.eval_author.trace_environment_candidate.v2"
+_VALIDATION_SCHEMA = "nemo.eval_author.trace_environment_validation.v4"
 
 
 def _run(*args: str) -> tuple[int, dict[str, Any]]:
@@ -42,12 +44,12 @@ def _atif(*, image_only: bool = False) -> dict[str, Any]:
             {
                 "step_id": 2,
                 "source": "agent",
-                "message": "Calling 10.2.3.4 with token Bearer abcdefghijklmnop",
+                "message": "Calling 10.2.3.4 for the fixture.",
                 "tool_calls": [
                     {
                         "tool_call_id": "call-1",
                         "function_name": "fixture.read",
-                        "arguments": {"phone": "+1 (303) 555-0119", "api_key": "secret-value"},
+                        "arguments": {"phone": "+1 (303) 555-0119"},
                     }
                 ],
                 "observation": {"results": [{"source_call_id": "call-1", "content": "Result for 123-45-6789"}]},
@@ -91,6 +93,7 @@ def _candidate(
     if ground_truth is None:
         ground_truth = {
             "availability": "absent",
+            "use": "none",
             "artifacts": [],
             "absence_reason": "No distinct reference artifact was recorded.",
         }
@@ -100,8 +103,9 @@ def _candidate(
         payload = {
             "schema": _CANDIDATE_SCHEMA,
             "status": "candidate",
+            "decision_basis": "safe_atif_only",
             "instruction": "Repair the local fixture.",
-            "requirements": ["The fixture check passes."],
+            "requirements": [{"description": "The fixture check passes.", "evidence_steps": [1, 2]}],
             "verification_mode": "execution",
             "evidence_steps": [1, 2],
             "uncertainties": [],
@@ -113,6 +117,7 @@ def _candidate(
         payload = {
             "schema": _CANDIDATE_SCHEMA,
             "status": "no_candidate",
+            "decision_basis": "safe_atif_only",
             "instruction": None,
             "requirements": [],
             "verification_mode": None,
@@ -125,13 +130,47 @@ def _candidate(
     _write_json(task_dir / "candidate.json", payload)
 
 
-def _ready_environment(task_dir: Path) -> None:
+def _review_privacy(task_dir: Path, *, reviewer_kind: str = "agent") -> None:
+    code, result = _run(
+        "review-privacy",
+        "--task-dir",
+        str(task_dir),
+        "--reviewer-kind",
+        reviewer_kind,
+        "--note",
+        "Reviewed every safe ATIF string and all contextual audit findings.",
+    )
+    assert code == 0, result
+
+
+def _record_reproducibility(task_dir: Path) -> None:
+    (task_dir / "reproducibility.json").unlink(missing_ok=True)
+    code, result = _run("record-reproducibility", "--task-dir", str(task_dir))
+    assert code == 0, result
+
+
+def _ready_environment(
+    task_dir: Path,
+    *,
+    mode: str = "separate",
+    nop_reward: float = 0.0,
+    oracle_reward: float = 1.0,
+    oracle_exception: object | None = None,
+    record_validation: bool = True,
+) -> None:
     task = task_dir / "task"
     (task / "environment").mkdir(parents=True)
     (task / "tests").mkdir()
     (task / "solution").mkdir()
-    (task / "task.toml").write_text('schema_version = "1.1"\n', encoding="utf-8")
+    verifier = f'\n[verifier]\nenvironment_mode = "{mode}"\n'
+    if mode == "separate":
+        verifier += 'network_mode = "no-network"\n\n[verifier.environment]\nnetwork_mode = "no-network"\n'
+    (task / "task.toml").write_text(
+        f'schema_version = "1.1"\n{verifier}\n[environment]\nnetwork_mode = "no-network"\n',
+        encoding="utf-8",
+    )
     (task / "instruction.md").write_text("Repair the fixture.\n", encoding="utf-8")
+    (task / "environment" / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
     (task / "README.md").write_text(
         """# Repair fixture
 
@@ -162,17 +201,83 @@ The human reviewer confirmed that this fixture accurately represents the recorde
         encoding="utf-8",
     )
     (task / "tests" / "test.sh").write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
-    (task / "solution" / "solve.sh").write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
-    (task_dir / "private" / "jobs" / "nop").mkdir(parents=True)
-    (task_dir / "private" / "jobs" / "oracle").mkdir()
-    _write_json(
-        task_dir / "validation.json",
-        {
-            "schema": _VALIDATION_SCHEMA,
-            "nop": {"reward": 0, "exception": None, "job_dir": "private/jobs/nop"},
-            "oracle": {"reward": 1, "exception": None, "job_dir": "private/jobs/oracle"},
-        },
-    )
+    if mode == "separate":
+        (task / "tests" / "Dockerfile").write_text(
+            "FROM scratch\nCOPY test.sh /tests/test.sh\n",
+            encoding="utf-8",
+        )
+    (task / "solution" / "solve.sh").write_text("#!/usr/bin/env bash\ntouch repaired\n", encoding="utf-8")
+    checksum = dirhash(task, "sha256")
+    if mode == "separate":
+        _record_reproducibility(task_dir)
+    control_source = task_dir / "private" / "negative_agent.py"
+    control_source.write_text("# Synthetic incomplete repair implementation.\n", encoding="utf-8")
+    for job_number, arm, reward, exception in (
+        (1, "nop-1", nop_reward, None),
+        (2, "nop-2", nop_reward, None),
+        (3, "oracle-1", oracle_reward, oracle_exception),
+        (4, "oracle-2", oracle_reward, oracle_exception),
+        (5, "negative-1", 0.0, None),
+    ):
+        proof_arm = arm.rsplit("-", 1)[0]
+        if mode == "separate":
+            extra = (
+                [
+                    "--negative-agent",
+                    "negative_agent:IncompleteRepair",
+                    "--negative-source",
+                    "private/negative_agent.py",
+                    "--negative-rationale",
+                    "Repair only one of the required fixture records.",
+                ]
+                if proof_arm == "negative"
+                else []
+            )
+            code, result = _run(
+                "record-run-inputs",
+                "--task-dir",
+                str(task_dir),
+                "--job-dir",
+                f"private/jobs/{arm}",
+                "--arm",
+                proof_arm,
+                *extra,
+            )
+            assert code == 0, result
+        trial = task_dir / "private" / "jobs" / arm / "task__trial"
+        trial.mkdir(parents=True)
+        _write_json(
+            trial / "result.json",
+            {
+                "task_checksum": checksum,
+                "verifier_environment_mode": mode,
+                "verifier_result": {"rewards": {"reward": reward}},
+                "exception_info": exception,
+                "config": {
+                    "job_id": f"job-{job_number}",
+                    "agent": {"name": proof_arm if proof_arm != "negative" else "negative_agent:IncompleteRepair"},
+                },
+            },
+        )
+    if record_validation:
+        code, result = _run(
+            "record-validation",
+            "--task-dir",
+            str(task_dir),
+            "--nop-job-dir",
+            "private/jobs/nop-1",
+            "--nop-job-dir",
+            "private/jobs/nop-2",
+            "--oracle-job-dir",
+            "private/jobs/oracle-1",
+            "--oracle-job-dir",
+            "private/jobs/oracle-2",
+            "--negative-job-dir",
+            "private/jobs/negative-1",
+            "--harbor-version",
+            "0.21.0",
+        )
+        assert code == 0, result
 
 
 def test_init_creates_private_gitignored_workspace(tmp_path: Path) -> None:
@@ -215,25 +320,23 @@ def test_prepare_preserves_original_and_writes_text_only_redacted_atif(tmp_path:
     assert "/home/jane" not in safe_text
     assert "10.2.3.4" not in safe_text
     assert "+1 (303) 555-0119" not in safe_text
-    assert "abcdefghijklmnop" not in safe_text
-    assert "secret-value" not in safe_text
     assert "123-45-6789" not in safe_text
     assert "session-1" not in safe_text
     assert "call-1" not in safe_text
-    assert privacy["manual_review_required"] is True
-    assert privacy["manual_review_complete"] is False
+    assert privacy["contextual_review_required"] is True
+    assert privacy["contextual_review_complete"] is False
     assert set(privacy["deterministic_redactions"]) >= {
-        "bearer_token",
         "email",
         "home_path",
         "identifier",
         "ipv4",
         "phone",
-        "secret_field",
         "ssn",
     }
-    assert summary["source"]["private_sha256"] == f"sha256:{hashlib.sha256(private.read_bytes()).hexdigest()}"
+    assert summary["source"]["original_sha256"] == f"sha256:{hashlib.sha256(private.read_bytes()).hexdigest()}"
     assert summary["source"]["safe_sha256"] == f"sha256:{hashlib.sha256(safe.read_bytes()).hexdigest()}"
+    assert (task_dir / "private" / "canonical.atif.json").is_file()
+    assert (task_dir / "private" / "privacy-audit.json").is_file()
 
 
 def test_prepare_reports_non_object_observation(tmp_path: Path) -> None:
@@ -263,6 +366,7 @@ def test_prepare_reports_non_object_observation(tmp_path: Path) -> None:
 def test_image_only_instruction_blocks_candidate_but_can_be_no_candidate(tmp_path: Path) -> None:
     task_dir, _ = _workspace(tmp_path, image_only=True)
     _candidate(task_dir)
+    _review_privacy(task_dir)
 
     code, result = _run(
         "finalize",
@@ -270,13 +374,12 @@ def test_image_only_instruction_blocks_candidate_but_can_be_no_candidate(tmp_pat
         str(task_dir),
         "--status",
         "candidate",
-        "--privacy-reviewed",
     )
 
     assert code == 1
     assert "unresolved non-text evidence" in result["error"]
     privacy = json.loads((task_dir / "safe" / "privacy.json").read_text(encoding="utf-8"))
-    assert privacy["manual_review_complete"] is False
+    assert privacy["contextual_review_complete"] is True
 
     _candidate(task_dir, status="no_candidate")
     code, result = _run("finalize", "--task-dir", str(task_dir), "--status", "no_candidate")
@@ -321,12 +424,19 @@ def test_summary_captures_ground_truth_and_proprietary_software(tmp_path: Path) 
         status="no_candidate",
         ground_truth={
             "availability": "available",
+            "use": "comparison_only",
             "artifacts": [
                 {
                     "kind": "expected_output",
                     "path": "private/ground-truth/expected.json",
                     "sha256": f"sha256:{hashlib.sha256(expected.read_bytes()).hexdigest()}",
-                    "evidence_steps": [2],
+                    "provenance": {
+                        "kind": "external",
+                        "step_ids": [],
+                        "uri": "https://example.test/fixtures/expected.json",
+                        "revision": "abc123",
+                        "source_id": None,
+                    },
                     "notes": "The trace records this expected fixture state.",
                 }
             ],
@@ -341,7 +451,13 @@ def test_summary_captures_ground_truth_and_proprietary_software(tmp_path: Path) 
                 "license": "proprietary",
                 "availability": "unavailable",
                 "redistributable": False,
-                "evidence_steps": [1, 2],
+                "provenance": {
+                    "kind": "atif_step",
+                    "step_ids": [1, 2],
+                    "uri": None,
+                    "revision": None,
+                    "source_id": None,
+                },
                 "notes": "The workflow requires its native file format and runtime.",
             }
         ],
@@ -374,7 +490,13 @@ def test_candidate_rejects_required_unavailable_software(tmp_path: Path) -> None
                 "license": "commercial",
                 "availability": "unavailable",
                 "redistributable": False,
-                "evidence_steps": [1],
+                "provenance": {
+                    "kind": "atif_step",
+                    "step_ids": [1],
+                    "uri": None,
+                    "revision": None,
+                    "source_id": None,
+                },
                 "notes": "No licensed runtime is available in the task environment.",
             }
         ],
@@ -386,7 +508,6 @@ def test_candidate_rejects_required_unavailable_software(tmp_path: Path) -> None
         str(task_dir),
         "--status",
         "candidate",
-        "--privacy-reviewed",
     )
 
     assert code == 1
@@ -403,12 +524,19 @@ def test_ground_truth_digest_must_match_retained_artifact(tmp_path: Path) -> Non
         status="no_candidate",
         ground_truth={
             "availability": "available",
+            "use": "verification",
             "artifacts": [
                 {
                     "kind": "expected_output",
                     "path": "private/ground-truth/expected.json",
                     "sha256": f"sha256:{'0' * 64}",
-                    "evidence_steps": [2],
+                    "provenance": {
+                        "kind": "atif_step",
+                        "step_ids": [2],
+                        "uri": None,
+                        "revision": None,
+                        "source_id": None,
+                    },
                     "notes": "The trace records this expected fixture state.",
                 }
             ],
@@ -432,12 +560,19 @@ def test_ground_truth_path_cannot_escape_private_directory(tmp_path: Path) -> No
         status="no_candidate",
         ground_truth={
             "availability": "available",
+            "use": "verification",
             "artifacts": [
                 {
                     "kind": "expected_output",
                     "path": "private/ground-truth/../outside.json",
                     "sha256": f"sha256:{hashlib.sha256(outside.read_bytes()).hexdigest()}",
-                    "evidence_steps": [2],
+                    "provenance": {
+                        "kind": "atif_step",
+                        "step_ids": [2],
+                        "uri": None,
+                        "revision": None,
+                        "source_id": None,
+                    },
                     "notes": "The trace records this expected fixture state.",
                 }
             ],
@@ -462,21 +597,18 @@ def test_ready_candidate_requires_privacy_review_and_both_harbor_arms(tmp_path: 
         str(task_dir),
         "--status",
         "candidate",
-        "--environment-status",
-        "ready",
     )
     assert code == 1
-    assert "--privacy-reviewed" in result["error"]
+    assert "review-privacy" in result["error"]
 
+    _review_privacy(task_dir, reviewer_kind="human")
     code, result = _run(
         "finalize",
         "--task-dir",
         str(task_dir),
         "--status",
         "candidate",
-        "--environment-status",
-        "ready",
-        "--privacy-reviewed",
+        "--human-reviewed",
         "--worked-well",
         "NOP and Oracle produced the required rewards.",
     )
@@ -484,8 +616,16 @@ def test_ready_candidate_requires_privacy_review_and_both_harbor_arms(tmp_path: 
     assert code == 0, result
     summary = json.loads((task_dir / "summary.json").read_text(encoding="utf-8"))
     assert summary["status"] == "candidate"
-    assert summary["environment"] == {"path": "task", "status": "ready", "validation": "validation.json"}
-    assert summary["privacy"]["manual_review_complete"] is True
+    assert summary["environment"] == {
+        "path": "task",
+        "status": "ready",
+        "technical_status": "passed",
+        "review_status": "human_reviewed",
+        "validation": "validation.json",
+        "verifier_environment_mode": "separate",
+        "isolation_status": "isolated",
+    }
+    assert summary["privacy"]["contextual_review_complete"] is True
     code, check = _run("check", "--task-dir", str(task_dir))
     assert code == 0, check
 
@@ -496,8 +636,9 @@ def test_ready_candidate_rejects_wrong_arm_reward(tmp_path: Path) -> None:
     _ready_environment(task_dir)
     validation_path = task_dir / "validation.json"
     validation = json.loads(validation_path.read_text(encoding="utf-8"))
-    validation["nop"]["reward"] = 1
+    validation["runs"]["nop"][0]["reward"] = 1
     _write_json(validation_path, validation)
+    _review_privacy(task_dir)
 
     code, result = _run(
         "finalize",
@@ -505,19 +646,17 @@ def test_ready_candidate_rejects_wrong_arm_reward(tmp_path: Path) -> None:
         str(task_dir),
         "--status",
         "candidate",
-        "--environment-status",
-        "ready",
-        "--privacy-reviewed",
     )
 
     assert code == 1
-    assert "validation.nop" in result["error"]
+    assert "differs from the retained Harbor result evidence" in result["error"]
 
 
 def test_ready_candidate_requires_reviewer_facing_readme(tmp_path: Path) -> None:
     task_dir, _ = _workspace(tmp_path)
     _candidate(task_dir)
     _ready_environment(task_dir)
+    _review_privacy(task_dir)
     (task_dir / "task" / "README.md").unlink()
 
     code, result = _run(
@@ -526,9 +665,6 @@ def test_ready_candidate_requires_reviewer_facing_readme(tmp_path: Path) -> None
         str(task_dir),
         "--status",
         "candidate",
-        "--environment-status",
-        "ready",
-        "--privacy-reviewed",
     )
 
     assert code == 1
@@ -539,6 +675,7 @@ def test_ready_candidate_requires_substantive_readme_sections(tmp_path: Path) ->
     task_dir, _ = _workspace(tmp_path)
     _candidate(task_dir)
     _ready_environment(task_dir)
+    _review_privacy(task_dir)
     readme = task_dir / "task" / "README.md"
     readme.write_text(
         readme.read_text(encoding="utf-8").replace(
@@ -553,13 +690,147 @@ def test_ready_candidate_requires_substantive_readme_sections(tmp_path: Path) ->
         str(task_dir),
         "--status",
         "candidate",
-        "--environment-status",
-        "ready",
-        "--privacy-reviewed",
     )
 
     assert code == 1
     assert "Verification explanation" in result["error"]
+
+
+def test_reproducibility_records_complete_task_tree_and_portability(tmp_path: Path) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _candidate(task_dir)
+    _ready_environment(task_dir, record_validation=False)
+
+    report = json.loads((task_dir / "reproducibility.json").read_text(encoding="utf-8"))
+
+    assert report["schema"] == "nemo.eval_author.trace_environment_reproducibility.v2"
+    assert report["task_tree_sha256"].startswith("sha256:")
+    assert report["file_count"] == 7
+    assert report["portability"]["state"] == "recipe_rebuildable"
+    assert report["network"] == {"agent": "no-network", "verifier": "no-network"}
+    assert report["contamination"]["passed"] is True
+
+
+def test_reproducibility_digest_covers_executable_bits(tmp_path: Path) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _candidate(task_dir)
+    _ready_environment(task_dir, record_validation=False)
+    _review_privacy(task_dir)
+    solve = task_dir / "task" / "solution" / "solve.sh"
+    solve.chmod(solve.stat().st_mode | stat.S_IXUSR)
+
+    code, result = _run("finalize", "--task-dir", str(task_dir), "--status", "candidate")
+
+    assert code == 1
+    assert "reproducibility.json differs from the current task tree" in result["error"]
+
+
+def test_reproducibility_retains_failed_contamination_evidence(tmp_path: Path) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _candidate(task_dir)
+    _ready_environment(task_dir, record_validation=False)
+    target = task_dir / "task/environment/.git/config"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text('[remote "origin"]\n', encoding="utf-8")
+    (task_dir / "reproducibility.json").unlink()
+
+    code, result = _run("record-reproducibility", "--task-dir", str(task_dir))
+
+    assert code == 1
+    assert result["contamination_findings"] == 1
+    report = json.loads((task_dir / "reproducibility.json").read_text(encoding="utf-8"))
+    assert report["contamination"]["passed"] is False
+    assert report["contamination"]["findings"][0]["code"] == "git_metadata_in_agent_context"
+
+
+def test_candidate_requires_no_network_agent_environment(tmp_path: Path) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _candidate(task_dir)
+    _ready_environment(task_dir, record_validation=False)
+    task_toml = task_dir / "task" / "task.toml"
+    task_toml.write_text(
+        task_toml.read_text(encoding="utf-8").replace(
+            '[environment]\nnetwork_mode = "no-network"', '[environment]\nnetwork_mode = "public"'
+        ),
+        encoding="utf-8",
+    )
+    _review_privacy(task_dir)
+
+    code, result = _run("finalize", "--task-dir", str(task_dir), "--status", "candidate")
+
+    assert code == 1
+    assert "[environment].network_mode must be no-network" in result["error"]
+
+
+def test_reproducibility_rejects_solution_file_in_agent_context(tmp_path: Path) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _candidate(task_dir)
+    _ready_environment(task_dir, record_validation=False)
+    (task_dir / "task" / "environment" / "answer.sh").write_bytes(
+        (task_dir / "task" / "solution" / "solve.sh").read_bytes()
+    )
+    (task_dir / "reproducibility.json").unlink()
+
+    code, result = _run("record-reproducibility", "--task-dir", str(task_dir))
+
+    assert code == 1
+    assert result["contamination_findings"] == 1
+    report = json.loads((task_dir / "reproducibility.json").read_text(encoding="utf-8"))
+    assert report["contamination"]["findings"][0]["code"] == "solution_in_agent_context"
+
+
+def test_validation_requires_independent_repeat_and_negative_jobs(tmp_path: Path) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _candidate(task_dir)
+    _ready_environment(task_dir, record_validation=False)
+
+    code, result = _run(
+        "record-validation",
+        "--task-dir",
+        str(task_dir),
+        "--nop-job-dir",
+        "private/jobs/nop-1",
+        "--oracle-job-dir",
+        "private/jobs/oracle-1",
+        "--negative-job-dir",
+        "private/jobs/negative-1",
+        "--harbor-version",
+        "0.21.0",
+    )
+
+    assert code == 1
+    assert "at least 2 independent nop Harbor jobs" in result["error"]
+
+
+def test_validation_requires_distinct_harbor_job_ids(tmp_path: Path) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _candidate(task_dir)
+    _ready_environment(task_dir, record_validation=False)
+    duplicate = task_dir / "private" / "jobs" / "nop-2" / "task__trial" / "result.json"
+    payload = json.loads(duplicate.read_text(encoding="utf-8"))
+    payload["config"]["job_id"] = "job-1"
+    _write_json(duplicate, payload)
+
+    code, result = _run(
+        "record-validation",
+        "--task-dir",
+        str(task_dir),
+        "--nop-job-dir",
+        "private/jobs/nop-1",
+        "--nop-job-dir",
+        "private/jobs/nop-2",
+        "--oracle-job-dir",
+        "private/jobs/oracle-1",
+        "--oracle-job-dir",
+        "private/jobs/oracle-2",
+        "--negative-job-dir",
+        "private/jobs/negative-1",
+        "--harbor-version",
+        "0.21.0",
+    )
+
+    assert code == 1
+    assert "config.job_id values must be distinct" in result["error"]
 
 
 def test_check_detects_changed_safe_evidence(tmp_path: Path) -> None:
@@ -575,6 +846,563 @@ def test_check_detects_changed_safe_evidence(tmp_path: Path) -> None:
     assert code == 1
     assert result["valid"] is False
     assert "safe_path is missing or its digest changed" in result["errors"]
+
+
+def test_prepare_narrowly_repairs_provider_redaction_quote(tmp_path: Path) -> None:
+    root = tmp_path / ".eval-author" / "trace-environments"
+    code, result = _run("init", "--root", str(root), "--task-id", "repair-quote")
+    assert code == 0, result
+    source = tmp_path / "broken.atif.json"
+    source.write_text(
+        '{"schema_version":"ATIF-v1.7","agent":{"name":"agent"},"steps":'
+        '[{"step_id":1,"source":"user","message":"prefix \\"PASSWORD=<redacted>" suffix"}]}',
+        encoding="utf-8",
+    )
+
+    code, result = _run(
+        "prepare",
+        "--task-dir",
+        result["task_dir"],
+        "--atif",
+        str(source),
+        "--source-kind",
+        "atif",
+    )
+
+    assert code == 0, result
+    assert result["normalization_count"] == 1
+    summary = json.loads((root / "repair-quote" / "summary.json").read_text(encoding="utf-8"))
+    assert summary["source"]["normalizations"][0]["kind"] == "escape_provider_redaction_placeholder_quote"
+    assert (root / "repair-quote" / "private" / "source.atif.json").read_bytes() == source.read_bytes()
+
+
+def test_prepare_bounds_string_encoded_images_and_audits_context(tmp_path: Path) -> None:
+    root = tmp_path / ".eval-author" / "trace-environments"
+    code, result = _run("init", "--root", str(root), "--task-id", "bound-image")
+    assert code == 0, result
+    task_dir = Path(result["task_dir"])
+    source = tmp_path / "image.atif.json"
+    payload = _atif()
+    payload["steps"][0]["message"] = [
+        {
+            "type": "text",
+            "text": "Use https://api.example.test/path for Example Labs at 123 Main Street and John Smith.",
+        },
+        {
+            "type": "image",
+            "source": {"type": "base64", "media_type": "image/png", "data": "A" * 100_001},
+        },
+    ]
+    payload["steps"][1]["observation"]["results"][0]["content"] = (
+        'before {"type":"image","source":{"type":"base64","media_type":"image/png","data":"DATA"}} after'
+    )
+    payload["steps"][1]["message"] = "Call service.default.svc.cluster.local"
+    _write_json(source, payload)
+
+    code, result = _run(
+        "prepare",
+        "--task-dir",
+        str(task_dir),
+        "--atif",
+        str(source),
+        "--source-kind",
+        "atif",
+    )
+
+    assert code == 0, result
+    canonical = json.loads((task_dir / "private" / "canonical.atif.json").read_text(encoding="utf-8"))
+    assert canonical["steps"][0]["message"][1]["source"]["data"] == ""
+    assert canonical["steps"][1]["observation"]["results"][0]["content"][1]["source"]["data"] == ""
+    safe_text = (task_dir / "safe" / "trace.atif.json").read_text(encoding="utf-8")
+    assert "svc.cluster.local" not in safe_text
+    audit = json.loads((task_dir / "private" / "privacy-audit.json").read_text(encoding="utf-8"))
+    assert audit["url_hosts"] == ["api.example.test"]
+    assert {finding["kind"] for finding in audit["candidate_findings"]} >= {
+        "organization",
+        "person_name",
+        "street_address",
+    }
+
+
+def test_shared_verifier_is_rejected(tmp_path: Path) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _candidate(task_dir)
+    _ready_environment(task_dir, mode="shared", record_validation=False)
+    _review_privacy(task_dir, reviewer_kind="human")
+
+    code, result = _run("finalize", "--task-dir", str(task_dir), "--status", "candidate", "--human-reviewed")
+
+    assert code == 1
+    assert "must explicitly set [verifier].environment_mode to separate" in result["error"]
+
+
+def test_candidate_requires_explicit_verifier_environment_mode(tmp_path: Path) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _candidate(task_dir)
+    _ready_environment(task_dir, record_validation=False)
+    task_toml = task_dir / "task" / "task.toml"
+    task_toml.write_text(
+        task_toml.read_text(encoding="utf-8").replace('environment_mode = "separate"\n', ""),
+        encoding="utf-8",
+    )
+    _review_privacy(task_dir)
+
+    code, result = _run("finalize", "--task-dir", str(task_dir), "--status", "candidate")
+
+    assert code == 1
+    assert "must explicitly set [verifier].environment_mode to separate" in result["error"]
+
+
+def test_candidate_requires_explicit_verifier_environment(tmp_path: Path) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _candidate(task_dir)
+    _ready_environment(task_dir, record_validation=False)
+    task_toml = task_dir / "task" / "task.toml"
+    task_toml.write_text(
+        task_toml.read_text(encoding="utf-8").replace(
+            '\n[verifier.environment]\nnetwork_mode = "no-network"\n',
+            "\n",
+        ),
+        encoding="utf-8",
+    )
+    _review_privacy(task_dir)
+
+    code, result = _run("finalize", "--task-dir", str(task_dir), "--status", "candidate")
+
+    assert code == 1
+    assert "must contain an explicit [verifier.environment] table" in result["error"]
+
+
+def test_verifier_environment_must_be_no_network(tmp_path: Path) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _candidate(task_dir)
+    _ready_environment(task_dir, record_validation=False)
+    task_toml = task_dir / "task" / "task.toml"
+    task_toml.write_text(
+        task_toml.read_text(encoding="utf-8").replace(
+            '[verifier.environment]\nnetwork_mode = "no-network"\n',
+            '[verifier.environment]\nnetwork_mode = "public"\n',
+        ),
+        encoding="utf-8",
+    )
+    _review_privacy(task_dir)
+
+    code, result = _run("finalize", "--task-dir", str(task_dir), "--status", "candidate")
+
+    assert code == 1
+    assert "[verifier.environment].network_mode must be no-network" in result["error"]
+
+
+def test_separate_verifier_can_inherit_image_without_tests_dockerfile(tmp_path: Path) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _candidate(task_dir)
+    _ready_environment(task_dir, record_validation=False)
+    (task_dir / "task" / "tests" / "Dockerfile").unlink()
+    _record_reproducibility(task_dir)
+    _review_privacy(task_dir)
+
+    code, result = _run("finalize", "--task-dir", str(task_dir), "--status", "candidate")
+
+    assert code == 0, result
+    summary = json.loads((task_dir / "summary.json").read_text(encoding="utf-8"))
+    assert summary["environment"]["status"] == "unproven"
+    assert summary["environment"]["isolation_status"] == "isolated"
+
+
+def test_step_verifier_cannot_override_separate_mode(tmp_path: Path) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _candidate(task_dir)
+    _ready_environment(task_dir, record_validation=False)
+    task_toml = task_dir / "task" / "task.toml"
+    task_toml.write_text(
+        task_toml.read_text(encoding="utf-8")
+        + '\n[[steps]]\nname = "grade"\n[steps.verifier]\nenvironment_mode = "shared"\n',
+        encoding="utf-8",
+    )
+    _review_privacy(task_dir)
+
+    code, result = _run("finalize", "--task-dir", str(task_dir), "--status", "candidate")
+
+    assert code == 1
+    assert "step 1 verifier must not override separate mode" in result["error"]
+
+
+def test_step_verifier_environment_must_be_no_network(tmp_path: Path) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _candidate(task_dir)
+    _ready_environment(task_dir, record_validation=False)
+    task_toml = task_dir / "task" / "task.toml"
+    task_toml.write_text(
+        task_toml.read_text(encoding="utf-8")
+        + '\n[[steps]]\nname = "grade"\n[steps.verifier.environment]\nnetwork_mode = "public"\n',
+        encoding="utf-8",
+    )
+    _review_privacy(task_dir)
+
+    code, result = _run("finalize", "--task-dir", str(task_dir), "--status", "candidate")
+
+    assert code == 1
+    assert "[steps.verifier.environment] for step 1 must set network_mode to no-network" in result["error"]
+
+
+def test_step_can_define_a_separate_no_network_verifier_environment(tmp_path: Path) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _candidate(task_dir)
+    _ready_environment(task_dir, record_validation=False)
+    task_toml = task_dir / "task" / "task.toml"
+    task_toml.write_text(
+        task_toml.read_text(encoding="utf-8")
+        + '\n[[steps]]\nname = "grade"\n[steps.verifier]\nenvironment_mode = "separate"\n'
+        + '[steps.verifier.environment]\nnetwork_mode = "no-network"\n',
+        encoding="utf-8",
+    )
+    _record_reproducibility(task_dir)
+    _review_privacy(task_dir)
+
+    code, result = _run("finalize", "--task-dir", str(task_dir), "--status", "candidate")
+
+    assert code == 0, result
+    summary = json.loads((task_dir / "summary.json").read_text(encoding="utf-8"))
+    assert summary["environment"]["status"] == "unproven"
+    assert summary["environment"]["isolation_status"] == "isolated"
+
+
+def test_failed_harbor_proof_is_validated_and_attached(tmp_path: Path) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _candidate(task_dir)
+    _ready_environment(task_dir, oracle_reward=0.0, oracle_exception={"type": "RuntimeError"})
+    _review_privacy(task_dir)
+
+    code, result = _run("finalize", "--task-dir", str(task_dir), "--status", "candidate")
+
+    assert code == 0, result
+    summary = json.loads((task_dir / "summary.json").read_text(encoding="utf-8"))
+    assert summary["environment"]["status"] == "failed"
+    assert summary["environment"]["technical_status"] == "failed"
+    assert summary["environment"]["validation"] == "validation.json"
+    code, check = _run("check", "--task-dir", str(task_dir))
+    assert code == 0, check
+
+
+def test_export_uses_a_strict_publication_whitelist(tmp_path: Path) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _candidate(task_dir)
+    _ready_environment(task_dir)
+    _review_privacy(task_dir, reviewer_kind="human")
+    code, result = _run("finalize", "--task-dir", str(task_dir), "--status", "candidate", "--human-reviewed")
+    assert code == 0, result
+    output = tmp_path / "product"
+
+    code, result = _run("export", "--task-dir", str(task_dir), "--output-dir", str(output))
+
+    assert code == 0, result
+    assert (output / "candidate.json").is_file()
+    assert (output / "reproducibility.json").is_file()
+    assert (output / "result.json").is_file()
+    assert (output / "task").is_dir()
+    assert not (output / "validation.json").exists()
+    assert not (output / "safe").exists()
+    assert not (output / "private").exists()
+    product = json.loads((output / "result.json").read_text(encoding="utf-8"))
+    assert product["schema"] == "nemo.eval_author.trace_environment_product.v2"
+    assert product["reproducibility"]["contamination_passed"] is True
+    assert product["technical_validation"]["minimum_runs"] == {"negative": 1, "nop": 2, "oracle": 2}
+
+
+def test_batch_prepare_is_resumable_and_reports_full_denominator(tmp_path: Path) -> None:
+    source_one = tmp_path / "one.json"
+    source_two = tmp_path / "two.json"
+    _write_json(source_one, _atif())
+    _write_json(source_two, _atif())
+    manifest = tmp_path / "manifest.json"
+    _write_json(
+        manifest,
+        {
+            "schema": "nemo.eval_author.trace_environment_batch.v1",
+            "members": [
+                {"task_id": "task-one", "atif": "one.json", "source_kind": "atif"},
+                {"task_id": "task-two", "atif": "two.json", "source_kind": "atif"},
+            ],
+        },
+    )
+    root = tmp_path / ".eval-author" / "trace-environments"
+
+    code, first = _run("batch-prepare", "--root", str(root), "--manifest", str(manifest))
+    assert code == 0, first
+    assert first["denominator"] == 2
+    assert first["counts"] == {"prepared": 2}
+    code, second = _run("batch-prepare", "--root", str(root), "--manifest", str(manifest))
+    assert code == 0, second
+    assert second["counts"] == {"existing": 2}
+    code, status = _run("batch-status", "--root", str(root), "--manifest", str(manifest))
+    assert code == 0, status
+    assert status["denominator"] == 2
+    assert status["counts"] == {"pending_prepared": 2}
+
+
+def test_batch_status_reports_malformed_workspace_without_aborting(tmp_path: Path) -> None:
+    source_one = tmp_path / "one.json"
+    source_two = tmp_path / "two.json"
+    _write_json(source_one, _atif())
+    _write_json(source_two, _atif())
+    manifest = tmp_path / "manifest.json"
+    manifest_payload = {
+        "schema": "nemo.eval_author.trace_environment_batch.v1",
+        "members": [
+            {"task_id": "task-one", "atif": "one.json", "source_kind": "atif"},
+            {"task_id": "task-two", "atif": "two.json", "source_kind": "atif"},
+        ],
+    }
+    _write_json(manifest, manifest_payload)
+    root = tmp_path / ".eval-author" / "trace-environments"
+    code, prepared = _run("batch-prepare", "--root", str(root), "--manifest", str(manifest))
+    assert code == 0, prepared
+    malformed_summary = root / "task-two" / "summary.json"
+    summary = json.loads(malformed_summary.read_text(encoding="utf-8"))
+    summary["unexpected"] = True
+    _write_json(malformed_summary, summary)
+    manifest_payload["members"].append({"task_id": "task-three", "atif": "missing.json", "source_kind": "atif"})
+    _write_json(manifest, manifest_payload)
+
+    code, status = _run("batch-status", "--root", str(root), "--manifest", str(manifest))
+
+    assert code == 1, status
+    assert status["denominator"] == 3
+    assert status["counts"] == {"invalid": 1, "missing": 1, "pending_prepared": 1}
+    assert status["valid"] is False
+    assert status["members"] == [
+        {"task_id": "task-one", "status": "pending_prepared"},
+        {
+            "task_id": "task-two",
+            "status": "invalid",
+            "error": "summary fields do not match the versioned contract",
+        },
+        {"task_id": "task-three", "status": "missing"},
+    ]
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "status",
+        "source.kind",
+        "privacy.reviewer_kind",
+        "environment.status",
+        "environment.technical_status",
+        "environment.review_status",
+        "environment.validation",
+        "environment.verifier_environment_mode",
+        "environment.isolation_status",
+    ],
+)
+@pytest.mark.parametrize("bad_value", [[], {}])
+def test_batch_status_contains_invalid_enum_types(tmp_path: Path, field: str, bad_value: object) -> None:
+    task_dir, source = _workspace(tmp_path)
+    path = task_dir / "summary.json"
+    summary = json.loads(path.read_text())
+    target = summary
+    keys = field.split(".")
+    for key in keys[:-1]:
+        target = target[key]
+    target[keys[-1]] = bad_value
+    _write_json(path, summary)
+    code, result = _run("init", "--root", str(task_dir.parent), "--task-id", "healthy")
+    assert code == 0, result
+    manifest = tmp_path / "batch.json"
+    _write_json(
+        manifest,
+        {
+            "schema": "nemo.eval_author.trace_environment_batch.v1",
+            "members": [
+                {"task_id": name, "atif": str(source), "source_kind": "atif"}
+                for name in (task_dir.name, "healthy", "missing")
+            ],
+        },
+    )
+    code, report = _run("batch-status", "--root", str(task_dir.parent), "--manifest", str(manifest))
+    assert code == 1
+    assert report["denominator"] == 3
+    assert report["valid"] is False
+    assert report["counts"] == {"invalid": 1, "pending_unprepared": 1, "missing": 1}
+    assert [row["task_id"] for row in report["members"]] == [task_dir.name, "healthy", "missing"]
+
+
+def _record_existing_jobs(task_dir: Path) -> tuple[int, dict[str, Any]]:
+    args = []
+    for arm, count in (("nop", 2), ("oracle", 2), ("negative", 1)):
+        for index in range(1, count + 1):
+            args.extend([f"--{arm}-job-dir", f"private/jobs/{arm}-{index}"])
+    return _run("record-validation", "--task-dir", str(task_dir), *args, "--harbor-version", "0.21.0")
+
+
+@pytest.mark.parametrize("change", ["verifier", "executable"])
+def test_stale_jobs_cannot_prove_a_changed_task(tmp_path: Path, change: str) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _ready_environment(task_dir, record_validation=False)
+    verifier = task_dir / "task/tests/test.sh"
+    if change == "verifier":
+        verifier.write_text("#!/bin/sh\nexit 99\n")
+    else:
+        verifier.chmod(verifier.stat().st_mode ^ stat.S_IXUSR)
+    _record_reproducibility(task_dir)
+    code, result = _record_existing_jobs(task_dir)
+    assert code == 1
+    assert "pre-run task snapshot differs" in result["error"]
+    assert not (task_dir / "validation.json").exists()
+
+
+def test_results_must_match_current_harbor_checksum(tmp_path: Path) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _ready_environment(task_dir, record_validation=False)
+    for path in (task_dir / "private/jobs").glob("*/task__*/result.json"):
+        result = json.loads(path.read_text())
+        result["task_checksum"] = "f" * 64
+        _write_json(path, result)
+    code, result = _record_existing_jobs(task_dir)
+    assert code == 1
+    assert "Harbor result task checksum differs" in result["error"]
+
+
+def test_run_inputs_cannot_be_attached_after_a_job_exists(tmp_path: Path) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _ready_environment(task_dir, record_validation=False)
+    code, result = _run(
+        "record-run-inputs", "--task-dir", str(task_dir), "--job-dir", "private/jobs/nop-1", "--arm", "nop"
+    )
+    assert code == 1
+    assert "before Harbor creates" in result["error"]
+
+
+def test_missing_pre_run_inputs_rejects_historical_proof(tmp_path: Path) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _ready_environment(task_dir, record_validation=False)
+    for path in (task_dir / "private/run-inputs").glob("*.json"):
+        path.unlink()
+    code, result = _record_existing_jobs(task_dir)
+    assert code == 1
+    assert "record-run-inputs is required" in result["error"]
+
+
+@pytest.mark.parametrize(
+    "arm,agent",
+    [
+        ("nop-1", None),
+        ("oracle-1", {"name": "nop"}),
+        ("negative-1", {"name": "nop"}),
+        ("negative-1", {"import_path": "harbor.agents.nop:NopAgent"}),
+        ("negative-1", {"import_path": "other_agent:WrongControl"}),
+        ("nop-1", {"name": "nop", "import_path": "other_agent:WrongControl"}),
+    ],
+)
+def test_wrong_proof_agent_is_rejected(tmp_path: Path, arm: str, agent: object) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _ready_environment(task_dir, record_validation=False)
+    path = task_dir / f"private/jobs/{arm}/task__trial/result.json"
+    result = json.loads(path.read_text())
+    result["config"]["agent"] = agent
+    _write_json(path, result)
+    code, result = _record_existing_jobs(task_dir)
+    assert code == 1
+    assert "agent" in result["error"]
+
+
+def test_import_path_agent_identity_is_supported(tmp_path: Path) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _ready_environment(task_dir, record_validation=False)
+    identities = {
+        "nop": "harbor.agents.nop:NopAgent",
+        "oracle": "harbor.agents.oracle:OracleAgent",
+        "negative": "negative_agent:IncompleteRepair",
+    }
+    for path in (task_dir / "private/jobs").glob("*/task__*/result.json"):
+        arm = path.parents[1].name.rsplit("-", 1)[0]
+        result = json.loads(path.read_text())
+        result["config"]["agent"] = {"name": None, "import_path": identities[arm]}
+        _write_json(path, result)
+    code, result = _record_existing_jobs(task_dir)
+    assert code == 0, result
+    assert result["passed"] is True
+
+
+def test_negative_source_mutation_invalidates_proof(tmp_path: Path) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _ready_environment(task_dir, record_validation=False)
+    (task_dir / "private/negative_agent.py").write_text("# Changed implementation\n")
+    code, result = _record_existing_jobs(task_dir)
+    assert code == 1
+    assert "negative control source" in result["error"]
+
+
+@pytest.mark.parametrize("agent", ["nop", "oracle", "harbor.agents.nop:NopAgent", "harbor.agents.oracle:OracleAgent"])
+def test_builtin_agent_cannot_be_declared_negative(tmp_path: Path, agent: str) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _ready_environment(task_dir, record_validation=False)
+    code, result = _run(
+        "record-run-inputs",
+        "--task-dir",
+        str(task_dir),
+        "--job-dir",
+        "private/jobs/new-negative",
+        "--arm",
+        "negative",
+        "--negative-agent",
+        agent,
+        "--negative-source",
+        "private/negative_agent.py",
+        "--negative-rationale",
+        "Incomplete repair",
+    )
+    assert code == 1
+    assert "distinct from NOP and Oracle" in result["error"]
+
+
+@pytest.mark.parametrize(
+    "copy_source,pinned",
+    [
+        ("example.invalid/tool:latest", False),
+        ("example.invalid/tool@sha256:" + "a" * 64, True),
+        ("builder", True),
+        ("0", True),
+        ("${TOOLS_IMAGE}", False),
+    ],
+)
+def test_portability_tracks_external_copy_sources(tmp_path: Path, copy_source: str, pinned: bool) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _ready_environment(task_dir, record_validation=False)
+    (task_dir / "task/environment/Dockerfile").write_text(
+        f'FROM scratch AS builder\nFROM scratch\nCOPY --from="{copy_source}" /tool /tool\n'
+    )
+    _record_reproducibility(task_dir)
+    report = json.loads((task_dir / "reproducibility.json").read_text())
+    assert report["portability"]["state"] == ("recipe_rebuildable" if pinned else "local_only")
+    copies = [image for image in report["portability"]["container_images"] if image["instruction"] == "copy"]
+    assert len(copies) == 1
+    assert copies[0]["reference"] == copy_source
+    assert copies[0]["internal_stage"] == (copy_source in ("builder", "0"))
+
+
+@pytest.mark.parametrize(
+    "location", ["environment", "verifier.environment", "steps.environment", "steps.verifier.environment"]
+)
+@pytest.mark.parametrize("pinned", [True, False])
+def test_portability_tracks_configured_images(tmp_path: Path, location: str, pinned: bool) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _ready_environment(task_dir, record_validation=False)
+    path = task_dir / "task/task.toml"
+    config = path.read_text()
+    image = "example.invalid/runtime@sha256:" + "b" * 64 if pinned else "example.invalid/runtime:latest"
+    if location.startswith("steps."):
+        config += f'\n[[steps]]\nname = "grade"\n[{location}]\nnetwork_mode = "no-network"\ndocker_image = "{image}"\n'
+    else:
+        config = config.replace(f"[{location}]", f'[{location}]\ndocker_image = "{image}"')
+    path.write_text(config)
+    _record_reproducibility(task_dir)
+    report = json.loads((task_dir / "reproducibility.json").read_text())
+    expected = (
+        "immutable_image" if pinned and location == "environment" else "recipe_rebuildable" if pinned else "local_only"
+    )
+    assert report["portability"]["state"] == expected
+    assert report["portability"]["configured_images"][0]["reference"] == image
 
 
 @pytest.mark.parametrize("task_id", ["Has-Caps", "has spaces", "../escape", ""])

--- a/plugins/nemo-eval-author/tests/test_trace_environment.py
+++ b/plugins/nemo-eval-author/tests/test_trace_environment.py
@@ -6,6 +6,7 @@
 import hashlib
 import json
 import os
+import shutil
 import stat
 import subprocess
 import sys
@@ -13,13 +14,13 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from dirhash import dirhash
+from harbor.models.task.task import Task
 
 _PLUGIN = Path(__file__).resolve().parents[1]
 _SCRIPT = _PLUGIN / "skills" / "eval-author-trace-environment" / "scripts" / "trace_environment.py"
 _SUMMARY_SCHEMA = "nemo.eval_author.trace_environment_summary.v2"
 _CANDIDATE_SCHEMA = "nemo.eval_author.trace_environment_candidate.v2"
-_VALIDATION_SCHEMA = "nemo.eval_author.trace_environment_validation.v4"
+_VALIDATION_SCHEMA = "nemo.eval_author.trace_environment_validation.v5"
 
 
 def _run(*args: str) -> tuple[int, dict[str, Any]]:
@@ -207,7 +208,7 @@ The human reviewer confirmed that this fixture accurately represents the recorde
             encoding="utf-8",
         )
     (task / "solution" / "solve.sh").write_text("#!/usr/bin/env bash\ntouch repaired\n", encoding="utf-8")
-    checksum = dirhash(task, "sha256")
+    checksum = Task(task).checksum
     if mode == "separate":
         _record_reproducibility(task_dir)
     control_source = task_dir / "private" / "negative_agent.py"
@@ -703,10 +704,11 @@ def test_reproducibility_records_complete_task_tree_and_portability(tmp_path: Pa
 
     report = json.loads((task_dir / "reproducibility.json").read_text(encoding="utf-8"))
 
-    assert report["schema"] == "nemo.eval_author.trace_environment_reproducibility.v2"
+    assert report["schema"] == "nemo.eval_author.trace_environment_reproducibility.v3"
     assert report["task_tree_sha256"].startswith("sha256:")
     assert report["file_count"] == 7
-    assert report["portability"]["state"] == "recipe_rebuildable"
+    assert report["portability"]["state"] == "image_pinned_recipe"
+    assert report["portability"]["dependency_closure"] == "unverified"
     assert report["network"] == {"agent": "no-network", "verifier": "no-network"}
     assert report["contamination"]["passed"] is True
 
@@ -1104,9 +1106,93 @@ def test_export_uses_a_strict_publication_whitelist(tmp_path: Path) -> None:
     assert not (output / "safe").exists()
     assert not (output / "private").exists()
     product = json.loads((output / "result.json").read_text(encoding="utf-8"))
-    assert product["schema"] == "nemo.eval_author.trace_environment_product.v2"
+    assert product["schema"] == "nemo.eval_author.trace_environment_product.v3"
     assert product["reproducibility"]["contamination_passed"] is True
     assert product["technical_validation"]["minimum_runs"] == {"negative": 1, "nop": 2, "oracle": 2}
+    assert product["technical_validation"]["distinct_jobs"] is True
+    assert product["technical_validation"]["container_freshness"] == "unverified"
+    assert "fresh_jobs" not in product["technical_validation"]
+    assert product["reproducibility"]["dependency_closure"] == "unverified"
+
+
+@pytest.mark.parametrize("executable_bits", [0, stat.S_IXUSR, stat.S_IXGRP, stat.S_IXOTH, 0o111])
+def test_export_preserves_executable_bits_and_task_digest(tmp_path: Path, executable_bits: int) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _candidate(task_dir)
+    _ready_environment(task_dir, record_validation=False)
+    scripts = (Path("tests/test.sh"), Path("solution/solve.sh"))
+    for relative in scripts:
+        (task_dir / "task" / relative).chmod(0o640 | executable_bits)
+    _record_reproducibility(task_dir)
+    _review_privacy(task_dir)
+    code, result = _run("finalize", "--task-dir", str(task_dir), "--status", "candidate")
+    assert code == 0, result
+    output = tmp_path / "product"
+    code, result = _run("export", "--task-dir", str(task_dir), "--output-dir", str(output))
+    assert code == 0, result
+
+    for relative in scripts:
+        exported = output / "task" / relative
+        assert stat.S_IMODE(exported.stat().st_mode) == 0o644 | executable_bits
+        assert exported.read_bytes() == (task_dir / "task" / relative).read_bytes()
+    if executable_bits & stat.S_IXUSR:
+        execution = subprocess.run([str(output / "task/tests/test.sh")], capture_output=True, check=False)
+        assert execution.returncode == 0, execution.stderr
+
+    # Independently rescan the actual exported tree through the public command.
+    code, result = _run("init", "--root", str(tmp_path / ".eval-author/imported"), "--task-id", "imported-task")
+    assert code == 0, result
+    imported = Path(result["task_dir"])
+    shutil.copytree(output / "task", imported / "task")
+    _record_reproducibility(imported)
+    expected = json.loads((task_dir / "reproducibility.json").read_text())
+    actual = json.loads((imported / "reproducibility.json").read_text())
+    published = json.loads((output / "reproducibility.json").read_text())
+    product = json.loads((output / "result.json").read_text())
+    assert actual == published == expected
+    assert product["reproducibility"]["task_tree_sha256"] == actual["task_tree_sha256"]
+
+
+@pytest.mark.parametrize(
+    "field,value", [("container_freshness", "verified"), ("distinct_jobs", False), ("fresh_jobs", True)]
+)
+def test_validation_rejects_unsupported_job_evidence_claims(tmp_path: Path, field: str, value: object) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _candidate(task_dir)
+    _ready_environment(task_dir)
+    path = task_dir / "validation.json"
+    validation = json.loads(path.read_text())
+    assert validation["distinct_jobs"] is True
+    assert validation["container_freshness"] == "unverified"
+    assert "fresh_jobs" not in validation
+    validation[field] = value
+    _write_json(path, validation)
+    _review_privacy(task_dir)
+    code, result = _run("finalize", "--task-dir", str(task_dir), "--status", "candidate")
+    assert code == 1
+    assert "versioned contract" in result["error"]
+
+
+def test_image_pinning_does_not_claim_dependency_closure(tmp_path: Path) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _candidate(task_dir)
+    _ready_environment(task_dir, record_validation=False)
+    (task_dir / "task/environment/Dockerfile").write_text(
+        "FROM example.invalid/runtime@sha256:" + "a" * 64 + "\nRUN pip install example-package\n"
+    )
+    _record_reproducibility(task_dir)
+    _review_privacy(task_dir)
+    code, result = _run("finalize", "--task-dir", str(task_dir), "--status", "candidate")
+    assert code == 0, result
+    output = tmp_path / "product"
+    code, result = _run("export", "--task-dir", str(task_dir), "--output-dir", str(output))
+    assert code == 0, result
+    manifest = json.loads((output / "reproducibility.json").read_text())
+    product = json.loads((output / "result.json").read_text())
+    assert manifest["portability"]["state"] == "image_pinned_recipe"
+    assert manifest["portability"]["dependency_closure"] == "unverified"
+    assert product["reproducibility"]["portability_state"] == "image_pinned_recipe"
+    assert product["reproducibility"]["dependency_closure"] == "unverified"
 
 
 def test_batch_prepare_is_resumable_and_reports_full_denominator(tmp_path: Path) -> None:
@@ -1374,7 +1460,7 @@ def test_portability_tracks_external_copy_sources(tmp_path: Path, copy_source: s
     )
     _record_reproducibility(task_dir)
     report = json.loads((task_dir / "reproducibility.json").read_text())
-    assert report["portability"]["state"] == ("recipe_rebuildable" if pinned else "local_only")
+    assert report["portability"]["state"] == ("image_pinned_recipe" if pinned else "local_only")
     copies = [image for image in report["portability"]["container_images"] if image["instruction"] == "copy"]
     assert len(copies) == 1
     assert copies[0]["reference"] == copy_source
@@ -1399,7 +1485,7 @@ def test_portability_tracks_configured_images(tmp_path: Path, location: str, pin
     _record_reproducibility(task_dir)
     report = json.loads((task_dir / "reproducibility.json").read_text())
     expected = (
-        "immutable_image" if pinned and location == "environment" else "recipe_rebuildable" if pinned else "local_only"
+        "immutable_image" if pinned and location == "environment" else "image_pinned_recipe" if pinned else "local_only"
     )
     assert report["portability"]["state"] == expected
     assert report["portability"]["configured_images"][0]["reference"] == image


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
<!-- In 1-3 plain sentences, explain what changes and why. Describe before-and-after behavior when it applies. -->

Hardens the Eval Author trace environment skill using findings from the 89-task Terminal-Bench 2.1 fixture experiment and subsequent review. Generated environments now require separate no-network verification, repeated controls, and proof bound to the current task and declared agent; malformed batch members retain their rows and denominator.

## Changes
<!-- List the concrete changes included in this pull request. -->

- Add versioned provenance, bounded text/media normalization, contextual privacy review, and whitelist-only product export.
- Require separate verifier environments, including step overrides; distinguish technical validation from human review.
- Add full task-tree digests, executable-bit coverage, contamination checks, and image inventories covering external COPY/RUN sources and configured agent/verifier/step images.
- Require pre-run receipts, current Harbor task checksums, matching agent identities, two NOP runs, two Oracle runs, and a retained task-specific negative-control implementation and rationale.
- Preserve the full batch denominator when a member is missing or malformed, including list/object values in enum fields.
- Preserve executable permissions during export so published task-tree digests remain valid; use Harbor's checksum API directly in tests.
- Narrow portability to image pinning (`image_pinned_recipe`, dependency closure unverified) and proof to distinct jobs (container freshness unverified).
- Document validation v5/reproducibility v3/public product v3 migration: preserve old reports and recheck unchanged evidence; historical results without pre-run receipts require new executions, not backfilled evidence.
- Remove synthetic credential test cases at the author's request. Credential-detection code remains; there are no changes to TruffleHog exclusions or other security configuration relative to the base.
- Consolidate the previously stacked history and fixes into a signed-off baseline, with a signed follow-up for the latest review fixes.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

<!-- List each command and result. Explain skipped, blocked, or non-successful checks without marking them as passed. -->

- `uv run --frozen pytest plugins/nemo-eval-author/tests -q` — **273 passed** (nine new regression cases for export permissions/digests and evidence-claim boundaries).
- `uv run pre-commit run -a` in `flox activate --dir tools/lint` with repository-pinned uv 0.9.14 and existing UI tooling — **all hooks passed**, including Ruff, formatting, type checks, lock checks, Helm, copyright and plugin boundaries.
- `git diff --check origin/main...HEAD` — passed. The earlier squash was independently verified to preserve its checkpoint tree; this follow-up adds only the latest four review fixes.
- Harbor 0.21.0 Docker evidence on the existing generated `cancel-async-tasks` fixture: NOP **[0, 0]**, Oracle **[1, 1]**, sequential negative control **[0]**; five separate-verifier jobs with no exceptions. Preserved previous reports and rechecked these same five jobs under validation v5/reproducibility v3. This follow-up did not execute new jobs.
- TruffleHog 3.95.3 current-tree scan of the Eval Author tests without path exclusions — no findings. Credential verification/network access were disabled for local scans.
- TruffleHog 3.95.3 Git-range scan from `79a673168d7d32045db4675bba76a4568f096b44` to `e39288ef0bcb7c0c64a63f356aec17252d253584` — **no findings**, using the unchanged base exclusion file. Scanned from a temporary normal clone because the scanner cannot read Git worktree indirection.

Scope and limitations:

- The five-job evidence recheck validates the updated helper on one existing task; it is **not** a new 89-task run. Historical fixture results retain their original contracts. Related fixture documentation: NVIDIA-dev/nemo-eval-author-fixtures#16.
- Image pinning does not establish complete dependency reproducibility. Unique job identities do not establish fresh containers. Both limitations are explicit in private reports and public exports.
- Follow-ups for publication review of every exported product and readiness gating of unknown required software remain deferred; this is not a claim of complete security hardening.
- The generic skill-creator validator rejects the repository's pre-existing extended frontmatter. Repository skill-contract tests pass; the existing metadata format is preserved.
