### PR TITLE
feat(evaluator): capture Relay's OTLP export so Fabric trials carry an OTLP trace

### DIFF
--- a/docs/evaluator/agent-eval/writing-metrics.mdx
+++ b/docs/evaluator/agent-eval/writing-metrics.mdx
@@ -241,8 +241,9 @@ consumer's job.
 ### Asking for one trace format
 
 A runner may record the same trial in more than one encoding. Harbor registers both under
-`trace:atif` and `trace:otlp` when the agent under test emits both. Pass `format=` to choose one
-and get a narrowed handle back, with no runtime branch:
+`trace:atif` and `trace:otlp` when the agent under test emits both, and Fabric registers both
+whenever it captures an OTLP trace from Relay. Pass `format=` to choose one and get a narrowed
+handle back, with no runtime branch:
 
 ```python
 from nemo_evaluator_sdk.values.evidence import CandidateEvidence
@@ -256,8 +257,8 @@ async def read_both_views(evidence: CandidateEvidence) -> None:
 ```
 
 `trace()` with no `format` still returns whichever encoding the runner made primary. For Harbor
-that is the OTLP trace when the agent emits one and the ATIF trace otherwise — there is no setting
-to choose between them. A `format=` request raises `KeyError` when the trial carries no trace in
+and Fabric alike that is the OTLP trace when one was recorded and the ATIF trace otherwise — there
+is no setting to choose between them. A `format=` request raises `KeyError` when the trial carries no trace in
 that encoding, so a metric that depends on one specific view fails loudly instead of silently
 scoring nothing.
 

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/fabric/otlp_receiver.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/fabric/otlp_receiver.py
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The OTLP endpoint Relay exports to, for both Fabric runtimes.
+
+Relay exports OTLP only over the network, so capturing a trace means listening for one. The local
+runtime imports this and runs it in a thread; the container runtime seeds this same file into the
+sandbox and runs it as a script beside the harness, where it writes into the directory that is
+downloaded when the task ends.
+
+Standard library only, and it stays that way: the sandbox image ships Fabric and its harnesses, not
+this package, so an import of anything else would have to be installed there first. That is also
+why each export is stored verbatim rather than as OTLP/JSON -- decoding needs protobuf, which the
+image does not guarantee, so :func:`nemo_evaluator_sdk...otlp_writer.fold_exports` does it later.
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from types import TracebackType
+
+TRACES_PATH = "/v1/traces"
+PROTOBUF_MEDIA_TYPE = "application/x-protobuf"
+MAX_EXPORT_BYTES = 256 * 1024 * 1024
+REQUEST_TIMEOUT_S = 30.0
+#: Written once the socket is bound, so the caller can start Relay without racing the listener.
+READY_FILENAME = "receiver.ready"
+#: Read back in export order, which `sorted()` gives while the counter is zero-padded.
+EXPORT_SUFFIX = ".otlp.pb"
+
+
+class _Handler(BaseHTTPRequestHandler):
+    server: OTLPReceiver  # type: ignore[assignment]
+    timeout = REQUEST_TIMEOUT_S
+
+    def do_POST(self) -> None:
+        if self.path.split("?")[0] != TRACES_PATH:
+            self.send_response(404)
+            self.end_headers()
+            return
+        if self.headers.get("Content-Type", "").split(";")[0].strip() != PROTOBUF_MEDIA_TYPE:
+            self.send_response(415)
+            self.end_headers()
+            return
+        try:
+            length = int(self.headers.get("Content-Length", "0"))
+        except ValueError:
+            self.send_response(400)
+            self.end_headers()
+            return
+        if length > MAX_EXPORT_BYTES:
+            self.send_response(413)
+            self.end_headers()
+            return
+        body = self.rfile.read(length)
+        try:
+            self.server.exports += 1
+            target = self.server.directory / f"{self.server.exports:06d}{EXPORT_SUFFIX}"
+            target.write_bytes(body)
+        except OSError:
+            # The agent is still running and its result stands on its own.
+            self.send_response(500)
+            self.end_headers()
+            return
+        self.send_response(200)
+        self.send_header("Content-Type", PROTOBUF_MEDIA_TYPE)
+        self.end_headers()
+        self.wfile.write(b"")
+
+    def log_message(self, format: str, *args: object) -> None:
+        return
+
+
+class OTLPReceiver(HTTPServer):
+    """Loopback OTLP endpoint that stores each export verbatim under ``directory``.
+
+    Used two ways: as a context manager, which serves on its own thread, and as a script via
+    :func:`main`, which serves on the main one.
+    """
+
+    def __init__(self, directory: Path, port: int = 0) -> None:
+        # Port 0 lets the OS pick, which is what the local runtime wants so parallel trials cannot
+        # collide. The container passes a fixed one because it has a sandbox to itself.
+        super().__init__(("127.0.0.1", port), _Handler)
+        directory.mkdir(parents=True, exist_ok=True)
+        self.directory = directory
+        self.exports = 0
+        self._thread: threading.Thread | None = None
+
+    @property
+    def endpoint(self) -> str:
+        return f"http://{self.server_address[0]}:{self.server_address[1]}{TRACES_PATH}"
+
+    def signal_ready(self) -> None:
+        """Announce that the socket is bound, for a caller that has to wait out of process."""
+        (self.directory / READY_FILENAME).write_text("ready\n", encoding="utf-8")
+
+    def __enter__(self) -> OTLPReceiver:
+        self._thread = threading.Thread(target=self.serve_forever, name="otlp-receiver", daemon=True)
+        self._thread.start()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        self.shutdown()
+        if self._thread is not None:
+            self._thread.join(timeout=10.0)
+        self.server_close()
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 3:
+        print(f"usage: {argv[0] if argv else 'receiver'} <directory> <port>", file=sys.stderr)
+        return 2
+    directory, port = Path(argv[1]), int(argv[2])
+    receiver = OTLPReceiver(directory, port)
+    receiver.signal_ready()
+    try:
+        receiver.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        receiver.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/fabric/otlp_receiver.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/fabric/otlp_receiver.py
@@ -21,6 +21,7 @@ import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from types import TracebackType
+from urllib.parse import urlparse
 
 TRACES_PATH = "/v1/traces"
 PROTOBUF_MEDIA_TYPE = "application/x-protobuf"
@@ -37,7 +38,7 @@ class _Handler(BaseHTTPRequestHandler):
     timeout = REQUEST_TIMEOUT_S
 
     def do_POST(self) -> None:
-        if self.path.split("?")[0] != TRACES_PATH:
+        if urlparse(self.path).path != TRACES_PATH:
             self.send_response(404)
             self.end_headers()
             return
@@ -48,6 +49,13 @@ class _Handler(BaseHTTPRequestHandler):
         try:
             length = int(self.headers.get("Content-Length", "0"))
         except ValueError:
+            self.send_response(400)
+            self.end_headers()
+            return
+        # Bounded below as well as above: ``rfile.read(-1)`` reads to EOF, so a negative length would
+        # hold this single-threaded receiver open for as long as the client kept the connection, and
+        # the agent sharing this loopback is untrusted code.
+        if length < 0:
             self.send_response(400)
             self.end_headers()
             return

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/fabric/otlp_writer.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/fabric/otlp_writer.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import logging
 import os
+import shutil
 from pathlib import Path
 from typing import Any
 
@@ -75,15 +76,22 @@ def fold_exports(directory: Path) -> int:
     """Fold the receiver's stored exports into one OTLP/JSON file, returning how many were folded.
 
     Streamed through a temporary file and moved into place, so a trace larger than memory still
-    folds and folding twice cannot double the spans.
+    folds. Additive: a fold consumes its inputs, so repeating it changes nothing, and a fold that
+    finds new exports appends to the trace already written rather than replacing it.
     """
     exports = sorted(directory.glob(f"*{EXPORT_SUFFIX}"))
     if not exports:
         return 0
