### PR TITLE
feat(evaluator): capture OTLP inside the Fabric sandbox for container trials

### DIFF
--- a/packages/nemo_evaluator_sdk/examples/fabric_container/run_e2e.py
+++ b/packages/nemo_evaluator_sdk/examples/fabric_container/run_e2e.py
@@ -4,10 +4,9 @@
 """Live end-to-end: run a real Fabric task inside a Docker sandbox via FabricContainerRuntime.
 
 Constructs the runtime directly (the plugin `_resolve_target` wiring is not yet in place — see
-AALGO-321) and drives one task through the hermes-sdk harness. The sandbox image is provisioned
-opaquely (build-if-missing) on first run — no Dockerfile to write. Requires a running Docker daemon,
-a NeMo-Fabric checkout (`$NEMO_FABRIC_REPO`) for the image build, and NVIDIA_API_KEY (or
-NVIDIA_API_KEY_FILE). See README.md.
+AALGO-321) and drives one task through the hermes harness. The sandbox image is provisioned opaquely
+(build-if-missing) on first run from published wheels — no Dockerfile to write and no source checkout.
+Requires a running Docker daemon and NVIDIA_API_KEY.
 """
 
 from __future__ import annotations

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/fabric/_common.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/fabric/_common.py
@@ -8,9 +8,9 @@
 (sandbox) map a Fabric ``RunResult`` to the *same* trial/evidence contract, so the pieces they share
 live here — one definition, so the two runtimes cannot drift apart.
 
-Trajectory capture is built from ``nemo_relay``'s own typed config objects (a hard dependency), so
-Relay owns its schema: a breaking Relay change fails construction here rather than silently producing
-a malformed profile.
+Trajectory capture is built from ``nemo_fabric``'s own typed config objects (a hard dependency), so
+Fabric owns the schema: a breaking Fabric change fails construction here rather than silently
+producing a block Fabric ignores.
 """
 
 from __future__ import annotations
@@ -20,22 +20,19 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
+from nemo_evaluator_sdk.agent_eval.runtimes.fabric.otlp_writer import otlp_endpoint_fields
 from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalTask
 from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial, AgentEvalTrialStatus
 from nemo_evaluator_sdk.values.evidence import CandidateEvidence, EvidenceDescriptor
 
-# Trajectory profile identity + the file-exporter output names we choose (Relay accepts these as
-# inputs). Shared so both runtimes select/emit the trajectory under identical names.
-TRAJECTORY_PROFILE_NAME = "eval_trajectory"
+# The file-exporter output names we choose (Relay accepts these as inputs). Shared so both runtimes
+# emit the trajectory under identical names.
 ATIF_FILENAME_TEMPLATE = "trajectory-{session_id}.atif.json"
 ATOF_FILENAME = "events.atof.jsonl"
 #: ATIF ``agent.version``. Both runtimes report the agent *framework* here so a consumer can group
 #: host and container traces together; ``agent.name`` is what distinguishes them. Not a real version
 #: yet — reporting the resolved nemo-fabric version would be the better answer.
 FABRIC_AGENT_VERSION = "fabric"
-# Fabric telemetry-profile selectors (Relay file exporter, no OTLP endpoint).
-TELEMETRY_PROVIDER = "relay"
-TELEMETRY_MODE = "sdk"
 
 
 def safe_path_name(value: str) -> str:
@@ -109,50 +106,87 @@ def build_failed_trial(
     )
 
 
-def trajectory_telemetry(*, relay_dir: str, agent_name: str, agent_version: str) -> dict[str, Any]:
-    """The ``telemetry`` block of a Fabric trajectory profile: Relay's ATIF/ATOF file exporter (mode=sdk).
+def relay_observability(
+    *,
+    relay_dir: str,
+    agent_name: str,
+    agent_version: str,
+    extra: Mapping[str, Any] | None = None,
+    otlp_endpoint: str | None = None,
+) -> Any:
+    """Relay's ATIF/ATOF file-exporter observability config, as ``nemo_fabric.RelayObservabilityConfig``.
 
-    Built from ``nemo_relay``'s own typed config so Relay owns its schema — no hand-maintained dict to
-    silently drift when Relay changes it. Callers wrap this in a profile with their own name +
-    ``runtime``/``environment`` blocks; ``relay_dir`` is where the ``trajectory-*.atif.json`` lands.
+    Built from Fabric's own typed relay models rather than ``nemo_relay``'s: Fabric is what has to
+    accept the block, so a breaking change there fails construction here instead of being silently
+    dropped from a config Fabric no longer understands.
 
-    ``nemo_relay`` is imported here rather than at module scope: it is a native extension costing
-    ~120ms to load, and this module is reachable from the evaluator plugin's job imports, so an
-    eager import would charge every consumer for trajectory capture they may never use.
+    ``nemo_fabric`` is imported here rather than at module scope: it is a native extension, and this
+    module is reachable from the evaluator plugin's job imports, so an eager import would charge every
+    consumer for trajectory capture they may never use.
     """
