### PR TITLE
docs(evaluator): Document sandboxed Gym agent evaluations

### DIFF
--- a/docs/evaluator/agent-eval/gym-custom-environment.mdx
+++ b/docs/evaluator/agent-eval/gym-custom-environment.mdx
@@ -1,0 +1,195 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+title: "Run a Custom NeMo Gym Environment"
+description: "Package a custom NeMo Gym environment as a FileSet and run it as a sandboxed agent-evaluate job."
+---
+
+A custom Gym environment runs from a NeMo Platform FileSet rather than from the components bundled
+in the Gym task image. Evaluator stages the FileSet onto job storage, mounts it read-only in an
+OpenSandbox Gym host, and returns the rollouts through the normal agent-evaluation result bundle.
+
+## Prerequisites
+
+- A running NeMo Platform with the Evaluator plugin.
+- An OpenSandbox-capable Kubernetes deployment configured for sandboxed Gym. See
+  [Configure Sandboxed Gym](/documentation/evaluate-models/agent-eval/gym-sandbox-configuration).
+- A taskset built from Gym rows as described in
+  [Evaluate a NeMo Gym Environment](/documentation/evaluate-models/agent-eval/gym-runner#submit-as-a-platform-job).
+- A model endpoint reachable from the sandbox.
+
+<Warning>
+
+FileSet-backed Gym environments cannot use colocated platform execution. Evaluator rejects the
+submission when
+`sandboxed_gym_default` is disabled or the selected execution profile does not provide compatible
+shared PVC storage.
+
+</Warning>
+
+## 1. Package the environment
+
+The FileSet must contain `nemo-environment.yaml` at its root. Evaluator accepts two formats:
+
+- `native-v1` installs component dependencies from each component's `requirements.txt`.
+- `wheels-v1` installs dependencies from a flat, non-empty `wheels/` directory without contacting a
+  package index.
+
+A minimal `native-v1` resource-server package looks like this:
+
+```text
+my-gym-environment/
+├── nemo-environment.yaml
+└── resources_servers/
+    └── custom_greeting/
+        ├── app.py
+        ├── requirements.txt
+        └── configs/
+            └── custom_greeting.yaml
+```
+
+```yaml
+format: native-v1
+config_paths:
+  - resources_servers/custom_greeting/configs/custom_greeting.yaml
+metadata:
+  name: custom-greeting
+  description: Return and score a requested greeting.
+```
+
+For `wheels-v1`, use the same manifest shape with `format: wheels-v1` and add the wheelhouse:
+
+```text
+my-gym-environment/
+├── nemo-environment.yaml
+├── wheels/
+│   ├── custom_greeting-0.1.0-py3-none-any.whl
+│   └── dependency-1.0.0-py3-none-any.whl
+└── resources_servers/
+    └── custom_greeting/
+        └── configs/
+            └── custom_greeting.yaml
+```
+
+The package must follow these rules:
+
+- Every `config_paths` entry is relative to the FileSet root and names an uploaded file.
+- `native-v1` config paths stay under `resources_servers/` or `responses_api_agents/`.
+- `wheels/` is flat and contains only `.whl` files.
+- Do not include `responses_api_models/`; model configuration is operator-owned.
+- Do not include dataset `.jsonl` files. Store evaluation rows in a separate taskset.
+
+## 2. Upload the environment
+
+Create an environment FileSet and upload the directory contents:
+
+```bash
+nemo files filesets create my-gym-environment \
+  --workspace default \
+  --purpose environment \
+  --description "Custom Gym environment"
+
+nemo files upload ./my-gym-environment/ my-gym-environment \
+  --workspace default
+
+nemo files list my-gym-environment --workspace default
+```
+
+Keep the trailing slash on `./my-gym-environment/`. It places `nemo-environment.yaml` at the FileSet
+root instead of creating an extra directory level.
+
+## 3. Create the job specification
+
+Create `gym-custom-environment.yaml`:
+
+```yaml
+tasks: default/my-gym-taskset
+target:
+  kind: gym
+  environment: default/my-gym-environment
+  agent: simple_agent
+  agent_config: responses_api_agents/simple_agent/configs/simple_agent.yaml
+  resources_server: custom_greeting
+  num_repeats: 1
+  concurrency: 1
+  hydra_params:
+    policy_base_url: http://nemo-platform-api.default.svc.cluster.local:8080/apis/inference-gateway/v2/workspaces/default/model/my-model/-/v1
+    policy_api_key: not-used
+    policy_model_name: my-model
+max_concurrent_tasks: 1
+fail_fast: true
+labels:
+  benchmark: custom-greeting
+```
+
+The Evaluator plugin skill includes the same shape as a validated JSON starting point at
+`skills/nemo-evaluator-plugin/assets/specs/gym_agent_eval.json`.
+
+Replace the service URL, workspace, model, taskset, and component names for your deployment.
+The model URL must be present in the deployment's sandbox egress configuration.
+
+If the package declares the selected agent instance, you can omit `agent_config`. Set
+`agent_ref_name` when the instance name registered by the package differs from `agent`.
+
+For an environment variable containing a credential, use a platform secret reference:
+
+```yaml
+target:
+  kind: gym
+  # ...
+  env_secrets:
+    EXTERNAL_MODEL_API_KEY: default/my-model-api-key
+```
+
+Do not place credentials in `env_vars`. Sandboxed submissions reject credential-shaped plaintext
+environment variables.
+
+## 4. Submit the job
+
+```bash
+nemo evaluator agent-evaluate submit \
+  --spec-file gym-custom-environment.yaml \
+  --workspace default \
+  --profile default
+```
+
+Evaluator compiles two ordered steps:
+
+1. `stage-environment` downloads the FileSet onto job-scoped persistent storage.
+2. `agent-evaluate` provisions `nmp-gym-host`, collects rollouts, scores them, and destroys the host.
+
+Both platform steps use `nmp-cpu-tasks`; Gym and Ray run in the separate sandbox host.
+
+## 5. Read the results
+
+Wait for the job to finish, then download the result bundle:
+
+```bash
+nemo jobs results download agent-eval-results \
+  --job <job-name> \
+  --output-file agent-eval-results.tar.gz
+```
+
+The archive contains `trials.jsonl`, `scores.jsonl`, `tasks.jsonl`, and `summary.json`. See
+[Reading Results](/documentation/evaluate-models/agent-eval/reading-results#results-from-platform-jobs)
+for the queryable result record and SDK retrieval path.
+
+## Troubleshooting
+
+- **FileSet purpose or manifest error:** Confirm the FileSet uses `purpose=environment` and contains
+  a valid root `nemo-environment.yaml`.
+- **Sandbox unavailable:** Confirm the deployment enabled sandboxed Gym and configured OpenSandbox,
+  the runtime image, a shared PVC, and model egress.
+- **PVC mismatch:** The Jobs execution profile and `sandbox_job_storage_pvc_claim` must name the same
+  claim.
+- **Agent returns no rollout:** Set `agent_ref_name` to the agent instance registered by the package.
+- **Model connection failure:** Add the model host and port to the deployment-owned egress allowlist.
+
+## Related
+
+<Cards>
+  <Card title="Evaluate a NeMo Gym Environment" href="/documentation/evaluate-models/agent-eval/gym-runner" />
+  <Card title="Configure Sandboxed Gym" href="/documentation/evaluate-models/agent-eval/gym-sandbox-configuration" />
+  <Card title="Reading Results" href="/documentation/evaluate-models/agent-eval/reading-results" />
+</Cards>

--- a/docs/evaluator/agent-eval/gym-runner.mdx
+++ b/docs/evaluator/agent-eval/gym-runner.mdx
@@ -13,12 +13,27 @@ through agent-eval — the same [`AgentEvaluator`](/documentation/evaluate-model
 same result and bundle as the [quickstart](/documentation/evaluate-models/agent-eval/quickstart).
 Only the runner changes.
 
-Gym owns execution **and** scoring here. The runner shells out to the `gym` CLI and adapts the
-rollout bundle into trials; `GymRewardMetric` surfaces Gym's per-attempt reward.
+## Choose how to run the evaluation
+
+There are two user-facing interfaces:
+
+| Interface | Use it for | How it runs |
+|---|---|---|
+| **Local SDK** | Developing the task set and runner on your machine | `AgentEvaluator().run(...)` invokes local `gym` subprocesses |
+| **Platform job** | Durable, repeatable execution with platform storage and results | Submit `agent-evaluate`; the deployment controls where Gym runs |
+
+On the platform, sandbox placement is an operator decision rather than another submission mode. A
+sandbox-enabled deployment runs Gym in a separate `nmp-gym-host`. A deployment without OpenSandbox
+can still run trusted, built-in Gym components inside the `nmp-gym-tasks` job container; this
+compatibility path is called **colocated execution**. Submitters do not select between them, and
+custom environment FileSets always require the sandboxed path.
+
+Gym owns execution **and** scoring through either interface. Both produce the same trial shape, and
+`GymRewardMetric` surfaces Gym's per-attempt reward.
 
 <Warning>
 
-Like the Harbor runner, this one is **not** zero-dependency — it shells out to the `gym` CLI:
+For a local SDK run, this runner is **not** zero-dependency — it shells out to the `gym` CLI:
 
 - **NeMo Gym**, installed into its own `uv` environment (below)
 - **The target environment's own dependencies** — each resources-server ships its own
@@ -35,12 +50,13 @@ Install Gym into **its own environment** and put that environment's `bin` on `PA
 at module load, and `nemo-platform` excludes Ray by constraint, so the two generally cannot share a
 virtualenv. The runner resolves `gym` from `PATH` only — there is deliberately no setting pointing at
 a checkout or another venv, because this config becomes a serialized job spec when Gym runs as a
-platform job, and a local path means nothing on the other side of that boundary. In a job image, the
-image owns `PATH` and this resolves normally.
+platform job, and a local path means nothing on the other side of that boundary. In a colocated job
+image, the image owns `PATH` and this resolves normally. A sandboxed job runs the CLI in a separate
+`nmp-gym-host` image instead.
 
 </Warning>
 
-## Credentials
+## Credentials for local SDK runs
 
 Gym's collector calls your model endpoint directly. It reads the credentials from an `env.yaml` in
 the directory you run from — **this SDK never reads or handles that file**:
@@ -52,6 +68,9 @@ policy_model_name: <model, e.g. meta/llama-3.1-8b-instruct>
 ```
 
 Keep it out of version control. Gym searches the working directory first, then its install root.
+Platform jobs do not read this local file. Configure their model route with `hydra_params`, and map
+secret environment variables through `GymRunnerTarget.env_secrets`. See
+[Configure Sandboxed Gym](/documentation/evaluate-models/agent-eval/gym-sandbox-configuration).
 
 ## The dataset
 
@@ -116,7 +135,7 @@ The mapping is:
 
 So `num_repeats=2` over a 5-row dataset yields 5 tasks and 10 trials.
 
-### Configuration
+### Local runner configuration
 
 | Field | Required | Notes |
 |---|---|---|
@@ -137,6 +156,20 @@ So `num_repeats=2` over a 5-row dataset yields 5 tasks and 10 trials.
 Anything `GymRuntimeConfig` does not expose can go through `hydra_params`, which is flattened to
 Hydra's override grammar and applied to `gym env start`. For the full set of knobs, see the
 [NeMo Gym documentation](https://github.com/NVIDIA-NeMo/Gym).
+
+Platform job specs use `GymRunnerTarget`, the serializable counterpart of the local
+`GymRuntimeConfig`. It adds three platform-only fields:
+
+- `environment` points to a FileSet containing Gym component configuration, code, and dependencies
+  that are not built into the runtime image.
+- `agent_ref_name` identifies the agent instance registered inside the sandbox when that instance
+  name differs from the `agent` component name.
+- `env_secrets` maps environment variable names to NeMo Platform secret references without placing
+  secret values in the job spec.
+
+`agent_config` remains required when the target uses an agent built into the Gym image. It becomes
+optional only when the environment FileSet supplies and registers the selected agent configuration.
+See [Run a Custom Gym Environment](/documentation/evaluate-models/agent-eval/gym-custom-environment).
 
 ## Read the results
 
@@ -182,7 +215,7 @@ Gym's own artifacts land in a `gym_run/` subdirectory — `rollouts.jsonl`,
 `rollouts_failures.jsonl`, `rollouts_aggregate_metrics.json`, and the materialized
 `gym_input.jsonl` handed to collection.
 
-## How it runs Gym
+## How local SDK and colocated platform runs execute Gym
 
 The runner uses Gym's **two-step** flow, which reads a dataset file directly — no split-driven data
 preparation and no HuggingFace downloads:
@@ -294,12 +327,14 @@ A value with no JSON form — a callable in `hydra_params`, say — is refused w
 that names neither the runner nor the field.
 
 The returned handle is an `AgentEvaluatorJobResource`. Unlike a dataset-driven job it has no
-`get_result()` or `download_artifacts()`, because an agent evaluation publishes agent-eval results
-and a summary rather than row scores. Read the scores through
-`client.evaluator.agent_eval_results`.
+`get_result()` or `download_artifacts()`. Wait for completion, then read the queryable record through
+`client.evaluator.agent_eval_results` or download the named `agent-eval-results` job result. See
+[Reading Results](/documentation/evaluate-models/agent-eval/reading-results#results-from-platform-jobs).
 
-Gym jobs run on their own `nmp-gym-tasks` container image rather than the shared CPU task image,
-because Gym requires Ray. No configuration is needed — the target selects it.
+On a sandbox-enabled deployment, the Evaluator step runs in `nmp-cpu-tasks` and calls a separate
+`nmp-gym-host`. On a deployment using the compatibility path, Evaluator and Gym run together in
+`nmp-gym-tasks`. A target with an `environment` FileSet is rejected on the compatibility path and
+adds `stage-environment` before `agent-evaluate` on a sandbox-enabled deployment.
 
 ## Caveats
 
@@ -309,13 +344,15 @@ because Gym requires Ray. No configuration is needed — the target selects it.
 - **`--no-serve --input` bypasses Gym's data-prep** — prompt templating and dataset materialization.
   Rows that are already complete, like the bundled `example.jsonl`, are faithful; an environment
   whose rows need templating would need that step run first.
-- **Service-side execution** — Docker or Kubernetes, Ray provisioning — is out of scope for this SDK
-  path. That is the evaluator plugin's concern.
+- **Custom environments require platform support.** Package the environment as a FileSet and use
+  sandboxed execution; a live `GymAgentTaskRunner` cannot carry `environment`, `agent_ref_name`, or
+  `env_secrets`.
 
 ## Next steps
 
 <Cards>
   <Card title="Agent Evaluation (concepts)" href="/documentation/evaluate-models/agent-eval" />
   <Card title="Targets and Runners" href="/documentation/evaluate-models/agent-eval/targets-and-runners" />
-  <Card title="Evaluate a Harbor Task Suite" href="/documentation/evaluate-models/agent-eval/harbor-runner" />
+  <Card title="Run a Custom Gym Environment" href="/documentation/evaluate-models/agent-eval/gym-custom-environment" />
+  <Card title="Configure Sandboxed Gym" href="/documentation/evaluate-models/agent-eval/gym-sandbox-configuration" />
 </Cards>

--- a/docs/evaluator/agent-eval/gym-sandbox-configuration.mdx
+++ b/docs/evaluator/agent-eval/gym-sandbox-configuration.mdx
@@ -1,0 +1,185 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+title: "Configure Sandboxed Gym for Evaluator"
+description: "Configure OpenSandbox, shared storage, images, and network policy for sandboxed Gym agent-evaluate jobs."
+---
+
+Sandboxed Gym runs NeMo Gym and environment code outside the trusted Evaluator task container.
+The Evaluator task keeps platform and OpenSandbox credentials, starts a per-run Gym host, sends
+rollout requests over HTTP, and destroys the host when the run ends.
+
+This page is for platform operators. Job submitters cannot select the host provider, runtime image,
+PVC, or egress policy.
+
+## Prerequisites
+
+- A Kubernetes or Volcano Jobs execution profile.
+- [OpenSandbox installed and connected to NeMo Platform](/documentation/kubernetes-deployment/setup/helm/opensandbox).
+- A shared job-storage PVC available to both Jobs pods and OpenSandbox pods. The claim should support
+  `ReadWriteMany` when the scheduler can place them on different nodes.
+- Published `nmp-cpu-tasks` and `nmp-gym-host` images for the platform release.
+- An allowlisted model endpoint reachable from the Gym host.
+
+## Execution topology
+
+For a built-in environment, sandboxed execution runs one platform step:
+
+```text
+agent-evaluate (nmp-cpu-tasks)
+  → OpenSandbox
+  → nmp-gym-host
+```
+
+For a custom environment FileSet, Evaluator runs two platform steps:
+
+```text
+stage-environment (nmp-cpu-tasks)
+  → shared job PVC
+  → agent-evaluate (nmp-cpu-tasks)
+  → OpenSandbox
+  → nmp-gym-host
+```
+
+The Gym host mounts the environment read-only and a separate workspace path read-write.
+
+## Configure Helm
+
+The following values show the required settings. Replace the namespace, Secret, image, PVC, and
+model URL for your deployment:
+
+```yaml
+sandboxClusterCapable: true
+
+opensandbox:
+  domain: opensandbox-server.opensandbox-system.svc.cluster.local
+  protocol: http
+  apiKeySecret: opensandbox-server-api-key
+  apiKeySecretKey: api-key
+
+platformConfig:
+  evaluator:
+    sandboxed_gym_default: true
+    sandbox_cluster_capable: true
+    sandbox_host_provider: opensandbox
+    sandbox_runtime_image: nvcr.io/nvidia/nemo-platform/nmp-gym-host:<release-tag>
+    sandbox_job_storage_pvc_claim: nemo-platform-core-storage
+    sandbox_policy_base_urls:
+      - http://nemo-platform-api.<namespace>.svc.cluster.local:8080
+    sandbox_resources:
+      cpu: "2"
+      memory: 8Gi
+```
+
+The top-level `sandboxClusterCapable` value injects the OpenSandbox connection into Kubernetes and
+Volcano jobs. The Evaluator-specific capability flag makes its compiler fail closed until the
+operator has configured the remaining sandbox settings.
+
+<Warning>
+
+`sandbox_job_storage_pvc_claim` must match the PVC configured on the Jobs execution profile.
+Evaluator rejects a FileSet-backed job when staging writes to one claim and OpenSandbox would mount
+another.
+
+</Warning>
+
+## Configuration reference
+
+| Setting | Default | Purpose |
+|---|---|---|
+| `sandboxed_gym_default` | `false` | Run Gym targets in a separate host. Custom environment FileSets require `true`. |
+| `sandbox_cluster_capable` | `false` | Confirm that this Evaluator deployment can provision sandbox hosts. |
+| `sandbox_runtime_image` | unset | Fully qualified `nmp-gym-host` image containing NeMo Gym and the host runtime. |
+| `sandbox_job_storage_pvc_claim` | unset | Shared claim used for staged environments and Gym workspaces. |
+| `sandbox_host_provider` | `opensandbox` | Host provider. `docker` is for local debugging and is not an isolation boundary. |
+| `sandbox_host_provider_options` | `{}` | Provider-specific connection options. Helm supplies the OpenSandbox protocol separately. |
+| `sandbox_environment_sub_path` | `environment` | Read-only environment location within job storage. |
+| `sandbox_workspace_sub_path` | `workspace` | Read-write Gym workspace location within job storage. |
+| `sandbox_resources` | unset | CPU and memory requests for each Gym host. Set these on shared clusters. |
+| `sandbox_policy_base_urls` | `[]` | Model or inference base URLs the Gym host may reach. |
+| `sandbox_egress_allow` | `[]` | Additional allowed destinations in `host:port` form. |
+| `sandbox_episode_backend` | `opensandbox` | Provider for nested episode sandboxes requested by an environment. |
+| `sandbox_allow_insecure_memory_backend` | `false` | Second opt-in required for the non-isolating local memory backend. |
+| `sandbox_approved_images` | `[]` | Images allowed for nested episode sandboxes. Empty rejects every episode request. |
+
+Evaluator requires at least one entry across `sandbox_policy_base_urls` and
+`sandbox_egress_allow`. The OpenSandbox provider applies a deny-by-default policy and adds the
+trusted episode broker automatically.
+
+## Configure model egress
+
+Use `sandbox_policy_base_urls` for model and inference endpoints:
+
+```yaml
+platformConfig:
+  evaluator:
+    sandbox_policy_base_urls:
+      - http://nemo-platform-api.nemo-platform.svc.cluster.local:8080
+      - https://inference-api.nvidia.com/v1
+```
+
+Use `sandbox_egress_allow` for non-model dependencies:
+
+```yaml
+platformConfig:
+  evaluator:
+    sandbox_egress_allow:
+      - artifacts.example.internal:443
+```
+
+Submitters cannot extend these lists from `GymRunnerTarget`. This prevents an environment from
+widening its own network access.
+
+## Configure credentials
+
+OpenSandbox credentials remain in the trusted Evaluator task. The Gym host receives only per-run
+tokens and the environment variables required by its selected Gym components.
+
+For a job-specific model credential, create a NeMo Platform secret and reference it through
+`GymRunnerTarget.env_secrets`:
+
+```yaml
+target:
+  kind: gym
+  # ...
+  env_secrets:
+    EXTERNAL_MODEL_API_KEY: default/my-model-api-key
+```
+
+Do not use `env_vars` for API keys, tokens, passwords, or other secrets. Evaluator rejects
+credential-shaped `env_vars` for sandboxed jobs because environment code can read them.
+
+## Local Docker provider
+
+Set `sandbox_host_provider: docker` only when debugging the runtime contract on a local deployment.
+It runs the same `nmp-gym-host` image but does not enforce the OpenSandbox egress policy and is not
+an isolation boundary.
+
+The `memory` episode backend is also local-only. It requires both:
+
+```yaml
+sandbox_episode_backend: memory
+sandbox_allow_insecure_memory_backend: true
+```
+
+Ordinary evaluations do not create nested episode sandboxes. Environments that request them must
+use the OpenSandbox episode backend and list every permitted image in `sandbox_approved_images`.
+
+## Verify the deployment
+
+Before accepting custom environment jobs, verify:
+
+1. OpenSandbox is ready and reachable over the configured in-cluster protocol.
+2. The selected Jobs profile uses Kubernetes or Volcano and mounts the configured PVC.
+3. `nmp-cpu-tasks` and `nmp-gym-host` can be pulled by pods in the platform namespace.
+4. The Gym host can reach each configured model URL but cannot reach an unlisted destination.
+5. A completed and a failed run both destroy their Gym hosts.
+
+## Related
+
+<Cards>
+  <Card title="Install OpenSandbox" href="/documentation/kubernetes-deployment/setup/helm/opensandbox" />
+  <Card title="Run a Custom Gym Environment" href="/documentation/evaluate-models/agent-eval/gym-custom-environment" />
+  <Card title="Evaluate a NeMo Gym Environment" href="/documentation/evaluate-models/agent-eval/gym-runner" />
+</Cards>

--- a/docs/evaluator/agent-eval/gym-sandbox-configuration.mdx
+++ b/docs/evaluator/agent-eval/gym-sandbox-configuration.mdx
@@ -15,10 +15,10 @@ PVC, or egress policy.
 
 ## Prerequisites
 
-- A Kubernetes or Volcano Jobs execution profile.
-- [OpenSandbox installed and connected to NeMo Platform](/documentation/kubernetes-deployment/setup/helm/opensandbox).
-- A shared job-storage PVC available to both Jobs pods and OpenSandbox pods. The claim should support
-  `ReadWriteMany` when the scheduler can place them on different nodes.
+- Complete the shared [OpenSandbox platform setup](/documentation/kubernetes-deployment/setup/helm/opensandbox).
+  It configures the server connection, credentials, and top-level platform sandbox capability.
+- A Kubernetes or Volcano Jobs execution profile with a shared job-storage PVC. The claim should
+  support `ReadWriteMany` when Jobs and OpenSandbox pods can run on different nodes.
 - Published `nmp-cpu-tasks` and `nmp-gym-host` images for the platform release.
 - An allowlisted model endpoint reachable from the Gym host.
 
@@ -44,20 +44,12 @@ stage-environment (nmp-cpu-tasks)
 
 The Gym host mounts the environment read-only and a separate workspace path read-write.
 
-## Configure Helm
+## Configure Evaluator
 
-The following values show the required settings. Replace the namespace, Secret, image, PVC, and
-model URL for your deployment:
+After completing the shared OpenSandbox setup, add the Evaluator-specific values. Replace the image,
+PVC, and model URL for your deployment:
 
 ```yaml
-sandboxClusterCapable: true
-
-opensandbox:
-  domain: opensandbox-server.opensandbox-system.svc.cluster.local
-  protocol: http
-  apiKeySecret: opensandbox-server-api-key
-  apiKeySecretKey: api-key
-
 platformConfig:
   evaluator:
     sandboxed_gym_default: true
@@ -72,9 +64,10 @@ platformConfig:
       memory: 8Gi
 ```
 
-The top-level `sandboxClusterCapable` value injects the OpenSandbox connection into Kubernetes and
-Volcano jobs. The Evaluator-specific capability flag makes its compiler fail closed until the
-operator has configured the remaining sandbox settings.
+The Evaluator-specific `sandbox_cluster_capable` flag is separate from the top-level
+`sandboxClusterCapable` value configured in the shared setup. Both must be `true`: the top-level
+value injects the OpenSandbox connection into Jobs pods, and the Evaluator flag makes its compiler
+fail closed until the remaining Evaluator settings are configured.
 
 <Warning>
 

--- a/docs/evaluator/agent-eval/index.mdx
+++ b/docs/evaluator/agent-eval/index.mdx
@@ -20,8 +20,9 @@ got there*. Each task carries its own metrics, so a single suite can grade heter
 - Use `await AgentEvaluator().run(tasks=..., target=...)` for local task-driven SDK runs
 that do not require running nemo-platform.
 - Use the Evaluator plugin's `uv run nemo evaluator agent-evaluate submit` job for durable runs with inline
-tasks or stored tasksets. The high-level `client.evaluator.submit` interface
-above remains dataset-driven only.
+tasks or stored tasksets. For a `GymAgentTaskRunner` that you have already validated locally,
+`client.evaluator.submit(tasks=TasksetRef(...), target=runner)` provides a high-level submission
+path; build other runner targets in an agent-evaluate spec.
 
 </Note>
 
@@ -117,6 +118,12 @@ for how to describe an HTTP agent target.
   — point a run at an agent behind an HTTP endpoint.
 - [Evaluate a Harbor Task Suite](/documentation/evaluate-models/agent-eval/harbor-runner) — run an
   existing Harbor dataset in Docker and score its verifier reward.
+- [Evaluate a NeMo Gym Environment](/documentation/evaluate-models/agent-eval/gym-runner) — collect
+  and score Gym rollouts locally or as a platform job.
+- [Run a Custom Gym Environment](/documentation/evaluate-models/agent-eval/gym-custom-environment)
+  — package a Gym environment as a FileSet and evaluate it in OpenSandbox.
+- [Evaluate with a NeMo Fabric Harness](/documentation/evaluate-models/agent-eval/fabric-runner) —
+  drive a supported agent harness and capture its trajectory.
 - [Score by Component](/documentation/evaluate-models/agent-eval/score-by-component) — score the
   trajectory (not just the answer) and roll metrics into a named view.
 - [Targets and Runners](/documentation/evaluate-models/agent-eval/targets-and-runners) — reference for

--- a/docs/evaluator/agent-eval/reading-results.mdx
+++ b/docs/evaluator/agent-eval/reading-results.mdx
@@ -196,6 +196,33 @@ JSON/JSONL artifacts and skips the HTML. The `.json` and `.jsonl` files are alwa
 
 </Note>
 
+## Results from platform jobs
+
+An `agent-evaluate` platform job persists the same JSON and JSONL data without `report.html`. It
+publishes two named job results:
+
+- `agent-eval-results` — the complete bundle, including tasks, trials, scores, metadata, and summary.
+- `summary` — `summary.json` by itself for lightweight retrieval.
+
+Wait for the platform job to reach a terminal state before reading either result:
+
+```python
+job.wait_until_done()
+stored = client.evaluator.agent_eval_results.retrieve("<result-name>")
+client.files.download(remote_path=stored.bundle_ref, local_path="agent-eval-run")
+```
+
+You can also download the bundle through the Jobs CLI:
+
+```bash
+nemo jobs results download agent-eval-results \
+  --job <job-name> \
+  --output-file agent-eval-results.tar.gz
+```
+
+The queryable `agent_eval_results` record stores aggregates, coverage, target identity, and the
+bundle reference. Individual trials remain in `trials.jsonl` inside the bundle.
+
 ## Related
 
 <Cards>

--- a/docs/evaluator/agent-eval/targets-and-runners.mdx
+++ b/docs/evaluator/agent-eval/targets-and-runners.mdx
@@ -136,8 +136,20 @@ by constraint. Install it into its own environment and put its `bin` on `PATH`.
 It can also be submitted as a platform job from the live runner object, via
 `client.evaluator.submit(tasks=..., target=runner)`, rather than described again as a spec.
 
+Platform job specifications use `GymRunnerTarget`. It adds fields that a live local runner cannot
+carry:
+
+- `environment` references a complete custom environment FileSet and requires sandboxed execution.
+- `env_secrets` maps environment variable names to NeMo Platform secret references.
+- `agent_ref_name` selects the registered Gym agent instance when it differs from `agent`.
+
+`agent_config` is required for `GymRuntimeConfig` and for a platform target without an environment
+FileSet. A FileSet-backed target can omit it when the package declares the selected agent instance.
+
 Full setup, configuration reference, and caveats:
 [Evaluate a NeMo Gym Environment](/documentation/evaluate-models/agent-eval/gym-runner).
+For custom packages, see
+[Run a Custom Gym Environment](/documentation/evaluate-models/agent-eval/gym-custom-environment).
 
 ### NeMo Fabric runtimes
 

--- a/docs/evaluator/index.mdx
+++ b/docs/evaluator/index.mdx
@@ -123,8 +123,9 @@ result = job.get_result()
 - Use `await AgentEvaluator().run(tasks=..., target=...)` for local task-driven SDK runs
 that do not require running nemo-platform.
 - Use the Evaluator plugin's `uv run nemo evaluator agent-evaluate submit` job for durable runs with inline
-tasks or stored tasksets. The high-level `client.evaluator.submit` interface
-above remains dataset-driven only.
+tasks or stored tasksets. A locally validated `GymAgentTaskRunner` can also be submitted with
+`client.evaluator.submit(tasks=TasksetRef(...), target=runner)`; other runner targets use an
+agent-evaluate spec.
 
 </Note>
 

--- a/docs/fern/versions/latest.yml
+++ b/docs/fern/versions/latest.yml
@@ -80,6 +80,12 @@ navigation:
               - page: Evaluate a NeMo Gym Environment
                 slug: gym-runner
                 path: ../../evaluator/agent-eval/gym-runner.mdx
+              - page: Run a Custom NeMo Gym Environment
+                slug: gym-custom-environment
+                path: ../../evaluator/agent-eval/gym-custom-environment.mdx
+              - page: Configure Sandboxed Gym for Evaluator
+                slug: gym-sandbox-configuration
+                path: ../../evaluator/agent-eval/gym-sandbox-configuration.mdx
               - page: Evaluate with a NeMo Fabric Harness
                 slug: fabric-runner
                 path: ../../evaluator/agent-eval/fabric-runner.mdx

--- a/docs/set-up/helm/opensandbox.mdx
+++ b/docs/set-up/helm/opensandbox.mdx
@@ -9,7 +9,10 @@ description: "Install OpenSandbox as a cluster engine and point NeMo Platform jo
 
 The NeMo Platform Helm chart does **not** install [OpenSandbox](https://github.com/opensandbox-group/OpenSandbox). Install the upstream charts, then point the platform at the running server.
 
-Install OpenSandbox when you run **sandboxed GRPO / NeMo Gym**: untrusted custom environment FileSets run in isolated pods, not in the training container. It does **not** sandbox the rest of the platform (API, DPO, SFT, inference).
+Install OpenSandbox when you run **sandboxed GRPO or Evaluator Gym jobs**: untrusted custom
+environment FileSets run in isolated pods, not in the training or evaluation container. It does
+**not** sandbox the rest of the platform (API, DPO, SFT, inference). For Evaluator-specific settings,
+see [Configure Sandboxed Gym for Evaluator](/documentation/evaluate-models/agent-eval/gym-sandbox-configuration).
 
 This page is the **shared-kernel** path: sandbox pods use the cluster default OCI runtime. That is often **runc** (containerd) or **crun** (CRI-O, including OKE and OpenShift). **A kernel-isolated runtime is not required.** Use [OpenSandbox with Kata](/documentation/kubernetes-deployment/setup/helm/opensandbox-kata) when those Gym/GRPO sandbox pods must be isolated from the host kernel. The documented path is Kata QEMU because it gives each sandbox its own guest kernel; other isolated runtimes may work but have not been tested. Example Helm values live in [`k8s/helm/examples/opensandbox/`](https://github.com/NVIDIA-NeMo/nemo-platform/tree/main/k8s/helm/examples/opensandbox).
 
@@ -38,7 +41,7 @@ Training and other job pods are OpenSandbox **clients**. They do not need a kube
 | Scheme | `platform.sandbox_server_protocol` / Gym `host_provider_options.connection.protocol` | Set **`http`** for the in-cluster Service. If unset, NeMo-RL health URLs default to **https** and stall |
 | Proxy | `use_server_proxy` | Leave true. Jobs cannot reach sandbox pod IPs |
 | Capability | `sandboxClusterCapable` / `platform.sandbox_cluster_capable` | Defaults to `false` (sandboxed GRPO fail-closes) |
-| Job PVC | `rl.job_storage_pvc_claim` | Required for sandboxed GRPO; sandboxes remount the same claim |
+| Job PVC | `rl.job_storage_pvc_claim` or `evaluator.sandbox_job_storage_pvc_claim` | Sandboxes remount the same claim used by the selected Jobs execution profile |
 
 Gym sample YAML uses `OPENSANDBOX_DOMAIN` / `OPENSANDBOX_API_KEY`. NeMo Platform and the SDK use `OPEN_SANDBOX_*`. Do not mix the names.
 

--- a/docs/troubleshooting/evaluator.mdx
+++ b/docs/troubleshooting/evaluator.mdx
@@ -90,17 +90,66 @@ The error contains the details about the checks that failed.
 For local setup, the platform API defaults to `http://localhost:8080`.
 If you changed the platform URL, use the value configured in `NMP_BASE_URL` or in your CLI context.
 
-## Advanced Troubleshooting
+## Agent evaluation job failures
 
-To troubleshoot an evaluation job that has failed, download the evaluation result archive and inspect the job logs.
+Inspect the platform job and its logs before interpreting a partial result:
+
+```bash
+nemo jobs get-logs <job-name> --workspace default --limit 100
+```
+
+An `agent-evaluate` job can fail while generating trials, scoring them, or publishing optional
+Intake results. The authoritative result bundle is saved before required Intake publication runs,
+so a publication failure can leave a downloadable bundle on a failed job.
+
+Wait for a terminal job state before downloading results. Progress reaching 100 percent does not
+mean artifact finalization is complete.
+
+## Sandboxed Gym failures
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `Gym environment FileSets require sandboxed execution` | The target sets `environment`, but sandboxing is disabled | Enable `evaluator.sandboxed_gym_default` or omit the custom environment |
+| Cluster is not marked sandbox-capable | Evaluator is configured to sandbox, but its capability gate is false | Install OpenSandbox, then enable the platform and Evaluator capability settings |
+| Missing `sandbox_runtime_image` or `sandbox_job_storage_pvc_claim` | Required operator configuration is incomplete | Configure the `nmp-gym-host` image and shared Jobs PVC |
+| Sandbox has no route to a model | Both model base URLs and additional egress lists are empty or incomplete | Add the model endpoint to `sandbox_policy_base_urls` |
+| Credential-shaped `env_vars` are rejected | A plaintext API key, password, or token would be visible to environment code | Store the value in NeMo Platform Secrets and map it through `env_secrets` |
+| Jobs PVC and sandbox PVC do not match | FileSet staging writes to a different claim from the Gym host mount | Set `sandbox_job_storage_pvc_claim` to the Jobs execution profile's PVC |
+| FileSet has the wrong purpose or no manifest | The package is not an Evaluator Gym environment | Use `purpose=environment` and place `nemo-environment.yaml` at the FileSet root |
+| Agent produces no rollout | The package registers the agent instance under another name | Set `agent_ref_name` to the registered instance |
+
+See [Configure Sandboxed Gym](/documentation/evaluate-models/agent-eval/gym-sandbox-configuration)
+for the complete operator configuration and
+[Run a Custom Gym Environment](/documentation/evaluate-models/agent-eval/gym-custom-environment)
+for package requirements.
+
+## Download agent evaluation results
+
+Platform agent evaluations publish `agent-eval-results` and `summary` as named Jobs results:
+
+```bash
+nemo jobs results download agent-eval-results \
+  --job <job-name> \
+  --output-file agent-eval-results.tar.gz
+```
+
+The task-driven job handle does not provide the dataset-evaluation `get_result()` or
+`download_artifacts()` methods. Query aggregates through `client.evaluator.agent_eval_results` and
+download individual trials from its bundle reference.
+
+## Legacy Evaluator API troubleshooting
+
+The endpoints below apply only to deployments that still expose the legacy `/v1/evaluation/jobs`
+API. New Evaluator plugin jobs use `/apis/evaluator/v2`, the Jobs log command above, and named job
+results.
 
 <Warning>
 
-These are advanced troubleshooting steps that should only be done after all other troubleshooting fails.
+Do not use `skip_validation_checks` or the legacy download endpoint with Evaluator plugin jobs.
 
 </Warning>
 
-### Evaluation Job Logs
+### Download legacy evaluation job logs
 
 To download the log files, use the `download-results` endpoint. 
 This endpoint downloads the result directory containing configuration files, logs, and evaluation results for a specific evaluation run. 

--- a/packages/nemo_evaluator_sdk/examples/gym/README.md
+++ b/packages/nemo_evaluator_sdk/examples/gym/README.md
@@ -111,7 +111,10 @@ logging.getLogger("nemo_evaluator_sdk.agent_eval.runtimes.gym").setLevel(logging
 - **One distinct row is one task.** Task identity is the row's content hash, so duplicate rows collapse into a single task and the runner warns. Repeating a row is *not* how you ask for repeated attempts — `num_repeats` is, since attempts are a run-level concern. Duplicates usually mean a data problem.
 - **Per-env deps are heterogeneous.** mcqa needs only `tiktoken`; other Gym envs pull `torch`/COMET/GPU or docker. The caller is responsible for a Gym runtime whose deps are installed.
 - **`--no-serve --input` bypasses Gym's data-prep** (prompt templating / dataset materialization). This example's `example.jsonl` rows are already complete, so it's faithful; an env whose rows need templating would need that step first.
-- Service-side execution (docker/k8s, Ray provisioning) is out of scope for this SDK path — that's the evaluator plugin's job.
+- This example covers the local subprocess path. Platform deployments can run the same target
+  colocated or provision a separate sandboxed Gym host; custom environment FileSets require the
+  sandboxed path. See the
+  [Evaluator Gym documentation](https://docs.nvidia.com/nemo-platform/documentation/evaluate-models/agent-eval/gym-runner).
 
 ## Next steps
 

--- a/packages/sandboxed_gym/README.md
+++ b/packages/sandboxed_gym/README.md
@@ -24,7 +24,7 @@ wheel exists.
 
 ## Architecture
 
-![Architecture](docs/architecture.png)
+![Architecture](docs/architecture.svg)
 
 The trusted side holds the OpenSandbox credential and the episode broker; the sandbox gets a
 per-run token and nothing else. The episode tier is only used by environments that ask for nested
@@ -32,7 +32,7 @@ sandboxes -- an ordinary evaluation never creates one.
 
 ### Two job-host providers
 
-![Host provider paths](docs/host-provider-paths.png)
+![Host provider paths](docs/host-provider-paths.svg)
 
 `get_host_provider` selects by name. **`docker` is for local execution only**: it runs the host as
 a container, records the egress allowlist rather than applying it, and bind-mounts host

--- a/plugins/nemo-evaluator/openapi/openapi.yaml
+++ b/plugins/nemo-evaluator/openapi/openapi.yaml
@@ -4282,11 +4282,11 @@ components:
       - resources_server
       title: GymRunnerTarget
       description: "Generate trials by driving a NeMo Gym environment through the\
-        \ SDK's :class:`GymAgentTaskRunner`.\n\nGym runs locally in the job container\
-        \ (the ``gym`` CLI must be installed in the same environment\nas this SDK).\
-        \ The environment dataset is recovered from the tasks at run time \u2014 the\
-        \ runner stamps\n``gym_dataset_path`` onto each task via ``discover_gym_tasks``,\
-        \ mirroring the Harbor pattern."
+        \ SDK's :class:`GymAgentTaskRunner`.\n\nThe deployment chooses colocated execution\
+        \ in the Gym task container or a separate sandboxed\nGym host. An environment\
+        \ FileSet requires the sandboxed path. The environment dataset is\nrecovered\
+        \ from the tasks at run time \u2014 ``discover_gym_tasks`` records the source\
+        \ row data needed\nto materialize the selected tasks for rollout collection."
     HTTPValidationError:
       properties:
         detail:

--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/agent_spec.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/agent_spec.py
@@ -138,9 +138,10 @@ class HarborRunnerTarget(BaseModel):
 class GymRunnerTarget(BaseModel):
     """Generate trials by driving a NeMo Gym environment through the SDK's :class:`GymAgentTaskRunner`.
 
-    Gym runs locally in the job container (the ``gym`` CLI must be installed in the same environment
-    as this SDK). The environment dataset is recovered from the tasks at run time — the runner stamps
-    ``gym_dataset_path`` onto each task via ``discover_gym_tasks``, mirroring the Harbor pattern.
+    The deployment chooses colocated execution in the Gym task container or a separate sandboxed
+    Gym host. An environment FileSet requires the sandboxed path. The environment dataset is
+    recovered from the tasks at run time — ``discover_gym_tasks`` records the source row data needed
+    to materialize the selected tasks for rollout collection.
     """
 
     model_config = ConfigDict(extra="forbid")

--- a/skills/nemo-evaluator-plugin/SKILL.md
+++ b/skills/nemo-evaluator-plugin/SKILL.md
@@ -114,6 +114,7 @@ under a different skills root.
 | `assets/specs/exact_match_metric.json` | Two-row offline smoke spec; submit as-is |
 | `assets/specs/llm_as_judge.json` | Online generation + judge; local-first (`NVIDIA_API_KEY`) |
 | `assets/specs/fabric_agent_eval.json` | Task-driven Fabric runner spec |
+| `assets/specs/gym_agent_eval.json` | Task-driven sandboxed Gym FileSet spec |
 | `assets/examples/plugin_sdk_examples.py` | Copyable SDK snippets for each plugin surface |
 
 ## Available Scripts
@@ -163,8 +164,9 @@ Submission accepts inline tasks or a stored `TasksetRef`. Stored tasksets are
 resolved in the target workspace.
 
 Read [Agent Evaluation](references/agent-evaluation.md) for inline tasks,
-`TasksetRef`, concurrency, fail-fast behavior, sparse-output denominators, result
-artifacts, and runner configuration.
+`TasksetRef`, concurrency, fail-fast behavior, sparse-output denominators,
+result artifacts, and runner configuration, including Gym FileSet and
+sandbox requirements.
 
 ### Prepare Fabric in a repository checkout
 

--- a/skills/nemo-evaluator-plugin/assets/examples/plugin_sdk_examples.py
+++ b/skills/nemo-evaluator-plugin/assets/examples/plugin_sdk_examples.py
@@ -116,3 +116,33 @@ def build_agent_eval_spec(metric_bundle: Any) -> Any:
         max_concurrent_tasks=2,
         labels={"benchmark": "geography-smoke"},
     )
+
+
+def build_gym_agent_eval_spec() -> Any:
+    """Build a sandboxed Gym evaluation for a stored taskset and environment FileSet."""
+    from nemo_evaluator.api.schemas import TasksetRef
+    from nemo_evaluator.filesets import FilesetRef
+    from nemo_evaluator.jobs.agent_spec import AgentEvalInputSpec, GymRunnerTarget
+
+    return AgentEvalInputSpec(
+        tasks=TasksetRef("default/my-gym-taskset"),
+        target=GymRunnerTarget(
+            environment=FilesetRef(root="default/my-gym-environment"),
+            agent="simple_agent",
+            agent_config="responses_api_agents/simple_agent/configs/simple_agent.yaml",
+            resources_server="custom_greeting",
+            num_repeats=1,
+            concurrency=1,
+            hydra_params={
+                "policy_base_url": (
+                    "http://nemo-platform-api.default.svc.cluster.local:8080/"
+                    "apis/inference-gateway/v2/workspaces/default/model/my-model/-/v1"
+                ),
+                "policy_api_key": "not-used",
+                "policy_model_name": "my-model",
+            },
+        ),
+        max_concurrent_tasks=1,
+        fail_fast=True,
+        labels={"benchmark": "custom-gym-environment"},
+    )

--- a/skills/nemo-evaluator-plugin/assets/specs/gym_agent_eval.json
+++ b/skills/nemo-evaluator-plugin/assets/specs/gym_agent_eval.json
@@ -1,0 +1,22 @@
+{
+  "tasks": "default/my-gym-taskset",
+  "target": {
+    "kind": "gym",
+    "environment": "default/my-gym-environment",
+    "agent": "simple_agent",
+    "agent_config": "responses_api_agents/simple_agent/configs/simple_agent.yaml",
+    "resources_server": "custom_greeting",
+    "num_repeats": 1,
+    "concurrency": 1,
+    "hydra_params": {
+      "policy_base_url": "http://nemo-platform-api.default.svc.cluster.local:8080/apis/inference-gateway/v2/workspaces/default/model/my-model/-/v1",
+      "policy_api_key": "not-used",
+      "policy_model_name": "my-model"
+    }
+  },
+  "max_concurrent_tasks": 1,
+  "fail_fast": true,
+  "labels": {
+    "benchmark": "custom-gym-environment"
+  }
+}

--- a/skills/nemo-evaluator-plugin/references/agent-evaluation.md
+++ b/skills/nemo-evaluator-plugin/references/agent-evaluation.md
@@ -170,6 +170,70 @@ target = FabricRunnerTarget(
 
 Do not use profile overlays. Fold the complete configuration into `config`.
 
+### Configure Gym as a task runner
+
+Use `discover_gym_tasks` to turn Gym JSONL rows into task definitions and attach
+`GymRewardMetric` to score each rollout's reward. A standalone
+`GymAgentTaskRunner` requires `agent`, `agent_config`, and `resources_server`.
+
+For a durable job that uses components already installed in `nmp-gym-tasks`,
+submit the validated live runner as shown above or build a `GymRunnerTarget`:
+
+```python
+from nemo_evaluator.jobs.agent_spec import GymRunnerTarget
+
+target = GymRunnerTarget(
+    agent="simple_agent",
+    agent_config="responses_api_agents/simple_agent/configs/simple_agent.yaml",
+    resources_server="mcqa",
+    num_repeats=1,
+    concurrency=4,
+)
+```
+
+The caller chooses between a local SDK run and a durable platform job. A local
+run executes Evaluator and the `gym` subprocesses on the caller's machine. For
+a platform job, sandbox placement is an operator decision: sandbox-enabled
+deployments run Gym in a separate `nmp-gym-host`; deployments without
+OpenSandbox can run trusted, built-in Gym components together with Evaluator in
+`nmp-gym-tasks`. The latter is the colocated compatibility path, not a separate
+submission interface.
+
+A custom environment supplies Gym component configuration, code, and
+dependencies that are not built into the platform's Gym runtime image. Package
+those files in a FileSet with `purpose=environment`, place
+`nemo-environment.yaml` at its root, and set `target.environment` to the whole
+FileSet reference. Evaluator accepts `native-v1` and `wheels-v1` packages.
+
+FileSet-backed environments require sandboxed platform execution. Evaluator
+compiles them into two ordered Jobs steps:
+
+1. `stage-environment` downloads the FileSet onto job-scoped shared storage.
+2. `agent-evaluate` provisions `nmp-gym-host` with the environment mounted
+   read-only, collects and scores rollouts, then destroys the host.
+
+```python
+from nemo_evaluator.filesets import FilesetRef
+from nemo_evaluator.jobs.agent_spec import GymRunnerTarget
+
+target = GymRunnerTarget(
+    environment=FilesetRef(root="default/my-gym-environment"),
+    agent="simple_agent",
+    agent_config="responses_api_agents/simple_agent/configs/simple_agent.yaml",
+    resources_server="custom_greeting",
+    env_secrets={"MODEL_API_KEY": "default/my-model-api-key"},
+)
+```
+
+`agent_config` can be omitted when the FileSet declares the selected agent.
+Set `agent_ref_name` when the package registers that agent under a different
+instance name. Use `env_secrets`, not `env_vars`, for credentials; sandboxed
+jobs reject credential-shaped plaintext environment variables.
+
+A live `GymAgentTaskRunner` cannot carry the wire-only `environment`,
+`agent_ref_name`, or `env_secrets` fields. Build `GymRunnerTarget` explicitly
+and submit it in an agent-evaluate spec for those cases.
+
 `max_concurrent_tasks` limits tasks evaluated concurrently. Target-specific
 settings such as inference parallelism or Harbor
 `n_concurrent_trials` control concurrency inside trial generation.

--- a/skills/nemo-evaluator-plugin/references/troubleshooting.md
+++ b/skills/nemo-evaluator-plugin/references/troubleshooting.md
@@ -38,6 +38,12 @@ nemo evaluator agent-evaluate explain
 | `UnsubmittableRunnerError` for a Gym runner | A `hydra_params` value has no JSON form; a hand-built target or CLI payload cannot carry it either | Replace the value with something JSON-representable, or run in-process with `AgentEvaluator()` |
 | Agent-eval rejects the spec | Both or neither of `target` and `trials` were provided | Provide exactly one |
 | Runner target fails to start | The runtime dependency, CLI, config, credentials, or Docker access is missing | Check the selected Fabric, Harbor, or Gym runner prerequisites. Gym resolves the `gym` CLI from `PATH` only, and installs into its own environment because it requires Ray |
+| Gym environment FileSet requires sandboxed execution | A `GymRunnerTarget.environment` was submitted to a deployment that runs Gym colocated | Enable `sandboxed_gym_default` and configure the sandbox prerequisites, or omit the environment FileSet |
+| Sandboxed Gym reports a missing capability, runtime image, PVC, or egress route | The Evaluator deployment cannot provision a usable Gym host | Configure `sandbox_cluster_capable`, `sandbox_runtime_image`, `sandbox_job_storage_pvc_claim`, and at least one model or additional egress destination |
+| FileSet-backed Gym reports a PVC mismatch | The Jobs execution profile stages onto a different claim from the OpenSandbox host | Set `sandbox_job_storage_pvc_claim` to the execution profile's job-storage PVC |
+| Sandboxed Gym rejects a credential-shaped `env_vars` entry | Plaintext credentials would be readable by environment code | Store the value in NeMo Platform Secrets and map it through `GymRunnerTarget.env_secrets` |
+| Gym environment FileSet is invalid | The FileSet has the wrong purpose, lacks a root `nemo-environment.yaml`, or violates the `native-v1` / `wheels-v1` layout | Use `purpose=environment`, upload the directory contents at the FileSet root, and fix the named manifest or package error |
+| Sandboxed Gym returns no rollout for the selected agent | The environment registers the agent under a different instance name | Set `GymRunnerTarget.agent_ref_name` to the registered instance |
 
 ## Debug in the smallest scope
 

--- a/skills/nemo-evaluator-plugin/scripts/generate_example_specs.py
+++ b/skills/nemo-evaluator-plugin/scripts/generate_example_specs.py
@@ -171,6 +171,31 @@ def build_fabric_agent_eval_spec() -> dict[str, Any]:
     }
 
 
+def build_gym_agent_eval_spec() -> dict[str, Any]:
+    """Return a durable custom-environment Gym agent-evaluation spec."""
+    return {
+        "tasks": "default/my-gym-taskset",
+        "target": {
+            "kind": "gym",
+            "environment": "default/my-gym-environment",
+            "agent": "simple_agent",
+            "agent_config": "responses_api_agents/simple_agent/configs/simple_agent.yaml",
+            "resources_server": "custom_greeting",
+            "num_repeats": 1,
+            "concurrency": 1,
+            "hydra_params": {
+                "policy_base_url": "http://nemo-platform-api.default.svc.cluster.local:8080/"
+                "apis/inference-gateway/v2/workspaces/default/model/my-model/-/v1",
+                "policy_api_key": "not-used",
+                "policy_model_name": "my-model",
+            },
+        },
+        "max_concurrent_tasks": 1,
+        "fail_fast": True,
+        "labels": {"benchmark": "custom-gym-environment"},
+    }
+
+
 SPEC_BUILDERS: dict[str, SpecBuilder] = {
     "exact_match_metric.json": build_exact_match_spec,
     "llm_as_judge.json": build_llm_as_judge_spec,
@@ -178,6 +203,7 @@ SPEC_BUILDERS: dict[str, SpecBuilder] = {
 
 AGENT_SPEC_BUILDERS: dict[str, SpecBuilder] = {
     "fabric_agent_eval.json": build_fabric_agent_eval_spec,
+    "gym_agent_eval.json": build_gym_agent_eval_spec,
 }
 
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
Documents how to run Gym agent evaluations through Evaluator, including sandboxed custom environments, configuration, results, and troubleshooting.

## Changes
- Add new guides for custom Gym environments and sandbox configuration.
- Clarify difference between local SDK and platform execution.
- Add Gym job examples and generated specifications.
- Document result retrieval and troubleshooting.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [x] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: No runtime behavior changes.
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification

- [ ] Pull request title follows the repository's Conventional Commit format
- [ ] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `make docs-check` — passed.
- `uv run --frozen --no-sync pytest plugins/nemo-evaluator/tests/test_skill_examples.py -q --no-cov` — 34 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added retrieval-evaluation API support, including job creation, monitoring, cancellation, logs, results, and downloads.
  * Added optional metric requirements and clearer coverage and sparse-output handling.
* **Documentation**
  * Added guidance for custom and sandboxed Gym environments, packaging, credentials, storage, execution modes, results, and troubleshooting.
  * Clarified local versus platform evaluation, runner targets, durable submissions, and sandbox requirements.
* **Examples**
  * Added reusable examples and a sample specification for sandboxed Gym evaluations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->