+    trace = directory / OTLP_FILENAME
     partial = directory / f"{OTLP_FILENAME}.partial"
     folded = 0
     try:
         with partial.open("w", encoding="utf-8") as handle:
+            # Carried forward rather than overwritten: the rewrite is atomic, so an earlier fold's
+            # spans have to be copied in or `os.replace` drops them.
+            if trace.exists():
+                with trace.open("r", encoding="utf-8") as previous:
+                    shutil.copyfileobj(previous, handle)
             for export in exports:
                 try:
                     line = export_to_json_line(export.read_bytes())
@@ -100,14 +108,34 @@ def fold_exports(directory: Path) -> int:
         raise
     if not folded:
         partial.unlink(missing_ok=True)
+        _drop(exports)
         return 0
-    os.replace(partial, directory / OTLP_FILENAME)
-    # The folded file is a lossless re-encoding of these, so keeping both would double a trace's
-    # footprint for nothing. Dropped only once the result is in place, so a fold that dies partway
-    # leaves its inputs to retry from.
-    for export in exports:
-        export.unlink(missing_ok=True)
+    os.replace(partial, trace)
+    _drop(exports)
     return folded
+
+
+def _drop(exports: list[Path]) -> None:
+    """Consume the exports a fold has read, best-effort.
+
+    Every export that got this far was either folded into the trace -- a lossless re-encoding, so
+    keeping both would double a trace's footprint -- or read and discarded as unusable. Leaving
+    either behind means the next fold re-reads it. Only a fold that *raises* keeps its inputs, so
+    there is something to retry from.
+
+    Cleanup never raises: it runs after the trace is committed, so failing here would cost the
+    caller a trace that is already safely on disk. It is loud instead, because a surviving input is
+    one a later fold would append a second time.
+    """
+    for export in exports:
+        try:
+            export.unlink(missing_ok=True)
+        except OSError as error:
+            logger.warning(
+                "Could not consume the OTLP export at %s (%s); folding this directory again would duplicate its spans.",
+                export,
+                error,
+            )
 
 
 def register_trace_evidence(

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/fabric/otlp_writer.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/fabric/otlp_writer.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Turn the exports an :mod:`otlp_receiver` stored into the trace evidence a metric reads.
+
+Split from the receiver because these need protobuf and the receiver must not: it is seeded into a
+sandbox image that carries Fabric and nothing of this package's own dependencies.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+from google.protobuf.json_format import MessageToJson
+from google.protobuf.message import DecodeError
+from nemo_evaluator_sdk.agent_eval.runtimes.fabric.otlp_receiver import EXPORT_SUFFIX
+from nemo_evaluator_sdk.values.evidence import (
+    EVIDENCE_FORMAT_ATIF,
+    EVIDENCE_FORMAT_OTLP,
+    EVIDENCE_TRACE,
+    EvidenceDescriptor,
+)
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
+
+logger = logging.getLogger(__name__)
+
+#: Where a trial's trace lands, relative to its evidence directory. ``traces`` because that is
+#: where Harbor puts its own, so the layout reads the same across runners.
+TRACES_SUBDIR = "traces"
+OTLP_FILENAME = "relay.jsonl"
+
+
+def traces_dir(evidence_dir: Path) -> Path:
+    return evidence_dir / TRACES_SUBDIR
+
+
+def otlp_trace_path(evidence_dir: Path) -> Path:
+    return traces_dir(evidence_dir) / OTLP_FILENAME
+
+
+def otlp_endpoint_fields(*, endpoint: str, service_name: str) -> dict[str, Any]:
+    """Relay OpenTelemetry endpoint settings, as plain values.
+
+    Returned unmaterialized because the two runtimes build the same endpoint out of different
+    classes -- ``nemo_fabric``'s ``Relay*`` models for a typed config object, ``nemo_relay``'s own
+    for a config dict -- and only the values are shared.
+    """
+    return {
+        # `full` rather than `gen_ai`/`openinference`: a projection chooses what to drop, and the
+        # captured file is the trial's whole trace rather than one view of it.
+        "type": "full",
+        "endpoint": endpoint,
+        "transport": "http_binary",
+        "service_name": service_name,
+    }
+
+
+def export_to_json_line(body: bytes) -> str | None:
+    """One OTLP/JSON line for a serialized export, or None when it carries no spans.
+
+    Raises:
+        google.protobuf.message.DecodeError: ``body`` is not an export request.
+    """
+    request = ExportTraceServiceRequest()
+    request.ParseFromString(body)
+    if not request.resource_spans:
+        return None
+    return MessageToJson(request, indent=None)
+
+
+def fold_exports(directory: Path) -> int:
+    """Fold the receiver's stored exports into one OTLP/JSON file, returning how many were folded.
+
+    Streamed through a temporary file and moved into place, so a trace larger than memory still
+    folds and folding twice cannot double the spans.
+    """
+    exports = sorted(directory.glob(f"*{EXPORT_SUFFIX}"))
+    if not exports:
+        return 0
+    partial = directory / f"{OTLP_FILENAME}.partial"
+    folded = 0
+    try:
+        with partial.open("w", encoding="utf-8") as handle:
+            for export in exports:
+                try:
+                    line = export_to_json_line(export.read_bytes())
+                except (OSError, DecodeError):
+                    logger.warning("Discarding an unreadable OTLP export at %s.", export)
+                    continue
+                if line is None:
+                    continue
+                handle.write(f"{line}\n")
+                folded += 1
+    except BaseException:
+        # Whatever went wrong, a half-written trace must not be left where a complete one goes.
+        partial.unlink(missing_ok=True)
+        raise
+    if not folded:
+        partial.unlink(missing_ok=True)
+        return 0
+    os.replace(partial, directory / OTLP_FILENAME)
+    # The folded file is a lossless re-encoding of these, so keeping both would double a trace's
+    # footprint for nothing. Dropped only once the result is in place, so a fold that dies partway
+    # leaves its inputs to retry from.
+    for export in exports:
+        export.unlink(missing_ok=True)
+    return folded
+
+
+def register_trace_evidence(
+    descriptors: dict[str, EvidenceDescriptor], *, atif: Path | None, otlp: Path | None
+) -> None:
+    """File each trace under its format-qualified key, and the primary one under ``trace``.
+
+    OTLP takes the primary key when it exists, ATIF otherwise -- the rule Harbor and Gym follow, so
+    a metric that asks for neither format gets the same kind of answer whatever ran the trial.
+
+    The two are admitted on different terms. ATIF is registered on a path alone, because Fabric
+    declares it in the run's artifact manifest and ``ATIFTraceHandle`` validates it on read. OTLP is
+    one we wrote ourselves, so an empty file means the exporter never flushed and is not a trace.
+    """
+    admitted = [(atif, EVIDENCE_FORMAT_ATIF)] if atif is not None else []
+    if otlp is not None and otlp.is_file() and otlp.stat().st_size > 0:
+        admitted.append((otlp, EVIDENCE_FORMAT_OTLP))
+    for path, trace_format in admitted:
+        descriptor = EvidenceDescriptor(kind=EVIDENCE_TRACE, format=trace_format, ref=str(path))
+        descriptors[EVIDENCE_TRACE] = descriptor
+        descriptors[f"{EVIDENCE_TRACE}:{trace_format}"] = descriptor

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/fabric/runtime.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/fabric/runtime.py
@@ -44,6 +44,14 @@ from uuid import uuid4
 
 from nemo_evaluator_sdk.agent_eval.runtimes.fabric import _common
 from nemo_evaluator_sdk.agent_eval.runtimes.fabric.hooks import FabricTaskRunHook, FabricTaskRunSession
+from nemo_evaluator_sdk.agent_eval.runtimes.fabric.otlp_receiver import OTLPReceiver
+from nemo_evaluator_sdk.agent_eval.runtimes.fabric.otlp_writer import (
+    fold_exports,
+    otlp_endpoint_fields,
+    otlp_trace_path,
+    register_trace_evidence,
+    traces_dir,
+)
 from nemo_evaluator_sdk.agent_eval.runtimes.fabric.skills import (
     SKILL_MODE_CODEX_SKILLS_DIR,
     AgentSkill,
@@ -63,8 +71,6 @@ from nemo_evaluator_sdk.agent_eval.trials import (
 )
 from nemo_evaluator_sdk.agent_eval.workspace_seeds import SEED_FILES_INPUT_KEY, seed_workspace
 from nemo_evaluator_sdk.values.evidence import (
-    EVIDENCE_FORMAT_ATIF,
-    EVIDENCE_TRACE,
     CandidateEvidence,
     EvidenceDescriptor,
 )
@@ -308,7 +314,11 @@ class FabricAgentRuntime:
         skill_provenances: list[SkillProvenance] = []
         hook_session = FabricTaskRunSession()
         hook_extras: dict[str, Any] | None = None
+        trace_receiver: OTLPReceiver | None = None
         try:
+            # Inside the guarded block: a port it cannot bind costs this trial its trace, like any
+            # other per-task failure, rather than aborting every task in the gather.
+            trace_receiver = self._start_trace_receiver(evidence_dir)
             # Stage seed files into the workspace for their on-disk side effect; the prompt is the task
             # instruction only, so the returned paths are unused.
             await asyncio.to_thread(seed_workspace, workspace_dir, task.inputs.get(SEED_FILES_INPUT_KEY))
@@ -333,7 +343,9 @@ class FabricAgentRuntime:
             # Everything the run needs lives in one typed config: Fabric no longer layers profile
             # overlays, so the per-task workspace/model/trajectory settings are composed on last and are
             # authoritative by construction. ``add_skill_path`` appends, so config-declared skills survive.
-            task_config = self._compose_config(agent_config, evidence_dir, workspace_dir, task=task)
+            task_config = self._compose_config(
+                agent_config, evidence_dir, workspace_dir, task=task, trace_receiver=trace_receiver
+            )
             for skill_path in skill_paths:
                 task_config.add_skill_path(skill_path)
 
@@ -383,6 +395,12 @@ class FabricAgentRuntime:
                 measurements=_atif_measurements(_relay_atif_path(evidence_dir)),
             )
         finally:
+            if trace_receiver is not None:
+                # Stopped before the fold, and both before `_to_trial` reads the evidence: the
+                # spans arrive on the exporter's own schedule, and a trace folded before the last
+                # flush looks complete.
+                trace_receiver.__exit__(None, None, None)
+                fold_exports(traces_dir(evidence_dir))
             if self._task_hook is not None:
                 try:
                     self._task_hook.cleanup(session=hook_session)
@@ -508,6 +526,7 @@ class FabricAgentRuntime:
             "result": EvidenceDescriptor(kind="json", format="json", ref=str(result_path)),
             _WORKSPACE_EVIDENCE_KEY: EvidenceDescriptor(kind=_WORKSPACE_EVIDENCE_KIND, ref=str(workspace_dir)),
         }
