### PR TITLE
feat(studio): default anonymizer feature flag to true

### DIFF
--- a/services/studio/src/nmp/studio/env_mappings.py
+++ b/services/studio/src/nmp/studio/env_mappings.py
@@ -67,7 +67,7 @@ ENV_MAPPINGS: list[EnvMapping] = [
     EnvMapping(
         marker="STUDIO_UI_VITE_FF_ANONYMIZER_ENABLED",
         config_path="studio.feature_flags.anonymizer_enabled",
-        default="false",
+        default="true",
     ),
     EnvMapping(
         marker="STUDIO_UI_VITE_FF_BASE_MODELS_ENABLED",

--- a/web/packages/studio/env/.env.dev.local.sample
+++ b/web/packages/studio/env/.env.dev.local.sample
@@ -22,7 +22,7 @@ VITE_AUTH_SCOPE_PREFIX="api://<your-client-id>"
 # See src/constants/featureFlags.ts for available flags and documentation.
 VITE_FF_AGENT_OVERVIEW_ENABLED='false'
 VITE_FF_AGENTS_ENABLED='true'
-VITE_FF_ANONYMIZER_ENABLED='false'
+VITE_FF_ANONYMIZER_ENABLED='true'
 VITE_FF_BASE_MODELS_ENABLED='true'
 VITE_FF_ASSISTANT_STUDIO_ENABLED=false
 VITE_FF_COPILOT_STUDIO_ENABLED=false

--- a/web/packages/studio/src/constants/featureFlags/featureFlags.ts
+++ b/web/packages/studio/src/constants/featureFlags/featureFlags.ts
@@ -56,7 +56,7 @@ import { z } from 'zod';
 export const flagDefinitions = {
   agentOverviewEnabled: booleanFlag('VITE_FF_AGENT_OVERVIEW_ENABLED', false),
   agentsEnabled: previewFlag('VITE_FF_AGENTS_ENABLED', true),
-  anonymizerEnabled: booleanFlag('VITE_FF_ANONYMIZER_ENABLED', false),
+  anonymizerEnabled: booleanFlag('VITE_FF_ANONYMIZER_ENABLED', true),
   baseModelsEnabled: previewFlag('VITE_FF_BASE_MODELS_ENABLED', true),
   assistantStudioEnabled: previewFlag('VITE_FF_ASSISTANT_STUDIO_ENABLED', false),
   copilotStudioEnabled: previewFlag('VITE_FF_COPILOT_STUDIO_ENABLED', false),


### PR DESCRIPTION
## Summary
Flips the `VITE_FF_ANONYMIZER_ENABLED` default from `false` to `true` so the anonymizer surfaces without an explicit override.

## Changes
- `featureFlags.ts`: code default flipped to `true`
- `env_mappings.py`: FastAPI/deployment default flipped to `true`
- `.env.dev.local.sample`: dev sample default flipped to `true`

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Quality Gates

- [x] Tests not applicable — justification: config default flip only, no behavior branching to test
- [x] Documentation not applicable — justification: internal feature flag default, no user-facing docs

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- Pre-commit hooks ran on commit (ruff, ty, UI typecheck) — all passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled the anonymizer by default in Studio.
  - Updated development environment defaults to reflect the anonymizer being enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->