### PR TITLE
test(evaluator): assert published spans land in Intake as OTLP

### DIFF
--- a/plugins/nemo-evaluator/tests/integration/test_publish_to_intake.py
+++ b/plugins/nemo-evaluator/tests/integration/test_publish_to_intake.py
@@ -620,6 +620,8 @@ async def test_publishing_a_trial_with_an_otlp_trace_lands_its_spans(platform_ba
         spans = await async_sdk.intake.spans.list(workspace=WORKSPACE, filter={"session_id": published.session_id})
         assert [span.name for span in spans.data] == ["agent run"]
 
+        assert {span.source for span in spans.data} == {"otel"}
+
         rows = await async_sdk.intake.spans.evaluator_results.list(published.span_id, workspace=WORKSPACE)
         assert [row.name for row in rows] == ["accuracy.score"]
 


### PR DESCRIPTION
Closes the last unverified acceptance criterion on [AALGO-569](https://linear.app/nvidia/issue/AALGO-569/switch-evaluators-primary-trajectory-format-from-atif-to-otlp): *"evaluation runs produce OTLP spans in Intake with `source_format="otel"`"*.

## The gap

`test_publishing_a_trial_with_an_otlp_trace_lands_its_spans` already covered a lot: spans land, they are indexed under the stamped session id, evaluator results attach to the producer's own span id, and a re-publish replaces rather than duplicates. What it never checked was `source_format`.

Intake sets that field from the ingest route taken, so it is the one thing separating **"we published OTLP"** from **"we published something and Intake made spans out of it"**. Both produce spans; only one satisfies the ticket. Intake's own suite does assert `otel`, but for *direct* ingest — a different route from the evaluator publish path, so the criterion held only by inference.

One line closes it.

## Verification

Run live against real Intake + ClickHouse, on current `main`:

```
6 passed in 37.53s
```

The assertion is not vacuous: the preceding line pins `spans.data` to exactly one span, so the set comparison has something to compare.

I also wrote and then removed a second assertion that re-queried with a `source` filter — it used a `span.id` field the model does not have, and it added nothing next to the criterion itself.

## Scope

Test-only. No production change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added verification that spans published through the OTLP integration are marked with the `"otel"` source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->