+        atif_path: Path | None = None
         for artifact in result.artifacts.artifacts:
             descriptors[artifact.name] = EvidenceDescriptor(
                 kind=artifact.kind or "file",
@@ -517,11 +536,9 @@ class FabricAgentRuntime:
             # Surface the Relay ATIF trajectory under the standard trace evidence key so graders
             # that consume a normalized trajectory find it.
             if artifact.kind == _ATIF_ARTIFACT_KIND:
-                descriptors[EVIDENCE_TRACE] = EvidenceDescriptor(
-                    kind=EVIDENCE_TRACE,
-                    format=EVIDENCE_FORMAT_ATIF,
-                    ref=str(artifact.path),
-                )
+                atif_path = Path(artifact.path)
+
+        register_trace_evidence(descriptors, atif=atif_path, otlp=otlp_trace_path(result_path.parent))
         return CandidateEvidence(
             descriptors=descriptors,
             metadata={
@@ -570,12 +587,19 @@ class FabricAgentRuntime:
             },
         )
 
+    def _start_trace_receiver(self, evidence_dir: Path) -> OTLPReceiver | None:
+        """A running receiver for this task's OTLP trace, or None when trajectory capture is off."""
+        if not self._capture_trajectory:
+            return None
+        return OTLPReceiver(traces_dir(evidence_dir)).__enter__()
+
     def _compose_config(
         self,
         agent_config: FabricConfig,
         evidence_dir: Path,
         workspace_dir: Path,
         task: AgentEvalTask,
+        trace_receiver: OTLPReceiver | None = None,
     ) -> FabricConfig:
         # nemo_fabric is already imported+validated in ``run_tasks``; this is a cached sys.modules
         # lookup, not a re-load, so the type is used where it's constructed instead of threaded down.
@@ -610,7 +634,7 @@ class FabricAgentRuntime:
             row_extra = {"nemo.optimizer.row_id": task.id} if task.id else None
             cfg.enable_relay(
                 output_dir=str(relay_dir),
-                observability=self._relay_config(relay_dir, extra=row_extra),
+                observability=self._relay_config(relay_dir, extra=row_extra, trace_receiver=trace_receiver),
             )
             cfg.runtime.artifacts = str(artifacts_dir)
             cfg.environment.artifacts = str(artifacts_dir)
@@ -621,6 +645,7 @@ class FabricAgentRuntime:
         self,
         relay_dir: Path,
         extra: Mapping[str, Any] | None = None,
+        trace_receiver: OTLPReceiver | None = None,
     ) -> RelayObservabilityConfig:
         # The ATIF/ATOF observability config is built from Fabric's own typed relay-config objects so
         # Fabric owns the schema (no hand-maintained dict that silently drifts when Fabric changes it),
@@ -633,13 +658,22 @@ class FabricAgentRuntime:
             RelayAtofConfig,
             RelayAtofFileSinkConfig,
             RelayObservabilityConfig,
+            RelayOpenTelemetryConfig,
+            RelayOpenTelemetryEndpointConfig,
         )
 
         relay_dir_str = str(relay_dir)
         atif_extra: dict[str, Any] | None = None
         if self._trajectory_extra or extra:
             atif_extra = {**(self._trajectory_extra or {}), **(dict(extra) if extra else {})}