-    from nemo_relay.observability import (
-        AtifConfig,
-        AtofConfig,
-        AtofFileSinkConfig,
-        ComponentSpec,
-        ObservabilityConfig,
+    from nemo_fabric import (  # ty: ignore[unresolved-import]
+        RelayAtifConfig,
+        RelayAtofConfig,
+        RelayAtofFileSinkConfig,
+        RelayObservabilityConfig,
+        RelayOpenTelemetryConfig,
+        RelayOpenTelemetryEndpointConfig,
     )
 
-    observability = ComponentSpec(
-        config=ObservabilityConfig(
-            atif=AtifConfig(
-                enabled=True,
-                output_directory=relay_dir,
-                filename_template=ATIF_FILENAME_TEMPLATE,
-                agent_name=agent_name,
-                agent_version=agent_version,
-            ),
-            atof=AtofConfig(
-                enabled=True,
-                sinks=[
-                    AtofFileSinkConfig(
-                        output_directory=relay_dir,
-                        filename=ATOF_FILENAME,
-                        mode="overwrite",
-                    )
-                ],
-            ),
-        )
+    opentelemetry = None
+    if otlp_endpoint is not None:
+        fields = otlp_endpoint_fields(endpoint=otlp_endpoint, service_name=agent_name)
+        opentelemetry = RelayOpenTelemetryConfig(enabled=True, endpoints=[RelayOpenTelemetryEndpointConfig(**fields)])
+    return RelayObservabilityConfig(
+        opentelemetry=opentelemetry,
+        atif=RelayAtifConfig(
+            enabled=True,
+            output_directory=relay_dir,
+            filename_template=ATIF_FILENAME_TEMPLATE,
+            agent_name=agent_name,
+            agent_version=agent_version,
+            extra=dict(extra) if extra else None,
+        ),
+        atof=RelayAtofConfig(
+            enabled=True,
+            sinks=[
+                RelayAtofFileSinkConfig(
+                    output_directory=relay_dir,
+                    filename=ATOF_FILENAME,
+                    mode="overwrite",
+                )
+            ],
+        ),
     )
-    return {
-        "enabled": True,
-        "provider": TELEMETRY_PROVIDER,
-        "mode": TELEMETRY_MODE,
-        "output_dir": relay_dir,
-        "config": {"version": 1, "components": [observability.to_dict()]},
-    }
+
+
+def relay_telemetry_fragment(
+    config: Mapping[str, Any],
+    *,
+    relay_dir: str,
+    agent_name: str,
+    agent_version: str,
+    otlp_endpoint: str | None = None,
+) -> dict[str, Any]:
+    """The Fabric config keys that enable Relay's file exporter, serialized by Fabric itself.
+
+    ``config`` supplies only the identity Fabric requires to validate (metadata + harness/workflow);
+    nothing else about it is carried over. Returning Fabric's own serialization of the keys, rather
+    than a hand-written envelope, is what keeps the block in whatever shape Fabric currently reads —
+    a config Fabric does not recognize is ignored rather than rejected, so a drifted envelope
+    produces a run with no trajectory at all and no error.
+    """
+    from nemo_fabric import FabricConfig  # ty: ignore[unresolved-import]
+
+    probe = FabricConfig.from_mapping(config)
+    probe.enable_relay(
+        output_dir=relay_dir,
+        observability=relay_observability(
+            relay_dir=relay_dir,
+            agent_name=agent_name,
+            agent_version=agent_version,
+            otlp_endpoint=otlp_endpoint,
+        ),
+    )
+    mapping = probe.to_mapping()
+    return {key: mapping[key] for key in ("telemetry", "relay")}

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/fabric/container_runtime.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/fabric/container_runtime.py
@@ -40,8 +40,16 @@ from collections.abc import Mapping, Sequence
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any, cast
 
-from nemo_evaluator_sdk.agent_eval.runtimes.fabric import _common
+from nemo_evaluator_sdk.agent_eval.runtimes.fabric import _common, otlp_receiver
 from nemo_evaluator_sdk.agent_eval.runtimes.fabric.image import ensure_fabric_image
+from nemo_evaluator_sdk.agent_eval.runtimes.fabric.otlp_receiver import READY_FILENAME, TRACES_PATH
+from nemo_evaluator_sdk.agent_eval.runtimes.fabric.otlp_writer import (
+    TRACES_SUBDIR,
+    fold_exports,
+    otlp_trace_path,
+    register_trace_evidence,
+    traces_dir,
+)
 from nemo_evaluator_sdk.agent_eval.runtimes.fabric.skills import (
     CODEX_SKILLS_DIR,
     SKILL_MODE_CODEX_SKILLS_DIR,
@@ -62,9 +70,7 @@ from nemo_evaluator_sdk.resolver_protocols import SecretResolver
 from nemo_evaluator_sdk.resolvers import LocalSecretResolver
 from nemo_evaluator_sdk.values.common import SecretRef
 from nemo_evaluator_sdk.values.evidence import (
-    EVIDENCE_FORMAT_ATIF,
     EVIDENCE_LOGS,
-    EVIDENCE_TRACE,
     CandidateEvidence,
     EvidenceDescriptor,
 )
@@ -96,6 +102,11 @@ _RELAY_DIR = f"{_OUT_DIR}/relay"
 _ARTIFACTS_DIR = f"{_OUT_DIR}/artifacts"
 _LOGS_DIR = f"{_OUT_DIR}/logs"
 _RESULT_PATH = f"{_OUT_DIR}/fabric_result.json"
+_TRACES_DIR = f"{_OUT_DIR}/{TRACES_SUBDIR}"
+_RECEIVER_PATH = f"{_IN_DIR}/otlp_receiver.py"
+#: OTLP/HTTP's default port, on the sandbox's own loopback. Nothing else in the image binds it.
+_OTLP_PORT = 4318
+_OTLP_ENDPOINT = f"http://127.0.0.1:{_OTLP_PORT}{TRACES_PATH}"
 _FABRIC_STDERR = f"{_LOGS_DIR}/fabric-stderr.txt"
 _AGENT_PATH = f"{_IN_DIR}/agent.json"
 _INPUT_PATH = f"{_IN_DIR}/input.txt"
@@ -259,6 +270,17 @@ class FabricContainerRuntime:
                 await self._seed_workspace(sandbox, task)
                 result = await sandbox.exec(self._fabric_command(), timeout_s=DEFAULT_FABRIC_TIMEOUT_S)
                 await sandbox.download_dir(_OUT_DIR, out_dir)
+            # After download, because folding needs protobuf and the sandbox image is not
+            # guaranteed to have it.
+            folded = await asyncio.to_thread(fold_exports, traces_dir(out_dir))
+            if not folded:
+                # Zero also means the receiver never started -- no `python3`, or the port taken --
+                # and that failure is invisible from the trial otherwise.
+                logger.warning(
+                    "No OTLP export was captured for task %s; its trace falls back to ATIF. See %s.",
+                    task.id,
+                    out_dir / "logs" / "otlp-receiver.log",
+                )
             # Codex self-injection seeds each bundle inside the workspace so the harness discovers it during
             # the run; drop them from the downloaded evidence before the workspace is exposed (else the
             # injected files read as agent output to workspace-reading metrics). Native staging lives under
@@ -300,9 +322,19 @@ class FabricContainerRuntime:
     def _fabric_command(self) -> str:
         """The driver invocation: pre-create the /out dirs Fabric chdirs into, run, capture stdout."""
         run = f"python3 {shlex.quote(_DRIVER_PATH)} {shlex.quote(_AGENT_PATH)} {shlex.quote(_INPUT_PATH)}"
+        ready = shlex.quote(f"{_TRACES_DIR}/{READY_FILENAME}")
+        # Wait for the file the receiver writes once bound: Relay's first export must not arrive
+        # before there is anything listening.
         return (
-            f"mkdir -p {_WORKSPACE_DIR} {_RELAY_DIR} {_ARTIFACTS_DIR} {_LOGS_DIR} && "
-            f"{run} > {shlex.quote(_RESULT_PATH)} 2> {shlex.quote(_FABRIC_STDERR)}"
+            f"mkdir -p {_WORKSPACE_DIR} {_RELAY_DIR} {_ARTIFACTS_DIR} {_LOGS_DIR} {_TRACES_DIR} && "
+            f"python3 {shlex.quote(_RECEIVER_PATH)} {shlex.quote(_TRACES_DIR)} {_OTLP_PORT} "
+            f"> {shlex.quote(f'{_LOGS_DIR}/otlp-receiver.log')} 2>&1 & "
+            f"RECEIVER=$!; "
+            f"for _ in $(seq 1 50); do [ -f {ready} ] && break; sleep 0.1; done; "
+            f"{run} > {shlex.quote(_RESULT_PATH)} 2> {shlex.quote(_FABRIC_STDERR)}; "
+            f"STATUS=$?; "
+            f"kill $RECEIVER 2>/dev/null; wait $RECEIVER 2>/dev/null; "
+            f"exit $STATUS"
         )
 
     def _seed_files(
@@ -320,6 +352,7 @@ class FabricContainerRuntime:
         files: dict[str, str] = {
             _INPUT_PATH: task.agent_prompt(),
             _DRIVER_PATH: _DRIVER_SOURCE.read_text(encoding="utf-8"),
+            _RECEIVER_PATH: _receiver_source(),
         }
         if self._skill_set.skills and skill_mode is not None:
             if skill_mode == SKILL_MODE_CODEX_SKILLS_DIR:
@@ -373,6 +406,7 @@ class FabricContainerRuntime:
                 relay_dir=_RELAY_DIR,
                 agent_name=_RUNTIME_NAME,
                 agent_version=_common.FABRIC_AGENT_VERSION,
+                otlp_endpoint=_OTLP_ENDPOINT,
             )
         )
 
@@ -466,11 +500,7 @@ class FabricContainerRuntime:
         logs_dir = out_dir / "logs"
         if logs_dir.is_dir():
             descriptors[EVIDENCE_LOGS] = EvidenceDescriptor(kind="logs", ref=str(logs_dir))
-        atif = _find_atif(out_dir / "relay")
-        if atif is not None:
-            descriptors[EVIDENCE_TRACE] = EvidenceDescriptor(
-                kind=EVIDENCE_TRACE, format=EVIDENCE_FORMAT_ATIF, ref=str(atif)
-            )
+        register_trace_evidence(descriptors, atif=_find_atif(out_dir / "relay"), otlp=otlp_trace_path(out_dir))
         return CandidateEvidence(
             descriptors=descriptors,
             metadata={"runtime": _RUNTIME_NAME, "sandbox_provider": self._provider.name, "image": self._image},
@@ -499,6 +529,11 @@ class FabricContainerRuntime:
         # working state lives at /out inside the sandbox and is downloaded here.
         root = (config.work_dir or Path.cwd()) / "evidence" / "fabric_container"
         return root / _common.task_subdir_name(index, task.id)
+
+
+def _receiver_source() -> str:
+    """The shared receiver's own source, seeded into the sandbox and run there as a script."""
+    return (Path(otlp_receiver.__file__)).read_text(encoding="utf-8")
 
 
 def _to_mapping(config: FabricConfig | Mapping[str, Any]) -> dict[str, Any]:

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/fabric/container_runtime.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/fabric/container_runtime.py
@@ -13,8 +13,9 @@ Per task it:
 
 1. seeds ``/in`` with the composed Fabric agent config and framed input, plus the task's workspace
    seed files;
-2. execs Fabric's own CLI (``fabric run``), which writes a normalized ``RunResult`` to stdout and the
-   workspace + Relay ATIF trajectory under a fixed ``/out`` layout;
+2. runs one Fabric invocation through a seeded in-sandbox driver
+   (:mod:`~nemo_evaluator_sdk.agent_eval.runtimes.fabric.sandbox_driver`), which writes a normalized
+   ``RunResult`` to stdout and the workspace + Relay ATIF trajectory under a fixed ``/out`` layout;
 3. downloads ``/out`` across the boundary into the durable per-task evidence dir; and
 4. maps it into the shared :class:`CandidateEvidence` contract the eval metrics consume — ``result``
    (json), ``trace`` (ATIF), plus ``workspace`` (filesystem) and ``logs`` — so the workspace-file,
@@ -87,7 +88,7 @@ _MISSING_FABRIC_MSG = (
 )
 
 # Fixed in-container layout. The runtime seeds ``/in`` (agent config, input), execs Fabric's
-# CLI, and reads the produced ``/out`` subtree back across the boundary.
+# driver, and reads the produced ``/out`` subtree back across the boundary.
 _IN_DIR = "/in"
 _OUT_DIR = "/out"
 _WORKSPACE_DIR = f"{_OUT_DIR}/workspace"
@@ -96,8 +97,11 @@ _ARTIFACTS_DIR = f"{_OUT_DIR}/artifacts"
 _LOGS_DIR = f"{_OUT_DIR}/logs"
 _RESULT_PATH = f"{_OUT_DIR}/fabric_result.json"
 _FABRIC_STDERR = f"{_LOGS_DIR}/fabric-stderr.txt"
-_AGENT_PATH = f"{_IN_DIR}/agent.yaml"
+_AGENT_PATH = f"{_IN_DIR}/agent.json"
 _INPUT_PATH = f"{_IN_DIR}/input.txt"
+#: Seeded as source rather than imported: the driver runs against the sandbox's Fabric, not the host's.
+_DRIVER_SOURCE = Path(__file__).with_name("sandbox_driver.py")
+_DRIVER_PATH = f"{_IN_DIR}/{_DRIVER_SOURCE.name}"
 # In-sandbox root for a natively-injected skill bundle. It lives under ``/in`` (not ``/out``), so it is
 # never part of the downloaded ``/out`` evidence — only codex-mode skills, which must sit in the workspace
 # for the harness to self-discover them, need post-download cleanup.
@@ -294,8 +298,8 @@ class FabricContainerRuntime:
         return str(adapter_id) if adapter_id is not None else ""
 
     def _fabric_command(self) -> str:
-        """The ``fabric run`` invocation: pre-create the /out dirs Fabric chdirs into, run, capture stdout."""
-        run = f"fabric run {shlex.quote(_AGENT_PATH)} --input-file {shlex.quote(_INPUT_PATH)}"
+        """The driver invocation: pre-create the /out dirs Fabric chdirs into, run, capture stdout."""
+        run = f"python3 {shlex.quote(_DRIVER_PATH)} {shlex.quote(_AGENT_PATH)} {shlex.quote(_INPUT_PATH)}"
         return (
             f"mkdir -p {_WORKSPACE_DIR} {_RELAY_DIR} {_ARTIFACTS_DIR} {_LOGS_DIR} && "
             f"{run} > {shlex.quote(_RESULT_PATH)} 2> {shlex.quote(_FABRIC_STDERR)}"
@@ -306,16 +310,17 @@ class FabricContainerRuntime:
     ) -> tuple[dict[str, str], list[SkillProvenance]]:
         """Return (files to seed into the sandbox, skill provenances).
 
-        The agent config is written as JSON, which the Fabric CLI parses as YAML. Fabric 0.1.0rc2 removed
-        profile overlays (``--profile`` and the ``profiles`` config key are both gone), so everything —
-        the runtime's in-container settings and any natively-injected skill paths — is composed into the
-        single agent config here. When skills are injected each bundle is also rendered into the seed set
+        Everything — the runtime's in-container settings and any natively-injected skill paths — is
+        composed into the single agent config here, written as JSON for the driver to load. When skills are injected each bundle is also rendered into the seed set
         at the harness's in-sandbox discovery path (native: ``/in/skills/<name>``; codex:
         ``<workspace>/.agents/skills/<name>``).
         """
         skill_paths: list[str] = []
         provenances: list[SkillProvenance] = []
-        files: dict[str, str] = {_INPUT_PATH: task.agent_prompt()}
+        files: dict[str, str] = {
+            _INPUT_PATH: task.agent_prompt(),
+            _DRIVER_PATH: _DRIVER_SOURCE.read_text(encoding="utf-8"),
+        }
         if self._skill_set.skills and skill_mode is not None:
             if skill_mode == SKILL_MODE_CODEX_SKILLS_DIR:
                 _check_codex_skill_collision(self._skill_set.skills, task.inputs.get(SEED_FILES_INPUT_KEY) or {})
@@ -358,13 +363,17 @@ class FabricContainerRuntime:
             "workspace": _WORKSPACE_DIR,
             "artifacts": _ARTIFACTS_DIR,
         }
-        # Relay ATIF/ATOF file exporter (sdk mode), built from nemo_relay's typed config via the shared
-        # helper so it stays a single source of truth with the host runtime. Replaced wholesale.
+        # Relay's ATIF/ATOF file exporter, spanning whatever keys Fabric currently serializes it into.
         # ``agent_name`` distinguishes this runtime from the host one; ``agent_version`` records the
         # agent framework and so matches the host's value, letting an ATIF consumer group both
-        # runtimes' traces. (Neither is a real version yet — see _common.trajectory_telemetry.)
-        config["telemetry"] = _common.trajectory_telemetry(
-            relay_dir=_RELAY_DIR, agent_name=_RUNTIME_NAME, agent_version=_common.FABRIC_AGENT_VERSION
+        # runtimes' traces. (Neither is a real version yet.)
+        config.update(
+            _common.relay_telemetry_fragment(
+                config,
+                relay_dir=_RELAY_DIR,
+                agent_name=_RUNTIME_NAME,
+                agent_version=_common.FABRIC_AGENT_VERSION,
+            )
         )
 
         declared_paths = _section(config, "skills").get("paths") or []
@@ -402,26 +411,29 @@ class FabricContainerRuntime:
         # a ``skills`` list plus the historical lone ``skill`` field, matching the host FabricAgentRuntime.
         base_metadata = {**self._base_metadata(), **_skill_metadata(skill_provenances or [])}
 
-        # Gate on the exec outcome first: a timed-out or non-zero ``fabric run`` is untrustworthy even
+        # Gate on the exec outcome first: a timed-out or non-zero driver run is untrustworthy even
         # when a stale/partial fabric_result.json is left behind (the shell ``>`` redirect truncates the
         # file regardless), so never grade such a run off that file.
         if result.error_type or result.return_code != 0:
             stderr = _read_text(out_dir / "logs" / "fabric-stderr.txt") or (result.stderr or "")
             detail = stderr.strip() or result.error_type or f"exit code {result.return_code}"
             return self._failed_trial(
-                task, evidence_dir, RuntimeError(f"fabric run failed: {detail}"), extra_metadata=base_metadata
+                task,
+                evidence_dir,
+                RuntimeError(f"fabric run failed in the sandbox: {detail}"),
+                extra_metadata=base_metadata,
             )
 
         result_path = out_dir / "fabric_result.json"
         result_payload = _read_json(result_path)
-        # `fabric run` writes a normalized RunResult object (a failed harness run still produces one, with
+        # The driver writes a normalized RunResult object (a failed harness run still produces one, with
         # status != "succeeded"). A missing, non-object, or unreadable payload means no usable result.
         if not isinstance(result_payload, Mapping):
             stderr = _read_text(out_dir / "logs" / "fabric-stderr.txt") or (result.stderr or "")
             return self._failed_trial(
                 task,
                 evidence_dir,
-                RuntimeError(f"fabric run produced no usable result: {stderr.strip()}"),
+                RuntimeError(f"the sandbox produced no usable Fabric result: {stderr.strip()}"),
                 extra_metadata=base_metadata,
             )
 

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/fabric/image.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/fabric/image.py
@@ -3,35 +3,28 @@
 
 """Build-if-missing provisioning for the Fabric sandbox image.
 
-``FabricContainerRuntime`` needs a container image with Fabric + its harness runtimes. Rather than
-make callers hand-write a Dockerfile, the SDK owns the recipe (:mod:`sandbox.Dockerfile`, a
-multi-stage build) and provisions the image opaquely: :func:`ensure_fabric_image` returns a usable
-image tag, building it only when it isn't already present locally. This mirrors the
-``ensure_task_image`` build-if-missing pattern (``docker image inspect`` → ``docker build``).
+``FabricContainerRuntime`` needs a container image with Fabric + its harness adapters. Rather than
+make callers hand-write a Dockerfile, the SDK owns the recipe (:mod:`sandbox.Dockerfile`) and
+provisions the image opaquely: :func:`ensure_fabric_image` returns a usable image tag, building it
+only when it isn't already present locally. This mirrors the ``ensure_task_image`` build-if-missing
+pattern (``docker image inspect`` → ``docker build``).
 
-The tag is content-addressed on the recipe + selected extras, so a recipe change produces a new tag
-(cache-bust) and an unchanged recipe reuses the cached image. The Fabric source is private/native
-(no public wheel), so the build needs a local NeMo-Fabric checkout — resolved from ``fabric_repo`` /
-``$NEMO_FABRIC_REPO`` / ``~/workspace/NeMo-Fabric``. Only the maturin build inputs are staged into the
-context (not the whole repo), and the multi-stage build keeps the source and Rust toolchain out of the
-final image.
+The image installs published wheels, so the build needs no source checkout and no build context
+beyond its own pins. It is pinned to the ``nemo-fabric`` version installed alongside this SDK,
+so the sandbox cannot run a Fabric that disagrees with the config the host composes for it.
+
+The tag is content-addressed on the recipe + version + adapters, so any of those changing produces a
+new tag (cache-bust) and an unchanged recipe reuses the cached image.
 
 This is the local-Docker provisioning path. The intended evolution is a remote image registry as a
 cache: :func:`ensure_fabric_image` keeps the same "return a usable tag" contract, its body swapping
 local build for a registry pull (build-and-push on miss).
-
-DEPENDENCY (as of July 2026): the multi-stage image installs the ``nemo-fabric`` wheel and discards
-the source, so Fabric must be able to resolve built-in adapters *from the installed distribution*.
-That only works on NeMo-Fabric's ``installed-adapter-discovery`` branch (which bundles the adapters
-under ``python/src/nemo_fabric/adapters`` and adds ``AdapterDescriptorSource::Installed``). On today's
-``main`` the wheel ships no adapter descriptors, so a wheel-only image cannot resolve e.g.
-``nvidia.fabric.hermes``. Once that lands on ``main``, switch to installing the top-level
-``adapters/*`` packages explicitly here instead of relying on the branch's packaging.
 """
 
 from __future__ import annotations
 
 import hashlib
+import importlib.metadata
 import logging
 import os
 import shutil
@@ -44,43 +37,57 @@ logger = logging.getLogger(__name__)
 # ``localhost/`` prefix so Docker treats it as an explicit local registry and does NOT qualify the tag
 # to ``docker.io/…`` — this image is built locally and never pushed to Docker Hub.
 DEFAULT_FABRIC_IMAGE_REPO = "localhost/nemo-evaluator/fabric-sandbox"
-FABRIC_REPO_ENV = "NEMO_FABRIC_REPO"
-_DEFAULT_FABRIC_REPO = Path.home() / "workspace" / "NeMo-Fabric"
+FABRIC_DISTRIBUTION = "nemo-fabric"
 _DOCKERFILE = Path(__file__).with_name("sandbox.Dockerfile")
 
 # Bound the docker subprocess calls so an unresponsive daemon fails fast instead of hanging the runtime.
-# ``inspect`` is near-instant; the build compiles nemo-fabric (minutes), so it gets a generous ceiling.
 _INSPECT_TIMEOUT_S = 30
-_BUILD_TIMEOUT_S = 3600
+_BUILD_TIMEOUT_S = 900
 
-#: Harness runtime deps baked into the (single, harness-agnostic) Fabric image. The native
-#: ``nemo-fabric`` build plus *all* built-in adapter descriptors are always present, so the CLI can
-#: resolve any built-in harness; these extras add the per-harness *runtime* deps (``hermes`` →
-#: ``hermes-agent``; ``relay`` → the ATIF exporter). Codex additionally needs node + the codex CLI +
-#: the nemo-relay gateway binary and is not provisioned yet (see AALGO-321); append it here when ready.
-_EXTRAS: tuple[str, ...] = ("hermes", "relay")
+#: Adapter distributions baked into the (single, harness-agnostic) Fabric image, pinned to the same
+#: version as ``nemo-fabric``. Codex and claude are absent: they need their own CLIs, which this image
+#: does not provision (see AALGO-321).
+_ADAPTER_DISTRIBUTIONS: tuple[str, ...] = ("nemo-fabric-adapters-hermes",)
 
-#: Paths under the NeMo-Fabric checkout that the maturin build actually needs. Staging only these
-#: (rather than the whole repo) keeps the build context small; the multi-stage build keeps them out
-#: of the final image entirely.
-_BUILD_SOURCE_PATHS = ("Cargo.toml", "Cargo.lock", "pyproject.toml", "README.md", "crates", "python")
+#: Requirements the harness needs that are not versioned with Fabric. ``hermes-agent`` is the harness
+#: itself, which no Fabric extra pulls in; ``tomli-w`` is what the adapter writes Relay's plugin config
+#: with, and without it the harness fails at start with ``tomli_w is not installed``. Pinned exactly,
+#: not compatible-released: the tag is a digest of these lines, so a requirement free to move would
+#: let the same tag name different image contents and be reused from cache.
+_HARNESS_REQUIREMENTS: tuple[str, ...] = ("hermes-agent==0.19.0", "tomli-w==1.2.0")
 
 
 class FabricImageError(RuntimeError):
     """Raised when the Fabric sandbox image cannot be provisioned."""
 
 
-def _extras_arg() -> str:
-    return ",".join(_EXTRAS)
+def fabric_version() -> str:
+    """The installed ``nemo-fabric`` version, which the image is pinned to."""
+    try:
+        return importlib.metadata.version(FABRIC_DISTRIBUTION)
+    except importlib.metadata.PackageNotFoundError as exc:
+        raise FabricImageError(
+            f"{FABRIC_DISTRIBUTION} is not installed, so the sandbox image has no version to pin to. "
+            "Install the SDK's `fabric` extra, or pass an already-built image."
+        ) from exc
 
 
-def fabric_image_tag(*, repo: str = DEFAULT_FABRIC_IMAGE_REPO) -> str:
-    """Content-addressed tag for the harness-agnostic Fabric image: ``<repo>:<digest(recipe + extras)>``.
+def _requirements(version: str) -> list[str]:
+    return [
+        f"nemo-fabric[relay]=={version}",
+        *(f"{distribution}=={version}" for distribution in _ADAPTER_DISTRIBUTIONS),
+        *_HARNESS_REQUIREMENTS,
+    ]
 
-    Not keyed by harness: one Fabric install + the bundled adapters runs any built-in harness, so the
-    image is the same regardless of which harness a task's config selects.
+
+def fabric_image_tag(*, repo: str = DEFAULT_FABRIC_IMAGE_REPO, version: str | None = None) -> str:
+    """Content-addressed tag for the harness-agnostic Fabric image: ``<repo>:<digest>``.
+
+    Not keyed by harness: one Fabric install plus the bundled adapters runs any of them, so the image
+    is the same regardless of which harness a task's config selects.
     """
-    recipe = _DOCKERFILE.read_bytes() + _extras_arg().encode("utf-8")
+    resolved = version or fabric_version()
+    recipe = _DOCKERFILE.read_bytes() + "\n".join(_requirements(resolved)).encode("utf-8")
     return f"{repo}:{hashlib.sha256(recipe).hexdigest()[:12]}"
 
 
@@ -108,59 +115,26 @@ def image_exists(tag: str, *, docker_bin: str = "docker") -> bool:
     return False
 
 
-def _resolve_fabric_repo(fabric_repo: str | Path | None) -> Path:
-    default = Path(os.environ.get(FABRIC_REPO_ENV, _DEFAULT_FABRIC_REPO))
-    repo = (Path(fabric_repo) if fabric_repo is not None else default).expanduser()
-    if not (repo / "pyproject.toml").is_file():
-        raise FabricImageError(
-            f"NeMo-Fabric source not found at {repo}. The Fabric image is built from source "
-            f"(no public wheel); set {FABRIC_REPO_ENV} or pass fabric_repo to point at a checkout."
-        )
-    return repo
-
-
-def _stage_source(repo: Path, dest: Path) -> None:
-    """Copy only the maturin build inputs from ``repo`` into ``dest`` (not the whole checkout)."""
-    dest.mkdir(parents=True, exist_ok=True)
-    for name in _BUILD_SOURCE_PATHS:
-        src = repo / name
-        if src.is_dir():
-            shutil.copytree(src, dest / name, ignore=shutil.ignore_patterns("target", "__pycache__", "*.whl"))
-        elif src.is_file():
-            shutil.copy2(src, dest / name)
-        else:
-            raise FabricImageError(f"expected Fabric build input {name!r} not found under {repo}")
-
-
-def ensure_fabric_image(
-    *,
-    fabric_repo: str | Path | None = None,
-    docker_bin: str = "docker",
-    force_build: bool = False,
-) -> str:
+def ensure_fabric_image(*, docker_bin: str = "docker", force_build: bool = False) -> str:
     """Return a usable Fabric image tag, building it only if not already present.
 
-    One harness-agnostic image serves every built-in harness. Idempotent and content-addressed: an
-    unchanged recipe reuses the cached image; a changed recipe yields a new tag. Builds from a staged
-    copy of the local NeMo-Fabric source (build inputs only).
+    One harness-agnostic image serves every bundled harness. Idempotent and content-addressed: an
+    unchanged recipe reuses the cached image; a changed recipe or Fabric version yields a new tag.
     """
-    tag = fabric_image_tag()
+    version = fabric_version()
+    tag = fabric_image_tag(version=version)
     if not force_build and image_exists(tag, docker_bin=docker_bin):
         logger.debug("Fabric image %s already present; skipping build.", tag)
         return tag
 
-    repo = _resolve_fabric_repo(fabric_repo)
-    logger.info(
-        "Building Fabric image (first build compiles nemo-fabric; this can take minutes)...",
-        extra=dict(tag=tag, repo=repo),
-    )
+    logger.info("Building Fabric image...", extra=dict(tag=tag, fabric_version=version))
     with tempfile.TemporaryDirectory(prefix="nemo-fabric-image-") as ctx_dir:
         ctx = Path(ctx_dir)
-        _stage_source(repo, ctx / "nemo-fabric")
         shutil.copy2(_DOCKERFILE, ctx / "Dockerfile")
+        (ctx / "requirements.txt").write_text("\n".join(_requirements(version)) + "\n", encoding="utf-8")
         try:
             subprocess.run(
-                [docker_bin, "build", "--build-arg", f"EXTRAS={_extras_arg()}", "-t", tag, str(ctx)],
+                [docker_bin, "build", "-t", tag, str(ctx)],
                 check=True,
                 env={**os.environ, "DOCKER_BUILDKIT": "1"},
                 timeout=_BUILD_TIMEOUT_S,

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/fabric/otlp_receiver.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/fabric/otlp_receiver.py
@@ -10,8 +10,8 @@ downloaded when the task ends.
 
 Standard library only, and it stays that way: the sandbox image ships Fabric and its harnesses, not
 this package, so an import of anything else would have to be installed there first. That is also
-why each export is stored verbatim rather than as OTLP/JSON -- decoding needs protobuf, which the
-image does not guarantee, so :func:`nemo_evaluator_sdk...otlp_writer.fold_exports` does it later.
+why each export is stored verbatim rather than as OTLP/JSON: decoding needs protobuf, which the
+image does not guarantee, so it happens after the exports are back on the host.
 """
 
 from __future__ import annotations

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/fabric/runtime.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/fabric/runtime.py
@@ -47,7 +47,6 @@ from nemo_evaluator_sdk.agent_eval.runtimes.fabric.hooks import FabricTaskRunHoo
 from nemo_evaluator_sdk.agent_eval.runtimes.fabric.otlp_receiver import OTLPReceiver
 from nemo_evaluator_sdk.agent_eval.runtimes.fabric.otlp_writer import (
     fold_exports,
-    otlp_endpoint_fields,
     otlp_trace_path,
     register_trace_evidence,
     traces_dir,
@@ -119,8 +118,6 @@ _SKILL_PROBE_PATH = "nemo-eval-skill-capability-probe"
 _WORKSPACE_EVIDENCE_KEY = "workspace"
 _WORKSPACE_EVIDENCE_KIND = "filesystem"
 # File-exporter output names we choose for the Relay ATIF/ATOF trajectory (Relay accepts these as inputs).
-_ATIF_FILENAME_TEMPLATE = "trajectory-{session_id}.atif.json"
-_ATOF_FILENAME = "events.atof.jsonl"
 # ``kind`` Fabric stamps on the promoted Relay ATIF artifact; used to surface it as trace evidence.
 _ATIF_ARTIFACT_KIND = "atif"
 
@@ -652,51 +649,15 @@ class FabricAgentRuntime:
         extra: Mapping[str, Any] | None = None,
         trace_receiver: OTLPReceiver | None = None,
     ) -> RelayObservabilityConfig:
-        # The ATIF/ATOF observability config is built from Fabric's own typed relay-config objects so
-        # Fabric owns the schema (no hand-maintained dict that silently drifts when Fabric changes it),
-        # mirroring nemo_fabric's own Harbor integration. It is handed straight to ``enable_relay`` via
-        # its ``observability=`` parameter — the SDK only configures ATIF/ATOF observability, so it needs
-        # neither a generic ``components`` list nor the legacy component-wrapped shape. nemo_fabric is
-        # already imported+validated in ``run_tasks``, so this is a cached sys.modules lookup.
-        from nemo_fabric import (  # ty: ignore[unresolved-import]
-            RelayAtifConfig,
-            RelayAtofConfig,
-            RelayAtofFileSinkConfig,
-            RelayObservabilityConfig,
-            RelayOpenTelemetryConfig,
-            RelayOpenTelemetryEndpointConfig,
-        )
-
-        relay_dir_str = str(relay_dir)
         atif_extra: dict[str, Any] | None = None
         if self._trajectory_extra or extra:
             atif_extra = {**(self._trajectory_extra or {}), **(dict(extra) if extra else {})}
-        opentelemetry = None
-        if trace_receiver is not None:
-            fields = otlp_endpoint_fields(endpoint=trace_receiver.endpoint, service_name=self._runtime_name)
-            opentelemetry = RelayOpenTelemetryConfig(
-                enabled=True, endpoints=[RelayOpenTelemetryEndpointConfig(**fields)]
-            )
-        return RelayObservabilityConfig(
-            opentelemetry=opentelemetry,
-            atif=RelayAtifConfig(
-                enabled=True,
-                output_directory=relay_dir_str,
-                filename_template=_ATIF_FILENAME_TEMPLATE,
-                agent_name=self._runtime_name,
-                agent_version=_common.FABRIC_AGENT_VERSION,
-                extra=atif_extra,
-            ),
-            atof=RelayAtofConfig(
-                enabled=True,
-                sinks=[
-                    RelayAtofFileSinkConfig(
-                        output_directory=relay_dir_str,
-                        filename=_ATOF_FILENAME,
-                        mode="overwrite",
-                    )
-                ],
-            ),
+        return _common.relay_observability(
+            relay_dir=str(relay_dir),
+            agent_name=self._runtime_name,
+            agent_version=_common.FABRIC_AGENT_VERSION,
+            extra=atif_extra,
+            otlp_endpoint=trace_receiver.endpoint if trace_receiver is not None else None,
         )
 
     def _evidence_dir(self, index: int, task: AgentEvalTask, config: AgentEvalRunConfig) -> Path:
@@ -797,7 +758,7 @@ def _relay_atif_path(evidence_dir: Path) -> Path | None:
     their own sessions. Picking one under-reports and summing double-counts a root that already
     aggregates, so anything other than a single match reports nothing rather than a wrong number.
     """
-    matches = sorted((evidence_dir / _RELAY_SUBDIR).glob(_ATIF_FILENAME_TEMPLATE.format(session_id="*")))
+    matches = sorted((evidence_dir / _RELAY_SUBDIR).glob(_common.ATIF_FILENAME_TEMPLATE.format(session_id="*")))
     if len(matches) == 1:
         return matches[0]
     if matches:

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/fabric/sandbox.Dockerfile
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/fabric/sandbox.Dockerfile
@@ -2,48 +2,22 @@
 # SPDX-License-Identifier: Apache-2.0
 
 #
-# Multi-stage image for FabricContainerRuntime. The builder compiles nemo-fabric (maturin/Rust) into
-# an isolated venv AND builds Fabric's own `fabric` CLI (the runtime execs `fabric run` to kick off
-# the harness). The final stage copies only the venv + the CLI binary + the built-in adapters — no
-# source tree and no Rust toolchain. Harness extras are selected via the EXTRAS build arg.
+# Image for FabricContainerRuntime: NeMo Fabric plus the harness adapters, installed from published
+# wheels. Fabric's adapter descriptors ship inside those wheels (under `share/nemo-fabric/adapters`),
+# so a wheel-only install resolves any bundled harness with no source checkout and no build context
+# beyond the pins in requirements.txt (written by image.py).
 ARG PYTHON_VERSION=3.12
 
-FROM python:${PYTHON_VERSION}-slim-bookworm AS builder
-ARG EXTRAS=hermes,relay
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends build-essential curl git pkg-config libssl-dev \
-    && rm -rf /var/lib/apt/lists/*
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o /tmp/rustup-init.sh \
-    && sh /tmp/rustup-init.sh -y --profile minimal \
-    && rm -f /tmp/rustup-init.sh
-ENV PATH=/root/.cargo/bin:$PATH
-RUN python -m venv /opt/venv
-ENV PATH=/opt/venv/bin:$PATH
-# Only the maturin build inputs are in the context (see image._stage_source): the native nemo-fabric
-# extension is compiled here and the harness/relay wheels are pulled from PyPI — into the venv only.
-COPY nemo-fabric /src
-RUN pip install --no-cache-dir "/src[${EXTRAS}]"
-# Fabric's own CLI (Rust). The runtime execs `fabric run <agent.yaml> --profile … --input-file …`,
-# which prints a normalized RunResult to stdout — so no in-image Python driver is needed.
-RUN cargo build --release --manifest-path /src/Cargo.toml -p fabric-cli
-
 FROM python:${PYTHON_VERSION}-slim-bookworm AS runtime
-COPY --from=builder /opt/venv /opt/venv
-COPY --from=builder /src/target/release/fabric /usr/local/bin/fabric
-# The CLI binary resolves built-in adapters from its compile-time repository path
-# (CARGO_MANIFEST_DIR/../../python/src/nemo_fabric/adapters); ship just that dir to the baked path so a
-# wheel-only image can resolve them. Depends on NeMo-Fabric's installed-adapter-discovery layout
-# (see image.py); swap to installing the top-level adapters/* packages once that lands on main.
-COPY --from=builder /src/python/src/nemo_fabric/adapters /src/python/src/nemo_fabric/adapters
-# The CLI's baked path is the literal `<fabric-core crate>/../../python/src/nemo_fabric/adapters`; the
-# kernel needs `/src/crates/fabric-core` to exist to walk the `..`, even though nothing lives there.
-RUN mkdir -p /src/crates/fabric-core
-ENV PATH=/opt/venv/bin:$PATH
-RUN python -c "from nemo_fabric import FabricClient" && fabric version
-# Run agent-generated code as a non-root user: this sandbox execs `fabric run` over untrusted,
-# agent-produced content, so dropping root narrows the blast radius of a container escape. Pre-create
-# and own the fixed /in (seeded inputs) and /out (workspace + results) trees, since a non-root process
-# cannot mkdir under / at exec time and the runtime creates /out/{workspace,relay,artifacts,logs} then.
+COPY requirements.txt /tmp/requirements.txt
+# Installed into the image's own interpreter rather than a venv: Fabric spawns its Python adapter host
+# as the absolute `/usr/local/bin/python`, so packages in a venv are invisible to the adapter.
+RUN pip install --no-cache-dir -r /tmp/requirements.txt && rm -f /tmp/requirements.txt
+RUN python -c "from nemo_fabric import Fabric, FabricConfig"
+# Run agent-generated code as a non-root user: this sandbox runs untrusted, agent-produced content, so
+# dropping root narrows the blast radius of a container escape. Pre-create and own the fixed /in
+# (seeded inputs) and /out (workspace + results) trees, since a non-root process cannot mkdir under /
+# at exec time and the runtime creates /out/{workspace,relay,artifacts,logs} then.
 RUN useradd --create-home --uid 1000 sandbox \
  && mkdir -p /in /out \
  && chown -R sandbox:sandbox /in /out

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/fabric/sandbox_driver.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/fabric/sandbox_driver.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""One Fabric run, executed inside the sandbox and printed as JSON on stdout.
+
+``FabricContainerRuntime`` seeds this file into the sandbox and runs it as a script: it reads this
+module's source rather than importing it, so the sandbox's Fabric is the one that has to satisfy
+these imports.
+
+Fabric's own CLI is not an option. It became a presets/examples experimentation tool in Fabric 0.2
+(binary ``nemo-fabric``, selectors ``--preset``/``--example``), so there is no config-driven CLI
+entrypoint to exec; the Python API is the supported way to run an arbitrary agent config.
+
+Errors are not caught: a traceback on a non-zero exit is what the runtime already grades a failed
+trial from, and swallowing it here would produce a well-formed result payload for a run that did
+not happen.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+from nemo_fabric import Fabric, FabricConfig  # ty: ignore[unresolved-import]
+
+
+def main(argv: list[str]) -> int:
+    """Run ``argv[1]`` (agent config) over ``argv[2]`` (input text) and print the ``RunResult``."""
+    config_path, input_path = Path(argv[1]), Path(argv[2])
+    config = FabricConfig.from_mapping(json.loads(config_path.read_text(encoding="utf-8")))
+    text = input_path.read_text(encoding="utf-8")
+    # Relative paths in the config resolve against the config's own directory, as they would for a
+    # caller that loaded it from there.
+    result = asyncio.run(Fabric().run(config, input=text, base_dir=str(config_path.parent)))
+    print(json.dumps(result.to_mapping(), default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_fabric_container_otlp.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_fabric_container_otlp.py
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for capturing OTLP inside the Fabric sandbox.
+
+The receiver itself is covered by the shared suite; what is specific here is running it the way
+the sandbox does -- as a seeded script in a separate process -- and the command that drives it.
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from nemo_evaluator_sdk.agent_eval.runtimes.fabric import container_runtime, otlp_receiver
+from nemo_evaluator_sdk.agent_eval.runtimes.fabric.otlp_receiver import EXPORT_SUFFIX, READY_FILENAME
+from nemo_evaluator_sdk.agent_eval.runtimes.fabric.otlp_writer import fold_exports, otlp_trace_path
+from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalTask
+
+from packages.nemo_evaluator_sdk.tests.agent_eval._otlp_testkit import export, post, span_names
+
+RECEIVER = Path(otlp_receiver.__file__)
+_TASK = AgentEvalTask(id="t", intent="i", inputs={"instruction": "do it"})
+
+
+def _runtime() -> container_runtime.FabricContainerRuntime:
+    return container_runtime.FabricContainerRuntime(
+        config={"metadata": {"name": "a"}, "harness": {"adapter_id": "nvidia.fabric.codex"}},
+        provider=object(),
+        image="img",
+    )
+
+
+def test_the_receiver_runs_as_a_seeded_script_and_its_exports_fold(tmp_path: Path, unused_tcp_port) -> None:
+    # Run the way the sandbox runs it: a separate interpreter, no import of this package.
+    traces = tmp_path / "traces"
+    process = subprocess.Popen([sys.executable, str(RECEIVER), str(traces), str(unused_tcp_port)])
+    try:
+        deadline = time.monotonic() + 15
+        while not (traces / READY_FILENAME).is_file():
+            assert time.monotonic() < deadline and process.poll() is None, "receiver never signalled ready"
+            time.sleep(0.05)
+
+        assert post(f"http://127.0.0.1:{unused_tcp_port}/v1/traces", export("codex-turn")) == 200
+    finally:
+        process.terminate()
+        process.wait(timeout=10)
+
+    assert fold_exports(traces) == 1
+    assert span_names(otlp_trace_path(tmp_path)) == ["codex-turn"]
+
+
+def test_the_seeded_receiver_needs_nothing_the_sandbox_image_lacks() -> None:
+    # The image ships Fabric and its harnesses, not this package or its dependencies, so a single
+    # non-stdlib import would make the receiver unrunnable there.
+    seeded = _runtime()._seed_files(_TASK, None)[0][container_runtime._RECEIVER_PATH]
+    assert seeded == RECEIVER.read_text(encoding="utf-8")
+
+    imported = set()
+    for node in ast.walk(ast.parse(seeded)):
+        if isinstance(node, ast.Import):
+            imported |= {alias.name.split(".")[0] for alias in node.names}
+        elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+            imported.add(node.module.split(".")[0])
+
+    assert imported <= sys.stdlib_module_names, imported - sys.stdlib_module_names
+
+
+def test_the_sandbox_command_waits_for_the_receiver_and_keeps_fabric_s_exit_status() -> None:
+    # Fabric must not start before the receiver can be reached, and stopping the receiver must not
+    # mask a failed run.
+    command = _runtime()._fabric_command()
+
+    assert READY_FILENAME in command
+    # Anchored on the seeded paths, so renaming either one cannot leave the ordering unchecked.
+    assert command.index(container_runtime._RECEIVER_PATH) < command.index(container_runtime._DRIVER_PATH)
+    assert "STATUS=$?" in command
+    assert command.rstrip().endswith("exit $STATUS")
+
+
+def test_the_receiver_writes_where_the_sandbox_download_will_find_it() -> None:
+    # /out is what the runtime downloads; a capture written anywhere else never leaves the sandbox.
+    command = _runtime()._fabric_command()
+
+    assert container_runtime._TRACES_DIR.startswith(f"{container_runtime._OUT_DIR}/")
+    assert container_runtime._TRACES_DIR in command
+
+
+def test_a_stored_export_that_will_not_decode_costs_the_flush_not_the_trial(tmp_path: Path) -> None:
+    traces = tmp_path / "traces"
+    traces.mkdir()
+    (traces / f"000001{EXPORT_SUFFIX}").write_bytes(b"\xff\xfe not protobuf")
+    (traces / f"000002{EXPORT_SUFFIX}").write_bytes(export("survivor"))
+
+    assert fold_exports(traces) == 1
+    assert span_names(otlp_trace_path(tmp_path)) == ["survivor"]

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_fabric_container_runtime.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_fabric_container_runtime.py
@@ -15,6 +15,7 @@ import sys
 import types
 from collections.abc import Sequence
 from pathlib import Path
+from typing import Any
 
 import pytest
 from nemo_evaluator_sdk.agent_eval.runtimes.fabric import container_runtime as crt
@@ -94,7 +95,7 @@ class _FakeProvider:
         self.uploaded_dirs.append((source_dir, target_dir))
 
     async def download_dir(self, handle: SandboxHandle, source_dir: str, target_dir: Path) -> None:
-        # Materialize the /out layout `fabric run` would have produced.
+        # Materialize the /out layout the in-sandbox driver would have produced.
         out = target_dir
         (out / "workspace").mkdir(parents=True, exist_ok=True)
         (out / "logs").mkdir(parents=True, exist_ok=True)
@@ -194,24 +195,25 @@ async def test_failed_trial_stamps_agent_ok_false(tmp_path: Path) -> None:
     assert trial.metadata["agent_ok"] is False
 
 
-async def test_seeds_composed_agent_config_and_execs_cli(tmp_path: Path) -> None:
+async def test_seeds_composed_agent_config_and_execs_driver(tmp_path: Path) -> None:
     provider = _FakeProvider()
     await _run(_runtime(provider), [_task()], tmp_path)
-    assert "/in/agent.yaml" in provider.seeded and "/in/input.txt" in provider.seeded
-    # Fabric dropped profile overlays, so everything rides in the single agent config: the caller's
-    # harness plus the runtime's workspace, artifact roots, and trajectory telemetry.
+    assert "/in/agent.json" in provider.seeded and "/in/input.txt" in provider.seeded
+    # Everything rides in the single agent config: the caller's harness plus the runtime's workspace,
+    # artifact roots, and trajectory telemetry.
     assert not [key for key in provider.seeded if key.startswith("/in/profile-")]
-    agent = json.loads(provider.seeded["/in/agent.yaml"])
+    agent = json.loads(provider.seeded["/in/agent.json"])
     assert agent["harness"]["adapter_id"] == _CONFIG["harness"]["adapter_id"]  # caller keys survive
     assert agent["environment"] == {"provider": "local", "workspace": "/out/workspace", "artifacts": "/out/artifacts"}
     assert agent["runtime"]["artifacts"] == "/out/artifacts"
-    assert agent["telemetry"]["provider"] == "relay"
+    assert "relay" in agent["telemetry"]["providers"]
     # Workspace seed files were staged and uploaded across the boundary.
     assert provider.uploaded_dirs and provider.uploaded_dirs[0][1] == "/out/workspace"
-    # Execs Fabric's own CLI (not an in-image Python driver), redirecting the RunResult to /out.
+    # The driver is seeded as source and the exec runs that file: naming a path nothing seeds would
+    # leave the sandbox with no entrypoint at all.
+    assert provider.seeded[crt._DRIVER_PATH] == crt._DRIVER_SOURCE.read_text(encoding="utf-8")
     (cmd,) = provider.execs
-    assert "fabric run /in/agent.yaml" in cmd
-    assert "--profile" not in cmd and "--input-file /in/input.txt" in cmd
+    assert f"python3 {crt._DRIVER_PATH} /in/agent.json /in/input.txt" in cmd
     assert "> /out/fabric_result.json" in cmd
 
 
@@ -321,24 +323,6 @@ def test_empty_instruction_is_rejected() -> None:
         AgentEvalTask(id="x", intent="ignored", inputs={"instruction": ""}).agent_prompt()
 
 
-def test_trajectory_telemetry_built_from_relay_types() -> None:
-    # The trajectory telemetry is built from nemo_relay's own typed config (a hard dependency), so drift
-    # in relay's schema fails construction here rather than silently emitting a malformed profile. Runs
-    # in CI now that nemo-relay is declared — no importorskip. Asserts the shape metrics rely on.
-    telemetry = FabricContainerRuntime({**_CONFIG}, provider=_FakeProvider())._composed_config()["telemetry"]
-    component = telemetry["config"]["components"][0]
-    assert component["kind"] == "observability" and component["enabled"] is True
-    cfg = component["config"]
-    # The ATIF/ATOF file exporter is configured with the names both runtimes agree on. Since
-    # Since nemo-relay 0.6 the ATOF destination lives in a typed sink list rather than flat on the config.
-    assert cfg["atif"]["enabled"] is True
-    assert cfg["atif"]["filename_template"] == crt._common.ATIF_FILENAME_TEMPLATE
-    assert cfg["atof"]["enabled"] is True
-    (atof_sink,) = cfg["atof"]["sinks"]
-    assert atof_sink["type"] == "file"
-    assert atof_sink["filename"] == crt._common.ATOF_FILENAME
-
-
 # --------------------------------------------------------------------------------------------------
 # Agent-skill injection (containerized) — mirrors the host-runtime skill tests in test_fabric_runtime.py.
 # --------------------------------------------------------------------------------------------------
@@ -355,43 +339,6 @@ def _harness_name(adapter_id: str) -> str:
     return next((harness for harness in _KNOWN_HARNESSES if harness in adapter_id), "custom")
 
 
-class _FakeHarness:
-    def __init__(self, adapter_id: str) -> None:
-        self.adapter_id = adapter_id
-
-
-class _FakeConfig:
-    """Minimal stand-in for nemo_fabric.FabricConfig — only what ``_resolve_skill_mode`` touches."""
-
-    def __init__(self, mapping: dict[str, object]) -> None:
-        self.mapping = mapping
-        harness = mapping.get("harness", {})
-        self.harness = _FakeHarness(harness.get("adapter_id", "") if isinstance(harness, dict) else "")
-        self.skill_paths: list[str] = []
-
-    @classmethod
-    def from_mapping(cls, mapping: dict[str, object]) -> _FakeConfig:
-        return cls(mapping)
-
-    def model_copy(self, *, deep: bool = False) -> _FakeConfig:
-        clone = _FakeConfig(self.mapping)
-        clone.skill_paths = list(self.skill_paths)
-        return clone
-
-    def add_skill_path(self, path: object) -> None:
-        self.skill_paths.append(str(path))
-
-
-class _FakeProfile:
-    def __init__(self, mapping: dict[str, object]) -> None:
-        self.mapping = mapping
-        self.name = mapping.get("name")
-
-    @classmethod
-    def from_mapping(cls, mapping: dict[str, object]) -> _FakeProfile:
-        return cls(mapping)
-
-
 class _FakeAdapterInfo:
     def __init__(self, harness: str) -> None:
         self.harness = harness
@@ -404,25 +351,30 @@ class _FakePlan:
 
 
 class _FakeFabric:
-    planned: list[dict[str, object]] = []
+    planned: list[dict[str, Any]] = []
 
-    def plan(self, agent: object, *, base_dir: object = None) -> _FakePlan:
+    def plan(self, agent: Any, *, base_dir: object = None) -> _FakePlan:
         # Mirror Fabric's planner: a ``skills`` route appears only when a skill path is attached, and it
         # routes ``harness_native`` iff the selected adapter accepts native skills.
         _FakeFabric.planned.append({"agent": agent})
         adapter_id = agent.harness.adapter_id
-        has_skill_path = bool(getattr(agent, "skill_paths", None))
+        has_skill_path = bool(agent.skills is not None and agent.skills.paths)
         native = has_skill_path and adapter_id in _NATIVE_SKILL_ADAPTERS
         routes = [{"kind": "skills", "target": "harness_native" if native else "unsupported"}] if has_skill_path else []
         return _FakePlan(capability_plan={"routes": routes}, harness=_harness_name(adapter_id))
 
 
 def _install_fake_fabric(monkeypatch: pytest.MonkeyPatch) -> type[_FakeFabric]:
-    """Inject a fake ``nemo_fabric`` module (the runtime imports it lazily only to plan skills routing)."""
+    """Inject a ``nemo_fabric`` module whose planner is fake, so skills routing is ours to decide."""
     _FakeFabric.planned = []
+    import nemo_fabric  # ty: ignore[unresolved-import]
+
+    # Only the planner is faked; every other symbol stays the installed one. The runtime also builds
+    # its config and telemetry out of this module, and a stand-in for those would happily accept a
+    # config Fabric itself rejects — which is the drift these tests exist to notice.
     module = types.ModuleType("nemo_fabric")
+    module.__dict__.update(nemo_fabric.__dict__)
     module.Fabric = _FakeFabric  # type: ignore[attr-defined]
-    module.FabricConfig = _FakeConfig  # type: ignore[attr-defined]
     monkeypatch.setitem(sys.modules, "nemo_fabric", module)
     return _FakeFabric
 
@@ -441,7 +393,7 @@ def _skill_bundle(base: Path, *, name: str = "code-review", extra: dict[str, str
 
 def _seeded_skill_paths(provider: _FakeProvider) -> list[str]:
     """``skills.paths`` on the composed agent config the runtime seeded into /in."""
-    agent = json.loads(provider.seeded["/in/agent.yaml"])
+    agent = json.loads(provider.seeded["/in/agent.json"])
     return list(agent.get("skills", {}).get("paths", []))
 
 
@@ -457,7 +409,7 @@ async def test_native_skill_seeds_bundle_into_seed_set_and_config(
 
     assert trial.status == AgentEvalTrialStatus.COMPLETED
     # The mode is resolved by probing Fabric's capability planner (with a probe skill path attached).
-    assert fabric.planned and fabric.planned[0]["agent"].skill_paths
+    assert fabric.planned and fabric.planned[0]["agent"].skills.paths
     # The bundle is rendered INTO the sandbox seed set at the native in-/in discovery path (not /out, so it
     # never lands in the downloaded workspace evidence).
     assert provider.seeded["/in/skills/code-review/SKILL.md"].startswith("---")

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_fabric_image.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_fabric_image.py
@@ -24,7 +24,7 @@ class _DockerRecorder:
         self.calls: list[list[str]] = []
         self._image_present = image_present
 
-        self.build_context: dict[str, bool] = {}
+        self.build_context: dict[str, str] = {}
 
     def __call__(self, argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[bytes]:
         self.calls.append(argv)
@@ -32,27 +32,13 @@ class _DockerRecorder:
             code = 0 if self._image_present else 1
         else:  # docker build <ctx> — snapshot the staged context before it is torn down.
             ctx = Path(argv[-1])
-            self.build_context = {
-                "Dockerfile": (ctx / "Dockerfile").is_file(),
-                "nemo-fabric": (ctx / "nemo-fabric").is_dir(),
-            }
+            self.build_context = {path.name: path.read_text(encoding="utf-8") for path in ctx.iterdir()}
             code = 0
         return subprocess.CompletedProcess(argv, code, b"", b"")
 
     @property
     def build_calls(self) -> list[list[str]]:
         return [c for c in self.calls if c[1] == "build"]
-
-
-def _fabric_repo(tmp_path: Path) -> Path:
-    """A stub checkout with every build input _stage_source requires."""
-    repo = tmp_path / "NeMo-Fabric"
-    (repo / "crates").mkdir(parents=True)
-    (repo / "python").mkdir(parents=True)
-    (repo / "pyproject.toml").write_text("[project]\nname='nemo-fabric'\n", encoding="utf-8")
-    for name in ("Cargo.toml", "Cargo.lock", "README.md"):
-        (repo / name).write_text("x", encoding="utf-8")
-    return repo
 
 
 def test_tag_is_content_addressed_and_harness_agnostic() -> None:
@@ -62,31 +48,48 @@ def test_tag_is_content_addressed_and_harness_agnostic() -> None:
     assert fabric_image_tag() == tag  # deterministic
 
 
-def test_ensure_skips_build_when_image_present(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_ensure_skips_build_when_image_present(monkeypatch: pytest.MonkeyPatch) -> None:
     recorder = _DockerRecorder(image_present=True)
     monkeypatch.setattr(image_mod.subprocess, "run", recorder)
-    tag = ensure_fabric_image(fabric_repo=_fabric_repo(tmp_path))
+    tag = ensure_fabric_image()
     assert tag == fabric_image_tag()
     assert recorder.build_calls == []  # inspected, found, no build
 
 
-def test_ensure_builds_when_image_absent(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_ensure_builds_when_image_absent(monkeypatch: pytest.MonkeyPatch) -> None:
     recorder = _DockerRecorder(image_present=False)
     monkeypatch.setattr(image_mod.subprocess, "run", recorder)
-    tag = ensure_fabric_image(fabric_repo=_fabric_repo(tmp_path))
+    tag = ensure_fabric_image()
     (build,) = recorder.build_calls
-    assert build[:2] == ["docker", "build"]
-    assert ["--build-arg", "EXTRAS=hermes,relay"] == build[2:4]  # baked harness runtime deps
-    assert build[4:6] == ["-t", tag]
-    # The staged context had the Dockerfile + the copied fabric source.
-    assert recorder.build_context == {"Dockerfile": True, "nemo-fabric": True}
+    assert build[:4] == ["docker", "build", "-t", tag]
+    assert sorted(recorder.build_context) == ["Dockerfile", "requirements.txt"]
 
 
-def test_ensure_errors_when_fabric_source_missing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_image_pins_every_requirement_to_the_installed_fabric(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The sandbox installs the same Fabric the host composes its config against.
+
+    A sandbox on a different Fabric reads a config the host wrote to another schema, and Fabric drops
+    telemetry keys it does not recognize rather than rejecting them — so the drift shows up as a trial
+    with no trajectory rather than as an error.
+    """
     recorder = _DockerRecorder(image_present=False)
     monkeypatch.setattr(image_mod.subprocess, "run", recorder)
-    with pytest.raises(FabricImageError, match="NeMo-Fabric source not found"):
-        ensure_fabric_image(fabric_repo=tmp_path / "does-not-exist")
+    ensure_fabric_image()
+
+    version = image_mod.fabric_version()
+    requirements = recorder.build_context["requirements.txt"].split()
+    fabric_pins = [line for line in requirements if line.startswith("nemo-fabric")]
+    assert any(line.startswith("nemo-fabric[") for line in fabric_pins), requirements
+    assert all(line.endswith(f"=={version}") for line in fabric_pins), fabric_pins
+    # Everything else is pinned too, just not to Fabric's version — an unpinned harness would make
+    # the content-addressed tag name an image whose contents move underneath it.
+    assert all("==" in line or "~=" in line for line in requirements), requirements
+
+
+def test_tag_changes_with_the_fabric_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A Fabric bump must not reuse the cached image built against the previous one."""
+    monkeypatch.setattr(image_mod, "fabric_version", lambda: "9.9.9")
+    assert fabric_image_tag() != fabric_image_tag(version="0.0.1")
 
 
 def test_image_exists_raises_when_daemon_unreachable(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_fabric_surface.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_fabric_surface.py
@@ -31,14 +31,20 @@ local ``uv sync --extra fabric`` (Fabric publishes a macOS arm64 wheel as of 0.1
 from __future__ import annotations
 
 import importlib.util
+import inspect
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 pytest.importorskip("nemo_fabric")
 
+from nemo_evaluator_sdk.agent_eval.runtimes.fabric import _common
+from nemo_evaluator_sdk.agent_eval.runtimes.fabric import container_runtime as crt
 from nemo_evaluator_sdk.agent_eval.runtimes.fabric import runtime as fabric_runtime
+from nemo_evaluator_sdk.agent_eval.runtimes.fabric.container_runtime import FabricContainerRuntime
 from nemo_evaluator_sdk.agent_eval.runtimes.fabric.runtime import FabricAgentRuntime
+from nemo_evaluator_sdk.agent_eval.runtimes.sandbox.providers.docker import DockerSandboxProvider
 from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalTask
 
 # The ``fabric`` extra installs claude/codex/deepagents/hermes. Codex and hermes are both covered
@@ -126,13 +132,13 @@ def test_compose_config_enables_relay_via_current_signature(tmp_path: Path) -> N
     atif = observability.atif
     assert atif is not None and atif.enabled is True
     assert str(atif.output_directory) == relay_dir
-    assert atif.filename_template == fabric_runtime._ATIF_FILENAME_TEMPLATE
+    assert atif.filename_template == _common.ATIF_FILENAME_TEMPLATE
 
     atof = observability.atof
     assert atof is not None and atof.enabled is True
     (atof_sink,) = atof.sinks or []
     assert str(atof_sink.output_directory) == relay_dir
-    assert atof_sink.filename == fabric_runtime._ATOF_FILENAME
+    assert atof_sink.filename == _common.ATOF_FILENAME
 
 
 @requires_harness_adapters
@@ -232,3 +238,154 @@ def test_codex_also_routes_skills_natively_so_the_workspace_branch_is_a_fallback
         resolve_skill_mode(capability_plan=plan.capability_plan, adapter_id=plan.adapter.adapter_id)
         == SKILL_MODE_NATIVE
     )
+
+
+# --------------------------------------------------------------------------------------------------
+# FabricContainerRuntime. The host runtime composes a typed ``FabricConfig`` and so is checked by
+# Fabric's own validator on every call; the container runtime marshals a plain mapping across the
+# sandbox boundary, where nothing validates it. These bind that mapping, and the in-sandbox
+# entrypoint it names, back to the installed Fabric.
+# --------------------------------------------------------------------------------------------------
+
+_CONTAINER_CONFIG = {
+    "metadata": {"name": "fabric-surface-container"},
+    "harness": {"adapter_id": _HERMES_ADAPTER_ID, "resolution": "preinstalled"},
+    "runtime": {"input_schema": "chat", "output_schema": "message"},
+}
+
+
+def _composed_container_config() -> Any:
+    from nemo_fabric import FabricConfig  # ty: ignore[unresolved-import]
+
+    # A real provider, never used: composing the config touches no sandbox.
+    runtime = FabricContainerRuntime(_CONTAINER_CONFIG, provider=DockerSandboxProvider(), image="unused")
+    return FabricConfig.from_mapping(runtime._composed_config())
+
+
+def test_container_composed_config_enables_relay_for_installed_fabric() -> None:
+    """The composed mapping actually switches Relay on, by installed Fabric's own reading of it.
+
+    Fabric ignores telemetry keys it does not recognize rather than rejecting them, so a stale
+    envelope yields a container trial that runs to success and captures no trajectory at all — no
+    ATIF, no ATOF, and no error. Asserting through ``FabricConfig.from_mapping`` is what makes the
+    envelope Fabric's to define instead of ours to guess.
+    """
+    composed = _composed_container_config()
+
+    assert composed.telemetry is not None
+    assert "relay" in composed.telemetry.providers
+    assert composed.relay is not None and str(composed.relay.output_dir) == crt._RELAY_DIR
+
+    # As on the host: the exporters must land on the declared fields, not in Fabric's extras bag.
+    observability = composed.relay.observability
+    assert observability is not None
+    atif = observability.atif
+    assert atif is not None and atif.enabled is True
+    assert str(atif.output_directory) == crt._RELAY_DIR
+    assert atif.filename_template == _common.ATIF_FILENAME_TEMPLATE
+    atof = observability.atof
+    assert atof is not None and atof.enabled is True
+    (atof_sink,) = atof.sinks or []
+    assert str(atof_sink.output_directory) == crt._RELAY_DIR
+    assert atof_sink.filename == _common.ATOF_FILENAME
+
+
+def test_container_composed_config_keeps_caller_and_runtime_keys() -> None:
+    """Enabling Relay does not cost the caller's harness or the runtime's own /out wiring.
+
+    The telemetry keys are merged onto the composed mapping rather than replacing it, and both sets
+    have to survive: a container trial whose workspace is unset writes outside the retrievable tree.
+    """
+    composed = _composed_container_config()
+
+    assert composed.harness is not None and composed.harness.adapter_id == _HERMES_ADAPTER_ID
+    assert composed.environment is not None
+    assert str(composed.environment.workspace) == crt._WORKSPACE_DIR
+    assert str(composed.runtime.artifacts) == crt._ARTIFACTS_DIR
+
+
+def test_sandbox_driver_calls_an_api_installed_fabric_still_has() -> None:
+    """The seeded driver's Fabric calls exist, are async, and take the arguments it passes.
+
+    The driver is transported as source and only ever executed inside the sandbox, so nothing else
+    imports it and no other test would notice Fabric retiring what it calls. Fabric has already done
+    this once — ``FabricClient`` became ``Fabric`` and ``run`` became a coroutine — and the symptom is
+    a container trial that fails on a traceback from a file the host wrote.
+    """
+    # Importing the driver is itself the check: its module-level ``from nemo_fabric import Fabric,
+    # FabricConfig`` is the line a rename retires, and nothing else imports this module.
+    from nemo_evaluator_sdk.agent_eval.runtimes.fabric import sandbox_driver
+    from nemo_fabric import Fabric, RunResult  # ty: ignore[unresolved-import]
+
+    assert callable(sandbox_driver.main)
+    assert inspect.iscoroutinefunction(Fabric.run)
+    assert {"config", "input", "base_dir"} <= set(inspect.signature(Fabric.run).parameters)
+    assert callable(RunResult.to_mapping)
+
+
+def test_sandbox_dockerfile_smoke_check_imports_resolve() -> None:
+    """The image's build-time import check names symbols the pinned Fabric still exports.
+
+    It is the image build's only guard that the wheels are usable, and it runs where nobody sees it
+    until a trial fails; ``from nemo_fabric import FabricClient`` outlived that class by two releases.
+    """
+    dockerfile = Path(crt.__file__).with_name("sandbox.Dockerfile").read_text(encoding="utf-8")
+    (check,) = [
+        line.split('python -c "', 1)[1].rsplit('"', 1)[0]
+        for line in dockerfile.splitlines()
+        if line.startswith("RUN python -c ")
+    ]
+    exec(compile(check, "<sandbox.Dockerfile>", "exec"), {})  # noqa: S102 - the recipe is repo source
+
+
+def test_otlp_endpoint_lands_on_relays_declared_opentelemetry_field() -> None:
+    """A configured OTLP endpoint reaches Fabric's declared field, not its extras bag.
+
+    Both runtimes route their receiver's endpoint through ``relay_observability``. Fabric's relay
+    models allow extras, so a stale field name is accepted in silence and simply never exported —
+    and because the whole block is optional, dropping it entirely also leaves a trial that runs to
+    success with an ATIF trajectory and no OTLP at all.
+    """
+    from nemo_fabric import RelayOpenTelemetryConfig  # ty: ignore[unresolved-import]
+
+    observability = _common.relay_observability(
+        relay_dir="/out/relay",
+        agent_name="fabric_container",
+        agent_version=_common.FABRIC_AGENT_VERSION,
+        otlp_endpoint="http://127.0.0.1:4318/v1/traces",
+    )
+
+    opentelemetry = observability.opentelemetry
+    assert isinstance(opentelemetry, RelayOpenTelemetryConfig)
+    assert opentelemetry.enabled is True
+    (endpoint,) = opentelemetry.endpoints or []
+    assert str(endpoint.endpoint) == "http://127.0.0.1:4318/v1/traces"
+    assert endpoint.service_name == "fabric_container"
+
+    # Omitting it must leave the field unset rather than half-configured: Relay treats a disabled
+    # section and an absent one alike, but a populated-but-endpointless one fails at export.
+    assert (
+        _common.relay_observability(
+            relay_dir="/out/relay", agent_name="fabric_container", agent_version=_common.FABRIC_AGENT_VERSION
+        ).opentelemetry
+        is None
+    )
+
+
+def test_otlp_endpoint_survives_the_serialized_telemetry_fragment() -> None:
+    """The endpoint reaches the mapping that crosses the sandbox boundary, not just the typed model.
+
+    ``relay_telemetry_fragment`` is where a container runner's endpoint is handed to Fabric, and it
+    accepts ``otlp_endpoint`` as a keyword — so failing to forward it is invisible at the call site
+    and costs the container trial its whole OTLP trace while leaving ATIF intact.
+    """
+    fragment = _common.relay_telemetry_fragment(
+        _CONTAINER_CONFIG,
+        relay_dir="/out/relay",
+        agent_name="fabric_container",
+        agent_version=_common.FABRIC_AGENT_VERSION,
+        otlp_endpoint="http://127.0.0.1:4318/v1/traces",
+    )
+
+    (endpoint,) = fragment["relay"]["observability"]["opentelemetry"]["endpoints"]
+    assert endpoint["endpoint"] == "http://127.0.0.1:4318/v1/traces"


### PR DESCRIPTION
Continues [AALGO-601](https://linear.app/nvidia/issue/AALGO-601/decide-how-fabric-emits-otlp-relays-exporter-is-endpoint-only-so-there). Stacked on #1910 ← #1932 — **review those first**; this is the container half #1910 deferred.

**#1932 is a hard prerequisite, not just a base.** `FabricContainerRuntime` has been unrunnable since Fabric 0.2, and its telemetry block is one Fabric 0.3 ignores — so on today's `main` this PR configures an OTLP endpoint that never reaches Relay, and the container captures nothing. #1932 fixes that; the endpoint now rides `_common.relay_telemetry_fragment`, which both runtimes share.

## Summary

`FabricContainerRuntime` had no OTLP trace. #1910 solved the local runner and left the container case out: a container cannot reach host loopback, so it looked like it needed a routable address plus a per-provider egress rule.

It doesn't. The sandbox already downloads `/out` to the host when a task ends, so the receiver runs **inside** the sandbox and writes there. Relay talks to the loopback it already has, and the capture comes home on the path the rest of the evidence already takes — no address to resolve, no policy to open, nothing provider-specific.

Before: a container trial's `trace` evidence was always ATIF. After: it is the OTLP capture when one was recorded, with ATIF at `trace:atif`.

## Changes

- **`container_runtime.py`** — seeds `otlp_receiver.py` into the sandbox, starts it, waits for the ready file it writes once bound, runs Fabric, stops it while preserving Fabric's exit status; folds the downloaded exports and registers the result.
- **`_common.trajectory_telemetry`** — takes an optional `otlp_endpoint`, built from the endpoint settings #1910 shares.

**No new receiver.** It runs the same `otlp_receiver` #1910 added, seeded as source and run by `python3` in the image (`python:3.12-slim-bookworm`). That is what the receiver's standard-library-only rule exists for. Folding, evidence registration and the Relay endpoint settings are all the shared ones, so the two runtimes cannot drift on what a trace is or which view is primary — a test asserts the seeded file is byte-identical to the module, and parses its imports to prove they are all stdlib.

## Design notes

**Verbatim in, decoded on the host.** The receiver cannot depend on protobuf being in the sandbox image, so it stores raw bodies and the host folds them after download.

**A receiver that never starts is reported.** No `python3`, or port 4318 already bound, and it dies before signalling ready. Fabric still runs and the trial still gets ATIF — losing a trace must not lose a trial — but it logs rather than degrading silently. (Found by review.)

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: #1910 already documents that Fabric registers both trace views and that OTLP is primary when recorded; that text covers both runtimes and needs no change.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `uv run pre-commit run -a` — **0 failures**
- `uv run --frozen pytest packages/nemo_evaluator_sdk plugins/nemo-evaluator` — **2855 passed, 38 skipped**
- `uv run --frozen pytest ... -k fabric` — **152 passed**
- `ty` clean on every changed file
- Five mutations against these tests, all caught: receiver writing outside `/out`, Fabric's exit status dropped, the ready-wait removed, a non-stdlib import added to the receiver, and the seeded file not being the shared module.

## Live verification

A containerised trial now captures OTLP end to end, on the stock image `ensure_fabric_image` builds, hermes harness, `nvidia/nemotron-3.5-lightning-30b-a3b`:

```
status: completed
output_text: Hello! The sum of 2 and 2 is 4.
evidence: ['logs', 'result', 'trace', 'trace:atif', 'trace:otlp', 'workspace']
primary trace format: otlp        atif reachable: True
traces/relay.jsonl — 105170 bytes, 2 spans

  root hermes-session-runtime-1789054115394-45-2   36100.76ms
       nvidia                                      36080.22ms

raw .pb left: []     partial left: []
```

That exercises the whole path this PR owns: the receiver starting inside the sandbox and signalling ready, the wait loop honouring it, `/out/traces` riding home with the rest of the evidence, `fold_exports` producing `relay.jsonl` and deleting the raw exports, and the primary trace descriptor flipping to OTLP with ATIF still reachable.

Not verified: Kubernetes/agent-sandbox providers — only Docker was exercised.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Fabric evaluations now collect and register OTLP telemetry and ATIF evidence from sandboxed executions.
  - Evaluation traces are consistently placed in the expected output location for retrieval.

- **Bug Fixes**
  - Improved handling of telemetry exports, including valid exports when others cannot be decoded.
  - Evaluation results now preserve the driver’s exit status and provide clearer failure reporting.
  - Invalid telemetry request sizes are rejected with an appropriate client error.
  - Telemetry request paths are matched more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