+        opentelemetry = None
+        if trace_receiver is not None:
+            fields = otlp_endpoint_fields(endpoint=trace_receiver.endpoint, service_name=self._runtime_name)
+            opentelemetry = RelayOpenTelemetryConfig(
+                enabled=True, endpoints=[RelayOpenTelemetryEndpointConfig(**fields)]
+            )
         return RelayObservabilityConfig(
+            opentelemetry=opentelemetry,
             atif=RelayAtifConfig(
                 enabled=True,
                 output_directory=relay_dir_str,

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/fabric/runtime.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/fabric/runtime.py
@@ -400,7 +400,12 @@ class FabricAgentRuntime:
                 # spans arrive on the exporter's own schedule, and a trace folded before the last
                 # flush looks complete.
                 trace_receiver.__exit__(None, None, None)
-                fold_exports(traces_dir(evidence_dir))
+                # Guarded because this runs in `finally`, where a raise escapes the handlers above
+                # and aborts the whole gather instead of failing this one task.
+                try:
+                    fold_exports(traces_dir(evidence_dir))
+                except Exception as exc:  # noqa: BLE001 - any fold failure costs the trace, not the trial
+                    logger.warning("Could not fold the OTLP trace for task %s: %s", task.id, exc)
             if self._task_hook is not None:
                 try:
                     self._task_hook.cleanup(session=hook_session)

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/_otlp_testkit.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/_otlp_testkit.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared helpers for the Fabric OTLP capture tests, used by both runtimes' suites."""
+
+from __future__ import annotations
+
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+from nemo_evaluator_sdk.agent_eval.runtimes.fabric.otlp_receiver import PROTOBUF_MEDIA_TYPE
+from nemo_evaluator_sdk.values.otlp import parse_resource_spans, resource_spans_from_text
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
+from opentelemetry.proto.common.v1.common_pb2 import AnyValue, KeyValue
+from opentelemetry.proto.trace.v1.trace_pb2 import ResourceSpans, ScopeSpans, Span
+
+
+def export(*names: str, padding: int = 0) -> bytes:
+    """A serialized export carrying one span per name, optionally padded to a realistic size."""
+    attributes = [KeyValue(key="pad", value=AnyValue(string_value="x" * padding))] if padding else []
+    spans = [
+        Span(
+            trace_id=bytes(range(16)),
+            span_id=bytes(range(8)),
+            name=name,
+            start_time_unix_nano=1,
+            attributes=attributes,
+        )
+        for name in names
+    ]
+    return ExportTraceServiceRequest(
+        resource_spans=[ResourceSpans(scope_spans=[ScopeSpans(spans=spans)])]
+    ).SerializeToString()
+
+
+def post(url: str, body: bytes, *, media_type: str = PROTOBUF_MEDIA_TYPE) -> int:
+    """POST an export and return the status, including for the error responses under test."""
+    request = urllib.request.Request(url, data=body, headers={"Content-Type": media_type}, method="POST")
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            return int(response.status)
+    except urllib.error.HTTPError as error:
+        return int(error.code)
+
+
+def span_names(path: Path) -> list[str]:
+    """The span names in a folded trace, read through the same reader a metric uses."""
+    spans = parse_resource_spans(resource_spans_from_text(path.read_text(encoding="utf-8")))
+    return [span.name for rs in spans for ss in rs.scope_spans for span in ss.spans]

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_fabric_integration.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_fabric_integration.py
@@ -22,6 +22,7 @@ import os
 import shutil
 import sys
 import types
+import urllib.request
 from pathlib import Path
 from typing import Any
 
@@ -30,7 +31,10 @@ from nemo_evaluator_sdk.agent_eval.evaluator import AgentEvaluator
 from nemo_evaluator_sdk.agent_eval.runtimes.fabric import runtime as fabric_runtime
 from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalRunConfig, AgentEvalTask
 from nemo_evaluator_sdk.metrics.protocol import MetricInput, MetricOutput, MetricOutputSpec, MetricResult
-from nemo_evaluator_sdk.values.evidence import EVIDENCE_FORMAT_ATIF, EVIDENCE_TRACE
+from nemo_evaluator_sdk.values.evidence import EVIDENCE_FORMAT_ATIF, EVIDENCE_FORMAT_OTLP, EVIDENCE_TRACE
+from nemo_evaluator_sdk.values.otlp import parse_resource_spans, resource_spans_from_text
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
+from opentelemetry.proto.trace.v1.trace_pb2 import ResourceSpans, ScopeSpans, Span
 
 
 class _TrajectoryEvidenceMetric:
@@ -51,8 +55,10 @@ class _TrajectoryEvidenceMetric:
         steps = 0
         evidence = input.candidate.evidence
         if evidence is not None:
-            descriptor = evidence.get(EVIDENCE_TRACE)
-            if descriptor is not None and descriptor.ref:
+            # Format-qualified: this metric parses ATIF, and the primary trace key is OTLP
+            # whenever the runner captured one.
+            descriptor = evidence.get(f"{EVIDENCE_TRACE}:{EVIDENCE_FORMAT_ATIF}") or evidence.get(EVIDENCE_TRACE)
+            if descriptor is not None and descriptor.ref and descriptor.format == EVIDENCE_FORMAT_ATIF:
                 payload = json.loads(Path(descriptor.ref).read_text(encoding="utf-8"))
                 steps = len(payload.get("steps") or [])
         return MetricResult(outputs=[MetricOutput(name="has_trajectory", value=steps > 0)])
@@ -198,6 +204,8 @@ async def test_fabric_runner_eval_exposes_trajectory_to_metric(tmp_path: Path, m
     setattr(module, "RelayAtifConfig", _FakeRelayModel)
     setattr(module, "RelayAtofConfig", _FakeRelayModel)
     setattr(module, "RelayAtofFileSinkConfig", _FakeRelayModel)
+    setattr(module, "RelayOpenTelemetryConfig", _FakeRelayModel)
+    setattr(module, "RelayOpenTelemetryEndpointConfig", _FakeRelayModel)
     monkeypatch.setitem(sys.modules, "nemo_fabric", module)
     # nemo_relay stays a hard (installed) dependency here so ``run_tasks``'s capture-trajectory fail-fast
     # (``import nemo_relay.observability``) resolves; only the optional native nemo_fabric SDK is faked.
@@ -218,9 +226,16 @@ async def test_fabric_runner_eval_exposes_trajectory_to_metric(tmp_path: Path, m
     # The trajectory is exposed under the standard trace key, as an existing ATIF file.
     assert trial.evidence is not None
     trace = trial.evidence.descriptors[EVIDENCE_TRACE]
+    # ATIF, not OTLP: this test's fake Fabric never runs Relay, so nothing exports a trace to
+    # capture. The primary key is OTLP only when one was actually produced.
     assert trace.format == EVIDENCE_FORMAT_ATIF
     assert trace.ref is not None
     assert Path(trace.ref).exists()
+    # ATIF stays reachable under its own key; the format decides which view is primary, never which
+    # is reachable -- the same rule Harbor follows.
+    atif = trial.evidence.descriptors[f"{EVIDENCE_TRACE}:{EVIDENCE_FORMAT_ATIF}"]
+    assert atif.format == EVIDENCE_FORMAT_ATIF
+    assert atif.ref is not None and Path(atif.ref).exists()
     # The metric received the evidence and scored from the trajectory content.
     scores = [s for s in result.scores if s.metric_type == "has-trajectory"]
     assert scores and scores[0].trial_id == trial.id
@@ -297,12 +312,96 @@ def test_fabric_codex_live_eval_captures_atif_trajectory(tmp_path: Path) -> None
     trial = result.trials[0]
     assert trial.status == "completed", trial.metadata
     assert trial.evidence is not None
+    # OTLP is primary because Relay exported one and the runner captured it; ATIF stays reachable
+    # under its own key, so a metric written against either view still finds it.
     trace = trial.evidence.descriptors[EVIDENCE_TRACE]
-    assert trace.format == EVIDENCE_FORMAT_ATIF
+    assert trace.format == EVIDENCE_FORMAT_OTLP
     assert trace.ref is not None
-    atif = Path(trace.ref)
+    otlp = Path(trace.ref)
+    assert otlp.exists() and otlp.stat().st_size > 0
+    spans = parse_resource_spans(resource_spans_from_text(otlp.read_text(encoding="utf-8")))
+    assert [span for rs in spans for ss in rs.scope_spans for span in ss.spans], "captured no spans"
+
+    atif_descriptor = trial.evidence.descriptors[f"{EVIDENCE_TRACE}:{EVIDENCE_FORMAT_ATIF}"]
+    assert atif_descriptor.ref is not None
+    atif = Path(atif_descriptor.ref)
     assert atif.exists() and atif.stat().st_size > 0
     assert "steps" in json.loads(atif.read_text(encoding="utf-8"))
     # The metric read the real trajectory and scored on it.
     scores = [s for s in result.scores if s.metric_type == "has-trajectory"]
     assert scores and scores[0].outputs[0].value in (True, 1.0)
+
+
+@pytest.mark.asyncio
+async def test_a_relay_export_is_captured_and_becomes_the_primary_trace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The runtime-to-writer wiring, without needing a live Relay.
+
+    The fake harness does what Relay does: read the OTLP endpoint out of the config it was handed
+    and POST an export to it. That covers the parts a writer unit test cannot -- that the endpoint
+    reaches Relay's config at all, that the capture is still open while the harness runs, and that
+    the resulting file is registered as the primary trace.
+    """
+    atif_path = tmp_path / "trajectory.atif.json"
+    atif_path.write_text(json.dumps({"schema_version": "atif/v1", "steps": [{"kind": "message"}]}), encoding="utf-8")
+    artifacts = [_FakeArtifact("relay_atif", "atif", atif_path)]
+
+    def _endpoint_from(config: Any) -> str:
+        opentelemetry = config.relay["observability"].kwargs["opentelemetry"]
+        return str(opentelemetry.kwargs["endpoints"][0].kwargs["endpoint"])
+
+    class _ExportingClient:
+        async def run(self, agent: Any, **kwargs: Any) -> _FakeResult:
+            span = Span(trace_id=bytes(range(16)), span_id=bytes(range(8)), name="codex-turn")
+            export = ExportTraceServiceRequest(resource_spans=[ResourceSpans(scope_spans=[ScopeSpans(spans=[span])])])
+            request = urllib.request.Request(
+                _endpoint_from(agent),
+                data=export.SerializeToString(),
+                headers={"Content-Type": "application/x-protobuf"},
+                method="POST",
+            )
+            with urllib.request.urlopen(request, timeout=10) as response:
+                assert response.status == 200
+            return _FakeResult(artifacts)
+
+    class _FakeRunRequest:
+        def __init__(self, **kwargs: Any) -> None:
+            self.__dict__.update(kwargs)
+
+    module = types.ModuleType("nemo_fabric")
+    setattr(module, "Fabric", _ExportingClient)
+    setattr(module, "FabricConfig", _FakeConfig)
+    setattr(module, "EnvironmentConfig", _FakeEnvironment)
+    setattr(module, "ModelConfig", _FakeModelConfig)
+    setattr(module, "RunRequest", _FakeRunRequest)
+    for name in (
+        "RelayObservabilityConfig",
+        "RelayAtifConfig",
+        "RelayAtofConfig",
+        "RelayAtofFileSinkConfig",
+        "RelayOpenTelemetryConfig",
+        "RelayOpenTelemetryEndpointConfig",
+    ):
+        setattr(module, name, _FakeRelayModel)
+    monkeypatch.setitem(sys.modules, "nemo_fabric", module)
+
+    runtime = fabric_runtime.FabricAgentRuntime(
+        config={"metadata": {"name": "a"}, "harness": {"adapter_id": "nvidia.fabric.codex"}},
+        work_root=tmp_path / "fabric",
+    )
+    result = AgentEvaluator().run_sync(
+        tasks=[_task()],
+        target=runtime,
+        config=AgentEvalRunConfig(work_dir=tmp_path / "out", parallelism=1),
+    )
+
+    trial = result.trials[0]
+    assert trial.status == "completed", trial.metadata
+    assert trial.evidence is not None
+    trace = trial.evidence.descriptors[EVIDENCE_TRACE]
+    assert trace.format == EVIDENCE_FORMAT_OTLP
+    assert trace.ref is not None
+    spans = parse_resource_spans(resource_spans_from_text(Path(trace.ref).read_text(encoding="utf-8")))
+    assert [span.name for rs in spans for ss in rs.scope_spans for span in ss.spans] == ["codex-turn"]
+    assert trial.evidence.descriptors[f"{EVIDENCE_TRACE}:{EVIDENCE_FORMAT_ATIF}"].format == EVIDENCE_FORMAT_ATIF

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_fabric_otlp_writer.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_fabric_otlp_writer.py
@@ -1,0 +1,220 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the OTLP capture both Fabric runtimes share.
+
+The receiver is exercised over real HTTP rather than by calling its methods: it exists because
+Relay will only talk to a socket, so the socket is the contract.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import urllib.error
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+from nemo_evaluator_sdk.agent_eval.runtimes.fabric.otlp_receiver import EXPORT_SUFFIX, READY_FILENAME, OTLPReceiver
+from nemo_evaluator_sdk.agent_eval.runtimes.fabric.otlp_writer import (
+    OTLP_FILENAME,
+    fold_exports,
+    otlp_endpoint_fields,
+    otlp_trace_path,
+    register_trace_evidence,
+    traces_dir,
+)
+from nemo_evaluator_sdk.values.evidence import EVIDENCE_FORMAT_ATIF, EVIDENCE_FORMAT_OTLP, EVIDENCE_TRACE
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
+
+from packages.nemo_evaluator_sdk.tests.agent_eval._otlp_testkit import export, post, span_names
+
+
+@pytest.fixture
+def receiver(tmp_path: Path):
+    with OTLPReceiver(traces_dir(tmp_path)) as running:
+        yield running
+
+
+def test_an_export_is_stored_and_folds_into_a_readable_trace(receiver, tmp_path: Path) -> None:
+    assert post(receiver.endpoint, export("agent run")) == 200
+
+    assert fold_exports(traces_dir(tmp_path)) == 1
+    assert span_names(otlp_trace_path(tmp_path)) == ["agent run"]
+
+
+def test_repeated_flushes_all_survive_the_fold(receiver, tmp_path: Path) -> None:
+    # An exporter flushes on its own schedule over a run; a later flush must not lose an earlier one.
+    for name in ("first", "second", "third"):
+        assert post(receiver.endpoint, export(name)) == 200
+
+    assert fold_exports(traces_dir(tmp_path)) == 3
+    assert span_names(otlp_trace_path(tmp_path)) == ["first", "second", "third"]
+
+
+def test_folding_twice_does_not_double_the_spans(receiver, tmp_path: Path) -> None:
+    # A caller that folds again -- a retry, or reprocessed evidence -- must not double what a
+    # span-counting metric sees.
+    post(receiver.endpoint, export("only"))
+
+    assert fold_exports(traces_dir(tmp_path)) == 1
+    assert fold_exports(traces_dir(tmp_path)) == 0
+    assert span_names(otlp_trace_path(tmp_path)) == ["only"]
+
+
+def test_a_folded_export_is_not_kept_alongside_its_own_re_encoding(receiver, tmp_path: Path) -> None:
+    post(receiver.endpoint, export("only"))
+
+    fold_exports(traces_dir(tmp_path))
+
+    assert not list(traces_dir(tmp_path).glob(f"*{EXPORT_SUFFIX}"))
+    assert otlp_trace_path(tmp_path).is_file()
+
+
+def test_a_large_export_survives_the_round_trip_whole(receiver, tmp_path: Path) -> None:
+    # A real capture ran to 722KB. A line torn across writes parses as neither export, and the
+    # reader reports the whole trace malformed rather than the one flush that tore.
+    for index in range(4):
+        assert post(receiver.endpoint, export(f"span-{index}", padding=150_000)) == 200
+
+    assert fold_exports(traces_dir(tmp_path)) == 4
+    lines = otlp_trace_path(tmp_path).read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 4
+    assert all(json.loads(line) for line in lines)
+
+
+def test_an_export_carrying_no_spans_leaves_no_trace_to_register(receiver, tmp_path: Path) -> None:
+    # An exporter may flush an empty batch on shutdown; that is not a trace, and an empty file
+    # would be registered as one.
+    assert post(receiver.endpoint, ExportTraceServiceRequest().SerializeToString()) == 200
+
+    assert fold_exports(traces_dir(tmp_path)) == 0
+    assert not otlp_trace_path(tmp_path).exists()
+
+
+def test_an_unreadable_export_costs_the_flush_not_the_trace(tmp_path: Path) -> None:
+    directory = traces_dir(tmp_path)
+    directory.mkdir(parents=True)
+    (directory / f"000001{EXPORT_SUFFIX}").write_bytes(b"\xff\xfe not protobuf")
+    (directory / f"000002{EXPORT_SUFFIX}").write_bytes(export("survivor"))
+
+    assert fold_exports(directory) == 1
+    assert span_names(otlp_trace_path(tmp_path)) == ["survivor"]
+
+
+def test_a_post_to_another_path_is_refused(receiver) -> None:
+    assert post(receiver.endpoint.replace("/v1/traces", "/v1/metrics"), export("agent run")) == 404
+
+
+def test_a_non_protobuf_body_is_refused_rather_than_guessed_at(receiver, tmp_path: Path) -> None:
+    # OTLP/JSON would decode into something plausible and wrong. Relay never sends it.
+    assert post(receiver.endpoint, b'{"resourceSpans": []}', media_type="application/json") == 415
+
+    assert fold_exports(traces_dir(tmp_path)) == 0
+
+
+def test_a_body_that_is_not_an_export_does_not_stop_the_receiver(receiver, tmp_path: Path) -> None:
+    # Stored verbatim, so a bad body is only found at fold time -- but the socket must stay up.
+    assert post(receiver.endpoint, b"\xff\xfe not protobuf") == 200
+
+    assert post(receiver.endpoint, export("agent run")) == 200
+    assert fold_exports(traces_dir(tmp_path)) == 1
+    assert span_names(otlp_trace_path(tmp_path)) == ["agent run"]
+
+
+def test_concurrent_flushes_each_land_as_their_own_export(receiver, tmp_path: Path) -> None:
+    names = [f"span-{index}" for index in range(12)]
+    with ThreadPoolExecutor(max_workers=6) as pool:
+        statuses = list(pool.map(lambda name: post(receiver.endpoint, export(name)), names))
+
+    assert statuses == [200] * len(names)
+    assert fold_exports(traces_dir(tmp_path)) == len(names)
+    assert sorted(span_names(otlp_trace_path(tmp_path))) == sorted(names)
+
+
+def test_the_endpoint_is_loopback_on_a_port_the_os_assigned(receiver) -> None:
+    # Port 0 rather than a fixed one: trials run in parallel and would otherwise collide.
+    assert receiver.endpoint.startswith("http://127.0.0.1:")
+    assert receiver.endpoint.endswith("/v1/traces")
+    assert receiver.server_address[1] != 0
+
+
+def test_leaving_the_context_stops_serving_and_leaves_no_thread(tmp_path: Path) -> None:
+    before = threading.active_count()
+    with OTLPReceiver(traces_dir(tmp_path)) as running:
+        endpoint = running.endpoint
+        assert post(endpoint, export("agent run")) == 200
+
+    with pytest.raises(urllib.error.URLError):
+        post(endpoint, export("after close"))
+    assert threading.active_count() == before
+
+
+def test_signal_ready_announces_a_bound_socket(tmp_path: Path) -> None:
+    # The container runtime waits on this file before starting the harness, so it must mean the
+    # socket already accepts exports.
+    with OTLPReceiver(traces_dir(tmp_path)) as running:
+        running.signal_ready()
+
+        assert (traces_dir(tmp_path) / READY_FILENAME).is_file()
+        assert post(running.endpoint, export("agent run")) == 200
+
+
+def test_the_primary_trace_is_otlp_when_there_is_one_and_atif_otherwise(tmp_path: Path) -> None:
+    # ATIF needs no file on disk: Fabric declares it in the artifact manifest and the handle
+    # validates it on read.
+    atif, otlp = tmp_path / "t.atif.json", tmp_path / OTLP_FILENAME
+
+    atif_only: dict = {}
+    register_trace_evidence(atif_only, atif=atif, otlp=otlp)
+    assert atif_only[EVIDENCE_TRACE].format == EVIDENCE_FORMAT_ATIF
+
+    otlp.write_text("{}\n", encoding="utf-8")
+    both: dict = {}
+    register_trace_evidence(both, atif=atif, otlp=otlp)
+    assert both[EVIDENCE_TRACE].format == EVIDENCE_FORMAT_OTLP
+    # The format decides which view is primary, never which is reachable.
+    assert both[f"{EVIDENCE_TRACE}:{EVIDENCE_FORMAT_ATIF}"].format == EVIDENCE_FORMAT_ATIF
+    assert both[f"{EVIDENCE_TRACE}:{EVIDENCE_FORMAT_OTLP}"].format == EVIDENCE_FORMAT_OTLP
+
+
+def test_an_empty_trace_file_is_not_registered(tmp_path: Path) -> None:
+    otlp = tmp_path / OTLP_FILENAME
+    otlp.touch()
+
+    descriptors: dict = {}
+    register_trace_evidence(descriptors, atif=None, otlp=otlp)
+
+    assert descriptors == {}
+
+
+def test_the_endpoint_fields_are_the_ones_relay_needs() -> None:
+    # Shared because both runtimes build this endpoint out of different classes; only the values
+    # are common, and a divergence would silently change what Relay exports.
+    fields = otlp_endpoint_fields(endpoint="http://127.0.0.1:1/v1/traces", service_name="fabric")
+
+    assert fields == {
+        "type": "full",
+        "endpoint": "http://127.0.0.1:1/v1/traces",
+        "transport": "http_binary",
+        "service_name": "fabric",
+    }
+
+
+def test_a_fold_that_dies_partway_leaves_the_previous_trace_intact(receiver, tmp_path: Path, monkeypatch) -> None:
+    # Written through a temporary file and moved into place: a half-written trace parses as
+    # malformed, and a reader cannot tell it from one the exporter never finished.
+    post(receiver.endpoint, export("first"))
+    fold_exports(traces_dir(tmp_path))
+    post(receiver.endpoint, export("second"))
+
+    def boom(_: bytes) -> str:
+        raise RuntimeError("disk full")
+
+    monkeypatch.setattr("nemo_evaluator_sdk.agent_eval.runtimes.fabric.otlp_writer.export_to_json_line", boom)
+    with pytest.raises(RuntimeError):
+        fold_exports(traces_dir(tmp_path))
+
+    assert span_names(otlp_trace_path(tmp_path)) == ["first"]
+    assert not list(traces_dir(tmp_path).glob("*.partial"))

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_fabric_otlp_writer.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_fabric_otlp_writer.py
@@ -10,13 +10,20 @@ Relay will only talk to a socket, so the socket is the contract.
 from __future__ import annotations
 
 import json
+import socket
 import threading
 import urllib.error
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
-from nemo_evaluator_sdk.agent_eval.runtimes.fabric.otlp_receiver import EXPORT_SUFFIX, READY_FILENAME, OTLPReceiver
+from nemo_evaluator_sdk.agent_eval.runtimes.fabric.otlp_receiver import (
+    EXPORT_SUFFIX,
+    PROTOBUF_MEDIA_TYPE,
+    READY_FILENAME,
+    TRACES_PATH,
+    OTLPReceiver,
+)
 from nemo_evaluator_sdk.agent_eval.runtimes.fabric.otlp_writer import (
     OTLP_FILENAME,
     fold_exports,
@@ -53,14 +60,30 @@ def test_repeated_flushes_all_survive_the_fold(receiver, tmp_path: Path) -> None
     assert span_names(otlp_trace_path(tmp_path)) == ["first", "second", "third"]
 
 
-def test_folding_twice_does_not_double_the_spans(receiver, tmp_path: Path) -> None:
-    # A caller that folds again -- a retry, or reprocessed evidence -- must not double what a
-    # span-counting metric sees.
+def test_folding_again_with_nothing_pending_leaves_the_trace_alone(receiver, tmp_path: Path) -> None:
+    # Folding consumes its inputs, so a repeat pass -- a retry, or reprocessed evidence -- is a
+    # no-op rather than a second copy of what a span-counting metric already saw.
     post(receiver.endpoint, export("only"))
 
     assert fold_exports(traces_dir(tmp_path)) == 1
     assert fold_exports(traces_dir(tmp_path)) == 0
     assert span_names(otlp_trace_path(tmp_path)) == ["only"]
+
+
+def test_folding_new_exports_appends_to_the_trace_already_written(receiver, tmp_path: Path) -> None:
+    """A later fold must extend the trace, not replace it with whatever arrived since.
+
+    The rewrite is atomic, so a fold that wrote only the pending exports would ``os.replace`` the
+    earlier spans away -- losing the first half of a run to nothing more than a second flush.
+    """
+    post(receiver.endpoint, export("first"))
+    assert fold_exports(traces_dir(tmp_path)) == 1
+
+    post(receiver.endpoint, export("second"))
+    # The return counts what this call folded, not the spans now in the trace.
+    assert fold_exports(traces_dir(tmp_path)) == 1
+
+    assert span_names(otlp_trace_path(tmp_path)) == ["first", "second"]
 
 
 def test_a_folded_export_is_not_kept_alongside_its_own_re_encoding(receiver, tmp_path: Path) -> None:
@@ -218,3 +241,106 @@ def test_a_fold_that_dies_partway_leaves_the_previous_trace_intact(receiver, tmp
 
     assert span_names(otlp_trace_path(tmp_path)) == ["first"]
     assert not list(traces_dir(tmp_path).glob("*.partial"))
+
+
+def _post_raw(endpoint: str, headers: str, body: bytes = b"") -> str:
+    """POST with hand-written headers, so a header urllib would never emit can be sent."""
+    host, _, port = endpoint.split("//", 1)[1].split("/", 1)[0].partition(":")
+    with socket.create_connection((host, int(port)), timeout=10) as connection:
+        connection.sendall(headers.encode("ascii") + body)
+        connection.settimeout(10)
+        return connection.recv(256).decode("ascii", errors="replace").splitlines()[0]
+
+
+def test_a_negative_content_length_is_refused_without_stalling_the_receiver(receiver, tmp_path: Path) -> None:
+    """A negative length must be rejected before the read, not passed to ``rfile.read``.
+
+    ``read(-1)`` consumes until EOF, so the receiver -- single-threaded, and reachable by the
+    untrusted agent sharing its loopback -- would serve nothing further until that client hung up,
+    silently costing the trial its trace.
+    """
+    status = _post_raw(
+        receiver.endpoint,
+        f"POST {TRACES_PATH} HTTP/1.1\r\nHost: localhost\r\n"
+        f"Content-Type: {PROTOBUF_MEDIA_TYPE}\r\nContent-Length: -1\r\n\r\n",
+    )
+    assert "400" in status, status
+
+    # The receiver is still serving: a real export after the bad one still lands.
+    assert post(receiver.endpoint, export("after")) == 200
+    assert fold_exports(traces_dir(tmp_path)) == 1
+    assert span_names(otlp_trace_path(tmp_path)) == ["after"]
+
+
+def test_a_spanless_export_is_consumed_rather_than_re_read(receiver, tmp_path: Path) -> None:
+    """An export carrying no spans still counts as read, so the next fold does not see it again.
+
+    Relay can flush an empty export. Left on disk it folds to nothing forever, so every later pass
+    reports zero folded — which is the signal the container runtime uses to warn that no OTLP was
+    captured at all.
+    """
+    assert post(receiver.endpoint, ExportTraceServiceRequest().SerializeToString()) == 200
+    traces = traces_dir(tmp_path)
+    assert list(traces.glob(f"*{EXPORT_SUFFIX}"))
+
+    assert fold_exports(traces) == 0
+    assert list(traces.glob(f"*{EXPORT_SUFFIX}")) == []
+    assert not otlp_trace_path(tmp_path).exists()
+
+
+def test_a_spanless_flush_does_not_disturb_a_trace_already_folded(receiver, tmp_path: Path) -> None:
+    # Consuming the empty export must not take the earlier trace with it: the partial is discarded,
+    # so `os.replace` never runs and what is already on disk stands.
+    post(receiver.endpoint, export("real"))
+    assert fold_exports(traces_dir(tmp_path)) == 1
+
+    post(receiver.endpoint, ExportTraceServiceRequest().SerializeToString())
+    assert fold_exports(traces_dir(tmp_path)) == 0
+
+    assert span_names(otlp_trace_path(tmp_path)) == ["real"]
+
+
+def test_the_path_check_reads_the_url_not_the_raw_request_target(receiver, tmp_path: Path) -> None:
+    """A query string or an absolute-form target still resolves to the traces path.
+
+    RFC 7230 lets a client send the whole URL as the request target, and comparing the raw target
+    against the path would 404 it — the export is refused and the trial silently loses its trace.
+    """
+    body = export("absolute form")
+    host = receiver.endpoint.split("//", 1)[1].split("/", 1)[0]
+    status = _post_raw(
+        receiver.endpoint,
+        f"POST http://{host}{TRACES_PATH}?compression=none HTTP/1.1\r\nHost: {host}\r\n"
+        f"Content-Type: {PROTOBUF_MEDIA_TYPE}\r\nContent-Length: {len(body)}\r\n\r\n",
+        body,
+    )
+    assert "200" in status, status
+
+    assert fold_exports(traces_dir(tmp_path)) == 1
+    assert span_names(otlp_trace_path(tmp_path)) == ["absolute form"]
+
+
+def test_an_unconsumable_export_does_not_cost_the_committed_trace(
+    receiver, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog
+) -> None:
+    """Cleanup runs after the commit, so it must not raise over a trace already on disk.
+
+    Removing an input needs the same directory permission the commit did, so this is narrow --
+    an immutable file, or one held open on Windows -- but the trace is safe by then and losing it
+    to a cleanup error would be strictly worse than leaving the input behind.
+    """
+    post(receiver.endpoint, export("kept"))
+    original = Path.unlink
+
+    def refuse(self: Path, missing_ok: bool = False) -> None:
+        if self.suffix == ".pb":
+            raise PermissionError("Operation not permitted")
+        original(self, missing_ok=missing_ok)
+
+    monkeypatch.setattr(Path, "unlink", refuse)
+
+    with caplog.at_level("WARNING"):
+        assert fold_exports(traces_dir(tmp_path)) == 1
+
+    assert span_names(otlp_trace_path(tmp_path)) == ["kept"]
+    assert "duplicate its spans" in caplog.text

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_fabric_runtime.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_fabric_runtime.py
@@ -253,6 +253,8 @@ def _install_fake_fabric(monkeypatch: pytest.MonkeyPatch, handler: Any) -> type:
     module.RelayAtifConfig = _FakeRelayModel  # type: ignore[attr-defined]
     module.RelayAtofConfig = _FakeRelayModel  # type: ignore[attr-defined]
     module.RelayAtofFileSinkConfig = _FakeRelayModel  # type: ignore[attr-defined]
+    module.RelayOpenTelemetryConfig = _FakeRelayModel  # type: ignore[attr-defined]
+    module.RelayOpenTelemetryEndpointConfig = _FakeRelayModel  # type: ignore[attr-defined]
     monkeypatch.setitem(sys.modules, "nemo_fabric", module)
 
     # ``run_tasks`` fails fast on ``import nemo_relay.observability`` when capture_trajectory is on

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_fabric_runtime.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_fabric_runtime.py
@@ -1266,3 +1266,33 @@ def test_sum_step_metric_treats_missing_steps_as_unmeasured_and_non_list_as_inva
     assert fabric_runtime._sum_step_metric({}, "prompt_tokens", is_float=False) == (None, True)
     assert fabric_runtime._sum_step_metric({"steps": None}, "prompt_tokens", is_float=False) == (None, True)
     assert fabric_runtime._sum_step_metric({"steps": 7}, "prompt_tokens", is_float=False) == (None, False)
+
+
+@pytest.mark.asyncio
+async def test_a_failing_trace_fold_costs_the_trace_not_the_batch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A fold that raises must not take the other tasks' trials with it.
+
+    The fold runs in ``finally``, past the per-task exception handlers, so an unguarded raise
+    propagates into the ``asyncio.gather`` over every task — turning one unwritable evidence
+    directory into a run with no results at all.
+    """
+
+    def handler(agent: Any, kwargs: dict[str, Any]) -> _FakeResult:
+        return _FakeResult(status="succeeded", output={"response": "ok"})
+
+    _install_fake_fabric(monkeypatch, handler)
+
+    def explode(directory: Path) -> int:
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr(fabric_runtime, "fold_exports", explode)
+    runtime = fabric_runtime.FabricAgentRuntime(config=_CONFIG, work_root=tmp_path / "fabric", capture_trajectory=True)
+
+    first, second = await runtime.run_tasks([_TASK, _TASK])
+
+    for trial in (first, second):
+        assert trial.status == "completed"
+        assert trial.evidence is not None
+        assert EVIDENCE_TRACE not in trial.evidence.descriptors


### PR DESCRIPTION
Implements [AALGO-601](https://linear.app/nvidia/issue/AALGO-601/decide-how-fabric-emits-otlp-relays-exporter-is-endpoint-only-so-there).

## Summary

Fabric was the only runner family with no OTLP trace at all — both its runtimes registered ATIF — so a metric written against the OTLP path that [AALGO-569](https://linear.app/nvidia/issue/AALGO-569/switch-evaluators-primary-trajectory-format-from-atif-to-otlp) makes primary got nothing from a Fabric trial. Relay cannot write OTLP to disk, so the runner now listens for it: a loopback receiver per task, capturing each export to `<evidence>/traces/relay.jsonl`.

Before: a Fabric trial's `trace` evidence was always the ATIF file. After: it is the OTLP capture when one was recorded, with ATIF still addressable at `trace:atif`.

## Changes

- **`fabric/otlp_receiver.py`** (new) — the endpoint Relay exports to: loopback `HTTPServer` on an OS-assigned port, accepting `POST /v1/traces` as `application/x-protobuf` and storing each export verbatim. 404 on another path, 415 on another media type, 400 on a malformed or negative `Content-Length`, 413 past the size ceiling. The request target is parsed rather than compared raw, so an absolute-form target or a query string still resolves. **Standard library only, deliberately** — the container runtime (#1915) seeds this same file into a sandbox that carries Fabric and nothing of this package, so there is one endpoint with two ways of running it rather than an implementation per runtime.
- **`fabric/otlp_writer.py`** (new) — everything that needs protobuf, and so cannot live in the receiver: folding stored exports into the OTLP/JSON the trace reader already reads, registering trace evidence, and the Relay endpoint settings both runtimes share.
- **`fabric/runtime.py`** — one receiver per task, started inside the guarded block, stopped and folded in `finally` before evidence is read (the fold guarded, since a raise from `finally` escapes the per-task handlers and would abort the whole `gather`); its address threaded into `RelayOpenTelemetryConfig`; the result registered as `trace:otlp` and as the primary `trace` key. ATIF now also gets `trace:atif`.
- **Docs** — the metrics guide described dual-format traces as Harbor-only; that is no longer true.

## Why a receiver rather than config

Verified against `NeMo-Relay@9c68f58` and the shipped `_native.abi3.so`, not inferred: `OpenTelemetrySectionConfig` is `{enabled, endpoints[]}` with no sink; the exporter is a two-arm match on `HttpBinary`/`Grpc`, both networked; `resolve_http_trace_endpoint` rejects any scheme but http/https; only `atif.rs` and `atof.rs` have file sinks; and the binary embeds the OTLP-endpoint env vars but not `OTEL_TRACES_EXPORTER`. Fabric only narrows the config it forwards, so it cannot add a sink Relay lacks.

**A file sink on Relay's OTel section would delete this module** and make Fabric's case the config line AALGO-601 originally assumed. Worth asking the Relay owners before anyone extends this.

## Type of Change

- [x] Code change with documentation updates

## Quality Gates

- [x] Tests added or updated for changed behavior
- [x] Documentation updated for user-visible behavior

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `uv run pre-commit run -a` — **15 hooks, 0 failures**
- `uv run --frozen pytest packages/nemo_evaluator_sdk plugins/nemo-evaluator` — **2850 passed, 38 skipped**
- `uv run --frozen ty check` — clean on every changed file (the 6 `unused-ignore-comment` warnings in `fabric/runtime.py` are present on `origin/main` unchanged; verified by stashing)
- `make vendor` and `make generate-cli-reference-docs` — no drift
- `lint-openapi` / `lint-sdk-vendored` need `mapfile` (bash 4+) and cannot run on macOS bash 3.2; both invariants checked directly instead, as above

**Live evidence.** `test_fabric_codex_live_eval_captures_atif_trajectory` runs real codex + real Relay (it self-skips without codex, nemo-relay and the adapter on PATH). It passes on this branch's HEAD. The captured trace carries what ATIF cannot — from one such run:

```
codex-turn                15919.93ms   root
  ├─ openai.responses       3434.04ms
  ├─ openai.responses       3108.79ms
  ├─ mcp__dev_brain__bootstrap  87.83ms
  └─ openai.responses       2801.13ms
```

ATIF for the same run: 5 steps, one `timestamp` each, no durations, and step order not matching the wall clock.

Span counts vary run to run with what the agent actually does — a later run captured 3 spans across 2 export flushes rather than 6 across 1. What is invariant, and what the tests pin, is that spans carry durations and parent links and that repeated flushes append rather than replace.

## Design notes

**Storing exports, then folding.** The receiver writes each export to disk verbatim and the fold happens once, at the end. That keeps the receiver free of protobuf so the container can run it, and means a trace never has to fit in memory. Folding streams through a temporary file and moves it into place, so a fold that dies partway cannot leave a half-written trace where a complete one goes; the raw exports are dropped once folded, since the result is a lossless re-encoding of them. It is additive in both directions — repeating a fold changes nothing, and a fold that finds new exports copies the existing trace into the rewrite before appending, since the atomic replace would otherwise drop the earlier spans. Every export a fold reads is consumed, spanless flushes included, so a later pass cannot re-read the same nothing.

**ATIF and OTLP are admitted on different terms.** ATIF is registered on a path alone — Fabric declares it in the run's artifact manifest and `ATIFTraceHandle` validates it on read. OTLP is one we wrote, so an empty file means the exporter never flushed and is not a trace.

## Known limitation

**Local harnesses only, in this PR.** The container runtime is handled in #1915, which reuses this receiver rather than adding a second one.

**A failed trial carries no trace.** `build_failed_trial` files only `error`, so a timed-out or errored run loses the partial OTLP capture even though the fold has already written it. That predates this PR — failed trials have never carried an ATIF trace either — but OTLP makes it more worth fixing, since spans up to the timeout are exactly what you want when diagnosing one. Left for a follow-up rather than restructuring the try/finally here.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Fabric task runs can capture OTLP traces emitted by Relay.
  - Captured OTLP traces are automatically converted into trajectory evidence.
  - ATIF and OTLP evidence remain available when both are produced.

- **Behavior Changes**
  - OTLP is used as the primary trace when available; ATIF is used as a fallback.
  - Trace-processing failures no longer prevent successful task results from completing.
  - Existing ATIF and ATOF exports remain supported.

- **Documentation**
  - Clarified trace handling for Harbor and Fabric.
  - Documented that no setting controls the default trace format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


