### PR TITLE
refactor(sdk): route platform clients through owned endpoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -417,11 +417,11 @@ PYTEST_CI_OPTS := --cov=src --cov=packages \
 	--cov-report xml:coverage.xml \
 	--durations=25
 
-# Global wall-clock timeout for CI test runs to prevent infinite hangs when
-# a pytest-xdist worker crashes (e.g. SIGABRT from wasmtime) and doesn't exit.
-# timeout sends SIGTERM after PYTEST_CI_TIMEOUT seconds, then SIGKILL after 60s.
+# CI-only wall-clock timeout. Send SIGINT first so pytest can flush junit,
+# coverage, and crash artifacts; if cleanup hangs, SIGKILL follows later.
 PYTEST_CI_TIMEOUT ?= 1800
-PYTEST_CI_CMD = timeout --kill-after=60s $(PYTEST_CI_TIMEOUT)s $(PYTEST_CMD)
+PYTEST_CI_KILL_AFTER ?= 600
+PYTEST_CI_CMD = timeout --signal=INT --kill-after=$(PYTEST_CI_KILL_AFTER)s $(PYTEST_CI_TIMEOUT)s $(PYTEST_CMD)
 
 # Unit/default runs keep ``loadscope`` so tests from the same module/class stay
 # on one worker and reuse normal pytest fixtures efficiently. The integration

--- a/packages/data_designer_nemo/src/data_designer_nemo/context.py
+++ b/packages/data_designer_nemo/src/data_designer_nemo/context.py
@@ -22,24 +22,25 @@ from data_designer_nemo.model_provider import (
 )
 from data_designer_nemo.person_reader import FilesetsPersonReader
 from data_designer_nemo.person_sampling import ensure_nemotron_personas_filesets
-from data_designer_nemo.sdk_translation import sync_to_async_sdk
 from data_designer_nemo.secret_resolver import NMPSecretResolver
 from data_designer_nemo.seed import validate_seed
 from data_designer_nemo.tool_configs import validate_no_tool_configs
 from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
 
 
-class DataDesignerContext:
-    def __init__(self, sdk: AsyncNeMoPlatform | NeMoPlatform, workspace: str):
-        self._sdk = sdk
+class DataDesignerValidationContext:
+    """Async-only context for remote config validation and provider resolution."""
+
+    def __init__(self, async_sdk: AsyncNeMoPlatform, workspace: str) -> None:
+        self._async_sdk = async_sdk
         self._workspace = workspace
         self._validated_filesystem_roots: set[str] = set()
 
-    def get_secret_resolver(self) -> SecretResolver:
-        return NMPSecretResolver(self._sdk, self._workspace)
+    @property
+    def validated_filesystem_roots(self) -> set[str]:
+        return set(self._validated_filesystem_roots)
 
     async def validate(self, config: dd.DataDesignerConfig) -> list[NDDError]:
-        async_sdk = self._async_sdk()
         errors: list[NDDError] = []
 
         try:
@@ -53,17 +54,47 @@ class DataDesignerContext:
             errors.append(e)
 
         try:
-            if validated_root := await validate_seed(config, self._workspace, async_sdk):
+            if validated_root := await validate_seed(config, self._workspace, self._async_sdk):
                 self._validated_filesystem_roots.add(validated_root)
         except NDDError as e:
             errors.append(e)
 
         try:
-            await ensure_nemotron_personas_filesets(config, async_sdk)
+            await ensure_nemotron_personas_filesets(config, self._async_sdk)
         except NDDError as e:
             errors.append(e)
 
         return errors
+
+    async def get_model_providers(self, model_configs: list[dd.ModelConfig]) -> list[dd.ModelProvider]:
+        if (
+            igw_registry := await make_model_provider_registry(
+                model_configs,
+                sdk=self._async_sdk,
+                default_workspace=self._workspace,
+            )
+        ) is not None:
+            return igw_registry.providers
+
+        return [make_noop_provider()]
+
+
+class DataDesignerExecutionContext:
+    """Sync-only context for the upstream Data Designer engine."""
+
+    def __init__(
+        self,
+        sdk: NeMoPlatform,
+        workspace: str,
+        *,
+        validated_roots: set[str] | None = None,
+    ) -> None:
+        self._sdk = sdk
+        self._workspace = workspace
+        self._validated_filesystem_roots = set(validated_roots or ())
+
+    def get_secret_resolver(self) -> SecretResolver:
+        return NMPSecretResolver(self._sdk, self._workspace)
 
     def get_seed_readers(self) -> list[SeedReader]:
         provider = FilesetFileSystemProvider(
@@ -81,25 +112,15 @@ class DataDesignerContext:
     def get_person_reader(self) -> PersonReader | None:
         return FilesetsPersonReader(self._sdk)
 
-    async def get_model_providers(self, model_configs: list[dd.ModelConfig]) -> list[dd.ModelProvider]:
-        sdk = self._async_sdk()
 
-        if (
-            igw_registry := await make_model_provider_registry(
-                model_configs,
-                sdk=sdk,
-                default_workspace=self._workspace,
-            )
-        ) is not None:
-            return igw_registry.providers
-
-        return [make_noop_provider()]
-
-    def _async_sdk(self) -> AsyncNeMoPlatform:
-        if isinstance(self._sdk, NeMoPlatform):
-            return sync_to_async_sdk(self._sdk)
-        return self._sdk
+def create_validation_context(async_sdk: AsyncNeMoPlatform, workspace: str) -> DataDesignerValidationContext:
+    return DataDesignerValidationContext(async_sdk, workspace)
 
 
-def create_data_designer_context(sdk: AsyncNeMoPlatform | NeMoPlatform, workspace: str) -> DataDesignerContext:
-    return DataDesignerContext(sdk, workspace)
+def create_execution_context(
+    sdk: NeMoPlatform,
+    workspace: str,
+    *,
+    validated_roots: set[str] | None = None,
+) -> DataDesignerExecutionContext:
+    return DataDesignerExecutionContext(sdk, workspace, validated_roots=validated_roots)

--- a/packages/data_designer_nemo/src/data_designer_nemo/fileset_file_seed_reader.py
+++ b/packages/data_designer_nemo/src/data_designer_nemo/fileset_file_seed_reader.py
@@ -7,7 +7,7 @@ import duckdb
 from data_designer.engine.resources.seed_reader import SeedReader
 from data_designer_nemo.fileset_file_seed_source import FilesetFileSeedSource
 from data_designer_nemo.filesystem import make_filesystem
-from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
+from nemo_platform import NeMoPlatform
 
 workspace_cvar = ContextVar[str | None]("workspace_cvar", default=None)
 
@@ -16,7 +16,7 @@ class FilesetFileSeedReader(SeedReader[FilesetFileSeedSource]):
     # The Data Designer library discovers seed-reader plugins by instantiating them with no args.
     # Within this plugin we always inject an SDK and pass a collection of readers that replaces
     # any library-produced default collection of readers.
-    def __init__(self, sdk: NeMoPlatform | AsyncNeMoPlatform | None = None):
+    def __init__(self, sdk: NeMoPlatform | None = None) -> None:
         self._sdk = sdk
 
     def create_duckdb_connection(self) -> duckdb.DuckDBPyConnection:

--- a/packages/data_designer_nemo/src/data_designer_nemo/fileset_filesystem_provider.py
+++ b/packages/data_designer_nemo/src/data_designer_nemo/fileset_filesystem_provider.py
@@ -13,8 +13,7 @@ from data_designer.engine.resources.seed_reader import (
 from data_designer_nemo.filesystem import make_filesystem
 from filesets import FilesetFileSystem, FilesetPathError, build_fileset_ref, parse_fileset_ref
 from fsspec.implementations.dirfs import DirFileSystem
-from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
-from nemo_platform_plugin.files.client import AsyncFilesClient, FilesClient
+from nemo_platform import NeMoPlatform
 
 
 class _FilesetDirFileSystem(DirFileSystem):
@@ -67,17 +66,15 @@ class FilesetFileSystemProvider:
 
     def __init__(
         self,
-        sdk: NeMoPlatform | AsyncNeMoPlatform,
+        sdk: NeMoPlatform,
         *,
         workspace: str,
         validated_roots: set[str] | None = None,
     ) -> None:
         self._sdk = sdk
         self._filesystem: FilesetFileSystem | None = None
-        self._files_client: FilesClient | None = None
-        self._async_files_client: AsyncFilesClient | None = None
         self._workspace = workspace
-        self._validated_roots = validated_roots or set()
+        self._validated_roots = set(validated_roots or ())
 
     def create_context(self, *, runtime_path: str) -> SeedReaderFileSystemContext:
         workspace, fileset, fragment = self._parse(runtime_path)

--- a/packages/data_designer_nemo/src/data_designer_nemo/filesystem.py
+++ b/packages/data_designer_nemo/src/data_designer_nemo/filesystem.py
@@ -1,22 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from data_designer_nemo.sdk_translation import async_to_sync_sdk
 from filesets import FilesetFileSystem
-from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
+from nemo_platform import NeMoPlatform
 from nemo_platform_plugin.client.adapter import client_from_platform
 from nemo_platform_plugin.files.client import FilesClient
 
 
-def make_filesystem(sdk: NeMoPlatform | AsyncNeMoPlatform) -> FilesetFileSystem:
-    # We MUST pass a sync FilesClient here: it forces fsspec into synchronous mode
-    # (necessary because the upstream DD library calls sync fsspec APIs) AND it
-    # avoids fsspec trying to reuse an AsyncNeMoPlatform on a different event loop
-    return FilesetFileSystem(client=_get_files_client(sdk))
-
-
-def _get_files_client(sdk: NeMoPlatform | AsyncNeMoPlatform) -> FilesClient:
-    if isinstance(sdk, NeMoPlatform):
-        return client_from_platform(sdk, FilesClient)
-
-    return client_from_platform(async_to_sync_sdk(sdk), FilesClient)
+def make_filesystem(sdk: NeMoPlatform) -> FilesetFileSystem:
+    return FilesetFileSystem(client=client_from_platform(sdk, FilesClient))

--- a/packages/data_designer_nemo/src/data_designer_nemo/model_provider.py
+++ b/packages/data_designer_nemo/src/data_designer_nemo/model_provider.py
@@ -9,7 +9,6 @@ from data_designer.config.default_model_settings import get_default_providers
 from data_designer.engine.model_provider import ModelProvider as NDDModelProvider
 from data_designer.engine.model_provider import ModelProviderRegistry, resolve_model_provider_registry
 from data_designer_nemo.errors import NDDInternalError, NDDInvalidConfigError
-from data_designer_nemo.sdk_translation import sync_to_async_sdk
 from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
 from nemo_platform_plugin.client.adapter import client_from_platform
 from nemo_platform_plugin.client.errors import NemoTransportError, NotFoundError, PermissionDeniedError
@@ -58,26 +57,6 @@ def _make_local_model_provider_registry() -> ModelProviderRegistry | None:
     providers = get_default_providers()
     if len(providers) > 0:
         return resolve_model_provider_registry(providers)
-
-
-async def _get_igw_model_provider_registry(
-    sdk: AsyncNeMoPlatform | NeMoPlatform,
-    model_configs: list[dd.ModelConfig],
-    default_workspace: str,
-) -> ModelProviderRegistry | None:
-    if isinstance(sdk, NeMoPlatform):
-        async_sdk = sync_to_async_sdk(sdk)
-    else:
-        async_sdk = sdk
-
-    try:
-        return await make_model_provider_registry(model_configs, sdk=async_sdk, default_workspace=default_workspace)
-    except (NDDInvalidConfigError, NDDInternalError) as e:
-        raise type(e)(
-            "Error(s) occurred while checking Inference Gateway for model providers. "
-            "Ensure all referenced providers are either defined in the local config file "
-            f"or are registered with the Models and Inference Gateway services. \n{e}"
-        ) from e
 
 
 @dataclass

--- a/packages/data_designer_nemo/src/data_designer_nemo/person_reader.py
+++ b/packages/data_designer_nemo/src/data_designer_nemo/person_reader.py
@@ -7,22 +7,17 @@ from data_designer_nemo.filesystem import make_filesystem
 from data_designer_nemo.nemotron_personas import (
     get_locale_fileset_file_ref,
 )
-from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
+from nemo_platform import NeMoPlatform
 
 
 class FilesetsPersonReader(PersonReader):
     """Provides DuckDB access to Nemotron personas datasets via filesets.
 
-    Accepts either a sync :class:`NeMoPlatform` (job-container path, sync
-    top-level) or an :class:`AsyncNeMoPlatform` (API-process path, used
-    from a worker thread under :func:`anyio.to_thread.run_sync`).
-
-    DuckDB calls into the SDK fileset filesystem synchronously, so when this
-    reader is constructed with an async SDK we rebuild a sync SDK first. Auth
-    and identity propagate; fsspec stays in sync mode.
+    DuckDB calls into the SDK fileset filesystem synchronously, so this reader
+    only accepts a sync :class:`NeMoPlatform`.
     """
 
-    def __init__(self, sdk: NeMoPlatform | AsyncNeMoPlatform):
+    def __init__(self, sdk: NeMoPlatform):
         self._sdk = sdk
 
     def create_duckdb_connection(self) -> duckdb.DuckDBPyConnection:

--- a/packages/data_designer_nemo/src/data_designer_nemo/runnable.py
+++ b/packages/data_designer_nemo/src/data_designer_nemo/runnable.py
@@ -21,13 +21,13 @@ run engine-level checks of its own.
 from __future__ import annotations
 
 import data_designer.config as dd
-from data_designer_nemo.context import DataDesignerContext
+from data_designer_nemo.context import DataDesignerValidationContext
 from data_designer_nemo.errors import NDDError, NDDInternalError, NDDInvalidConfigError
 from data_designer_nemo.model_configs import get_model_configs
 
 
 async def resolve_runnable_config(
-    dd_ctx: DataDesignerContext,
+    dd_ctx: DataDesignerValidationContext,
     config: dd.DataDesignerConfig,
 ) -> tuple[list[NDDError], list[dd.ModelConfig], list[dd.ModelProvider]]:
     """Run the producer pass against ``config`` and return ``(errors, model_configs, model_providers)``.

--- a/packages/data_designer_nemo/src/data_designer_nemo/sdk_translation.py
+++ b/packages/data_designer_nemo/src/data_designer_nemo/sdk_translation.py
@@ -13,29 +13,13 @@ validation and job-container runtime code, so those paths need an async sibling
 that preserves the same base URL, workspace, headers, query defaults, timeout,
 and retry settings.
 
-``async_to_sync_sdk`` is the inverse boundary used by Data Designer's fileset
-filesystem integration. DuckDB and upstream Data Designer seed/person readers
-call fsspec synchronously, so the fileset filesystem must be constructed in
-sync fsspec mode even when the API process starts with an injected
+The inverse boundary is deliberately absent. DuckDB and upstream Data Designer
+seed/person readers call fsspec synchronously, so callers must pass a separate
+sync ``NeMoPlatform`` into execution paths instead of rebuilding one from an
 ``AsyncNeMoPlatform``.
 """
 
-import httpx
 from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
-
-
-def async_to_sync_sdk(async_sdk: AsyncNeMoPlatform) -> NeMoPlatform:
-    """Build a sync :class:`NeMoPlatform` mirroring an async SDK's config."""
-    sdk = NeMoPlatform(
-        base_url=async_sdk.base_url,
-        default_headers=dict(async_sdk._custom_headers) if async_sdk._custom_headers else None,
-        default_query=dict(async_sdk._custom_query) if async_sdk._custom_query else None,
-        timeout=async_sdk.timeout,
-        max_retries=async_sdk.max_retries,
-        workspace=async_sdk.workspace,
-    )
-    _attach_transport_and_router(original=async_sdk, clone=sdk)
-    return sdk
 
 
 def sync_to_async_sdk(sdk: NeMoPlatform) -> AsyncNeMoPlatform:
@@ -47,17 +31,6 @@ def sync_to_async_sdk(sdk: NeMoPlatform) -> AsyncNeMoPlatform:
         timeout=sdk.timeout,
         max_retries=sdk.max_retries,
         workspace=sdk.workspace,
+        inference_base_url=sdk.inference_base_url,
     )
-    _attach_transport_and_router(original=sdk, clone=async_sdk)
     return async_sdk
-
-
-def _attach_transport_and_router(
-    *, clone: NeMoPlatform | AsyncNeMoPlatform, original: NeMoPlatform | AsyncNeMoPlatform
-) -> None:
-    transport = getattr(original._client, "_transport", None)
-    if isinstance(transport, httpx.ASGITransport):
-        setattr(clone._client, "asgi_app", transport.app)
-    if router := getattr(original, "_nmp_request_router", None):
-        setattr(clone, "_nmp_request_router", router)
-        clone._prepare_url = router.resolve

--- a/packages/data_designer_nemo/src/data_designer_nemo/secret_resolver.py
+++ b/packages/data_designer_nemo/src/data_designer_nemo/secret_resolver.py
@@ -3,7 +3,6 @@
 
 import logging
 
-import anyio.from_thread
 from data_designer.engine.errors import SecretResolutionError
 from data_designer_nemo.errors import NDDInternalError, NDDInvalidConfigError
 from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
@@ -45,31 +44,18 @@ class NMPSecretResolver:
     library only accepts NeMo Platform secrets in fields treated as secrets by the library.
 
     Public ``.resolve(secret) -> str`` is sync because the DD engine library is
-    sync. Internally the resolver accepts either a sync :class:`NeMoPlatform`
-    (used by the job container, which runs sync top-level) or an
-    :class:`AsyncNeMoPlatform` (used inside the API process, where work runs
-    on an :func:`anyio.to_thread.run_sync` worker thread that bridges back to
-    the loop via :func:`anyio.from_thread.run`). Secrets should be validated
-    in advance using :func:`validate_secret`.
+    sync. Secrets should be validated in advance using :func:`validate_secret`.
     """
 
-    def __init__(self, sdk: NeMoPlatform | AsyncNeMoPlatform, default_workspace: str):
+    def __init__(self, sdk: NeMoPlatform, default_workspace: str):
         self._sdk = sdk
         self._default_workspace = default_workspace
 
     def resolve(self, secret: str) -> str:
         try:
             workspace, name = _parse_secret_reference(secret, self._default_workspace)
-            if isinstance(self._sdk, AsyncNeMoPlatform):
-                # ``anyio.from_thread.run`` only forwards positional args, so wrap the
-                # kwargs-only client call in a no-arg coroutine factory.
-                async_secrets = client_from_platform(self._sdk, AsyncSecretsClient)
-                result = anyio.from_thread.run(
-                    lambda: async_secrets.access_secret(name=name, workspace=workspace)
-                ).data()
-            else:
-                secrets = client_from_platform(self._sdk, SecretsClient)
-                result = secrets.access_secret(name=name, workspace=workspace).data()
+            secrets = client_from_platform(self._sdk, SecretsClient)
+            result = secrets.access_secret(name=name, workspace=workspace).data()
             return result.value
         except Exception as e:
             raise SecretResolutionError(f"Error resolving secret {secret!r}: {e}") from e

--- a/packages/data_designer_nemo/tests/unit/test_filesystem.py
+++ b/packages/data_designer_nemo/tests/unit/test_filesystem.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import Mock, patch
+
+from data_designer_nemo.filesystem import make_filesystem
+from nemo_platform import NeMoPlatform
+from nemo_platform_plugin.files.client import FilesClient
+
+
+def test_make_filesystem_uses_sync_client_for_sync_sdk() -> None:
+    sdk = Mock(spec=NeMoPlatform)
+    files_client = Mock()
+    filesystem = Mock()
+
+    with (
+        patch("data_designer_nemo.filesystem.client_from_platform", return_value=files_client) as client_from_platform,
+        patch("data_designer_nemo.filesystem.FilesetFileSystem", return_value=filesystem) as fileset_filesystem,
+    ):
+        result = make_filesystem(sdk)
+
+    assert result is filesystem
+    client_from_platform.assert_called_once_with(sdk, FilesClient)
+    fileset_filesystem.assert_called_once_with(client=files_client)

--- a/packages/data_designer_nemo/tests/unit/test_remote_filesystem_seeds.py
+++ b/packages/data_designer_nemo/tests/unit/test_remote_filesystem_seeds.py
@@ -8,11 +8,11 @@ from unittest.mock import AsyncMock, Mock, patch
 import data_designer.config as dd
 import pytest
 from data_designer.engine.resources.seed_reader import DirectorySeedReader, FileContentsSeedReader
-from data_designer_nemo.context import DataDesignerContext
+from data_designer_nemo.context import DataDesignerExecutionContext
 from data_designer_nemo.errors import NDDInvalidConfigError
 from data_designer_nemo.fileset_file_seed_source import FilesetFileSeedSource
 from data_designer_nemo.seed import _validate_seed_from_files_service, validate_seed
-from nemo_platform import AsyncNeMoPlatform
+from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
 from nemo_platform_plugin.files.types import ListFilesQueryParams
 
 
@@ -21,7 +21,7 @@ def _list_files_response(paths: list[str]) -> Mock:
 
 
 def test_remote_context_includes_filesystem_seed_readers() -> None:
-    readers = DataDesignerContext(Mock(), "default").get_seed_readers()
+    readers = DataDesignerExecutionContext(Mock(spec=NeMoPlatform), "default").get_seed_readers()
 
     assert any(isinstance(reader, DirectorySeedReader) for reader in readers)
     assert any(isinstance(reader, FileContentsSeedReader) for reader in readers)

--- a/packages/data_designer_nemo/tests/unit/test_runnable.py
+++ b/packages/data_designer_nemo/tests/unit/test_runnable.py
@@ -45,9 +45,9 @@ def _make_dd_ctx(
     providers: list[dd.ModelProvider] | None = None,
     providers_exc: BaseException | None = None,
 ) -> AsyncMock:
-    """Stub ``DataDesignerContext`` whose validate / get_model_providers we control.
+    """Stub validation context whose validate / get_model_providers we control.
 
-    Returns the bare :class:`AsyncMock` (not ``spec=DataDesignerContext``) so
+    Returns the bare :class:`AsyncMock` so
     the test bodies can access the mock-only ``assert_not_called`` /
     ``assert_called_once`` introspection methods directly.
     """

--- a/packages/filesets/src/filesets/__init__.py
+++ b/packages/filesets/src/filesets/__init__.py
@@ -11,6 +11,7 @@ Located at: nemo_platform/filesets/ (after vendoring)
 
 from .filesystem.callbacks import RichFileProgressCallback as RichFileProgressCallback
 from .filesystem.callbacks import RichProgressCallback as RichProgressCallback
+from .filesystem.filesystem import AsyncFilesetFileSystem as AsyncFilesetFileSystem
 from .filesystem.filesystem import FilesetFileSystem as FilesetFileSystem
 from .filesystem.filesystem import FilesetPathError as FilesetPathError
 from .filesystem.filesystem import build_fileset_ref as build_fileset_ref

--- a/packages/filesets/src/filesets/filesystem/filesystem.py
+++ b/packages/filesets/src/filesets/filesystem/filesystem.py
@@ -10,15 +10,16 @@ import os
 from collections.abc import AsyncIterator, Coroutine, Iterator, Sequence
 from datetime import datetime, timezone
 from glob import has_magic
+from pathlib import Path
 from typing import Any, Literal, TypedDict, TypeVar, overload
 
 import anyio
-import fsspec.asyn
+import httpx
 from anyio import to_thread
 from fsspec.asyn import AbstractAsyncStreamedFile, AsyncFileSystem, _get_batch_size
 from fsspec.callbacks import DEFAULT_CALLBACK, Callback
 from fsspec.implementations.local import LocalFileSystem, make_path_posix, trailing_sep
-from fsspec.spec import AbstractBufferedFile
+from fsspec.spec import AbstractBufferedFile, AbstractFileSystem
 from fsspec.utils import other_paths
 from nemo_platform_plugin.files.client import AsyncFilesClient, FilesClient
 from nemo_platform_plugin.files.types import FilesetFileOutput, ListFilesQueryParams
@@ -286,27 +287,15 @@ def build_fileset_ref(
     return f"{ws}/{fs}"
 
 
-class FilesetFileSystem(AsyncFileSystem):
+class FilesetFileSystem(AbstractFileSystem):
     """
-    fsspec filesystem for NeMo Platform fileset storage.
+    Synchronous fsspec filesystem for NeMo Platform fileset storage.
 
     URL format: fileset://[workspace/]fileset_name[#path]
-
-    The optional `#` separator distinguishes the fileset name from the file path.
-    If omitted, assumes root of fileset. Workspace is optional - if omitted,
-    uses the client's default workspace.
-
-    Examples:
-        >>> from nemo_platform_plugin.files.client import AsyncFilesClient
-        >>> client = AsyncFilesClient(base_url="http://localhost:8000", workspace="default")
-        >>> fs = FilesetFileSystem(client=client)
-        >>> fs.ls("my-fileset")  # root of fileset, workspace from client default
-        >>> fs.ls("my-fileset#data/")  # specific path within fileset
-        >>> fs.ls("default/my-fileset#data/")  # explicit workspace
     """
 
     protocol = "fileset"
-    _client: AsyncFilesClient
+    _client: FilesClient
 
     @classmethod
     def register_fsspec(cls) -> None:
@@ -317,6 +306,510 @@ class FilesetFileSystem(AsyncFileSystem):
         from fsspec import register_implementation
 
         register_implementation(cls.protocol, cls, clobber=True)
+
+    default_batch_size = 4
+    blocksize = 16 * 1024 * 1024
+    _fallback_timestamp = datetime.fromtimestamp(0, tz=timezone.utc)
+
+    def __init__(
+        self,
+        *,
+        client: FilesClient,
+        batch_size: int | None = None,
+        blocksize: int | None = None,
+        **kwargs,
+    ) -> None:
+        if batch_size is None:
+            batch_size = self.default_batch_size
+
+        if blocksize is None:
+            blocksize = self.blocksize
+
+        super().__init__(**kwargs)
+        self._client = client
+        self.batch_size = batch_size
+        self.blocksize = blocksize
+
+    @property
+    def _workspace(self) -> str | None:
+        return self._client.workspace
+
+    def to_fileset_files(self, results: dict[str, Any]) -> list[FilesetFileOutput]:
+        """Convert fsspec find results to FilesetFileOutput objects."""
+        files = []
+        for name, info in results.items():
+            if info.get("type") == "directory":
+                continue
+            workspace, fileset, file_path = parse_fileset_ref(name, workspace_fallback=None)
+            files.append(
+                FilesetFileOutput(
+                    file_ref=f"{workspace}/{fileset}#{file_path}",
+                    file_url=f"/apis/files/v2/workspaces/{workspace}/filesets/{fileset}/-/{file_path}",
+                    path=file_path,
+                    size=info.get("size", 0),
+                )
+            )
+        return files
+
+    def invalidate_cache(self, path: str | None = None) -> None:
+        """Discard cached directory information."""
+        if path is None:
+            self.dircache.clear()
+        else:
+            self.dircache.pop(path.rstrip("/"), None)
+        super().invalidate_cache(path)
+
+    def created(self, path: str) -> datetime:
+        self.info(path)
+        return self._fallback_timestamp
+
+    def modified(self, path: str) -> datetime:
+        self.info(path)
+        return self._fallback_timestamp
+
+    def _populate_dircache_from_response(
+        self,
+        response,
+        workspace: str,
+        fileset: str,
+        prefix: str,
+    ) -> dict[str, list[FileInfo]]:
+        """Parse recursive API response and populate dircache for all directory levels."""
+        base_path = f"{workspace}/{fileset}"
+        root = f"{base_path}#{prefix}" if prefix else base_path
+
+        dir_contents: dict[str, list[FileInfo]] = {root: []}
+        seen_subdirs: dict[str, set[str]] = {root: set()}
+
+        for file_info in response.data:
+            file_path = file_info.path.lstrip("/")
+            full_path = f"{base_path}#{file_path}"
+
+            parent = self._parent(full_path)
+            if parent not in dir_contents:
+                dir_contents[parent] = []
+                seen_subdirs[parent] = set()
+            dir_contents[parent].append({"name": full_path, "size": file_info.size, "type": "file"})
+
+            current = parent
+            while current != root and len(current) > len(root):
+                parent_of_current = self._parent(current)
+                if parent_of_current not in dir_contents:
+                    dir_contents[parent_of_current] = []
+                    seen_subdirs[parent_of_current] = set()
+                subdir_name = current.split("#", 1)[1].rsplit("/", 1)[-1]
+                if subdir_name not in seen_subdirs[parent_of_current]:
+                    seen_subdirs[parent_of_current].add(subdir_name)
+                    dir_contents[parent_of_current].append({"name": current, "size": 0, "type": "directory"})
+                current = parent_of_current
+
+        if self.dircache.use_listings_cache:
+            for path, contents in dir_contents.items():
+                self.dircache[path] = contents
+
+        return dir_contents
+
+    def info(self, path: str, **kwargs) -> FileInfo:
+        """Get file info, using dircache when available."""
+        _, _, file_path = parse_fileset_ref(path, workspace_fallback=self._workspace)
+        path_key = build_fileset_ref(path)
+        parent_path = self._parent(path_key)
+
+        if path_key in self.dircache:
+            return {"name": path_key, "size": 0, "type": "directory"}
+
+        if parent_path != path_key and parent_path in self.dircache:
+            for entry in self.dircache[parent_path]:
+                if entry["name"].rstrip("/") == path_key:
+                    return entry
+            raise FileNotFoundError(path)
+
+        if not file_path:
+            try:
+                self.ls(path_key, detail=True)
+                return {"name": path_key, "size": 0, "type": "directory"}
+            except Exception as e:
+                raise FileNotFoundError(path) from e
+
+        try:
+            self.ls(parent_path, detail=True)
+        except Exception as e:
+            raise FileNotFoundError(path) from e
+
+        if parent_path in self.dircache:
+            for entry in self.dircache[parent_path]:
+                if entry["name"].rstrip("/") == path_key:
+                    return entry
+
+        raise FileNotFoundError(path)
+
+    def cat_file(self, path: str, start: int | None = None, end: int | None = None, **kwargs) -> bytes:
+        """Fetch file content with optional byte range."""
+        workspace, fileset, file_path = parse_fileset_ref(path, workspace_fallback=self._workspace)
+        if not file_path:
+            raise IsADirectoryError(path)
+
+        client = self._client
+        if start is not None or end is not None:
+            client = client.with_headers({"Range": f"bytes={start or 0}-{(end - 1) if end else ''}"})
+
+        response = client.download_file(workspace=workspace, name=fileset, path=file_path)
+        return response.read()
+
+    @classmethod
+    def _parent(cls, path: str) -> str:
+        """Get the parent directory path, handling the # separator correctly."""
+        workspace, fileset, file_path = parse_fileset_ref(path.rstrip("/"), workspace_fallback=None)
+
+        fileset_root = f"{workspace}/{fileset}"
+        if not file_path:
+            return fileset_root
+        if "/" in file_path:
+            return f"{fileset_root}#{file_path.rsplit('/', 1)[0]}"
+        return fileset_root
+
+    def ls(self, path: str, detail: bool = True, refresh: bool = False, **kwargs) -> list[FileInfo] | list[str]:
+        """List files in a fileset or directory."""
+        workspace, fileset, prefix = parse_fileset_ref(path, workspace_fallback=self._workspace)
+        prefix = prefix.rstrip("/")
+        path_key = build_fileset_ref(prefix, workspace=workspace, fileset=fileset)
+
+        if self.dircache.use_listings_cache and not refresh:
+            try:
+                out = self.dircache[path_key]
+                return out if detail else [f["name"] for f in out]
+            except KeyError:
+                pass
+
+        query_params: ListFilesQueryParams | None = {"path": prefix} if prefix else None
+        response = self._client.list_files(
+            workspace=workspace,
+            name=fileset,
+            query_params=query_params,
+        ).data()
+        dir_contents = self._populate_dircache_from_response(response, workspace, fileset, prefix)
+
+        result = dir_contents.get(path_key, [])
+        return result if detail else [f["name"] for f in result]
+
+    def rm_file(self, path: str, **kwargs) -> None:
+        """Delete a single file."""
+        workspace, fileset, file_path = parse_fileset_ref(path, workspace_fallback=self._workspace)
+        if not file_path:
+            raise ValueError("Cannot delete fileset root via rm")
+        self._client.delete_file(workspace=workspace, name=fileset, path=file_path)
+        self.invalidate_cache(self._parent(build_fileset_ref(path)))
+
+    def pipe_file(self, path: str, value: bytes, mode: str = "overwrite", **kwargs) -> None:
+        """Write bytes to a file."""
+        workspace, fileset, file_path = parse_fileset_ref(path, workspace_fallback=self._workspace)
+        if not file_path:
+            raise ValueError("File path required for upload")
+        self._client.upload_file(workspace=workspace, name=fileset, path=file_path, content=value)
+        self.invalidate_cache(self._parent(build_fileset_ref(path)))
+
+    def pipe_stream(
+        self,
+        path: str,
+        stream: Iterator[bytes],
+        content_length: int | None = None,
+    ) -> None:
+        """Write a sync byte stream to a file."""
+        if hasattr(stream, "__anext__"):
+            raise TypeError("FilesetFileSystem.pipe_stream requires a sync iterator")
+
+        workspace, fileset, file_path = parse_fileset_ref(path, workspace_fallback=self._workspace)
+        if not file_path:
+            raise ValueError("File path required for upload")
+
+        client = self._client
+        if content_length is not None:
+            client = client.with_headers({"Content-Length": str(content_length)})
+
+        client.upload_file(workspace=workspace, name=fileset, path=file_path, content=stream)
+        self.invalidate_cache(self._parent(build_fileset_ref(path)))
+
+    def put(
+        self,
+        lpath,
+        rpath,
+        recursive=False,
+        callback=DEFAULT_CALLBACK,
+        maxdepth=None,
+        **kwargs,
+    ) -> None:
+        """Copy local file(s) into the fileset."""
+        kwargs.pop("batch_size", None)
+        if isinstance(lpath, list) and isinstance(rpath, list):
+            rpaths = rpath
+            lpaths = lpath
+        else:
+            source_is_str = isinstance(lpath, str)
+            if source_is_str:
+                lpath = make_path_posix(lpath)
+            fs = LocalFileSystem()
+            lpaths = fs.expand_path(lpath, recursive=recursive, maxdepth=maxdepth)
+            if source_is_str and (not recursive or maxdepth is not None):
+                lpaths = [path for path in lpaths if not (trailing_sep(path) or fs.isdir(path))]
+                if not lpaths:
+                    return
+
+            source_is_file = len(lpaths) == 1
+            dest_is_dir = isinstance(rpath, str) and (trailing_sep(rpath) or self.isdir(rpath))
+
+            rpath = self._strip_protocol(rpath)
+            exists = source_is_str and (
+                (has_magic(lpath) and source_is_file)
+                or (not has_magic(lpath) and dest_is_dir and not trailing_sep(lpath))
+            )
+            rpaths = other_paths(
+                lpaths,
+                rpath,
+                exists=exists,
+                flatten=not source_is_str,
+            )
+
+        file_pairs = [(local, remote) for local, remote in zip(lpaths, rpaths) if not os.path.isdir(local)]
+
+        callback.set_size(len(file_pairs))
+        for local, remote in file_pairs:
+            with callback.branched(local, remote) as child:
+                self.put_file(local, remote, callback=child, **kwargs)
+            callback.relative_update(1)
+
+    def put_file(
+        self,
+        lpath: str,
+        rpath: str,
+        callback: Callback = DEFAULT_CALLBACK,
+        mode: str = "overwrite",
+        **kwargs,
+    ) -> None:
+        """Upload a local file to a fileset."""
+        workspace, fileset, file_path = parse_fileset_ref(rpath, workspace_fallback=self._workspace)
+        if not file_path:
+            raise ValueError("File path required for upload")
+
+        file_size = os.path.getsize(lpath)
+        callback.set_size(file_size)
+
+        def stream_file() -> Iterator[bytes]:
+            with open(lpath, "rb") as f:
+                while chunk := f.read(self.blocksize):
+                    callback.relative_update(len(chunk))
+                    yield chunk
+
+        self._client.with_headers({"Content-Length": str(file_size)}).upload_file(
+            workspace=workspace,
+            name=fileset,
+            path=file_path,
+            content=stream_file(),
+        )
+        self.invalidate_cache(self._parent(build_fileset_ref(rpath)))
+
+    @overload
+    def find(
+        self, path: str, maxdepth: int | None = None, withdirs: bool = False, detail: Literal[False] = ..., **kwargs
+    ) -> list[str]: ...
+
+    @overload
+    def find(
+        self, path: str, maxdepth: int | None = None, withdirs: bool = False, detail: Literal[True] = ..., **kwargs
+    ) -> dict[str, FileInfo]: ...
+
+    def find(
+        self, path: str, maxdepth: int | None = None, withdirs: bool = False, detail: bool = False, **kwargs
+    ) -> dict[str, FileInfo] | list[str]:
+        """Find all files under path using a single recursive listing."""
+        workspace, fileset, prefix = parse_fileset_ref(path, workspace_fallback=self._workspace)
+        prefix = prefix.rstrip("/")
+        query_params: ListFilesQueryParams | None = {"path": prefix} if prefix else None
+        response = self._client.list_files(
+            workspace=workspace,
+            name=fileset,
+            query_params=query_params,
+        ).data()
+
+        self._populate_dircache_from_response(response, workspace, fileset, prefix)
+
+        out: dict[str, FileInfo] = {}
+        seen_dirs: set[str] = set()
+
+        if withdirs:
+            root_path = build_fileset_ref(path, workspace=self._workspace)
+            out[root_path] = {"name": root_path, "size": 0, "type": "directory"}
+
+        for file_info in response.data:
+            file_path = file_info.path.lstrip("/")
+            full_path = f"{workspace}/{fileset}#{file_path}"
+            out[full_path] = {"name": full_path, "size": file_info.size, "type": "file"}
+
+            if withdirs:
+                parts = file_path.split("/")
+                for i in range(1, len(parts)):
+                    dir_path = "/".join(parts[:i])
+                    full_dir_path = f"{workspace}/{fileset}#{dir_path}"
+                    if full_dir_path not in seen_dirs:
+                        seen_dirs.add(full_dir_path)
+                        out[full_dir_path] = {
+                            "name": full_dir_path,
+                            "size": 0,
+                            "type": "directory",
+                        }
+
+        names = sorted(out)
+        if detail:
+            return {name: out[name] for name in names}
+        return names
+
+    def get_file(self, rpath: str, lpath: str, callback: Callback = DEFAULT_CALLBACK, outfile=None, **kwargs) -> None:
+        """Download a file to local path."""
+        workspace, fileset, file_path = parse_fileset_ref(rpath, workspace_fallback=self._workspace)
+
+        if not file_path:
+            return
+
+        response = self._client.download_file(
+            workspace=workspace,
+            name=fileset,
+            path=file_path,
+        )
+
+        with response.stream() as chunks:
+            content_length = response.http_response.headers.get("content-length")
+            if content_length:
+                callback.set_size(int(content_length))
+            close_file = outfile is None
+            if outfile is None:
+                Path(lpath).parent.mkdir(parents=True, exist_ok=True)
+                f = open(lpath, "wb")
+            else:
+                f = outfile
+            try:
+                try:
+                    for chunk in chunks:
+                        f.write(chunk)
+                        callback.relative_update(len(chunk))
+                except httpx.StreamConsumed:
+                    content = response.http_response.content
+                    f.write(content)
+                    callback.relative_update(len(content))
+            finally:
+                if close_file:
+                    f.close()
+
+    def get(
+        self,
+        rpath: str | list[str],
+        lpath: str | list[str],
+        recursive: bool = True,
+        callback: Callback = DEFAULT_CALLBACK,
+        maxdepth: int | None = None,
+        **kwargs,
+    ) -> None:
+        """Download files using a single find call for efficiency."""
+        kwargs.pop("batch_size", None)
+        if isinstance(rpath, list) and isinstance(lpath, list):
+            if not rpath:
+                return
+            callback.set_size(len(rpath))
+            for remote, local in zip(rpath, lpath, strict=True):
+                with callback.branched(remote, local) as child:
+                    self.get_file(remote, local, callback=child, **kwargs)
+                callback.relative_update(1)
+            return
+
+        if not isinstance(rpath, str) or not isinstance(lpath, str):
+            raise TypeError("rpath and lpath must both be strings or both be lists")
+
+        source_files = self.find(rpath, maxdepth=maxdepth, withdirs=False)
+        if not source_files:
+            return
+
+        rpath_normalized = build_fileset_ref(rpath, workspace=self._workspace).rstrip("/")
+        lpath_stripped = lpath.rstrip("/")
+        source_is_file = len(source_files) == 1 and self._strip_protocol(source_files[0]) == rpath_normalized
+
+        if source_is_file:
+            source = source_files[0]
+            dest_is_dir = lpath.endswith("/") or os.path.isdir(lpath)
+            if dest_is_dir:
+                _, _, source_file_path = parse_fileset_ref(source, workspace_fallback=None)
+                filename = source_file_path.rsplit("/", 1)[-1]
+                dest = f"{lpath_stripped}/{filename}"
+            else:
+                dest = lpath_stripped
+
+            callback.set_size(1)
+            with callback.branched(source, dest) as child:
+                self.get_file(source, dest, callback=child, **kwargs)
+            callback.relative_update(1)
+            return
+
+        _, _, file_path = parse_fileset_ref(rpath, workspace_fallback=self._workspace)
+        copy_contents_directly = rpath.endswith("/") or not file_path
+        source_name = file_path.rsplit("/", 1)[-1] if file_path else ""
+
+        file_pairs = []
+        for source in source_files:
+            source_stripped = self._strip_protocol(source)
+            relative = source_stripped[len(rpath_normalized) :].lstrip("#/")
+
+            if copy_contents_directly:
+                dest = f"{lpath_stripped}/{relative}"
+            else:
+                dest = f"{lpath_stripped}/{source_name}/{relative}"
+
+            file_pairs.append((source, dest))
+
+        callback.set_size(len(file_pairs))
+        for source, dest in file_pairs:
+            with callback.branched(source, dest) as child:
+                self.get_file(source, dest, callback=child, **kwargs)
+            callback.relative_update(1)
+
+    def _open(
+        self,
+        path: str,
+        mode: str = "rb",
+        block_size: int | None = None,
+        autocommit: bool = True,
+        cache_options: dict | None = None,
+        **kwargs,
+    ) -> FilesetFile:
+        """Open a file for reading or writing."""
+        return FilesetFile(
+            self,
+            path,
+            mode=mode,
+            block_size=block_size or self.blocksize,
+            autocommit=autocommit,
+            cache_options=cache_options,
+            **kwargs,
+        )
+
+
+class AsyncFilesetFileSystem(AsyncFileSystem):
+    """
+    Asynchronous fsspec filesystem for NeMo Platform fileset storage.
+
+    URL format: fileset://[workspace/]fileset_name[#path]
+
+    The optional `#` separator distinguishes the fileset name from the file path.
+    If omitted, assumes root of fileset. Workspace is optional - if omitted,
+    uses the client's default workspace.
+
+    Examples:
+        >>> from nemo_platform_plugin.files.client import AsyncFilesClient
+        >>> client = AsyncFilesClient(base_url="http://localhost:8000", workspace="default")
+        >>> fs = AsyncFilesetFileSystem(client=client)
+        >>> await fs._ls("my-fileset")  # root of fileset, workspace from client default
+        >>> await fs._ls("my-fileset#data/")  # specific path within fileset
+        >>> await fs._ls("default/my-fileset#data/")  # explicit workspace
+    """
+
+    protocol = "fileset"
+    _client: AsyncFilesClient
 
     # Default concurrency for file transfers
     default_batch_size = 4
@@ -332,54 +825,19 @@ class FilesetFileSystem(AsyncFileSystem):
     def __init__(
         self,
         *,
-        client: FilesClient | AsyncFilesClient,
-        async_client: AsyncFilesClient | None = None,
+        client: AsyncFilesClient,
         batch_size: int | None = None,
         blocksize: int | None = None,
         **kwargs,
-    ):
-        async_client = async_client or self._ensure_async(client)
-        is_async = isinstance(client, AsyncFilesClient)
-
+    ) -> None:
         if batch_size is None:
             batch_size = self.default_batch_size
 
         if blocksize is None:
             blocksize = self.blocksize
 
-        super().__init__(asynchronous=is_async, batch_size=batch_size, blocksize=blocksize, **kwargs)
-        self._client = async_client
-
-    @staticmethod
-    def _ensure_async(client: FilesClient | AsyncFilesClient) -> AsyncFilesClient:
-        """Ensure we have an AsyncFilesClient, converting from sync if needed."""
-        if isinstance(client, AsyncFilesClient):
-            return client
-
-        import httpx
-
-        # A timeout lives in two layers, so mirror each from its own source: the
-        # transport carries the client-level default, and ``_timeout`` the
-        # per-request override that ``send`` puts on every request. Leave the
-        # transport's unset and httpx falls back to its own 5s, which a multi-GB
-        # upload blows through waiting for the server to commit the body to storage.
-        asgi_app = getattr(client._http, "asgi_app", None)
-        http_client = httpx.AsyncClient(
-            transport=httpx.ASGITransport(app=asgi_app) if asgi_app is not None else None,
-            base_url=client.base_url,
-            headers=dict(client._default_headers) if client._default_headers else None,
-            timeout=client._http.timeout,
-        )
-        return AsyncFilesClient(
-            base_url=client.base_url,
-            workspace=client.workspace,
-            auth=client._auth,
-            default_headers=client._default_headers or None,
-            timeout=client._timeout,
-            retry=client._retry,
-            http_client=http_client,
-            url_resolver=client._url_resolver,
-        )
+        super().__init__(asynchronous=True, batch_size=batch_size, blocksize=blocksize, **kwargs)
+        self._client = client
 
     @property
     def _workspace(self) -> str | None:
@@ -646,14 +1104,14 @@ class FilesetFileSystem(AsyncFileSystem):
         # Invalidate parent directory's cache since file info is stored there
         self.invalidate_cache(self._parent(build_fileset_ref(path)))
 
-    def pipe_stream(
+    async def pipe_stream(
         self,
         path: str,
         stream: AsyncIterator[bytes] | Iterator[bytes],
         content_length: int | None = None,
     ) -> None:
-        """Sync wrapper for _pipe_stream. See _pipe_stream for details."""
-        return fsspec.asyn.sync(self.loop, self._pipe_stream, path, stream, content_length)
+        """Write a byte stream to a file."""
+        await self._pipe_stream(path, stream, content_length)
 
     async def _put(
         self,

--- a/packages/filesets/src/filesets/resources.py
+++ b/packages/filesets/src/filesets/resources.py
@@ -34,6 +34,7 @@ from nemo_platform_plugin.files.types import (
 )
 
 from filesets.filesystem.filesystem import (
+    AsyncFilesetFileSystem,
     FilesetFileSystem,
     build_fileset_ref,
     parse_fileset_path,
@@ -151,13 +152,11 @@ class FilesResource:
         client,
         *,
         files_client: FilesClient | None = None,
-        async_files_client: AsyncFilesClient | None = None,
     ) -> None:
         # Retain the platform client so the generated fileset/otlp sub-resources
         # (which speak to the platform client, not the FilesClient) can be exposed.
         self._platform_client = client
         self._generated_files = GeneratedFilesResource(client)
-        self._async_client = async_files_client
         if files_client is not None:
             self._client = files_client
         else:
@@ -186,7 +185,7 @@ class FilesResource:
     @cached_property
     def fsspec(self) -> FilesetFileSystem:
         """Access the underlying fsspec filesystem."""
-        return FilesetFileSystem(client=self._client, async_client=self._async_client)
+        return FilesetFileSystem(client=self._client)
 
     def _ensure_fileset_exists(self, workspace: str, fileset: str) -> None:
         """Create fileset if it doesn't exist (idempotent)."""
@@ -285,10 +284,7 @@ class FilesResource:
             # Build list of (remote, local) path pairs preserving directory structure
             rpaths = [build_fileset_ref(p, workspace=ws, fileset=fileset) for p in remote_path]
             lpaths = [str(PurePath(local_path) / p) for p in remote_path]
-            kwargs: dict = {"rpath": rpaths, "lpath": lpaths, "batch_size": max_workers}
-            if callback is not None:
-                kwargs["callback"] = callback
-            self.fsspec.get(**kwargs)
+            self.fsspec.get(rpath=rpaths, lpath=lpaths, callback=callback or DEFAULT_CALLBACK)
             return
 
         ws, path_fileset, path = parse_fileset_path(
@@ -308,16 +304,15 @@ class FilesResource:
             # Build list of (remote, local) path pairs preserving directory structure
             rpaths = [build_fileset_ref(f.path, workspace=ws, fileset=fileset) for f in matching_files.data]
             lpaths = [str(PurePath(local_path) / f.path) for f in matching_files.data]
-            kwargs = {"rpath": rpaths, "lpath": lpaths, "batch_size": max_workers}
-            if callback is not None:
-                kwargs["callback"] = callback
-            self.fsspec.get(**kwargs)
+            self.fsspec.get(rpath=rpaths, lpath=lpaths, callback=callback or DEFAULT_CALLBACK)
         else:
             fileset_ref = build_fileset_ref(path, workspace=ws, fileset=fileset)
-            kwargs = {"rpath": fileset_ref, "lpath": local_path, "recursive": True, "batch_size": max_workers}
-            if callback is not None:
-                kwargs["callback"] = callback
-            self.fsspec.get(**kwargs)
+            self.fsspec.get(
+                rpath=fileset_ref,
+                lpath=local_path,
+                recursive=True,
+                callback=callback or DEFAULT_CALLBACK,
+            )
 
     def upload(
         self,
@@ -406,10 +401,12 @@ class FilesResource:
         if fileset_auto_create:
             self._ensure_fileset_exists(ws, fileset)
 
-        kwargs: dict = {"lpath": local_path, "rpath": fileset_ref, "recursive": True, "batch_size": max_workers}
-        if callback is not None:
-            kwargs["callback"] = callback
-        self.fsspec.put(**kwargs)
+        self.fsspec.put(
+            lpath=local_path,
+            rpath=fileset_ref,
+            recursive=True,
+            callback=callback or DEFAULT_CALLBACK,
+        )
 
         return self._client.get_fileset(name=fileset, workspace=ws).data()
 
@@ -730,9 +727,9 @@ class AsyncFilesResource:
         return AsyncOtlpResource(self._platform_client)
 
     @cached_property
-    def fsspec(self) -> FilesetFileSystem:
+    def fsspec(self) -> AsyncFilesetFileSystem:
         """Access the underlying fsspec filesystem."""
-        return FilesetFileSystem(client=self._client)
+        return AsyncFilesetFileSystem(client=self._client)
 
     async def _ensure_fileset_exists(self, workspace: str, fileset: str) -> None:
         """Create fileset if it doesn't exist (idempotent)."""

--- a/packages/filesets/tests/test_filesystem_client.py
+++ b/packages/filesets/tests/test_filesystem_client.py
@@ -1,19 +1,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Client construction inside FilesetFileSystem.
-
-Uploads and downloads run on the async client built by ``_ensure_async``, not on
-the sync client the caller configured. Anything that client fails to carry over
-is silently dropped from every transfer.
-"""
+"""Client construction inside Fileset filesystem classes."""
 
 from __future__ import annotations
 
 import httpx
-from filesets.filesystem.filesystem import FilesetFileSystem
+from filesets.filesystem.filesystem import AsyncFilesetFileSystem, FilesetFileSystem
 from nemo_platform_plugin.client.types import RetryPolicy
-from nemo_platform_plugin.files.client import FilesClient
+from nemo_platform_plugin.files.client import AsyncFilesClient, FilesClient
 
 BASE = "http://test:8000"
 UPLOAD_TIMEOUT = httpx.Timeout(30.0, write=10 * 60, read=5 * 60)
@@ -32,41 +27,77 @@ def _sync_client(*, timeout: httpx.Timeout) -> FilesClient:
     )
 
 
-def test_ensure_async_carries_transport_timeout() -> None:
-    """With no override to carry, the transport's own timeout is what governs.
-
-    Without this the new AsyncClient falls back to httpx's 5s default.
-    """
-    async_client = FilesetFileSystem._ensure_async(_sync_client(timeout=httpx.Timeout(60.0)))
-
-    assert async_client._timeout is None
-    assert async_client._http.timeout == httpx.Timeout(60.0)
-    assert async_client._http.timeout != httpx.Timeout(5.0)
-
-
-def test_ensure_async_carries_per_request_timeout_override() -> None:
-    """An override goes out on every request, so it governs regardless of the transport."""
-    client = _sync_client(timeout=httpx.Timeout(60.0)).with_options(timeout=UPLOAD_TIMEOUT)
-
-    async_client = FilesetFileSystem._ensure_async(client)
-
-    assert async_client._timeout == UPLOAD_TIMEOUT
-    # Each layer is copied from its own counterpart, so the transport keeps the
-    # client-level default it had on the sync side rather than the override.
-    assert async_client._http.timeout == httpx.Timeout(60.0)
+def _async_client() -> AsyncFilesClient:
+    http_client = httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda request: httpx.Response(200, request=request)),
+        timeout=httpx.Timeout(60.0),
+    )
+    return AsyncFilesClient(
+        base_url=BASE,
+        workspace="default",
+        http_client=http_client,
+        retry=RetryPolicy(max_retries=2),
+    )
 
 
-def test_ensure_async_preserves_workspace_and_retry() -> None:
+def test_sync_filesystem_uses_sync_client() -> None:
     client = _sync_client(timeout=httpx.Timeout(60.0))
 
-    async_client = FilesetFileSystem._ensure_async(client)
+    fs = FilesetFileSystem(client=client)
 
-    assert async_client.workspace == "default"
-    assert async_client.retry == RetryPolicy(max_retries=2)
+    assert fs._client is client
+    assert fs._client.workspace == "default"
+    assert fs._client.retry == RetryPolicy(max_retries=2)
+
+
+async def test_async_filesystem_uses_async_client() -> None:
+    async_client = _async_client()
+
+    try:
+        fs = AsyncFilesetFileSystem(client=async_client)
+
+        assert fs._client is async_client
+        assert fs._client.workspace == "default"
+        assert fs._client.retry == RetryPolicy(max_retries=2)
+    finally:
+        await async_client._http.aclose()
+
+
+def test_platform_files_resource_returns_sync_filesystem() -> None:
+    from nemo_platform import NeMoPlatform
+
+    http_client = httpx.Client(
+        transport=httpx.MockTransport(lambda request: httpx.Response(200, request=request)),
+        timeout=httpx.Timeout(60.0),
+    )
+    platform = NeMoPlatform(base_url=BASE, workspace="default", http_client=http_client)
+
+    fs = platform.files.fsspec
+
+    assert isinstance(fs, FilesetFileSystem)
+    assert fs._client._http is http_client
+
+
+async def test_async_platform_files_resource_returns_async_filesystem() -> None:
+    from nemo_platform import AsyncNeMoPlatform
+
+    http_client = httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda request: httpx.Response(200, request=request)),
+        timeout=httpx.Timeout(60.0),
+    )
+    platform = AsyncNeMoPlatform(base_url=BASE, workspace="default", http_client=http_client)
+
+    try:
+        fs = platform.files.fsspec
+
+        assert isinstance(fs, AsyncFilesetFileSystem)
+        assert fs._client._http is http_client
+    finally:
+        await http_client.aclose()
 
 
 def test_upload_timeout_survives_the_whole_client_chain() -> None:
-    """End to end: an SDK-level timeout override reaches the client that transfers."""
+    """End to end: an SDK-level timeout override reaches the sync transfer client."""
     from nemo_platform import NeMoPlatform
 
     http_client = httpx.Client(
@@ -78,3 +109,4 @@ def test_upload_timeout_survives_the_whole_client_chain() -> None:
     fs = platform.with_options(timeout=UPLOAD_TIMEOUT).files.fsspec
 
     assert fs._client._timeout == UPLOAD_TIMEOUT
+    assert fs._client._http is http_client

--- a/packages/nemo_platform/pyproject.toml
+++ b/packages/nemo_platform/pyproject.toml
@@ -504,7 +504,7 @@ nmp-common = [
   "base58>=2.1.1",
   "pydantic>=2.10.3",
   "pydantic-settings>=2.8.1",
-  "fastapi[standard]>=0.115.4",
+  "fastapi[standard]>=0.137.2",
   "lark>=1.1.0",
   "nemo-platform-plugin",
   "pyyaml>=6.0.2",

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/client/enhanced.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/client/enhanced.py
@@ -17,6 +17,7 @@ from nemo_platform import (
     DefaultAsyncHttpxClient,
     DefaultHttpxClient,
     NotGiven,
+    Omit,
     __version__,
     not_given,
 )
@@ -76,7 +77,7 @@ class NeMoPlatform(SyncAPIClient):
         access_token: str | None = None,
         timeout: float | Timeout | None | NotGiven = not_given,
         max_retries: int = DEFAULT_MAX_RETRIES,
-        default_headers: Mapping[str, str] | None = None,
+        default_headers: Mapping[str, str | Omit] | None = None,
         default_query: Mapping[str, object] | None = None,
         # Configure a custom httpx client.
         # We provide a `DefaultHttpxClient` class that you can pass to retain the default values we use for `limits`, `timeout` & `follow_redirects`.
@@ -240,8 +241,8 @@ class NeMoPlatform(SyncAPIClient):
         timeout: float | Timeout | None | NotGiven = not_given,
         http_client: httpx.Client | None = None,
         max_retries: int | NotGiven = not_given,
-        default_headers: Mapping[str, str] | None = None,
-        set_default_headers: Mapping[str, str] | None = None,
+        default_headers: Mapping[str, str | Omit] | None = None,
+        set_default_headers: Mapping[str, str | Omit] | None = None,
         default_query: Mapping[str, object] | None = None,
         set_default_query: Mapping[str, object] | None = None,
         _extra_kwargs: Mapping[str, Any] = {},
@@ -304,7 +305,7 @@ class AsyncNeMoPlatform(AsyncAPIClient):
         access_token: str | None = None,
         timeout: float | Timeout | None | NotGiven = not_given,
         max_retries: int = DEFAULT_MAX_RETRIES,
-        default_headers: Mapping[str, str] | None = None,
+        default_headers: Mapping[str, str | Omit] | None = None,
         default_query: Mapping[str, object] | None = None,
         # Configure a custom httpx client.
         # We provide a `DefaultAsyncHttpxClient` class that you can pass to retain the default values we use for `limits`, `timeout` & `follow_redirects`.
@@ -490,8 +491,8 @@ class AsyncNeMoPlatform(AsyncAPIClient):
         timeout: float | Timeout | None | NotGiven = not_given,
         http_client: httpx.AsyncClient | None = None,
         max_retries: int | NotGiven = not_given,
-        default_headers: Mapping[str, str] | None = None,
-        set_default_headers: Mapping[str, str] | None = None,
+        default_headers: Mapping[str, str | Omit] | None = None,
+        set_default_headers: Mapping[str, str | Omit] | None = None,
         default_query: Mapping[str, object] | None = None,
         set_default_query: Mapping[str, object] | None = None,
         _extra_kwargs: Mapping[str, Any] = {},

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/client/factory.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/client/factory.py
@@ -53,10 +53,11 @@ import asyncio
 import logging
 import os
 import threading
+from collections.abc import Awaitable, Callable, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Literal, Mapping, Protocol
+from typing import Any, Literal, Protocol
 
 import httpx
 from nemo_platform import (
@@ -64,6 +65,7 @@ from nemo_platform import (
     DefaultHttpxClient,
     NeMoPlatform,
     NotGiven,
+    Omit,
     not_given,
 )
 from nemo_platform_plugin.client.constants import WORKLOAD_IDENTITY_TOKEN_FILE_ENVVAR
@@ -97,6 +99,12 @@ class _AccessTokenProvider(Protocol):
     async def get_access_token_async(self) -> str: ...
 
 
+_SyncRequestHook = Callable[[httpx.Request], None]
+_AsyncRequestHook = Callable[[httpx.Request], Awaitable[None]]
+_SyncHttpClientFactory = Callable[[_SyncRequestHook, str | Literal[True]], httpx.Client]
+_AsyncHttpClientFactory = Callable[[_AsyncRequestHook, str | Literal[True]], httpx.AsyncClient]
+
+
 @dataclass(frozen=True)
 class ClientInitConfig:
     """Everything the SDK client constructor needs after config resolution.
@@ -108,7 +116,7 @@ class ClientInitConfig:
 
     base_url: str
     workspace: str | None
-    default_headers: Mapping[str, str] | None = None
+    default_headers: Mapping[str, str | Omit] | None = None
     http_client: httpx.Client | httpx.AsyncClient | None = None
     client_verify: str | Literal[True] = True
 
@@ -119,7 +127,7 @@ class _ResolvedBootstrap:
 
     base_url: str
     workspace: str | None
-    default_headers: dict[str, str]
+    default_headers: dict[str, str | Omit]
     token_provider: _AccessTokenProvider | None  # None for non-OAuth users
     client_verify: str | Literal[True]
     certificate_authority: str | None = None
@@ -271,7 +279,7 @@ class _LazyWorkloadTokenExchangeProvider:
 # ---------------------------------------------------------------------------
 
 
-def _make_auth_event_hook(provider: _AccessTokenProvider):
+def _make_auth_event_hook(provider: _AccessTokenProvider) -> _SyncRequestHook:
     """Create a **sync** httpx request event hook that injects the Bearer token.
 
     Called before every SDK HTTP request.  ``provider.get_access_token()``
@@ -286,7 +294,7 @@ def _make_auth_event_hook(provider: _AccessTokenProvider):
     return inject_auth
 
 
-def _make_async_auth_event_hook(provider: _AccessTokenProvider):
+def _make_async_auth_event_hook(provider: _AccessTokenProvider) -> _AsyncRequestHook:
     """Create an **async** httpx request event hook for AsyncNeMoPlatform.
 
     The actual refresh still runs in a worker thread (via
@@ -300,7 +308,10 @@ def _make_async_auth_event_hook(provider: _AccessTokenProvider):
     return inject_auth
 
 
-def _headers_with_seeded_auth(headers: Mapping[str, str], provider: _AccessTokenProvider) -> dict[str, str]:
+def _headers_with_seeded_auth(
+    headers: Mapping[str, str | Omit],
+    provider: _AccessTokenProvider,
+) -> dict[str, str | Omit]:
     seeded_headers = dict(headers)
     if isinstance(provider, _LazyWorkloadTokenExchangeProvider):
         token = provider.get_cached_access_token()
@@ -502,7 +513,7 @@ def _resolve_bootstrap(
     base_url: str | httpx.URL | None,
     context_name: str | None,
     access_token: str | None,
-    extra_headers: Mapping[str, str] | None,
+    extra_headers: Mapping[str, str | Omit] | None,
 ) -> _ResolvedBootstrap:
     """Resolve the full client bootstrap: config, OIDC discovery, token provider.
 
@@ -529,7 +540,7 @@ def _resolve_bootstrap(
     base_url = str(resolved.cluster.base_url)
     certificate_authority = resolved.cluster.certificate_authority
     client_verify = client_verify_from_env(certificate_authority)
-    headers: dict[str, str] = dict(extra_headers) if extra_headers else {}
+    headers: dict[str, str | Omit] = dict(extra_headers) if extra_headers else {}
 
     workload_identity_token_file = _workload_identity_token_file_from_env()
     if workload_identity_token_file is not None and access_token is None and not os.environ.get("NMP_ACCESS_TOKEN"):
@@ -629,7 +640,8 @@ def build_client_init_kwargs(
     base_url: str | httpx.URL | None = None,
     context_name: str | None = None,
     access_token: str | None = None,
-    extra_headers: Mapping[str, str] | None = None,
+    extra_headers: Mapping[str, str | Omit] | None = None,
+    http_client_factory: _SyncHttpClientFactory | None = None,
 ) -> ClientInitConfig:
     """Build constructor kwargs for a **sync** NeMoPlatform client.
 
@@ -659,10 +671,14 @@ def build_client_init_kwargs(
     # The event hook will overwrite it with a fresh token on each request.
     headers = _headers_with_seeded_auth(bootstrap.default_headers, bootstrap.token_provider)
     hook = _make_auth_event_hook(bootstrap.token_provider)
-    http_client = DefaultHttpxClient(
-        event_hooks={"request": [hook], "response": []},
-        follow_redirects=True,
-        verify=bootstrap.client_verify,
+    http_client = (
+        http_client_factory(hook, bootstrap.client_verify)
+        if http_client_factory is not None
+        else DefaultHttpxClient(
+            event_hooks={"request": [hook], "response": []},
+            follow_redirects=True,
+            verify=bootstrap.client_verify,
+        )
     )
     return ClientInitConfig(
         base_url=bootstrap.base_url,
@@ -679,7 +695,8 @@ def build_async_client_init_kwargs(
     base_url: str | httpx.URL | None = None,
     context_name: str | None = None,
     access_token: str | None = None,
-    extra_headers: Mapping[str, str] | None = None,
+    extra_headers: Mapping[str, str | Omit] | None = None,
+    http_client_factory: _AsyncHttpClientFactory | None = None,
 ) -> ClientInitConfig:
     """Build constructor kwargs for an **async** AsyncNeMoPlatform client.
 
@@ -704,10 +721,14 @@ def build_async_client_init_kwargs(
 
     headers = _headers_with_seeded_auth(bootstrap.default_headers, bootstrap.token_provider)
     hook = _make_async_auth_event_hook(bootstrap.token_provider)
-    http_client = DefaultAsyncHttpxClient(
-        event_hooks={"request": [hook], "response": []},
-        follow_redirects=True,
-        verify=bootstrap.client_verify,
+    http_client = (
+        http_client_factory(hook, bootstrap.client_verify)
+        if http_client_factory is not None
+        else DefaultAsyncHttpxClient(
+            event_hooks={"request": [hook], "response": []},
+            follow_redirects=True,
+            verify=bootstrap.client_verify,
+        )
     )
     return ClientInitConfig(
         base_url=bootstrap.base_url,
@@ -726,7 +747,7 @@ def create_client(
     access_token: str | None = None,
     timeout: float | httpx.Timeout | None | NotGiven = not_given,
     max_retries: int = 2,
-    extra_headers: Mapping[str, str] | None = None,
+    extra_headers: Mapping[str, str | Omit] | None = None,
 ) -> NeMoPlatform:
     """Create a NeMoPlatform client from the nmp config.
 

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/dependencies.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/dependencies.py
@@ -9,17 +9,15 @@ The platform injects real implementations via app.dependency_overrides.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
+from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
 from nemo_platform_plugin.client.client import AsyncNemoClient
-
-if TYPE_CHECKING:
-    from nemo_platform import AsyncNeMoPlatform
-    from nemo_platform_plugin.config import PlatformConfig
-    from nemo_platform_plugin.entities import EntityClient
+from nemo_platform_plugin.config import PlatformConfig
+from nemo_platform_plugin.entities import EntityClient
 
 
-def get_platform_config() -> "PlatformConfig":
+def get_platform_config() -> PlatformConfig:
     """FastAPI dependency for getting the platform config.
 
     This is a placeholder — the actual config is injected via
@@ -42,7 +40,7 @@ def get_service_config() -> Any:
     )
 
 
-def get_sdk_client() -> "AsyncNeMoPlatform":
+def get_sdk_client() -> AsyncNeMoPlatform:
     """FastAPI dependency for getting the async platform SDK client.
 
     This is a placeholder — the actual client is injected via
@@ -50,6 +48,18 @@ def get_sdk_client() -> "AsyncNeMoPlatform":
     """
     raise RuntimeError(
         "get_sdk_client() was called without being overridden. Ensure your Service subclass calls super().create_app()."
+    )
+
+
+def get_sync_sdk_client() -> NeMoPlatform:
+    """FastAPI dependency for getting the sync platform SDK client.
+
+    This is a placeholder — the actual client is injected via
+    app.dependency_overrides in Service.create_app().
+    """
+    raise RuntimeError(
+        "get_sync_sdk_client() was called without being overridden. "
+        "Ensure your Service subclass calls super().create_app()."
     )
 
 
@@ -77,7 +87,7 @@ def get_effective_principal_id() -> str:
     )
 
 
-def get_entity_client() -> "EntityClient":
+def get_entity_client() -> EntityClient:
     """FastAPI dependency for getting the EntityClient.
 
     This is a placeholder — the actual client is injected via

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/functions/routes.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/functions/routes.py
@@ -14,13 +14,11 @@ It returns an :class:`APIRouter` carrying a single ``POST`` route that:
   header.
 - Resolves keyword-only DI parameters on
   :meth:`~nemo_platform_plugin.function.NemoFunction.run` by parameter name —
-  ``ctx`` (FunctionContext), ``async_sdk``
+  ``ctx`` (FunctionContext), ``sdk`` (``NeMoPlatform``), ``async_sdk``
   (``AsyncNeMoPlatform``, resolved from
-  :func:`~nemo_platform_plugin.dependencies.get_sdk_client`), and ``is_local=False``. Functions
-  intentionally do **not** receive a sync ``sdk`` here: the API
-  process is async; sync work belongs inside
-  :func:`anyio.to_thread.run_sync` and bridges back to the loop via
-  :func:`anyio.from_thread.run`.
+  :func:`~nemo_platform_plugin.dependencies.get_sdk_client`), and ``is_local=False``.
+  Functions that need sync-only libraries may request ``sdk`` and run that
+  work inside :func:`anyio.to_thread.run_sync` / :func:`asyncio.to_thread`.
 - Awaits ``run(spec, **resolved)``.
 - If the result is an async iterator/generator, wraps it in a
   :class:`StreamingResponse` with media type
@@ -60,19 +58,17 @@ import json
 import logging
 from collections.abc import AsyncGenerator, AsyncIterator
 from contextlib import suppress
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from fastapi import APIRouter, Depends, Header
 from fastapi.responses import JSONResponse, StreamingResponse
+from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
 from nemo_platform_plugin.authz import AuthzScope, CallerKind, path_rule
-from nemo_platform_plugin.dependencies import get_sdk_client
+from nemo_platform_plugin.dependencies import get_sdk_client, get_sync_sdk_client
 from nemo_platform_plugin.function import NemoFunction, returns_async_iterator
 from nemo_platform_plugin.function_context import FunctionContext
 from nemo_platform_plugin.functions.frames import Heartbeat
 from pydantic import BaseModel
-
-if TYPE_CHECKING:
-    pass
 
 logger = logging.getLogger(__name__)
 
@@ -168,6 +164,7 @@ def add_function_routes(
     instance = function_cls()
     run_params = function_cls.run_signature().parameters
     wants_ctx = "ctx" in run_params
+    wants_sdk = "sdk" in run_params
     wants_async_sdk = "async_sdk" in run_params
     wants_is_local = "is_local" in run_params
 
@@ -184,6 +181,7 @@ def add_function_routes(
         instance=instance,
         spec_schema=spec_schema,
         wants_ctx=wants_ctx,
+        wants_sdk=wants_sdk,
         wants_async_sdk=wants_async_sdk,
         wants_is_local=wants_is_local,
         send_headers_before_first_frame=function_cls.send_headers_before_first_frame,
@@ -234,6 +232,7 @@ def _build_route_handler(
     instance: NemoFunction,
     spec_schema: type[BaseModel],
     wants_ctx: bool,
+    wants_sdk: bool,
     wants_async_sdk: bool,
     wants_is_local: bool,
     send_headers_before_first_frame: bool,
@@ -243,17 +242,24 @@ def _build_route_handler(
 
     FastAPI inspects the handler's signature at registration time;
     every parameter with a ``Depends`` is resolved on every request.
-    Declaring ``Depends(get_sdk_client)`` on a function that doesn't
-    want ``async_sdk`` would force a runtime error on every request
-    until the platform installs ``app.dependency_overrides`` for the
-    SDK. Building the closure body's call-shape from booleans keeps
-    each function's surface as narrow as the function declared.
+    Declaring SDK dependencies on a function that doesn't want them
+    would force a runtime error on every request until the platform
+    installs ``app.dependency_overrides`` for the SDKs. Building the
+    closure body's call-shape from booleans keeps each function's
+    surface as narrow as the function declared.
     """
 
-    async def _invoke(spec_obj: BaseModel, ctx: FunctionContext | None, async_sdk: Any) -> Any:
+    async def _invoke(
+        spec_obj: BaseModel,
+        ctx: FunctionContext | None,
+        sdk: NeMoPlatform | None,
+        async_sdk: AsyncNeMoPlatform | None,
+    ) -> Any:
         kwargs: dict[str, Any] = {}
         if ctx is not None:
             kwargs["ctx"] = ctx
+        if wants_sdk:
+            kwargs["sdk"] = sdk
         if wants_async_sdk:
             kwargs["async_sdk"] = async_sdk
         if wants_is_local:
@@ -267,16 +273,39 @@ def _build_route_handler(
             return StreamingResponse(_to_ndjson(stream), media_type=NDJSON_MEDIA_TYPE)
         return await result
 
-    if wants_ctx and wants_async_sdk:
+    if wants_ctx and wants_sdk and wants_async_sdk:
 
         async def handler(
             workspace: str,
             request_body,
             x_request_id: str | None = Header(default=None, alias="X-Request-ID"),
-            async_sdk: Any = Depends(get_sdk_client),
+            sdk: NeMoPlatform = Depends(get_sync_sdk_client),
+            async_sdk: AsyncNeMoPlatform = Depends(get_sdk_client),
         ) -> Any:
             ctx = FunctionContext(workspace=workspace, request_id=x_request_id)
-            return await _invoke(request_body, ctx, async_sdk)
+            return await _invoke(request_body, ctx, sdk, async_sdk)
+
+    elif wants_ctx and wants_sdk:
+
+        async def handler(
+            workspace: str,
+            request_body,
+            x_request_id: str | None = Header(default=None, alias="X-Request-ID"),
+            sdk: NeMoPlatform = Depends(get_sync_sdk_client),
+        ) -> Any:
+            ctx = FunctionContext(workspace=workspace, request_id=x_request_id)
+            return await _invoke(request_body, ctx, sdk, None)
+
+    elif wants_ctx and wants_async_sdk:
+
+        async def handler(
+            workspace: str,
+            request_body,
+            x_request_id: str | None = Header(default=None, alias="X-Request-ID"),
+            async_sdk: AsyncNeMoPlatform = Depends(get_sdk_client),
+        ) -> Any:
+            ctx = FunctionContext(workspace=workspace, request_id=x_request_id)
+            return await _invoke(request_body, ctx, None, async_sdk)
 
     elif wants_ctx:
 
@@ -286,16 +315,35 @@ def _build_route_handler(
             x_request_id: str | None = Header(default=None, alias="X-Request-ID"),
         ) -> Any:
             ctx = FunctionContext(workspace=workspace, request_id=x_request_id)
-            return await _invoke(request_body, ctx, None)
+            return await _invoke(request_body, ctx, None, None)
+
+    elif wants_sdk and wants_async_sdk:
+
+        async def handler(
+            workspace: str,
+            request_body,
+            sdk: NeMoPlatform = Depends(get_sync_sdk_client),
+            async_sdk: AsyncNeMoPlatform = Depends(get_sdk_client),
+        ) -> Any:
+            return await _invoke(request_body, None, sdk, async_sdk)
+
+    elif wants_sdk:
+
+        async def handler(
+            workspace: str,
+            request_body,
+            sdk: NeMoPlatform = Depends(get_sync_sdk_client),
+        ) -> Any:
+            return await _invoke(request_body, None, sdk, None)
 
     elif wants_async_sdk:
 
         async def handler(
             workspace: str,
             request_body,
-            async_sdk: Any = Depends(get_sdk_client),
+            async_sdk: AsyncNeMoPlatform = Depends(get_sdk_client),
         ) -> Any:
-            return await _invoke(request_body, None, async_sdk)
+            return await _invoke(request_body, None, None, async_sdk)
 
     else:
 
@@ -303,7 +351,7 @@ def _build_route_handler(
             workspace: str,
             request_body,
         ) -> Any:
-            return await _invoke(request_body, None, None)
+            return await _invoke(request_body, None, None, None)
 
     # FastAPI inspects ``__annotations__`` (via ``get_type_hints``)
     # rather than the literal source annotation, and a closure-captured

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/inference_middleware.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/inference_middleware.py
@@ -72,7 +72,11 @@ from abc import ABC
 from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, AsyncIterator, Protocol, TypeAlias, Union, runtime_checkable
+from typing import TYPE_CHECKING, Any, AsyncIterator, Protocol, TypeAlias, Union, runtime_checkable
+
+if TYPE_CHECKING:
+    # Keep this public base import-light; importing the generated SDK loads pydantic.
+    from nemo_platform import AsyncNeMoPlatform
 
 
 class BackendFormat(str, Enum):
@@ -747,6 +751,7 @@ class NemoInferenceMiddleware(ABC):
 
     def __init__(self) -> None:
         self._cache: InferenceMiddlewareCacheAccessor | None = None
+        self._platform_sdk: AsyncNeMoPlatform | None = None
 
     # ------------------------------------------------------------------
     # IGW-called injection point (not part of the plugin author API)
@@ -758,6 +763,21 @@ class NemoInferenceMiddleware(ABC):
         Plugin authors must not call this method directly.
         """
         self._cache = cache
+
+    def _inject_platform_sdk(self, sdk: AsyncNeMoPlatform) -> None:
+        """Called by IGW to inject a caller-owned SDK before on_startup().
+
+        Plugin authors must not call or close this SDK directly.
+        """
+        self._platform_sdk = sdk
+
+    def _get_platform_sdk(self, method_name: str) -> AsyncNeMoPlatform:
+        if self._platform_sdk is None:
+            raise RuntimeError(
+                f"{method_name}() is not available before IGW injects the platform SDK. "
+                f"Call {method_name}() from on_startup() or later."
+            )
+        return self._platform_sdk
 
     def _get_cache(self, method_name: str) -> InferenceMiddlewareCacheAccessor:
         if self._cache is None:

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/jobs/file_manager.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/jobs/file_manager.py
@@ -10,8 +10,7 @@ from pathlib import Path
 from typing import Protocol
 
 import anyio
-import fsspec.asyn
-from filesets import FilesetFileSystem, build_fileset_ref, parse_fileset_ref
+from filesets import AsyncFilesetFileSystem, FilesetFileSystem, build_fileset_ref, parse_fileset_ref
 from nemo_platform_plugin.files.types import CreateFilesetRequest
 from nemo_platform_plugin.jobs.schemas import FileStorageType
 
@@ -83,6 +82,11 @@ async def _list_local_files(local_path: Path) -> list[str]:
     return files
 
 
+def _list_local_files_sync(local_path: Path) -> list[str]:
+    """List all files in a local directory recursively."""
+    return [str(file_path.relative_to(local_path)) for file_path in local_path.rglob("*") if file_path.is_file()]
+
+
 class FileManager(Protocol):
     """
     Protocol for a generic file provider. Both the async and sync versions must be implemented,
@@ -133,13 +137,6 @@ class BaseFilesetFileManager:
 
     workspace: str
     fileset_name: str
-    filesystem: FilesetFileSystem
-    ensure_fileset_exists: bool = True
-
-    _fs: FilesetFileSystem = field(init=False)
-
-    def __post_init__(self):
-        self._fs = self.filesystem
 
     def url(self, remote_path: str | None = None) -> str:
         """Return fileset reference for the given path."""
@@ -155,6 +152,81 @@ class BaseFilesetFileManager:
         if remote_path:
             return build_fileset_ref(remote_path, workspace=self.workspace, fileset=self.fileset_name)
         return f"{self.workspace}/{self.fileset_name}"
+
+
+@dataclass
+class FilesetFileManager(BaseFilesetFileManager):
+    """Synchronous FileManager implementation for Filesets."""
+
+    filesystem: FilesetFileSystem
+    ensure_fileset_exists: bool = True
+
+    _fs: FilesetFileSystem = field(init=False)
+
+    def __post_init__(self) -> None:
+        self._fs = self.filesystem
+
+    def validate_storage(self) -> None:
+        """Check if fileset exists, create if ensure_fileset_exists=True."""
+        try:
+            self._fs.info(self._fileset_path())
+        except FileNotFoundError:
+            if self.ensure_fileset_exists:
+                logger.info(f"Creating new fileset: [{self.fileset_name}] in workspace [{self.workspace}]")
+                self._fs._client.create_fileset(
+                    body=CreateFilesetRequest(name=self.fileset_name), workspace=self.workspace
+                )
+            else:
+                raise FileStorageDoesNotExist(
+                    f"Fileset [{self.fileset_name}] in workspace [{self.workspace}] does not exist."
+                )
+
+    def upload(self, local_path: Path, remote_path: str, ignore_patterns: list[str] | str | None = None) -> str:
+        """Upload file or directory to fileset."""
+        full_remote_path = self._fileset_path(remote_path)
+        if local_path.is_dir():
+            all_files = _list_local_files_sync(local_path)
+            files_to_upload = _filter_files_by_patterns(all_files, ignore_patterns)
+            for rel_path in files_to_upload:
+                self._fs.put_file(str(local_path / rel_path), f"{full_remote_path}/{rel_path}")
+        else:
+            self._fs.put_file(str(local_path), full_remote_path)
+        return self.url(remote_path)
+
+    def download_from_url(self, url: str, local_dir: str | Path | None = None) -> TmpDirPath:
+        """Download from fileset:// URL."""
+        workspace, fileset, remote_path = parse_fileset_ref(url, workspace_fallback=self.workspace)
+        if workspace != self.workspace or fileset != self.fileset_name:
+            raise ValueError(f"URL [{url}] is not a valid fileset:// URL for this manager.")
+
+        if local_dir is None:
+            local_dir = tempfile.mkdtemp()
+        if isinstance(local_dir, str):
+            local_dir = Path(local_dir)
+
+        full_remote_path = self._fileset_path(remote_path)
+        info = self._fs.info(full_remote_path)
+
+        if info["type"] == "directory":
+            self._fs.get(full_remote_path, str(local_dir), recursive=True)
+            return TmpDirPath(path=local_dir / remote_path.split("/")[-1], tmp_dir=local_dir)
+
+        local_file_path = local_dir / Path(remote_path).name
+        self._fs.get_file(full_remote_path, str(local_file_path))
+        return TmpDirPath(path=local_file_path, tmp_dir=local_dir)
+
+
+@dataclass
+class AsyncFilesetFileManager(BaseFilesetFileManager):
+    """Asynchronous FileManager implementation for Filesets."""
+
+    filesystem: AsyncFilesetFileSystem
+    ensure_fileset_exists: bool = True
+
+    _fs: AsyncFilesetFileSystem = field(init=False)
+
+    def __post_init__(self) -> None:
+        self._fs = self.filesystem
 
     async def _validate_storage(self) -> None:
         """Check if fileset exists, create if ensure_fileset_exists=True."""
@@ -204,31 +276,6 @@ class BaseFilesetFileManager:
             local_file_path = local_dir / Path(remote_path).name
             await self._fs._get_file(full_remote_path, str(local_file_path))
             return TmpDirPath(path=local_file_path, tmp_dir=local_dir)
-
-
-@dataclass
-class FilesetFileManager(BaseFilesetFileManager):
-    """Synchronous FileManager implementation for Filesets.
-
-    Uses fsspec's sync mechanism to bridge sync/async code. This schedules async
-    operations on fsspec's global daemon event loop, avoiding issues with
-    httpx.AsyncClient being bound to closed event loops (which can happen when
-    using anyio.start_blocking_portal() which creates/destroys event loops per call).
-    """
-
-    def validate_storage(self) -> None:
-        fsspec.asyn.sync(self._fs.loop, self._validate_storage)
-
-    def upload(self, local_path: Path, remote_path: str, ignore_patterns: list[str] | str | None = None) -> str:
-        return fsspec.asyn.sync(self._fs.loop, self._upload, local_path, remote_path, ignore_patterns)
-
-    def download_from_url(self, url: str, local_dir: str | Path | None = None) -> TmpDirPath:
-        return fsspec.asyn.sync(self._fs.loop, self._download_from_url, url, local_dir)
-
-
-@dataclass
-class AsyncFilesetFileManager(BaseFilesetFileManager):
-    """Asynchronous FileManager implementation for Filesets."""
 
     async def validate_storage(self) -> None:
         await self._validate_storage()

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/jobs/result_manager.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/jobs/result_manager.py
@@ -7,7 +7,7 @@ import tarfile
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from filesets import FilesetFileSystem, parse_fileset_ref
+from filesets import AsyncFilesetFileSystem, FilesetFileSystem, parse_fileset_ref
 from nemo_platform_plugin.client.errors import ConflictError as ClientConflictError
 from nemo_platform_plugin.client.errors import NemoClientError
 from nemo_platform_plugin.files.client import AsyncFilesClient, FilesClient
@@ -140,7 +140,7 @@ class AsyncResultManager(BaseResultManager):
         return AsyncFilesetFileManager(
             workspace=self.workspace,
             fileset_name=fileset_name,
-            filesystem=FilesetFileSystem(client=self.files_client),
+            filesystem=AsyncFilesetFileSystem(client=self.files_client),
         )
 
     async def create_result(

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/sdk_provider.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/sdk_provider.py
@@ -281,8 +281,12 @@ class DefaultSDKProvider:
                     headers["X-NMP-Principal-Email"] = principal["email"]
                 if principal.get("groups"):
                     headers["X-NMP-Principal-Groups"] = ",".join(principal["groups"])
+                if principal.get("on_behalf_of"):
+                    headers.update(_on_behalf_of_headers(principal))
 
         if on_behalf_of is not None:
+            headers.pop("X-NMP-Principal-On-Behalf-Of-Email", None)
+            headers.pop("X-NMP-Principal-On-Behalf-Of-Groups", None)
             headers["X-NMP-Principal-On-Behalf-Of"] = on_behalf_of
 
         return headers

--- a/packages/nemo_platform_plugin/tests/test_factory_authz.py
+++ b/packages/nemo_platform_plugin/tests/test_factory_authz.py
@@ -23,10 +23,10 @@ from nemo_platform_plugin.jobs.api_factory import (
     FileResultSerializer,
     JobRouteOption,
     PlatformJobResultRoute,
-    PlatformJobSpec,
     job_route_factory,
 )
 from nemo_platform_plugin.jobs.routes import _rebase_job_collection_routes
+from nemo_platform_plugin.jobs.spec import PlatformJobSpec
 from nemo_platform_plugin.service import NemoService, RouterSpec
 from pydantic import BaseModel
 

--- a/packages/nemo_platform_plugin/tests/test_functions_routes.py
+++ b/packages/nemo_platform_plugin/tests/test_functions_routes.py
@@ -15,7 +15,7 @@ Covers:
 - DI: ``ctx`` annotation gets a :class:`FunctionContext` with the
   workspace from the path and the request id from the
   ``X-Request-ID`` header.
-- DI: ``async_sdk`` annotation gets the request-scoped platform
+- DI: ``sdk`` and ``async_sdk`` annotations get the request-scoped platform
   handle (overridden via ``app.dependency_overrides``).
 
 The tests mount the auto-derived router under
@@ -28,12 +28,13 @@ from __future__ import annotations
 import asyncio
 import json
 from collections.abc import AsyncIterator
+from dataclasses import dataclass
 from typing import Annotated, Any, ClassVar, Literal
 
 import pytest
 from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
-from nemo_platform_plugin.dependencies import get_sdk_client
+from nemo_platform_plugin.dependencies import get_sdk_client, get_sync_sdk_client
 from nemo_platform_plugin.function import NemoFunction
 from nemo_platform_plugin.function_context import FunctionContext
 from nemo_platform_plugin.functions.frames import Done, FrameModel, Heartbeat
@@ -56,6 +57,11 @@ class GreetSpec(BaseModel):
 
 class GreetResponse(BaseModel):
     message: str
+
+
+@dataclass(frozen=True)
+class _MarkerSdk:
+    marker: str
 
 
 class _NonStreamingGreet(NemoFunction[GreetSpec]):
@@ -114,10 +120,30 @@ class _SdkGreet(NemoFunction[GreetSpec]):
     name: ClassVar[str] = "sdk-greet"
     spec_schema: ClassVar[type[BaseModel]] = GreetSpec
 
-    async def run(self, spec: GreetSpec, *, async_sdk: object) -> dict:
+    async def run(self, spec: GreetSpec, *, async_sdk: _MarkerSdk) -> dict:
         # Echo a marker attribute so the test can assert the override
         # actually flowed through.
-        return {"name": spec.name, "sdk_marker": getattr(async_sdk, "marker", None)}
+        return {"name": spec.name, "sdk_marker": async_sdk.marker}
+
+
+class _SyncSdkGreet(NemoFunction[GreetSpec]):
+    name: ClassVar[str] = "sync-sdk-greet"
+    spec_schema: ClassVar[type[BaseModel]] = GreetSpec
+
+    async def run(self, spec: GreetSpec, *, sdk: _MarkerSdk) -> dict:
+        return {"name": spec.name, "sdk_marker": sdk.marker}
+
+
+class _BothSdkGreet(NemoFunction[GreetSpec]):
+    name: ClassVar[str] = "both-sdk-greet"
+    spec_schema: ClassVar[type[BaseModel]] = GreetSpec
+
+    async def run(self, spec: GreetSpec, *, sdk: _MarkerSdk, async_sdk: _MarkerSdk) -> dict:
+        return {
+            "name": spec.name,
+            "sdk_marker": sdk.marker,
+            "async_sdk_marker": async_sdk.marker,
+        }
 
 
 class _LocalityGreet(NemoFunction[GreetSpec]):
@@ -358,11 +384,8 @@ class TestSignatureDi:
         assert body["request_id"] is None
 
     def test_async_sdk_resolved_from_dependency_override(self) -> None:
-        class FakeSdk:
-            marker = "fake-sdk"
-
         app = _build_app(_SdkGreet)
-        app.dependency_overrides[get_sdk_client] = lambda: FakeSdk()
+        app.dependency_overrides[get_sdk_client] = lambda: _MarkerSdk("fake-sdk")
         client = TestClient(app)
         resp = client.post(
             "/apis/example/v2/workspaces/default/sdk-greet",
@@ -382,6 +405,33 @@ class TestSignatureDi:
             json={"name": "world"},
         )
         assert resp.status_code == 500
+
+    def test_sync_sdk_resolved_from_dependency_override(self) -> None:
+        app = _build_app(_SyncSdkGreet)
+        app.dependency_overrides[get_sync_sdk_client] = lambda: _MarkerSdk("fake-sync-sdk")
+        client = TestClient(app)
+        resp = client.post(
+            "/apis/example/v2/workspaces/default/sync-sdk-greet",
+            json={"name": "world"},
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"name": "world", "sdk_marker": "fake-sync-sdk"}
+
+    def test_sync_and_async_sdks_resolved_independently(self) -> None:
+        app = _build_app(_BothSdkGreet)
+        app.dependency_overrides[get_sync_sdk_client] = lambda: _MarkerSdk("fake-sync-sdk")
+        app.dependency_overrides[get_sdk_client] = lambda: _MarkerSdk("fake-async-sdk")
+        client = TestClient(app)
+        resp = client.post(
+            "/apis/example/v2/workspaces/default/both-sdk-greet",
+            json={"name": "world"},
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "name": "world",
+            "sdk_marker": "fake-sync-sdk",
+            "async_sdk_marker": "fake-async-sdk",
+        }
 
 
 # ---------------------------------------------------------------------------

--- a/packages/nemo_platform_plugin/tests/test_sdk_provider.py
+++ b/packages/nemo_platform_plugin/tests/test_sdk_provider.py
@@ -166,6 +166,31 @@ class TestDefaultSDKProvider:
 
         assert sdk.default_headers["X-NMP-Principal-On-Behalf-Of"] == "user@ex.com"
 
+    def test_get_platform_sdk_propagates_env_principal_on_behalf_of(self, monkeypatch):
+        monkeypatch.setenv("NMP_BASE_URL", "http://test:9090")
+        monkeypatch.setenv(
+            "NMP_PRINCIPAL",
+            json.dumps(
+                {
+                    "id": "service:evaluator",
+                    "email": "evaluator@service.test",
+                    "groups": ["system:serviceaccounts"],
+                    "on_behalf_of": "creator@ex.com",
+                    "on_behalf_of_email": "creator@ex.com",
+                    "on_behalf_of_groups": ["workspace-editors", "ml-team"],
+                }
+            ),
+        )
+
+        sdk = DefaultSDKProvider().get_platform_sdk()
+
+        assert sdk.default_headers["X-NMP-Principal-Id"] == "service:evaluator"
+        assert sdk.default_headers["X-NMP-Principal-Email"] == "evaluator@service.test"
+        assert sdk.default_headers["X-NMP-Principal-Groups"] == "system:serviceaccounts"
+        assert sdk.default_headers["X-NMP-Principal-On-Behalf-Of"] == "creator@ex.com"
+        assert sdk.default_headers["X-NMP-Principal-On-Behalf-Of-Email"] == "creator@ex.com"
+        assert sdk.default_headers["X-NMP-Principal-On-Behalf-Of-Groups"] == "workspace-editors,ml-team"
+
 
 # ---------------------------------------------------------------------------
 # get_async_task_sdk — the async sibling of get_task_sdk
@@ -246,8 +271,26 @@ class _CustomProvider:
     def get_task_sdk(self, service_name: str) -> NeMoPlatform:
         return NeMoPlatform(base_url="http://custom:1234")
 
-    def get_platform_sdk(self, **kwargs) -> NeMoPlatform:
+    def get_async_task_sdk(self, service_name: str) -> AsyncNeMoPlatform:
+        return AsyncNeMoPlatform(base_url="http://custom:1234")
+
+    def get_platform_sdk(
+        self,
+        *,
+        as_service: str | None = None,
+        internal: bool = False,
+        on_behalf_of: str | None = None,
+    ) -> NeMoPlatform:
         return NeMoPlatform(base_url="http://custom:1234")
+
+    def get_async_platform_sdk(
+        self,
+        *,
+        as_service: str | None = None,
+        internal: bool = False,
+        on_behalf_of: str | None = None,
+    ) -> AsyncNeMoPlatform:
+        return AsyncNeMoPlatform(base_url="http://custom:1234")
 
 
 class _FakeEntryPoint:

--- a/packages/nmp_common/pyproject.toml
+++ b/packages/nmp_common/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "base58>=2.1.1",
     "pydantic>=2.10.3",
     "pydantic-settings>=2.8.1",
-    "fastapi[standard]>=0.115.4",
+    "fastapi[standard]>=0.137.2",
     "lark>=1.1.0",
     "nemo-platform-plugin",
     "pyyaml>=6.0.2",

--- a/packages/nmp_common/src/nmp/common/auth/access_key_lifecycle.py
+++ b/packages/nmp_common/src/nmp/common/auth/access_key_lifecycle.py
@@ -49,14 +49,11 @@ class AccessKeyLifecycleAuthenticator:
 
     def _get_sdk(self) -> AsyncNeMoPlatform:
         if self._sdk is None:
-            # Import lazily to avoid an auth -> SDK factory import cycle. The
-            # factory attaches PlatformRequestRouter, which owns service
-            # discovery and transport selection for /apis/auth requests.
-            from nmp.common.sdk_factory import get_async_platform_sdk, with_options_preserving_request_router
+            # Import lazily to avoid an auth -> SDK factory import cycle.
+            from nmp.common.sdk_factory import get_async_platform_sdk
 
             sdk = get_async_platform_sdk(http_client=self._http_client)
-            self._sdk = with_options_preserving_request_router(
-                sdk,
+            self._sdk = sdk.with_options(
                 max_retries=0,
                 _extra_kwargs={"_strict_response_validation": True},
             )

--- a/packages/nmp_common/src/nmp/common/client_factory.py
+++ b/packages/nmp_common/src/nmp/common/client_factory.py
@@ -8,8 +8,8 @@ This is the :class:`~nemo_platform_plugin.client.client.NemoClient` sibling of
 platform machinery the SDK factory uses:
 
 - base URL from :class:`~nmp.common.config.Configuration`;
-- per-service URL routing via :class:`~nmp.common.sdk_factory.PlatformRequestRouter`;
-- the shared sync/async HTTP clients (connection-pool + SSL-context reuse);
+- per-service URL routing via :class:`~nmp.common.platform_endpoint.PlatformEndpoint`;
+- endpoint-aware sync/async HTTP clients;
 - principal / auth + internal-request headers via ``_get_default_headers``;
 - OTEL trace-propagation headers captured on the current request.
 
@@ -22,7 +22,6 @@ from __future__ import annotations
 
 import logging
 import os
-from collections.abc import Callable
 from pathlib import Path
 
 import httpx
@@ -33,50 +32,32 @@ from nemo_platform_plugin.client.constants import (
     is_workload_identity_token_file_set,
 )
 from nmp.common.auth import Principal, principal_from_env
-from nmp.common.config import get_platform_config
-from nmp.common.http_clients import shared_async_http_client, shared_sync_http_client
 from nmp.common.observability import MARK_INTERNAL_REQUEST_HEADERS
 from nmp.common.observability.otel import get_otel_headers
 from nmp.common.platform_endpoint import PlatformEndpoint, resolve_platform_endpoint
-from nmp.common.sdk_factory import PlatformRequestRouter, _get_default_headers, _should_bootstrap_workload_identity
+from nmp.common.sdk_factory import _get_default_headers, _should_bootstrap_workload_identity
 
 logger = logging.getLogger(__name__)
-
-# Test-only: async HTTP client to use for NemoClient requests in test context.
-# Set by test fixtures to route requests through the in-process test transport,
-# mirroring ``nmp.common.sdk_factory._test_http_client``.
-_test_http_client: httpx.AsyncClient | None = None
 
 
 def _sync_http_client_for_endpoint(
     endpoint: PlatformEndpoint,
     http_client: httpx.Client | None,
 ) -> httpx.Client:
-    """Endpoint-aware sync client: honour an explicit client, else a UDS
-    transport for ``unix://`` endpoints, else the shared TCP client."""
+    """Endpoint-aware sync client, honoring explicit clients first."""
     if http_client is not None:
         return http_client
-    if endpoint.transport == "uds":
-        return endpoint.sync_http_client()
-    return shared_sync_http_client()
+    return endpoint.sync_sdk_http_client()
 
 
 def _async_http_client_for_endpoint(
     endpoint: PlatformEndpoint,
     http_client: httpx.AsyncClient | None,
 ) -> httpx.AsyncClient:
-    """Async counterpart of :func:`_sync_http_client_for_endpoint`.
-
-    Preserves the module-level ``_test_http_client`` fixture hook ahead of the
-    UDS / shared-client selection (mirrors ``sdk_factory``).
-    """
+    """Async counterpart of :func:`_sync_http_client_for_endpoint`."""
     if http_client is not None:
         return http_client
-    if _test_http_client is not None:
-        return _test_http_client
-    if endpoint.transport == "uds":
-        return endpoint.async_http_client()
-    return shared_async_http_client()
+    return endpoint.async_sdk_http_client()
 
 
 def _workload_identity_auth(base_url: str) -> TokenProvider:
@@ -92,25 +73,6 @@ def _workload_identity_auth(base_url: str) -> TokenProvider:
 
 def _workload_identity_headers(internal: bool) -> dict[str, str]:
     return MARK_INTERNAL_REQUEST_HEADERS.copy() if internal else {}
-
-
-def _absolute_url(url: str) -> httpx.URL:
-    """Default resolver for the request router.
-
-    :class:`NemoClient` hands its ``url_resolver`` the fully-qualified request
-    URL (``base_url`` + path), so — unlike the generated SDK's ``_prepare_url``,
-    which resolves a relative path — the router just needs to parse it.
-    """
-    return httpx.URL(url)
-
-
-def _platform_url_resolver() -> Callable[[str], httpx.URL]:
-    """Build a per-service URL router bound to the current platform config."""
-    router = PlatformRequestRouter(
-        platform_config=get_platform_config(),
-        default_resolver=_absolute_url,
-    )
-    return router.resolve
 
 
 def _platform_headers(
@@ -154,7 +116,7 @@ def get_nemo_client(
             :class:`~nemo_platform_plugin.client_provider.NemoClientProvider`
             protocol narrows ``on_behalf_of`` to ``str | None``.
         workspace: Default workspace used to fill ``{workspace}`` path params.
-        http_client: Optional sync HTTP client; defaults to the shared client.
+        http_client: Optional sync HTTP client; defaults to an endpoint-aware client.
 
     Note:
         OTEL trace-propagation headers are captured once, at construction, from
@@ -175,14 +137,15 @@ def get_nemo_client(
             auth=_workload_identity_auth(endpoint.connect_base_url),
             default_headers=_workload_identity_headers(internal) or None,
             http_client=_sync_http_client_for_endpoint(endpoint, http_client),
-            url_resolver=_platform_url_resolver(),
+            url_resolver=lambda url: endpoint.route_request_url(url).url,
         )
+    headers = _platform_headers(as_service, internal, on_behalf_of)
     return NemoClient(
         base_url=endpoint.connect_base_url,
         workspace=workspace,
-        default_headers=_platform_headers(as_service, internal, on_behalf_of) or None,
+        default_headers=headers or None,
         http_client=_sync_http_client_for_endpoint(endpoint, http_client),
-        url_resolver=_platform_url_resolver(),
+        url_resolver=lambda url: endpoint.route_request_url(url).url,
     )
 
 
@@ -196,9 +159,8 @@ def get_async_nemo_client(
 ) -> AsyncNemoClient:
     """Async counterpart of :func:`get_nemo_client`.
 
-    Uses the explicitly provided ``http_client`` (e.g. from a test fixture), then
-    the module-level ``_test_http_client`` fallback, then the shared async
-    client — mirroring ``nmp.common.sdk_factory.get_async_platform_sdk``.
+    Uses the explicitly provided ``http_client`` (e.g. from a test fixture), or
+    creates one from the resolved platform endpoint.
     """
     endpoint = resolve_platform_endpoint()
     if _should_bootstrap_workload_identity(
@@ -213,14 +175,15 @@ def get_async_nemo_client(
             auth=_workload_identity_auth(endpoint.connect_base_url),
             default_headers=_workload_identity_headers(internal) or None,
             http_client=_async_http_client_for_endpoint(endpoint, http_client),
-            url_resolver=_platform_url_resolver(),
+            url_resolver=lambda url: endpoint.route_request_url(url).url,
         )
+    headers = _platform_headers(as_service, internal, on_behalf_of)
     return AsyncNemoClient(
         base_url=endpoint.connect_base_url,
         workspace=workspace,
-        default_headers=_platform_headers(as_service, internal, on_behalf_of) or None,
+        default_headers=headers or None,
         http_client=_async_http_client_for_endpoint(endpoint, http_client),
-        url_resolver=_platform_url_resolver(),
+        url_resolver=lambda url: endpoint.route_request_url(url).url,
     )
 
 
@@ -291,7 +254,7 @@ def get_async_task_nemo_client(
 
 class PlatformNemoClientProvider:
     """Rich :class:`~nemo_platform_plugin.client_provider.NemoClientProvider`
-    that uses platform internals (shared HTTP clients, URL routing, OTEL
+    that uses platform internals (endpoint-aware HTTP clients, URL routing, OTEL
     headers, auth context).
 
     Registered as a ``nemo.client_provider`` entry-point so it is discovered

--- a/packages/nmp_common/src/nmp/common/immutable_http_client.py
+++ b/packages/nmp_common/src/nmp/common/immutable_http_client.py
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Immutability helpers for SDK-owned HTTP clients.
+
+NeMo Platform SDK instances reuse their underlying httpx client when callers
+derive scoped SDKs via ``with_options()`` or pass the SDK into typed plugin
+clients. Those clients must be created with their required transport-level
+configuration and then left alone.
+
+Caller-specific request configuration, including auth headers, belongs on the
+SDK instance or on a separate explicit client. Mutating an SDK-owned client
+after it has been handed out is a bug because that state can leak into derived
+SDKs or requests. These wrappers make those bugs fail immediately.
+"""
+
+from types import MappingProxyType
+from typing import NoReturn
+
+import httpx
+from httpx._types import CookieTypes, HeaderTypes
+from nemo_platform import DefaultAsyncHttpxClient, DefaultHttpxClient
+
+_IMMUTABLE_CLIENT_ATTRS = {
+    "_base_url",
+    "_cookies",
+    "_event_hooks",
+    "_headers",
+    "_params",
+    "_timeout",
+    "_transport",
+    "_mounts",
+    "_trust_env",
+    "base_url",
+    "cookies",
+    "event_hooks",
+    "follow_redirects",
+    "headers",
+    "max_redirects",
+    "params",
+    "timeout",
+    "trust_env",
+}
+
+
+def _raise_immutable_client_mutation_error() -> NoReturn:
+    raise TypeError(
+        "SDK HTTP clients are immutable. Pass per-SDK options as SDK constructor "
+        "arguments, or pass a separate httpx client configured for that use case."
+    )
+
+
+class _ImmutableHeaders(httpx.Headers):
+    def __setitem__(self, key: str, value: str) -> None:
+        _raise_immutable_client_mutation_error()
+
+    def __delitem__(self, key: str) -> None:
+        _raise_immutable_client_mutation_error()
+
+    def clear(self) -> None:
+        _raise_immutable_client_mutation_error()
+
+    def pop(self, key: str, default: object = None) -> str:
+        _raise_immutable_client_mutation_error()
+
+    def popitem(self) -> tuple[str, str]:
+        _raise_immutable_client_mutation_error()
+
+    def setdefault(self, key: str, default: str = "") -> str:
+        _raise_immutable_client_mutation_error()
+
+    def update(self, headers: HeaderTypes | None = None) -> None:
+        _raise_immutable_client_mutation_error()
+
+
+class _ImmutableCookies(httpx.Cookies):
+    def extract_cookies(self, response: httpx.Response) -> None:
+        # httpx normally persists response cookies on the client. SDK clients
+        # should not carry request/session state between derived SDK handles.
+        pass
+
+    def set(self, name: str, value: str, domain: str = "", path: str = "/") -> None:
+        _raise_immutable_client_mutation_error()
+
+    def delete(
+        self,
+        name: str,
+        domain: str | None = None,
+        path: str | None = None,
+    ) -> None:
+        _raise_immutable_client_mutation_error()
+
+    def clear(self, domain: str | None = None, path: str | None = None) -> None:
+        _raise_immutable_client_mutation_error()
+
+    def update(self, cookies: CookieTypes | None = None) -> None:
+        _raise_immutable_client_mutation_error()
+
+    def __setitem__(self, name: str, value: str) -> None:
+        _raise_immutable_client_mutation_error()
+
+    def __delitem__(self, name: str) -> None:
+        _raise_immutable_client_mutation_error()
+
+
+class ImmutableHttpClientMixin:
+    """Mixin for httpx client subclasses that are immutable after construction."""
+
+    _immutable_http_client_frozen = False
+
+    def __setattr__(self, name: str, value: object) -> None:
+        if self._immutable_http_client_frozen and name in _IMMUTABLE_CLIENT_ATTRS:
+            raise AttributeError(
+                "SDK HTTP clients are immutable. Pass a separate httpx client "
+                "when client-level configuration needs to differ."
+            )
+        super().__setattr__(name, value)
+
+    def _freeze_http_client(self) -> None:
+        # Assignment blocking is not enough because these attributes are mutable
+        # containers. Replace them with immutable versions before sharing the
+        # client through SDK clones or plugin adapters.
+        self._headers = _ImmutableHeaders(self._headers)
+        self._cookies = _ImmutableCookies(self._cookies)
+        self._event_hooks = MappingProxyType(
+            {hook_name: tuple(hooks) for hook_name, hooks in self._event_hooks.items()}
+        )
+        self._mounts = MappingProxyType(self._mounts)
+        self._immutable_http_client_frozen = True
+
+
+class ImmutableHttpxClient(ImmutableHttpClientMixin, httpx.Client):
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._freeze_http_client()
+
+
+class ImmutableAsyncHttpxClient(ImmutableHttpClientMixin, httpx.AsyncClient):
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._freeze_http_client()
+
+
+class ImmutableDefaultHttpxClient(ImmutableHttpClientMixin, DefaultHttpxClient):
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._freeze_http_client()
+
+
+class ImmutableDefaultAsyncHttpxClient(ImmutableHttpClientMixin, DefaultAsyncHttpxClient):
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._freeze_http_client()

--- a/packages/nmp_common/src/nmp/common/jobs/result_manager.py
+++ b/packages/nmp_common/src/nmp/common/jobs/result_manager.py
@@ -15,12 +15,25 @@ from nemo_platform_plugin.jobs.result_manager import AsyncResultManager as Async
 from nemo_platform_plugin.jobs.result_manager import ResultManager as ResultManager
 from nemo_platform_plugin.jobs.result_manager import async_result_manager_factory as typed_async_result_manager_factory
 from nemo_platform_plugin.jobs.result_manager import result_manager_factory as typed_result_manager_factory
+from nmp.common.sdk_factory import get_async_platform_sdk
+
+__all__ = [
+    "AsyncFilesetFileManager",
+    "AsyncResultManager",
+    "FilesetFileManager",
+    "ResultManager",
+    "TmpDirPath",
+    "async_result_manager_factory",
+    "download_from_result_info",
+    "result_manager_factory",
+]
 
 
 def result_manager_factory(
     job_name: str,
     *,
     attempt_id: str | None = None,
+    workspace: str | None = None,
     sdk: NeMoPlatform,
 ) -> ResultManager:
     """Create a sync ResultManager for uploading job results.
@@ -31,6 +44,7 @@ def result_manager_factory(
     return typed_result_manager_factory(
         job_name=job_name,
         attempt_id=attempt_id,
+        workspace=workspace,
         files_client=client_from_platform(sdk, FilesClient),
         jobs_client=client_from_platform(sdk, JobsClient),
     )
@@ -40,12 +54,14 @@ def async_result_manager_factory(
     job_name: str,
     *,
     attempt_id: str | None = None,
+    workspace: str | None = None,
     sdk: AsyncNeMoPlatform,
 ) -> AsyncResultManager:
     """Create an async ResultManager for uploading job results."""
     return typed_async_result_manager_factory(
         job_name=job_name,
         attempt_id=attempt_id,
+        workspace=workspace,
         files_client=client_from_platform(sdk, AsyncFilesClient),
         jobs_client=client_from_platform(sdk, AsyncJobsClient),
     )
@@ -56,7 +72,8 @@ async def download_from_result_info(
     job_name: str,
     *,
     artifact_url: str,
-    sdk: AsyncNeMoPlatform,
+    workspace: str | None = None,
+    sdk: AsyncNeMoPlatform | None = None,
 ) -> tuple[str, TmpDirPath]:
     """Backward-compatible wrapper that uses the local async result manager factory.
 
@@ -64,20 +81,30 @@ async def download_from_result_info(
     in tests also affects download_from_result_info, preserving the old monkeypatch
     behavior.
     """
-    mgr = async_result_manager_factory(
-        job_name=job_name,
-        sdk=sdk,
-    )
+    owned_sdk: AsyncNeMoPlatform | None = None
+    if sdk is None:
+        owned_sdk = get_async_platform_sdk()
+        sdk = owned_sdk
 
-    tmp_dir_path = await mgr.download_artifact(artifact_url=artifact_url)
-    filename = result_name
+    try:
+        mgr = async_result_manager_factory(
+            job_name=job_name,
+            workspace=workspace,
+            sdk=sdk,
+        )
 
-    if tmp_dir_path.path.is_dir():
-        filename = f"{filename}.tar.gz"
-        tar_path = tmp_dir_path.tmp_dir / filename
-        with tarfile.open(tar_path, "w:gz") as tar:
-            tar.add(tmp_dir_path.path, arcname=os.path.basename(tmp_dir_path.path))
+        tmp_dir_path = await mgr.download_artifact(artifact_url=artifact_url)
+        filename = result_name
 
-        tmp_dir_path.path = tar_path
+        if tmp_dir_path.path.is_dir():
+            filename = f"{filename}.tar.gz"
+            tar_path = tmp_dir_path.tmp_dir / filename
+            with tarfile.open(tar_path, "w:gz") as tar:
+                tar.add(tmp_dir_path.path, arcname=os.path.basename(tmp_dir_path.path))
 
-    return filename, tmp_dir_path
+            tmp_dir_path.path = tar_path
+
+        return filename, tmp_dir_path
+    finally:
+        if owned_sdk is not None:
+            await owned_sdk.close()

--- a/packages/nmp_common/src/nmp/common/platform_endpoint.py
+++ b/packages/nmp_common/src/nmp/common/platform_endpoint.py
@@ -5,17 +5,135 @@
 
 from __future__ import annotations
 
+import logging
 import os
-from dataclasses import dataclass
+import re
+from collections.abc import Awaitable, Callable, Iterable, Mapping
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Literal
+from types import MappingProxyType
+from typing import Literal, TypedDict
 
 import httpx
 from httpx._types import TimeoutTypes
-from nemo_platform import DefaultAsyncHttpxClient, DefaultHttpxClient
-from nmp.common.config import PlatformConfig
+from nemo_platform_plugin.client.tls import client_verify_from_env
+from nmp.common.config import Configuration, PlatformConfig
+from nmp.common.immutable_http_client import (
+    ImmutableAsyncHttpxClient,
+    ImmutableDefaultAsyncHttpxClient,
+    ImmutableDefaultHttpxClient,
+    ImmutableHttpxClient,
+)
 
 UDS_BASE_URL = "http://nemo-platform.local"
+logger = logging.getLogger(__name__)
+_SyncRequestHook = Callable[[httpx.Request], None]
+_AsyncRequestHook = Callable[[httpx.Request], Awaitable[None]]
+_SyncEventHooks = Mapping[str, list[_SyncRequestHook]]
+_AsyncEventHooks = Mapping[str, list[_AsyncRequestHook]]
+
+
+class _SyncClientKwargs(TypedDict, total=False):
+    event_hooks: _SyncEventHooks
+    follow_redirects: bool
+    timeout: TimeoutTypes
+    transport: httpx.BaseTransport
+    verify: str | bool
+
+
+class _AsyncClientKwargs(TypedDict, total=False):
+    event_hooks: _AsyncEventHooks
+    follow_redirects: bool
+    timeout: TimeoutTypes
+    transport: httpx.AsyncBaseTransport
+    verify: str | bool
+
+
+def _empty_service_endpoints() -> Mapping[str, "PlatformEndpoint"]:
+    return MappingProxyType({})
+
+
+def _sync_event_hooks(request_hooks: Iterable[_SyncRequestHook] | None) -> _SyncEventHooks | None:
+    hooks = list(request_hooks) if request_hooks is not None else []
+    return {"request": hooks, "response": []} if hooks else None
+
+
+def _async_event_hooks(request_hooks: Iterable[_AsyncRequestHook] | None) -> _AsyncEventHooks | None:
+    hooks = list(request_hooks) if request_hooks is not None else []
+    return {"request": hooks, "response": []} if hooks else None
+
+
+def _sync_default_sdk_client(
+    *,
+    timeout: TimeoutTypes | None,
+    event_hooks: _SyncEventHooks | None,
+    verify: str | bool | None = None,
+    transport: httpx.BaseTransport | None = None,
+) -> httpx.Client:
+    kwargs: _SyncClientKwargs = {}
+    if timeout is not None:
+        kwargs["timeout"] = timeout
+    if event_hooks is not None:
+        kwargs["event_hooks"] = event_hooks
+    if verify is not None:
+        kwargs["verify"] = verify
+    if transport is not None:
+        kwargs["transport"] = transport
+    return ImmutableDefaultHttpxClient(**kwargs)
+
+
+def _sync_uds_sdk_client(
+    *,
+    transport: httpx.BaseTransport,
+    timeout: TimeoutTypes | None,
+    event_hooks: _SyncEventHooks | None,
+) -> httpx.Client:
+    kwargs: _SyncClientKwargs = {"transport": transport, "follow_redirects": True}
+    if timeout is not None:
+        kwargs["timeout"] = timeout
+    if event_hooks is not None:
+        kwargs["event_hooks"] = event_hooks
+    return ImmutableHttpxClient(**kwargs)
+
+
+def _async_default_sdk_client(
+    *,
+    timeout: TimeoutTypes | None,
+    event_hooks: _AsyncEventHooks | None,
+    verify: str | bool | None = None,
+    transport: httpx.AsyncBaseTransport | None = None,
+) -> httpx.AsyncClient:
+    kwargs: _AsyncClientKwargs = {}
+    if timeout is not None:
+        kwargs["timeout"] = timeout
+    if event_hooks is not None:
+        kwargs["event_hooks"] = event_hooks
+    if verify is not None:
+        kwargs["verify"] = verify
+    if transport is not None:
+        kwargs["transport"] = transport
+    return ImmutableDefaultAsyncHttpxClient(**kwargs)
+
+
+def _async_uds_sdk_client(
+    *,
+    transport: httpx.AsyncBaseTransport,
+    timeout: TimeoutTypes | None,
+    event_hooks: _AsyncEventHooks | None,
+) -> httpx.AsyncClient:
+    kwargs: _AsyncClientKwargs = {"transport": transport, "follow_redirects": True}
+    if timeout is not None:
+        kwargs["timeout"] = timeout
+    if event_hooks is not None:
+        kwargs["event_hooks"] = event_hooks
+    return ImmutableAsyncHttpxClient(**kwargs)
+
+
+def _get_platform_config() -> PlatformConfig:
+    platform_config = Configuration.get_platform_config()
+    if not isinstance(platform_config, PlatformConfig):
+        raise TypeError("Expected PlatformConfig from Configuration.get_platform_config()")
+    return platform_config
 
 
 @dataclass(frozen=True)
@@ -23,6 +141,12 @@ class PlatformEndpoint:
     connect_base_url: str
     socket_path: Path | None
     transport: Literal["tcp", "uds"]
+    service_pattern: re.Pattern[str] | None = field(default=None, repr=False, compare=False)
+    service_endpoints: Mapping[str, "PlatformEndpoint"] = field(
+        default_factory=_empty_service_endpoints,
+        repr=False,
+        compare=False,
+    )
 
     def sync_http_client(self, *, timeout: TimeoutTypes | None = None) -> httpx.Client:
         if self.transport == "uds":
@@ -48,40 +172,148 @@ class PlatformEndpoint:
             return httpx.AsyncClient(follow_redirects=True)
         return httpx.AsyncClient(follow_redirects=True, timeout=timeout)
 
-    def sync_sdk_http_client(self, *, timeout: TimeoutTypes | None = None) -> httpx.Client:
+    def sync_sdk_http_client(
+        self,
+        *,
+        timeout: TimeoutTypes | None = None,
+        http_client: httpx.Client | None = None,
+        request_hooks: Iterable[_SyncRequestHook] | None = None,
+        verify: str | bool | None = None,
+    ) -> httpx.Client:
+        if http_client is not None:
+            if not self.service_endpoints:
+                return http_client
+            return ImmutableDefaultHttpxClient(
+                base_url=http_client.base_url,
+                cookies=http_client.cookies,
+                follow_redirects=http_client.follow_redirects,
+                headers=http_client.headers,
+                max_redirects=http_client.max_redirects,
+                params=http_client.params,
+                timeout=http_client.timeout,
+                transport=_SyncExplicitClientRoutingTransport(endpoint=self, http_client=http_client),
+            )
+        event_hooks = _sync_event_hooks(request_hooks)
+        if self.service_endpoints:
+            transport = _SyncPlatformEndpointRoutingTransport(endpoint=self, verify=verify)
+            return _sync_default_sdk_client(transport=transport, timeout=timeout, event_hooks=event_hooks)
         if self.transport == "uds":
-            return self.sync_http_client(timeout=timeout)
-        if timeout is None:
-            return DefaultHttpxClient()
-        return DefaultHttpxClient(timeout=timeout)
+            if self.socket_path is None:
+                raise ValueError("UDS endpoint is missing a socket path")
+            transport = httpx.HTTPTransport(uds=str(self.socket_path))
+            return _sync_uds_sdk_client(transport=transport, timeout=timeout, event_hooks=event_hooks)
+        return _sync_default_sdk_client(timeout=timeout, event_hooks=event_hooks, verify=verify)
 
-    def async_sdk_http_client(self, *, timeout: TimeoutTypes | None = None) -> httpx.AsyncClient:
+    def async_sdk_http_client(
+        self,
+        *,
+        timeout: TimeoutTypes | None = None,
+        http_client: httpx.AsyncClient | None = None,
+        request_hooks: Iterable[_AsyncRequestHook] | None = None,
+        verify: str | bool | None = None,
+    ) -> httpx.AsyncClient:
+        if http_client is not None:
+            if not self.service_endpoints:
+                return http_client
+            return ImmutableDefaultAsyncHttpxClient(
+                base_url=http_client.base_url,
+                cookies=http_client.cookies,
+                follow_redirects=http_client.follow_redirects,
+                headers=http_client.headers,
+                max_redirects=http_client.max_redirects,
+                params=http_client.params,
+                timeout=http_client.timeout,
+                transport=_AsyncExplicitClientRoutingTransport(endpoint=self, http_client=http_client),
+            )
+        event_hooks = _async_event_hooks(request_hooks)
+        if self.service_endpoints:
+            transport = _AsyncPlatformEndpointRoutingTransport(endpoint=self, verify=verify)
+            return _async_default_sdk_client(transport=transport, timeout=timeout, event_hooks=event_hooks)
         if self.transport == "uds":
-            return self.async_http_client(timeout=timeout)
-        if timeout is None:
-            return DefaultAsyncHttpxClient()
-        return DefaultAsyncHttpxClient(timeout=timeout)
+            if self.socket_path is None:
+                raise ValueError("UDS endpoint is missing a socket path")
+            transport = httpx.AsyncHTTPTransport(uds=str(self.socket_path))
+            return _async_uds_sdk_client(transport=transport, timeout=timeout, event_hooks=event_hooks)
+        return _async_default_sdk_client(timeout=timeout, event_hooks=event_hooks, verify=verify)
+
+    def route_request_url(self, url: str | httpx.URL) -> "RoutedPlatformEndpointRequest":
+        """Resolve one outgoing SDK URL using this endpoint's fixed routing table."""
+
+        request_url = httpx.URL(url)
+        endpoint = self
+        service_name = "unknown"
+
+        match = self.service_pattern.search(request_url.path) if self.service_pattern is not None else None
+        if match is not None:
+            service_name = match.group(1)
+            endpoint = self.service_endpoints.get(service_name) or self
+            routed_url = _url_for_endpoint(request_url, endpoint)
+        else:
+            routed_url = request_url
+
+        logger.debug(
+            "Routing SDK URL to service endpoint"
+            if service_name != "unknown"
+            else "Routing SDK URL to default endpoint",
+            extra={
+                "service": service_name,
+                "path": request_url.path,
+                "host": routed_url.host,
+                "port": routed_url.port,
+                "transport": endpoint.transport,
+            },
+        )
+        return RoutedPlatformEndpointRequest(url=routed_url, endpoint=endpoint)
+
+
+@dataclass(frozen=True)
+class RoutedPlatformEndpointRequest:
+    url: httpx.URL
+    endpoint: PlatformEndpoint
 
 
 def resolve_platform_endpoint(platform_config: PlatformConfig | None = None) -> PlatformEndpoint:
     """Resolve the default platform endpoint from ``NMP_BASE_URL`` / config."""
 
     if platform_config is None:
-        from nmp.common.config import Configuration
-
-        platform_config = Configuration.get_platform_config()
-    return parse_platform_endpoint(platform_config.base_url)
+        platform_config = _get_platform_config()
+    default_endpoint = parse_platform_endpoint(platform_config.base_url)
+    service_endpoints = {
+        service_name: resolve_service_endpoint(service_name, platform_config)
+        for service_name in sorted(_service_route_names(platform_config, os.environ))
+    }
+    return PlatformEndpoint(
+        connect_base_url=default_endpoint.connect_base_url,
+        socket_path=default_endpoint.socket_path,
+        transport=default_endpoint.transport,
+        service_pattern=platform_config.create_service_pattern(),
+        service_endpoints=MappingProxyType(service_endpoints),
+    )
 
 
 def resolve_service_endpoint(service_name: str, platform_config: PlatformConfig | None = None) -> PlatformEndpoint:
     """Resolve a service endpoint using ``NMP_<SERVICE>_URL`` before ``NMP_BASE_URL``."""
 
     if platform_config is None:
-        from nmp.common.config import Configuration
+        platform_config = _get_platform_config()
+    normalized_name = _normalize_service_name(service_name)
+    local_service_name = _matching_service_name(normalized_name, platform_config.get_services())
+    if local_service_name is not None:
+        return parse_platform_endpoint(platform_config.get_service_url(local_service_name))
 
-        platform_config = Configuration.get_platform_config()
-    env_name = f"NMP_{service_name.upper().replace('-', '_')}_URL"
-    endpoint = os.environ.get(env_name) or platform_config.get_service_url(service_name)
+    env_name = _service_url_env_var_name(service_name)
+    env_endpoint = os.environ.get(env_name)
+    parsed_env_endpoint = _parse_optional_platform_endpoint(env_endpoint)
+    if parsed_env_endpoint is not None:
+        return parsed_env_endpoint
+
+    configured_service_name = _matching_service_name(normalized_name, platform_config.service_discovery)
+    if configured_service_name is not None:
+        configured_endpoint = platform_config.get_service_url(configured_service_name)
+        if configured_endpoint != env_endpoint:
+            return parse_platform_endpoint(configured_endpoint)
+
+    endpoint = platform_config.base_url
     return parse_platform_endpoint(endpoint)
 
 
@@ -109,3 +341,173 @@ def _parse_unix_socket_path(endpoint: str) -> Path:
     if not raw_path.startswith("/"):
         raise ValueError(f"UDS endpoint must use an absolute socket path, got {endpoint!r}")
     return Path(raw_path)
+
+
+def _service_route_names(platform_config: PlatformConfig, env: Mapping[str, str]) -> set[str]:
+    names: set[str] = set()
+    for service_name, endpoint in platform_config.service_discovery.items():
+        normalized_name = _normalize_service_name(service_name)
+        if _is_invalid_env_service_url(normalized_name, endpoint, env):
+            continue
+        names.add(normalized_name)
+    names.update(_normalize_service_name(service_name) for service_name in platform_config.get_services())
+    names.update(_service_route_names_from_env(env))
+    names.discard("")
+    return names
+
+
+def _service_route_names_from_env(env: Mapping[str, str]) -> set[str]:
+    names: set[str] = set()
+    for env_name, endpoint in env.items():
+        if not env_name.startswith("NMP_") or not env_name.endswith("_URL"):
+            continue
+        raw_service_name = env_name.removeprefix("NMP_").removesuffix("_URL")
+        if raw_service_name == "BASE":
+            continue
+        if _parse_optional_platform_endpoint(endpoint) is None:
+            continue
+        names.add(_normalize_service_name(raw_service_name))
+    return names
+
+
+def _service_url_env_var_name(service_name: str) -> str:
+    return f"NMP_{_normalize_service_name(service_name).upper().replace('-', '_')}_URL"
+
+
+def _matching_service_name(normalized_name: str, configured_names: Iterable[str]) -> str | None:
+    for configured_name in configured_names:
+        if _normalize_service_name(configured_name) == normalized_name:
+            return configured_name
+    return None
+
+
+def _is_invalid_env_service_url(service_name: str, endpoint: str, env: Mapping[str, str]) -> bool:
+    env_endpoint = env.get(_service_url_env_var_name(service_name))
+    return env_endpoint == endpoint and _parse_optional_platform_endpoint(endpoint) is None
+
+
+def _parse_optional_platform_endpoint(endpoint: str | None) -> PlatformEndpoint | None:
+    if not endpoint:
+        return None
+    try:
+        return parse_platform_endpoint(endpoint)
+    except ValueError:
+        return None
+
+
+def _normalize_service_name(service_name: str) -> str:
+    return service_name.strip().lower().replace("_", "-")
+
+
+def _url_for_endpoint(url: httpx.URL, endpoint: PlatformEndpoint) -> httpx.URL:
+    if endpoint.transport == "uds":
+        return url.copy_with(scheme="http", host=httpx.URL(UDS_BASE_URL).host, port=None)
+    endpoint_url = httpx.URL(endpoint.connect_base_url)
+    return url.copy_with(scheme=endpoint_url.scheme, host=endpoint_url.host, port=endpoint_url.port)
+
+
+def _set_request_url(request: httpx.Request, url: httpx.URL) -> None:
+    if request.url == url:
+        return
+    request.url = url
+    if url.host:
+        request.headers["Host"] = url.netloc.decode("ascii")
+
+
+def _uds_socket_paths(endpoint: PlatformEndpoint) -> frozenset[Path]:
+    paths: set[Path] = set()
+    for candidate in (endpoint, *endpoint.service_endpoints.values()):
+        if candidate.transport != "uds":
+            continue
+        if candidate.socket_path is None:
+            raise ValueError("UDS endpoint is missing a socket path")
+        paths.add(candidate.socket_path)
+    return frozenset(paths)
+
+
+class _SyncPlatformEndpointRoutingTransport(httpx.BaseTransport):
+    def __init__(self, *, endpoint: PlatformEndpoint, verify: str | bool | None = None) -> None:
+        self._endpoint = endpoint
+        client_verify = client_verify_from_env() if verify is None else verify
+        self._tcp_transport = (
+            httpx.HTTPTransport() if client_verify is True else httpx.HTTPTransport(verify=client_verify)
+        )
+        self._uds_transports = {
+            socket_path: httpx.HTTPTransport(uds=str(socket_path)) for socket_path in _uds_socket_paths(endpoint)
+        }
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        routed = self._endpoint.route_request_url(request.url)
+        _set_request_url(request, routed.url)
+        return self._transport_for_endpoint(routed.endpoint).handle_request(request)
+
+    def close(self) -> None:
+        self._tcp_transport.close()
+        for transport in self._uds_transports.values():
+            transport.close()
+
+    def _transport_for_endpoint(self, endpoint: PlatformEndpoint) -> httpx.HTTPTransport:
+        if endpoint.transport == "tcp":
+            return self._tcp_transport
+        if endpoint.socket_path is None:
+            raise ValueError("UDS endpoint is missing a socket path")
+        return self._uds_transports[endpoint.socket_path]
+
+
+class _SyncExplicitClientRoutingTransport(httpx.BaseTransport):
+    def __init__(self, *, endpoint: PlatformEndpoint, http_client: httpx.Client) -> None:
+        self._endpoint = endpoint
+        self._http_client = http_client
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        routed = self._endpoint.route_request_url(request.url)
+        _set_request_url(request, routed.url)
+        return self._http_client.send(request, stream=True)
+
+    def close(self) -> None:
+        # The wrapped explicit client is caller-owned.
+        pass
+
+
+class _AsyncPlatformEndpointRoutingTransport(httpx.AsyncBaseTransport):
+    def __init__(self, *, endpoint: PlatformEndpoint, verify: str | bool | None = None) -> None:
+        self._endpoint = endpoint
+        client_verify = client_verify_from_env() if verify is None else verify
+        self._tcp_transport = (
+            httpx.AsyncHTTPTransport() if client_verify is True else httpx.AsyncHTTPTransport(verify=client_verify)
+        )
+        self._uds_transports = {
+            socket_path: httpx.AsyncHTTPTransport(uds=str(socket_path)) for socket_path in _uds_socket_paths(endpoint)
+        }
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        routed = self._endpoint.route_request_url(request.url)
+        _set_request_url(request, routed.url)
+        return await self._transport_for_endpoint(routed.endpoint).handle_async_request(request)
+
+    async def aclose(self) -> None:
+        await self._tcp_transport.aclose()
+        for transport in self._uds_transports.values():
+            await transport.aclose()
+
+    def _transport_for_endpoint(self, endpoint: PlatformEndpoint) -> httpx.AsyncHTTPTransport:
+        if endpoint.transport == "tcp":
+            return self._tcp_transport
+        if endpoint.socket_path is None:
+            raise ValueError("UDS endpoint is missing a socket path")
+        return self._uds_transports[endpoint.socket_path]
+
+
+class _AsyncExplicitClientRoutingTransport(httpx.AsyncBaseTransport):
+    def __init__(self, *, endpoint: PlatformEndpoint, http_client: httpx.AsyncClient) -> None:
+        self._endpoint = endpoint
+        self._http_client = http_client
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        routed = self._endpoint.route_request_url(request.url)
+        _set_request_url(request, routed.url)
+        return await self._http_client.send(request, stream=True)
+
+    async def aclose(self) -> None:
+        # The wrapped explicit client is caller-owned.
+        pass

--- a/packages/nmp_common/src/nmp/common/sdk_factory.py
+++ b/packages/nmp_common/src/nmp/common/sdk_factory.py
@@ -4,157 +4,205 @@
 """SDK factory functions for creating NeMo Platform SDK instances."""
 
 import logging
-from dataclasses import dataclass
-from typing import Any, Callable, Optional, TypeVar, cast
+from collections.abc import Awaitable, Callable, Mapping
+from pathlib import Path
+from typing import Optional, override
 
 import httpx
-from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
+from nemo_platform import DEFAULT_MAX_RETRIES, AsyncNeMoPlatform, NeMoPlatform, NotGiven, Omit, Timeout, not_given
 from nemo_platform_plugin.client.constants import is_workload_identity_token_file_set
 from nmp.common.auth import Principal, get_principal_auth_headers, principal_from_env
 from nmp.common.config import Configuration, PlatformConfig
-from nmp.common.http_clients import shared_async_http_client, shared_sync_http_client
+from nmp.common.immutable_http_client import ImmutableDefaultAsyncHttpxClient, ImmutableDefaultHttpxClient
 from nmp.common.observability import MARK_INTERNAL_REQUEST_HEADERS
 from nmp.common.observability.otel import get_otel_headers
-from nmp.common.platform_endpoint import PlatformEndpoint, resolve_platform_endpoint, resolve_service_endpoint
+from nmp.common.platform_endpoint import PlatformEndpoint, resolve_platform_endpoint
 
 logger = logging.getLogger(__name__)
-PlatformSDKT = TypeVar("PlatformSDKT", NeMoPlatform, AsyncNeMoPlatform)
-
-# Test-only: HTTP clients to use for SDK requests in test context.
-# Set by test fixtures to route requests through the in-process test transport.
-#
-# TODO: Remove these module-level variables once all direct get_platform_sdk() /
-# get_async_platform_sdk() callers are migrated to use DependencyProvider. See
-# architecture/docs/http-client-injection.md for migration path and best practices.
-_test_http_client: Optional[httpx.AsyncClient] = None
+_SyncRequestHook = Callable[[httpx.Request], None]
+_AsyncRequestHook = Callable[[httpx.Request], Awaitable[None]]
 
 
-def _base_url_from_config() -> str:
-    return Configuration.get_platform_config().base_url
+def _get_platform_config() -> PlatformConfig:
+    platform_config = Configuration.get_platform_config()
+    if not isinstance(platform_config, PlatformConfig):
+        raise TypeError("Expected PlatformConfig from Configuration.get_platform_config()")
+    return platform_config
 
 
-def resolve_platform_request_url(
-    url: str,
-    *,
-    platform_config: PlatformConfig,
-    default_resolver: Callable[[str], httpx.URL],
-) -> httpx.URL:
-    """Resolve the destination URL for an SDK request.
-
-    The generated SDK builds requests from relative paths like
-    ``/apis/entities/v2/...`` and then calls its private ``_prepare_url`` hook.
-    Keep the routing policy here, not in that private hook:
-
-    - resolve the SDK URL normally against ``platform.base_url``;
-    - if the path targets ``/apis/{api_name}/...``, replace only the origin
-      with ``platform.get_service_url(api_name)``;
-    - preserve the original path and query string.
-    """
-    request_url = default_resolver(url)
-    service_pattern = platform_config.create_service_pattern()
-    if service_pattern is None:
-        return request_url
-    match = service_pattern.search(request_url.path)
-    if match is None:
-        logger.debug(
-            "Routing URL to original URL",
-            extra={"service": "unknown", "path": request_url.path, "host": request_url.host, "port": request_url.port},
-        )
-        return request_url
-
-    api_name = match.group(1)
-    svc_endpoint = resolve_service_endpoint(api_name, platform_config)
-    if svc_endpoint.transport == "uds":
-        logger.debug(
-            "Routing URL to UDS service",
-            extra={
-                "service": api_name,
-                "path": request_url.path,
-                "transport": svc_endpoint.transport,
-            },
-        )
-        return request_url.copy_with(scheme="http", host="nemo-platform.local", port=None)
-    service_url = httpx.URL(svc_endpoint.connect_base_url)
-    routed_url = request_url.copy_with(
-        scheme=service_url.scheme,
-        host=service_url.host,
-        port=service_url.port,
-    )
-    logger.debug(
-        "Routing URL to service URL",
-        extra={
-            "service": api_name,
-            "path": request_url.path,
-            "host": routed_url.host,
-            "port": routed_url.port,
-        },
-    )
-    return routed_url
-
-
-@dataclass(frozen=True)
-class PlatformRequestRouter:
-    """Routes SDK requests to the platform gateway or a service-specific origin."""
-
-    platform_config: PlatformConfig
-    default_resolver: Callable[[str], httpx.URL]
-
-    def resolve(self, url: str) -> httpx.URL:
-        return resolve_platform_request_url(
-            url,
-            platform_config=self.platform_config,
-            default_resolver=self.default_resolver,
-        )
-
-
-def attach_platform_request_router(sdk: PlatformSDKT) -> PlatformSDKT:
-    """Attach the platform request router to a generated SDK instance.
-
-    Stainless sends every request through ``_prepare_url``. Assigning the hook is
-    the SDK integration point; the routing policy itself lives in
-    :class:`PlatformRequestRouter`.
-    """
-    router = PlatformRequestRouter(
-        platform_config=Configuration.get_platform_config(),
-        default_resolver=sdk._prepare_url,
-    )
-    setattr(sdk, "_nmp_request_router", router)
-    sdk._prepare_url = router.resolve
-    return sdk
-
-
-def with_options_preserving_request_router(base_sdk: PlatformSDKT, **kwargs: Any) -> PlatformSDKT:
-    """Return ``base_sdk.with_options(...)`` while preserving platform request routing."""
-    scoped_sdk = cast(PlatformSDKT, base_sdk.with_options(**kwargs))
-    router = getattr(base_sdk, "_nmp_request_router", None)
-    if isinstance(router, PlatformRequestRouter):
-        setattr(scoped_sdk, "_nmp_request_router", router)
-        scoped_sdk._prepare_url = router.resolve
-    return scoped_sdk
-
-
-def _sync_http_client_for_endpoint(
+def _sync_sdk_http_client(
     endpoint: PlatformEndpoint,
+    base_url: str | None,
     http_client: httpx.Client | None,
 ) -> httpx.Client:
     if http_client is not None:
-        return http_client
-    if endpoint.transport == "uds":
-        return endpoint.sync_http_client()
-    return shared_sync_http_client()
+        return endpoint.sync_sdk_http_client(http_client=http_client)
+    if base_url is not None and not endpoint.service_endpoints:
+        return ImmutableDefaultHttpxClient()
+    return endpoint.sync_sdk_http_client()
 
 
-def _async_http_client_for_endpoint(
+def _async_sdk_http_client(
     endpoint: PlatformEndpoint,
+    base_url: str | None,
     http_client: httpx.AsyncClient | None,
 ) -> httpx.AsyncClient:
     if http_client is not None:
-        return http_client
-    if _test_http_client is not None:
-        return _test_http_client
-    if endpoint.transport == "uds":
-        return endpoint.async_http_client()
-    return shared_async_http_client()
+        return endpoint.async_sdk_http_client(http_client=http_client)
+    if base_url is not None and not endpoint.service_endpoints:
+        return ImmutableDefaultAsyncHttpxClient()
+    return endpoint.async_sdk_http_client()
+
+
+def _sync_workload_identity_http_client_factory(
+    endpoint: PlatformEndpoint,
+) -> Callable[[_SyncRequestHook, str | bool], httpx.Client]:
+    def create_http_client(request_hook: _SyncRequestHook, verify: str | bool) -> httpx.Client:
+        return endpoint.sync_sdk_http_client(request_hooks=(request_hook,), verify=verify)
+
+    return create_http_client
+
+
+def _async_workload_identity_http_client_factory(
+    endpoint: PlatformEndpoint,
+) -> Callable[[_AsyncRequestHook, str | bool], httpx.AsyncClient]:
+    def create_http_client(request_hook: _AsyncRequestHook, verify: str | bool) -> httpx.AsyncClient:
+        return endpoint.async_sdk_http_client(request_hooks=(request_hook,), verify=verify)
+
+    return create_http_client
+
+
+class _WorkloadIdentityRoutedNeMoPlatform(NeMoPlatform):
+    _platform_endpoint: PlatformEndpoint
+
+    def __init__(
+        self,
+        *,
+        workspace: str | None = None,
+        base_url: str | httpx.URL | None = None,
+        inference_base_url: str | httpx.URL | None = None,
+        config_path: Path | None = None,
+        context_name: str | None = None,
+        access_token: str | None = None,
+        timeout: float | Timeout | None | NotGiven = not_given,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+        default_headers: Mapping[str, str | Omit] | None = None,
+        default_query: Mapping[str, object] | None = None,
+        http_client: httpx.Client | None = None,
+        _strict_response_validation: bool = False,
+        platform_config: PlatformConfig | None = None,
+        platform_endpoint: PlatformEndpoint | None = None,
+    ) -> None:
+        resolved_config = platform_config or _get_platform_config()
+        self._platform_endpoint = platform_endpoint or resolve_platform_endpoint(resolved_config)
+        if http_client is None:
+            from nemo_platform_ext.client.factory import build_client_init_kwargs
+
+            client_init_kwargs = build_client_init_kwargs(
+                config_path=config_path,
+                base_url=base_url,
+                context_name=context_name,
+                access_token=access_token,
+                extra_headers=default_headers,
+                http_client_factory=_sync_workload_identity_http_client_factory(self._platform_endpoint),
+            )
+            base_url = client_init_kwargs.base_url
+            if workspace is None:
+                workspace = client_init_kwargs.workspace
+            default_headers = client_init_kwargs.default_headers
+            if client_init_kwargs.http_client is not None and not isinstance(
+                client_init_kwargs.http_client, httpx.Client
+            ):
+                raise TypeError("Expected httpx.Client from sync client factory")
+            if client_init_kwargs.http_client is not None:
+                http_client = client_init_kwargs.http_client
+            else:
+                http_client = self._platform_endpoint.sync_sdk_http_client(verify=client_init_kwargs.client_verify)
+        super().__init__(
+            workspace=workspace,
+            base_url=base_url,
+            inference_base_url=inference_base_url,
+            config_path=config_path,
+            context_name=context_name,
+            access_token=access_token,
+            timeout=timeout,
+            max_retries=max_retries,
+            default_headers=default_headers,
+            default_query=default_query,
+            http_client=http_client,
+            _strict_response_validation=_strict_response_validation,
+        )
+
+    @override
+    def _prepare_url(self, url: str) -> httpx.URL:
+        return self._platform_endpoint.route_request_url(super()._prepare_url(url)).url
+
+
+class _WorkloadIdentityRoutedAsyncNeMoPlatform(AsyncNeMoPlatform):
+    _platform_endpoint: PlatformEndpoint
+
+    def __init__(
+        self,
+        *,
+        workspace: str | None = None,
+        base_url: str | httpx.URL | None = None,
+        inference_base_url: str | httpx.URL | None = None,
+        config_path: Path | None = None,
+        context_name: str | None = None,
+        access_token: str | None = None,
+        timeout: float | Timeout | None | NotGiven = not_given,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+        default_headers: Mapping[str, str | Omit] | None = None,
+        default_query: Mapping[str, object] | None = None,
+        http_client: httpx.AsyncClient | None = None,
+        _strict_response_validation: bool = False,
+        platform_config: PlatformConfig | None = None,
+        platform_endpoint: PlatformEndpoint | None = None,
+    ) -> None:
+        resolved_config = platform_config or _get_platform_config()
+        self._platform_endpoint = platform_endpoint or resolve_platform_endpoint(resolved_config)
+        if http_client is None:
+            from nemo_platform_ext.client.factory import build_async_client_init_kwargs
+
+            client_init_kwargs = build_async_client_init_kwargs(
+                config_path=config_path,
+                base_url=base_url,
+                context_name=context_name,
+                access_token=access_token,
+                extra_headers=default_headers,
+                http_client_factory=_async_workload_identity_http_client_factory(self._platform_endpoint),
+            )
+            base_url = client_init_kwargs.base_url
+            if workspace is None:
+                workspace = client_init_kwargs.workspace
+            default_headers = client_init_kwargs.default_headers
+            if client_init_kwargs.http_client is not None and not isinstance(
+                client_init_kwargs.http_client,
+                httpx.AsyncClient,
+            ):
+                raise TypeError("Expected httpx.AsyncClient from async client factory")
+            if client_init_kwargs.http_client is not None:
+                http_client = client_init_kwargs.http_client
+            else:
+                http_client = self._platform_endpoint.async_sdk_http_client(verify=client_init_kwargs.client_verify)
+        super().__init__(
+            workspace=workspace,
+            base_url=base_url,
+            inference_base_url=inference_base_url,
+            config_path=config_path,
+            context_name=context_name,
+            access_token=access_token,
+            timeout=timeout,
+            max_retries=max_retries,
+            default_headers=default_headers,
+            default_query=default_query,
+            http_client=http_client,
+            _strict_response_validation=_strict_response_validation,
+        )
+
+    @override
+    def _prepare_url(self, url: str) -> httpx.URL:
+        return self._platform_endpoint.route_request_url(super()._prepare_url(url)).url
 
 
 def _should_bootstrap_workload_identity(
@@ -262,7 +310,8 @@ def get_platform_sdk(
     Returns:
         Configured NeMoPlatform SDK instance.
     """
-    endpoint = resolve_platform_endpoint()
+    platform_config = _get_platform_config()
+    endpoint = resolve_platform_endpoint(platform_config)
     if _should_bootstrap_workload_identity(
         as_service=as_service,
         on_behalf_of=on_behalf_of,
@@ -270,19 +319,19 @@ def get_platform_sdk(
         endpoint=endpoint,
     ):
         headers = _workload_identity_extra_headers(internal=internal)
-        sdk = NeMoPlatform(
+        return _WorkloadIdentityRoutedNeMoPlatform(
             base_url=base_url or endpoint.connect_base_url,
             default_headers=headers if headers else None,
+            platform_config=platform_config,
+            platform_endpoint=endpoint,
         )
-        return attach_platform_request_router(sdk)
 
     headers = _get_default_headers(as_service, internal, on_behalf_of)
-    sdk = NeMoPlatform(
+    return NeMoPlatform(
         base_url=base_url or endpoint.connect_base_url,
-        http_client=_sync_http_client_for_endpoint(endpoint, http_client),
+        http_client=_sync_sdk_http_client(endpoint, base_url, http_client),
         default_headers=headers if headers else None,
     )
-    return attach_platform_request_router(sdk)
 
 
 def get_task_sdk(as_service: str, http_client: httpx.Client | None = None) -> NeMoPlatform:
@@ -301,9 +350,6 @@ def get_task_sdk(as_service: str, http_client: httpx.Client | None = None) -> Ne
     """
     if http_client is None and is_workload_identity_token_file_set():
         return get_platform_sdk(internal=True)
-
-    if http_client is None:
-        http_client = resolve_platform_endpoint().sync_sdk_http_client()
 
     principal = principal_from_env()
     if principal is None:
@@ -335,9 +381,6 @@ def get_async_task_sdk(as_service: str, http_client: Optional[httpx.AsyncClient]
     """
     if http_client is None and is_workload_identity_token_file_set():
         return get_async_platform_sdk(internal=True)
-
-    if http_client is None:
-        http_client = resolve_platform_endpoint().async_sdk_http_client()
 
     principal = principal_from_env()
     if principal is None:
@@ -377,7 +420,8 @@ def get_async_platform_sdk(
     Returns:
         Configured AsyncNeMoPlatform SDK instance.
     """
-    endpoint = resolve_platform_endpoint()
+    platform_config = _get_platform_config()
+    endpoint = resolve_platform_endpoint(platform_config)
     if _should_bootstrap_workload_identity(
         as_service=as_service,
         on_behalf_of=on_behalf_of,
@@ -385,31 +429,19 @@ def get_async_platform_sdk(
         endpoint=endpoint,
     ):
         headers = _workload_identity_extra_headers(internal=internal)
-        if _test_http_client is None:
-            sdk = AsyncNeMoPlatform(
-                base_url=base_url or endpoint.connect_base_url,
-                default_headers=headers if headers else None,
-            )
-        else:
-            sdk = AsyncNeMoPlatform(
-                base_url=base_url or endpoint.connect_base_url,
-                http_client=_async_http_client_for_endpoint(endpoint, http_client),
-                default_headers=headers if headers else None,
-            )
-        return attach_platform_request_router(sdk)
+        return _WorkloadIdentityRoutedAsyncNeMoPlatform(
+            base_url=base_url or endpoint.connect_base_url,
+            default_headers=headers if headers else None,
+            platform_config=platform_config,
+            platform_endpoint=endpoint,
+        )
 
     headers = _get_default_headers(as_service, internal, on_behalf_of)
-
-    # Use explicitly provided http_client (from DependencyProvider) or fall back to
-    # module-level _test_http_client for backward compatibility with direct callers.
-    effective_client = _async_http_client_for_endpoint(endpoint, http_client)
-
-    sdk = AsyncNeMoPlatform(
+    return AsyncNeMoPlatform(
         base_url=base_url or endpoint.connect_base_url,
-        http_client=effective_client,
+        http_client=_async_sdk_http_client(endpoint, base_url, http_client),
         default_headers=headers if headers else None,
     )
-    return attach_platform_request_router(sdk)
 
 
 def get_request_scoped_sdk(
@@ -440,7 +472,21 @@ def get_request_scoped_sdk(
     # If we have headers to add, create a new SDK with them
     # This reuses the underlying HTTP client (lightweight operation)
     if headers:
-        return with_options_preserving_request_router(base_sdk, set_default_headers=headers)
+        return base_sdk.with_options(default_headers=headers)
+
+    return base_sdk
+
+
+def get_request_scoped_sync_sdk(
+    base_sdk: NeMoPlatform,
+) -> NeMoPlatform:
+    """Create a request-scoped sync SDK with current auth and observability headers."""
+
+    headers = get_otel_headers().copy()
+    headers.update(get_principal_auth_headers())
+
+    if headers:
+        return base_sdk.with_options(default_headers=headers)
 
     return base_sdk
 
@@ -482,21 +528,18 @@ def get_sdk_on_behalf_of(
         ```
     """
     # Merge existing headers with the new on-behalf-of header
-    headers = base_sdk.default_headers or {}
+    merged_headers: dict[str, str | Omit] = dict(base_sdk._custom_headers)
     if isinstance(on_behalf_of, Principal):
-        merged_headers = {
-            **headers,
-            "X-NMP-Principal-On-Behalf-Of": on_behalf_of.effective_principal.id,
-        }
+        merged_headers["X-NMP-Principal-On-Behalf-Of"] = on_behalf_of.effective_principal.id
         if on_behalf_of.effective_principal.email:
             merged_headers["X-NMP-Principal-On-Behalf-Of-Email"] = on_behalf_of.effective_principal.email
         if on_behalf_of.effective_principal.groups:
             merged_headers["X-NMP-Principal-On-Behalf-Of-Groups"] = ",".join(on_behalf_of.effective_principal.groups)
     else:
-        merged_headers = {**headers, "X-NMP-Principal-On-Behalf-Of": on_behalf_of}
+        merged_headers["X-NMP-Principal-On-Behalf-Of"] = on_behalf_of
         merged_headers.pop("X-NMP-Principal-On-Behalf-Of-Groups", None)
         merged_headers.pop("X-NMP-Principal-On-Behalf-Of-Email", None)
-    return with_options_preserving_request_router(base_sdk, set_default_headers=merged_headers)
+    return base_sdk.with_options(set_default_headers=merged_headers)
 
 
 def get_entity_parts(name: str, default_workspace: str | None = None) -> tuple[str, str]:

--- a/packages/nmp_common/src/nmp/common/service/__init__.py
+++ b/packages/nmp_common/src/nmp/common/service/__init__.py
@@ -10,6 +10,7 @@ from nmp.common.service.dependencies import (
     get_platform_config,
     get_sdk_client,
     get_service_config,
+    get_sync_sdk_client,
 )
 from nmp.common.service.deptree import CircularDependencyError, resolve_service_loading_order
 from nmp.common.service.headers import build_downstream_service_headers
@@ -25,5 +26,6 @@ __all__ = [
     "get_platform_config",
     "get_sdk_client",
     "get_service_config",
+    "get_sync_sdk_client",
     "resolve_service_loading_order",
 ]

--- a/packages/nmp_common/src/nmp/common/service/base.py
+++ b/packages/nmp_common/src/nmp/common/service/base.py
@@ -11,15 +11,16 @@ from abc import ABC, abstractmethod
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from threading import RLock
-from typing import ClassVar, Dict, Generic, List, Optional, Self, Type, TypeVar, cast, get_args, get_origin
+from typing import Any, ClassVar, Dict, Generic, List, Optional, Self, Type, TypeVar, cast, get_args, get_origin
 
 import httpx
 from fastapi import APIRouter, FastAPI, Request
 from fastapi.openapi.utils import get_openapi
-from nemo_platform import AsyncNeMoPlatform
+from fastapi.routing import APIRoute, iter_route_contexts
+from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
 from nemo_platform_plugin.client.client import AsyncNemoClient
 from nmp.common.api.utils import register_query_param_schemas
-from nmp.common.config import Configuration, PlatformConfig, ServiceConfig
+from nmp.common.config import Configuration, PlatformConfig, ServiceConfig, get_platform_config
 from nmp.common.controller import Controller
 from nmp.common.entities.client import EntityClient
 from nmp.common.platform_endpoint import resolve_platform_endpoint, resolve_service_endpoint
@@ -35,6 +36,44 @@ class RouterConfig:
     tag: str
     description: str
     prefix: str = ""
+
+
+class _ServiceFastAPI(FastAPI):
+    """FastAPI app that keeps NeMo service OpenAPI customization lazy."""
+
+    def __init__(
+        self,
+        *,
+        service_title: str,
+        service_version: str,
+        service_openapi_tags: List[Dict[str, str]],
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self._nmp_service_title = service_title
+        self._nmp_service_version = service_version
+        self._nmp_service_openapi_tags = service_openapi_tags
+
+    def openapi(self) -> dict[str, Any]:
+        if self.openapi_schema:
+            return self.openapi_schema
+
+        # Keep schema generation lazy. Service construction sits on the hot path for
+        # in-process test apps; eagerly walking all routes and registering schemas
+        # made auth-heavy integration tests spend much of their 120s timeout budget
+        # before the test body ran. FastAPI calls this method only when the schema
+        # is requested, and caches the result in ``openapi_schema``.
+        openapi_schema = get_openapi(
+            title=self._nmp_service_title,
+            version=self._nmp_service_version,
+            summary=f"This is the OpenAPI Schema for the {self._nmp_service_title}.",
+            description="",
+            routes=self.routes,
+            tags=self._nmp_service_openapi_tags,
+        )
+        openapi_schema = register_query_param_schemas(openapi_schema)
+        self.openapi_schema = openapi_schema
+        return self.openapi_schema
 
 
 TConfig = TypeVar("TConfig", bound=ServiceConfig)
@@ -72,7 +111,9 @@ class DependencyProvider:
     def __init__(self) -> None:
         self._client_lock = RLock()
         self._http_client: Optional[httpx.AsyncClient] = None
+        self._sync_http_client: Optional[httpx.Client] = None
         self._sdk_client: Optional[AsyncNeMoPlatform] = None
+        self._sync_sdk_client: Optional[NeMoPlatform] = None
         self._platform_config: Optional[PlatformConfig] = None
         self._service_name: str = "platform"
 
@@ -94,6 +135,13 @@ class DependencyProvider:
             if self._http_client is None:
                 self._http_client = resolve_platform_endpoint().async_sdk_http_client()
             return self._http_client
+
+    def get_sync_http_client(self) -> httpx.Client:
+        """Return the httpx.Client for sync-only SDK consumers."""
+        with self._client_lock:
+            if self._sync_http_client is None:
+                self._sync_http_client = resolve_platform_endpoint().sync_sdk_http_client()
+            return self._sync_http_client
 
     def get_sdk_client(self, as_service: str | None = None) -> AsyncNeMoPlatform:
         """Return the async platform SDK client.
@@ -120,6 +168,18 @@ class DependencyProvider:
             if self._sdk_client is None:
                 self._sdk_client = get_async_platform_sdk(http_client=self.get_http_client())
             return self._sdk_client
+
+    def get_sync_sdk_client(self, as_service: str | None = None) -> NeMoPlatform:
+        """Return the sync platform SDK client."""
+        from nmp.common.sdk_factory import get_platform_sdk
+
+        if as_service is not None:
+            return get_platform_sdk(as_service=as_service, internal=True, http_client=self.get_sync_http_client())
+
+        with self._client_lock:
+            if self._sync_sdk_client is None:
+                self._sync_sdk_client = get_platform_sdk(http_client=self.get_sync_http_client())
+            return self._sync_sdk_client
 
     def get_entity_client(self, as_service: str | None = None) -> Optional[EntityClient]:
         """Return the EntityClient.
@@ -157,19 +217,20 @@ class DependencyProvider:
         Uses the cached base SDK and applies per-request headers via .with_options()
         (lightweight — reuses the HTTP connection pool).
         """
-        from nmp.common.sdk_factory import with_options_preserving_request_router
         from nmp.common.service.headers import build_downstream_service_headers
 
         base_sdk = self.get_sdk_client()
         headers = build_downstream_service_headers(self._service_name)
 
-        return with_options_preserving_request_router(base_sdk, set_default_headers=headers)
+        return base_sdk.with_options(set_default_headers=headers)
 
     def get_platform_config(self) -> PlatformConfig:
         """Return the PlatformConfig (lazily initialized)."""
-        if self._platform_config is None:
-            self._platform_config = Configuration.get_platform_config()
-        return self._platform_config
+        platform_config = self._platform_config
+        if platform_config is None:
+            platform_config = get_platform_config()
+            self._platform_config = platform_config
+        return platform_config
 
     def get_request_scoped_sdk(self) -> AsyncNeMoPlatform:
         """Return a request-scoped SDK with current auth and OTEL headers.
@@ -181,6 +242,13 @@ class DependencyProvider:
 
         base_sdk = self.get_sdk_client()  # Cached base SDK
         return get_request_scoped_sdk(base_sdk)
+
+    def get_request_scoped_sync_sdk(self) -> NeMoPlatform:
+        """Return a request-scoped sync SDK with current auth and OTEL headers."""
+        from nmp.common.sdk_factory import get_request_scoped_sync_sdk
+
+        base_sdk = self.get_sync_sdk_client()
+        return get_request_scoped_sync_sdk(base_sdk)
 
     def get_request_scoped_nemo_client(self) -> AsyncNemoClient:
         """Return a fresh async NemoClient with request-scoped headers."""
@@ -203,9 +271,11 @@ class DependencyProvider:
             get_platform_config,
             get_sdk_client,
             get_service_config,
+            get_sync_sdk_client,
         )
 
         app.dependency_overrides[get_sdk_client] = self.get_request_scoped_sdk
+        app.dependency_overrides[get_sync_sdk_client] = self.get_request_scoped_sync_sdk
         app.dependency_overrides[get_nemo_client] = self.get_request_scoped_nemo_client
         app.dependency_overrides[get_entity_client] = self.get_entity_client
         app.dependency_overrides[get_effective_principal_id] = self.get_effective_principal_id
@@ -217,11 +287,16 @@ class DependencyProvider:
         """Close the provider-owned HTTP transport and clear cached wrappers."""
         with self._client_lock:
             http_client = self._http_client
+            sync_http_client = self._sync_http_client
             self._http_client = None
+            self._sync_http_client = None
             self._sdk_client = None
+            self._sync_sdk_client = None
 
         if http_client is not None:
             await http_client.aclose()
+        if sync_http_client is not None:
+            sync_http_client.close()
 
 
 class Service(ABC, Generic[TConfig]):
@@ -470,7 +545,10 @@ class Service(ABC, Generic[TConfig]):
         router_configs = self.get_routers()
         openapi_tags: List[Dict[str, str]] = [{"name": rc.tag, "description": rc.description} for rc in router_configs]
 
-        app = FastAPI(
+        app = _ServiceFastAPI(
+            service_title=self.title,
+            service_version=self.version,
+            service_openapi_tags=openapi_tags,
             title=self.title,
             description=self.description,
             version=self.version,
@@ -496,35 +574,13 @@ class Service(ABC, Generic[TConfig]):
 
         # Include service-specific routers, tagging any routes that have no tags yet
         for rc in router_configs:
-            for route in rc.router.routes:
-                if hasattr(route, "tags") and not route.tags:
-                    route.tags = [rc.tag]
+            for route_context in iter_route_contexts(rc.router.routes):
+                route = route_context.original_route
+                if isinstance(route, APIRoute) and not route.tags:
+                    route.tags.append(rc.tag)
             app.include_router(rc.router, prefix=rc.prefix)
 
-        # Setup custom OpenAPI schema
-        self._setup_custom_openapi(app, openapi_tags)
-
         return app
-
-    def _setup_custom_openapi(self, app: FastAPI, openapi_tags: List[Dict[str, str]]) -> None:
-        """Configure custom OpenAPI schema generation."""
-
-        def custom_openapi():
-            if app.openapi_schema:
-                return app.openapi_schema
-            openapi_schema = get_openapi(
-                title=self.title,
-                version=self.version,
-                summary=f"This is the OpenAPI Schema for the {self.title}.",
-                description="",
-                routes=app.routes,
-                tags=openapi_tags,
-            )
-            openapi_schema = register_query_param_schemas(openapi_schema)
-            app.openapi_schema = openapi_schema
-            return app.openapi_schema
-
-        app.openapi = custom_openapi  # type: ignore[method-assign]
 
     # =========================================================================
     # Startup and readiness

--- a/packages/nmp_common/src/nmp/common/service/dependencies.py
+++ b/packages/nmp_common/src/nmp/common/service/dependencies.py
@@ -18,6 +18,7 @@ from nemo_platform_plugin.dependencies import get_nemo_client as get_nemo_client
 from nemo_platform_plugin.dependencies import get_platform_config as get_platform_config
 from nemo_platform_plugin.dependencies import get_sdk_client as get_sdk_client
 from nemo_platform_plugin.dependencies import get_service_config as get_service_config
+from nemo_platform_plugin.dependencies import get_sync_sdk_client as get_sync_sdk_client
 from nmp.common.config import ServiceConfig
 
 T = TypeVar("T", bound=ServiceConfig)
@@ -37,12 +38,12 @@ def get_service_config_factory(config_class: type[T]) -> Callable[[Request], T]:
     """
 
     def _get_config(request: Request) -> T:
-        registry: dict[type[ServiceConfig], ServiceConfig] = getattr(request.app.state, "service_configs", {})
+        registry: dict[type[T], T] = getattr(request.app.state, "service_configs", {})
         if config_class not in registry:
             raise RuntimeError(
                 f"Service config {config_class.__name__} not registered. "
                 "Ensure the service is loaded and its config is added to app.state.service_configs."
             )
-        return registry[config_class]  # type: ignore[return-value]
+        return registry[config_class]
 
     return _get_config

--- a/packages/nmp_common/tests/auth/test_dependencies.py
+++ b/packages/nmp_common/tests/auth/test_dependencies.py
@@ -31,6 +31,7 @@ def test_principal_from_env_parses_json(clean_env, monkeypatch):
     )
 
     principal = principal_from_env()
+    assert principal is not None
     headers = principal.get_headers()
 
     assert headers["X-NMP-Principal-Id"] == "job-creator@example.com"
@@ -50,6 +51,7 @@ def test_principal_from_env_handles_id_only(clean_env, monkeypatch):
     )
 
     principal = principal_from_env()
+    assert principal is not None
     headers = principal.get_headers()
 
     assert headers["X-NMP-Principal-Id"] == "service-account"
@@ -76,6 +78,7 @@ def test_principal_from_env_does_not_modify_context(clean_env, monkeypatch):
     )
 
     principal = principal_from_env()
+    assert principal is not None
     headers = principal.get_headers()
     assert headers["X-NMP-Principal-Id"] == "test-user"
 
@@ -96,6 +99,7 @@ def test_principal_from_env_handles_empty_groups(clean_env, monkeypatch):
     )
 
     principal = principal_from_env()
+    assert principal is not None
     headers = principal.get_headers()
 
     assert headers["X-NMP-Principal-Id"] == "user"

--- a/packages/nmp_common/tests/client_factory/test_client_factory.py
+++ b/packages/nmp_common/tests/client_factory/test_client_factory.py
@@ -4,10 +4,11 @@
 """Tests for :mod:`nmp.common.client_factory` — the rich NemoClient provider.
 
 Covers what the platform provider adds over the plugin's env-var default:
-per-service URL routing, shared HTTP clients, principal/auth + internal +
-OTEL headers, workspace defaults, and test-client injection.
+per-service URL routing, endpoint-aware HTTP clients, principal/auth +
+internal + OTEL headers, workspace defaults, and explicit client injection.
 """
 
+from pathlib import Path
 from unittest.mock import patch
 
 import httpx
@@ -18,18 +19,16 @@ from nemo_platform_plugin.client_provider import NemoClientProvider
 from nmp.common import client_factory as cf
 from nmp.common.config import Configuration
 from nmp.common.observability.otel import scoped_otel_headers
+from nmp.common.platform_endpoint import _AsyncPlatformEndpointRoutingTransport, _SyncPlatformEndpointRoutingTransport
 
 
 @pytest.fixture(autouse=True)
 def _reset_client_factory_state():
-    """Keep tests order-independent: clear the injected test client and config cache."""
-    old = cf._test_http_client
-    cf._test_http_client = None
+    """Keep tests order-independent by clearing the config cache."""
     Configuration.clear_cache()
     try:
         yield
     finally:
-        cf._test_http_client = old
         Configuration.clear_cache()
 
 
@@ -76,9 +75,14 @@ class TestSyncConstruction:
         client = cf.get_nemo_client(workspace="team-a")
         assert client.workspace == "team-a"
 
-    def test_reuses_shared_sync_http_client(self):
+    def test_uses_endpoint_sync_http_client(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("NMP_BASE_URL", "https://nemo-gateway:8080")
+        monkeypatch.setenv("NMP_ENTITIES_URL", "http://entities-svc:9999")
+        Configuration.clear_cache()
+
         client = cf.get_nemo_client()
-        assert client._http is cf.shared_sync_http_client()
+
+        assert isinstance(client._http._transport, _SyncPlatformEndpointRoutingTransport)
 
     def test_explicit_http_client_wins(self):
         with httpx.Client() as explicit:
@@ -102,9 +106,15 @@ class TestAsyncConstruction:
         assert client._default_headers["X-NMP-Principal-Id"] == "service:evaluator"
         assert client._default_headers["X-NMP-Internal"] == "true"
 
-    def test_falls_back_to_shared_async_client(self):
+    async def test_uses_endpoint_async_http_client(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+        socket_path = tmp_path / "entities.sock"
+        monkeypatch.setenv("NMP_BASE_URL", "https://nemo-gateway:8080")
+        monkeypatch.setenv("NMP_ENTITIES_URL", f"unix://{socket_path}")
+        Configuration.clear_cache()
+
         client = cf.get_async_nemo_client()
-        assert isinstance(client._http, httpx.AsyncClient)
+
+        assert isinstance(client._http._transport, _AsyncPlatformEndpointRoutingTransport)
 
 
 # ---------------------------------------------------------------------------
@@ -125,6 +135,23 @@ class TestUrlRouting:
         assert str(captured[0].url) == "http://entities-svc:9999/apis/entities/v2/foo"
         assert captured[0].headers["X-NMP-Principal-Id"] == "service:entities"
         assert captured[0].headers["X-NMP-Internal"] == "true"
+
+    def test_allows_credentialed_uds_service_route(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        socket_path = tmp_path / "entities.sock"
+        monkeypatch.setenv("NMP_BASE_URL", "https://nemo-gateway:8080")
+        monkeypatch.setenv("NMP_ENTITIES_URL", f"unix://{socket_path}")
+        Configuration.clear_cache()
+
+        captured: list[httpx.Request] = []
+        client = cf.get_nemo_client(as_service="entities", internal=True, http_client=_mock_client(captured))
+        client.send(_get("/apis/entities/v2/foo"))
+
+        assert str(captured[0].url) == "http://nemo-platform.local/apis/entities/v2/foo"
+        assert captured[0].headers["X-NMP-Principal-Id"] == "service:entities"
 
     def test_preserves_query_string_when_routing(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("NMP_BASE_URL", "https://nemo-gateway:8080")
@@ -206,24 +233,13 @@ class TestHeadersAuth:
 
 
 class TestTestClientInjection:
-    def test_async_uses_module_level_test_client(self):
+    async def test_async_uses_explicit_http_client(self):
         test_client = httpx.AsyncClient(base_url="http://testserver")
-        cf._test_http_client = test_client
         try:
-            client = cf.get_async_nemo_client(as_service="evaluator")
+            client = cf.get_async_nemo_client(as_service="evaluator", http_client=test_client)
             assert client._http is test_client
         finally:
-            cf._test_http_client = None
-
-    def test_async_explicit_http_client_beats_module_level(self):
-        module_client = httpx.AsyncClient(base_url="http://module")
-        explicit = httpx.AsyncClient(base_url="http://explicit")
-        cf._test_http_client = module_client
-        try:
-            client = cf.get_async_nemo_client(http_client=explicit)
-            assert client._http is explicit
-        finally:
-            cf._test_http_client = None
+            await test_client.aclose()
 
 
 # ---------------------------------------------------------------------------
@@ -371,23 +387,21 @@ class TestUdsTransport:
         # concatenating an API path yields a valid URL, not a broken one.
         assert client.base_url + "/apis/entities/v2/foo" == "http://nemo-platform.local/apis/entities/v2/foo"
 
-    def test_uds_sync_client_binds_socket_transport(self, monkeypatch: pytest.MonkeyPatch):
+    def test_uds_sync_client_uses_http_transport(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("NMP_BASE_URL", "unix:///tmp/nemo-platform.sock")
         Configuration.clear_cache()
         client = cf.get_nemo_client()
         transport = client._http._transport
         assert isinstance(transport, httpx.HTTPTransport)
-        assert transport._pool._uds == "/tmp/nemo-platform.sock"
 
-    async def test_uds_async_client_binds_socket_transport(self, monkeypatch: pytest.MonkeyPatch):
+    async def test_uds_async_client_uses_http_transport(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("NMP_BASE_URL", "unix:///tmp/nemo-platform.sock")
         Configuration.clear_cache()
         client = cf.get_async_nemo_client()
         transport = client._http._transport
         assert isinstance(transport, httpx.AsyncHTTPTransport)
-        assert transport._pool._uds == "/tmp/nemo-platform.sock"
 
-    def test_tcp_client_uses_shared_client(self, monkeypatch: pytest.MonkeyPatch):
+    def test_tcp_client_uses_platform_base_url(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("NMP_BASE_URL", "http://platform:8080")
         Configuration.clear_cache()
         client = cf.get_nemo_client()

--- a/packages/nmp_common/tests/entities/test_client.py
+++ b/packages/nmp_common/tests/entities/test_client.py
@@ -3,6 +3,7 @@
 
 import json
 from datetime import datetime, timezone
+from inspect import signature
 from typing import Annotated, Any, Dict, List, Literal, Optional
 from unittest.mock import AsyncMock, Mock
 
@@ -70,7 +71,7 @@ def test_entity_base_get_data_fields():
         field_7: float
         field_8: bool
         field_9: bytes
-        _field_10: str | None = PrivateAttr(default="some_string")
+        _field_10: str = PrivateAttr(default="some_string")
 
         @property
         def field_10(self) -> str:
@@ -113,7 +114,7 @@ def test_entity_base_convert_api_entity_to_model():
         field_1: str
         field_2: str | None
         field_3: int
-        _field_4: str | None = PrivateAttr(default="some_string")
+        _field_4: str = PrivateAttr(default="some_string")
 
         @property
         def field_4(self) -> str:
@@ -575,19 +576,10 @@ async def test_entity_client_list_rejects_combined_filter_operation_and_filter_s
     mock_api.list.assert_not_called()
 
 
-@pytest.mark.asyncio
-async def test_entity_client_list_rejects_search_kwarg():
-    """The legacy `search` alias is gone — passing it must be a TypeError."""
+def test_entity_client_list_rejects_search_kwarg():
+    """The legacy `search` alias is gone from the typed public signature."""
 
-    class TestEntity(EntityBase):
-        field_1: str
-
-    mock_api = Mock()
-    mock_api.list = AsyncMock()
-    client = EntityClient(mock_api)
-
-    with pytest.raises(TypeError):
-        await client.list(TestEntity, search='{"field_1":"value"}')  # type: ignore[call-arg]
+    assert "search" not in signature(EntityClient.list).parameters
 
 
 def test_sync_entity_client_create_uses_generic_entity_conversion():
@@ -636,32 +628,32 @@ class TestDatetimeFilter:
     def test_accepts_gte_without_dollar(self):
         """Test that DatetimeFilter accepts 'gte' (without $) as input."""
         dt = datetime(2025, 1, 1, 0, 0, 0)
-        f = DatetimeFilter(gte=dt)
+        f = DatetimeFilter.model_validate({"gte": dt})
         assert f.gte == dt
 
     def test_accepts_gte_with_dollar(self):
         """Test that DatetimeFilter accepts '$gte' (with $) as input."""
         dt = datetime(2025, 1, 1, 0, 0, 0)
-        f = DatetimeFilter(**{"$gte": dt})
+        f = DatetimeFilter.model_validate({"$gte": dt})
         assert f.gte == dt
 
     def test_accepts_lte_without_dollar(self):
         """Test that DatetimeFilter accepts 'lte' (without $) as input."""
         dt = datetime(2025, 12, 31, 23, 59, 59)
-        f = DatetimeFilter(lte=dt)
+        f = DatetimeFilter.model_validate({"lte": dt})
         assert f.lte == dt
 
     def test_accepts_lte_with_dollar(self):
         """Test that DatetimeFilter accepts '$lte' (with $) as input."""
         dt = datetime(2025, 12, 31, 23, 59, 59)
-        f = DatetimeFilter(**{"$lte": dt})
+        f = DatetimeFilter.model_validate({"$lte": dt})
         assert f.lte == dt
 
     def test_model_dump_outputs_dollar_prefix(self):
         """Test that model_dump outputs $gte/$lte with by_alias=True."""
         dt_start = datetime(2025, 1, 1, 0, 0, 0)
         dt_end = datetime(2025, 12, 31, 23, 59, 59)
-        f = DatetimeFilter(gte=dt_start, lte=dt_end)
+        f = DatetimeFilter.model_validate({"gte": dt_start, "lte": dt_end})
         result = f.model_dump(exclude_none=True, by_alias=True, mode="json")
 
         assert "$gte" in result
@@ -674,7 +666,7 @@ class TestDatetimeFilter:
     def test_model_dump_json_serializes_datetime(self):
         """Test that mode='json' serializes datetime to ISO string."""
         dt = datetime(2025, 1, 1, 0, 0, 0)
-        f = DatetimeFilter(gte=dt)
+        f = DatetimeFilter.model_validate({"gte": dt})
         result = f.model_dump(exclude_none=True, by_alias=True, mode="json")
 
         # Result should be JSON-serializable (datetime as string)
@@ -686,14 +678,14 @@ class TestDatetimeFilter:
         """Test that DatetimeFilter accepts both fields together."""
         dt_start = datetime(2025, 1, 1, 0, 0, 0)
         dt_end = datetime(2025, 12, 31, 23, 59, 59)
-        f = DatetimeFilter(gte=dt_start, lte=dt_end)
+        f = DatetimeFilter.model_validate({"gte": dt_start, "lte": dt_end})
         assert f.gte == dt_start
         assert f.lte == dt_end
 
     def test_handles_timezone_aware_datetime(self):
         """Test that timezone-aware datetimes are handled correctly."""
         dt = datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
-        f = DatetimeFilter(gte=dt)
+        f = DatetimeFilter.model_validate({"gte": dt})
         result = f.model_dump(exclude_none=True, by_alias=True, mode="json")
         # Pydantic serializes UTC as "Z" suffix instead of "+00:00"
         assert result["$gte"] in (dt.isoformat(), "2025-01-01T00:00:00Z")
@@ -709,47 +701,47 @@ class TestStringFilter:
 
     def test_accepts_eq_without_dollar(self):
         """Test that StringFilter accepts 'eq' (without $) as input."""
-        f = StringFilter(eq="value")
+        f = StringFilter.model_validate({"eq": "value"})
         assert f.eq == "value"
 
     def test_accepts_eq_with_dollar(self):
         """Test that StringFilter accepts '$eq' (with $) as input."""
-        f = StringFilter(**{"$eq": "value"})
+        f = StringFilter.model_validate({"$eq": "value"})
         assert f.eq == "value"
 
     def test_accepts_like_without_dollar(self):
         """Test that StringFilter accepts 'like' (without $) as input."""
-        f = StringFilter(like="%pattern%")
+        f = StringFilter.model_validate({"like": "%pattern%"})
         assert f.like == "%pattern%"
 
     def test_accepts_like_with_dollar(self):
         """Test that StringFilter accepts '$like' (with $) as input."""
-        f = StringFilter(**{"$like": "%pattern%"})
+        f = StringFilter.model_validate({"$like": "%pattern%"})
         assert f.like == "%pattern%"
 
     def test_accepts_in_without_dollar(self):
         """Test that StringFilter accepts 'in_' (without $) as input."""
-        f = StringFilter(in_=["a", "b"])
+        f = StringFilter.model_validate({"in_": ["a", "b"]})
         assert f.in_ == ["a", "b"]
 
     def test_accepts_in_with_dollar(self):
         """Test that StringFilter accepts '$in' (with $) as input."""
-        f = StringFilter(**{"$in": ["a", "b"]})
+        f = StringFilter.model_validate({"$in": ["a", "b"]})
         assert f.in_ == ["a", "b"]
 
     def test_accepts_nin_without_dollar(self):
         """Test that StringFilter accepts 'nin' (without $) as input."""
-        f = StringFilter(nin=["x", "y"])
+        f = StringFilter.model_validate({"nin": ["x", "y"]})
         assert f.nin == ["x", "y"]
 
     def test_accepts_nin_with_dollar(self):
         """Test that StringFilter accepts '$nin' (with $) as input."""
-        f = StringFilter(**{"$nin": ["x", "y"]})
+        f = StringFilter.model_validate({"$nin": ["x", "y"]})
         assert f.nin == ["x", "y"]
 
     def test_model_dump_outputs_dollar_prefix(self):
         """Test that model_dump outputs $eq/$like/$in/$nin with by_alias=True."""
-        f = StringFilter(eq="a", like="%b%", in_=["c", "d"], nin=["e"])
+        f = StringFilter.model_validate({"eq": "a", "like": "%b%", "in_": ["c", "d"], "nin": ["e"]})
         result = f.model_dump(exclude_none=True, by_alias=True, mode="json")
 
         assert "$eq" in result
@@ -767,7 +759,7 @@ class TestStringFilter:
 
     def test_model_dump_json_serializable(self):
         """Test that model_dump output is JSON-serializable."""
-        f = StringFilter(eq="value", in_=["a", "b"])
+        f = StringFilter.model_validate({"eq": "value", "in_": ["a", "b"]})
         result = f.model_dump(exclude_none=True, by_alias=True, mode="json")
 
         json_str = json.dumps(result)
@@ -777,7 +769,7 @@ class TestStringFilter:
 
     def test_accepts_multiple_operators(self):
         """Test that StringFilter accepts several operators together."""
-        f = StringFilter(eq="a", like="%b%")
+        f = StringFilter.model_validate({"eq": "a", "like": "%b%"})
         assert f.eq == "a"
         assert f.like == "%b%"
 
@@ -1463,10 +1455,8 @@ class TestAuthContextSanitization:
 # ---------------------------------------------------------------------------
 #
 # ``as_service()`` re-expresses service-principal elevation on top of
-# ``NemoClient.with_options``. The Stainless transport it replaced needed
-# ``with_options_preserving_request_router`` because its ``with_options`` built a
-# fresh client and dropped the platform ``_prepare_url`` hook. ``NemoClient``
-# clones with ``copy.copy``, so ``_url_resolver`` survives and no fixup is needed.
+# ``NemoClient.with_options``. ``NemoClient`` clones with ``copy.copy``, so the
+# typed-client URL resolver survives and no fixup is needed.
 #
 # That is an assumption about someone else's implementation, so these tests pin
 # it. If ``with_options`` ever stops shallow-copying, the resolver assertion here

--- a/packages/nmp_common/tests/jobs/conftest.py
+++ b/packages/nmp_common/tests/jobs/conftest.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from nemo_platform import AsyncNeMoPlatform
 from nmp.common.entities import DEFAULT_WORKSPACE
 from nmp.common.entities.utils import get_random_bytes
 from nmp.common.jobs.file_manager import FilesetFileManager
@@ -44,7 +45,7 @@ def mock_nmp_sdk():
 @pytest.fixture
 def mock_async_nmp_sdk():
     """Mock async NeMoPlatform SDK for jobs operations."""
-    m = AsyncMock()
+    m = AsyncMock(spec=AsyncNeMoPlatform)
 
     async def _create(**kwargs):
         return SimpleNamespace(id=f"jobresult-{get_random_bytes()}", **kwargs)
@@ -56,15 +57,16 @@ def mock_async_nmp_sdk():
 @pytest.fixture
 def mock_fileset_fs():
     """Mock FilesetFileSystem for testing."""
-    import fsspec.asyn
-
     fs = MagicMock()
+    fs.info = MagicMock(return_value={"name": "test", "size": 0, "type": "directory"})
+    fs.put_file = MagicMock()
+    fs.get = MagicMock()
+    fs.get_file = MagicMock()
     fs._info = AsyncMock(return_value={"name": "test", "size": 0, "type": "directory"})
     fs._put_file = AsyncMock()
     fs._get = AsyncMock()
     fs._get_file = AsyncMock()
-    # Provide the fsspec global event loop for sync-to-async bridging
-    fs.loop = fsspec.asyn.get_loop()
+    fs._client = MagicMock()
     return fs
 
 

--- a/packages/nmp_common/tests/jobs/test_file_manager.py
+++ b/packages/nmp_common/tests/jobs/test_file_manager.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 from nemo_platform_plugin.jobs.file_manager import _filter_files_by_patterns
 from nmp.common.jobs.file_manager import FilesetFileManager, FileStorageType
@@ -126,14 +126,13 @@ def test_fileset_storage_type():
 def test_fileset_validate_storage_exists(fileset_manager, mock_fileset_fs):
     """Test validate_storage when fileset already exists."""
     fileset_manager.validate_storage()
-    mock_fileset_fs._info.assert_called()
+    mock_fileset_fs.info.assert_called()
 
 
 def test_fileset_validate_storage_creates(fileset_manager, mock_fileset_fs):
     """Test validate_storage creates fileset when missing."""
     mock_fileset_fs._client = MagicMock()
-    mock_fileset_fs._client.create_fileset = AsyncMock()
-    mock_fileset_fs._info.side_effect = FileNotFoundError("not found")
+    mock_fileset_fs.info.side_effect = FileNotFoundError("not found")
     fileset_manager.validate_storage()
     mock_fileset_fs._client.create_fileset.assert_called_once()
 
@@ -145,7 +144,7 @@ def test_fileset_upload_file(tmp_path, fileset_manager, mock_fileset_fs):
 
     result = fileset_manager.upload(test_file, "remote/test.txt")
 
-    mock_fileset_fs._put_file.assert_called()
+    mock_fileset_fs.put_file.assert_called()
     assert result == "default/job-results-jobid-123#remote/test.txt"
 
 
@@ -157,47 +156,47 @@ def test_fileset_upload_directory(tmp_path, fileset_manager, mock_fileset_fs):
 
     result = fileset_manager.upload(test_dir, "remote/mydir")
 
-    mock_fileset_fs._put_file.assert_called()
+    mock_fileset_fs.put_file.assert_called()
     assert result == "default/job-results-jobid-123#remote/mydir"
 
 
 def test_fileset_download_from_url_file(tmp_path, fileset_manager, mock_fileset_fs):
     """Test downloading a single file from URL."""
-    mock_fileset_fs._info.return_value = {"name": "test", "size": 100, "type": "file"}
+    mock_fileset_fs.info.return_value = {"name": "test", "size": 100, "type": "file"}
 
     result = fileset_manager.download_from_url(
         url="default/job-results-jobid-123#remote/test.txt",
         local_dir=tmp_path,
     )
 
-    mock_fileset_fs._get_file.assert_called()
+    mock_fileset_fs.get_file.assert_called()
     assert result.tmp_dir == tmp_path
 
 
 def test_fileset_download_from_url_directory(tmp_path, fileset_manager, mock_fileset_fs):
     """Test downloading a directory from URL."""
-    mock_fileset_fs._info.return_value = {"name": "test", "size": 0, "type": "directory"}
+    mock_fileset_fs.info.return_value = {"name": "test", "size": 0, "type": "directory"}
 
     result = fileset_manager.download_from_url(
         url="default/job-results-jobid-123#remote/mydir",
         local_dir=tmp_path,
     )
 
-    mock_fileset_fs._get.assert_called()
+    mock_fileset_fs.get.assert_called()
     assert result.tmp_dir == tmp_path
 
 
 def test_fileset_download_from_legacy_url_normalizes_to_hash_file_ref(tmp_path, fileset_manager, mock_fileset_fs):
     """Legacy workspace/fileset/path URLs should be normalized to workspace/fileset#path."""
-    mock_fileset_fs._info.return_value = {"name": "test", "size": 100, "type": "file"}
+    mock_fileset_fs.info.return_value = {"name": "test", "size": 100, "type": "file"}
 
     fileset_manager.download_from_url(
         url="fileset://default/job-results-jobid-123/legacy/path/test.txt",
         local_dir=tmp_path,
     )
 
-    mock_fileset_fs._info.assert_called_once_with("default/job-results-jobid-123#legacy/path/test.txt")
-    mock_fileset_fs._get_file.assert_called_once_with(
+    mock_fileset_fs.info.assert_called_once_with("default/job-results-jobid-123#legacy/path/test.txt")
+    mock_fileset_fs.get_file.assert_called_once_with(
         "default/job-results-jobid-123#legacy/path/test.txt",
         str(tmp_path / "test.txt"),
     )
@@ -205,15 +204,15 @@ def test_fileset_download_from_legacy_url_normalizes_to_hash_file_ref(tmp_path, 
 
 def test_fileset_download_from_legacy_url_normalizes_to_hash_directory_ref(tmp_path, fileset_manager, mock_fileset_fs):
     """Legacy workspace/fileset/path directory URLs should still download correctly."""
-    mock_fileset_fs._info.return_value = {"name": "test", "size": 0, "type": "directory"}
+    mock_fileset_fs.info.return_value = {"name": "test", "size": 0, "type": "directory"}
 
     fileset_manager.download_from_url(
         url="fileset://default/job-results-jobid-123/legacy/path/mydir",
         local_dir=tmp_path,
     )
 
-    mock_fileset_fs._info.assert_called_once_with("default/job-results-jobid-123#legacy/path/mydir")
-    mock_fileset_fs._get.assert_called_once_with(
+    mock_fileset_fs.info.assert_called_once_with("default/job-results-jobid-123#legacy/path/mydir")
+    mock_fileset_fs.get.assert_called_once_with(
         "default/job-results-jobid-123#legacy/path/mydir",
         str(tmp_path),
         recursive=True,
@@ -223,15 +222,11 @@ def test_fileset_download_from_legacy_url_normalizes_to_hash_directory_ref(tmp_p
 def test_fileset_file_manager_multiple_sequential_operations(tmp_path, fileset_manager, mock_fileset_fs):
     """Test that FilesetFileManager can perform multiple sequential operations.
 
-    This exercises the blocking portal implementation which maintains a persistent
-    event loop for the lifetime of the FilesetFileManager instance. Without a
-    persistent portal, the event loop would be closed after the first operation,
-    causing "Event loop is closed" errors on subsequent operations.
+    This exercises the sync filesystem surface used by the sync file manager.
     """
-    mock_fileset_fs._info.return_value = {"name": "test", "size": 0, "type": "file"}
+    mock_fileset_fs.info.return_value = {"name": "test", "size": 0, "type": "file"}
 
-    # Multiple operations in sequence - this pattern would fail without the
-    # persistent blocking portal
+    # Multiple operations in sequence should stay on the sync filesystem surface.
     fileset_manager.validate_storage()
 
     test_file = tmp_path / "test.txt"
@@ -241,9 +236,9 @@ def test_fileset_file_manager_multiple_sequential_operations(tmp_path, fileset_m
     fileset_manager.download_from_url("default/job-results-jobid-123#remote/file.txt", tmp_path)
 
     # Verify all operations were called
-    assert mock_fileset_fs._info.call_count >= 1
-    assert mock_fileset_fs._put_file.called
-    assert mock_fileset_fs._get_file.called
+    assert mock_fileset_fs.info.call_count >= 1
+    assert mock_fileset_fs.put_file.called
+    assert mock_fileset_fs.get_file.called
 
 
 async def test_fileset_upload_directory_with_ignore_patterns(tmp_path, mock_fileset_fs):

--- a/packages/nmp_common/tests/jobs/test_result_manager.py
+++ b/packages/nmp_common/tests/jobs/test_result_manager.py
@@ -13,7 +13,6 @@ from nemo_platform_plugin.files.client import AsyncFilesClient, FilesClient
 from nemo_platform_plugin.jobs.client import AsyncJobsClient, JobsClient
 from nemo_platform_plugin.jobs.constants import NEMO_JOB_WORKSPACE_ENVVAR
 from nemo_platform_plugin.jobs.result_manager import CreateJobResultError
-from nmp.common.config import Configuration
 from nmp.common.jobs import result_manager as rm
 from nmp.common.jobs.file_manager import TmpDirPath
 
@@ -56,10 +55,8 @@ def _generated_async_sdk(workspace: str | None = "test-ws") -> AsyncNeMoPlatform
 # =============================================================================
 
 
-@patch.object(Configuration, "get_platform_config")
-def test_result_manager_factory_fileset(mock_platform_config):
+def test_result_manager_factory_fileset():
     """Test factory creates ResultManager with FilesetFileManager class."""
-    mock_platform_config.return_value.base_url = "http://localhost:8080"
     sdk = _generated_sync_sdk()
 
     mgr = rm.result_manager_factory(
@@ -72,13 +69,11 @@ def test_result_manager_factory_fileset(mock_platform_config):
     assert isinstance(mgr.files_client, FilesClient)
     assert mgr.files_client._http is sdk._client
     assert isinstance(mgr.jobs_client, JobsClient)
+    assert mgr.jobs_client._http is sdk._client
 
 
-@pytest.mark.asyncio
-@patch.object(Configuration, "get_platform_config")
-async def test_result_manager_factory_fileset_async(mock_platform_config):
+def test_result_manager_factory_fileset_async():
     """Test factory creates AsyncResultManager with AsyncFilesetFileManager class."""
-    mock_platform_config.return_value.base_url = "http://localhost:8080"
     sdk = _generated_async_sdk()
 
     mgr = rm.async_result_manager_factory(
@@ -91,6 +86,7 @@ async def test_result_manager_factory_fileset_async(mock_platform_config):
     assert isinstance(mgr.files_client, AsyncFilesClient)
     assert mgr.files_client._http is sdk._client
     assert isinstance(mgr.jobs_client, AsyncJobsClient)
+    assert mgr.jobs_client._http is sdk._client
 
 
 @pytest.mark.asyncio
@@ -109,13 +105,14 @@ async def test_download_from_result_info(mock_factory, tmp_path):
         result_name="my-result",
         job_name="test-job",
         artifact_url="my-workspace/url-fileset-name#path/to/artifact",
+        workspace="my-workspace",
         sdk=sdk,
     )
 
     # Verify factory was called with correct parameters
     call_kwargs = mock_factory.call_args.kwargs
     assert call_kwargs["job_name"] == "test-job"
-    assert "workspace" not in call_kwargs
+    assert call_kwargs["workspace"] == "my-workspace"
     assert call_kwargs["sdk"] is sdk
 
 
@@ -173,7 +170,9 @@ def test_create_result_returns_existing_on_conflict_sync(tmp_path, mock_sync_fil
     mock_jobs.create_job_result.side_effect = _conflict_error()
     mock_jobs.get_job_result.return_value = _resp(existing_result)
     # Job retrieval provides the fileset name.
-    mock_jobs.get_job.return_value = _resp(MagicMock(attempt_id="att-123", fileset="test-fileset"))
+    mock_jobs.get_job.return_value = _resp(
+        MagicMock(attempt_id="att-123", fileset="test-fileset", output_location=None)
+    )
 
     sdk = _sync_client()
     mgr = rm.ResultManager(
@@ -195,7 +194,9 @@ def test_create_result_wraps_transport_errors_sync(tmp_path, mock_sync_file_mana
     test_file.write_bytes(b"test content")
     request = httpx.Request("POST", "http://test/apis/jobs/v2/workspaces/test-ws/jobs/test-job/results/my-result")
     mock_jobs = MagicMock(spec=JobsClient)
-    mock_jobs.get_job.return_value = _resp(MagicMock(attempt_id="att-123", fileset="test-fileset"))
+    mock_jobs.get_job.return_value = _resp(
+        MagicMock(attempt_id="att-123", fileset="test-fileset", output_location=None)
+    )
     mock_jobs.create_job_result.side_effect = NemoTransportError(
         httpx.ConnectError("Connection refused", request=request)
     )
@@ -226,7 +227,9 @@ async def test_create_result_returns_existing_on_conflict_async(tmp_path, mock_a
     mock_jobs.create_job_result = AsyncMock(side_effect=_conflict_error())
     mock_jobs.get_job_result = AsyncMock(return_value=_resp(existing_result))
     # Job retrieval provides the fileset name.
-    mock_jobs.get_job = AsyncMock(return_value=_resp(MagicMock(attempt_id="att-123", fileset="test-fileset")))
+    mock_jobs.get_job = AsyncMock(
+        return_value=_resp(MagicMock(attempt_id="att-123", fileset="test-fileset", output_location=None))
+    )
 
     sdk = _async_client()
     mgr = rm.AsyncResultManager(
@@ -249,7 +252,9 @@ async def test_create_result_wraps_transport_errors_async(tmp_path, mock_async_f
     test_file.write_bytes(b"test content")
     request = httpx.Request("POST", "http://test/apis/jobs/v2/workspaces/test-ws/jobs/test-job/results/my-result")
     mock_jobs = MagicMock(spec=AsyncJobsClient)
-    mock_jobs.get_job = AsyncMock(return_value=_resp(MagicMock(attempt_id="att-123", fileset="test-fileset")))
+    mock_jobs.get_job = AsyncMock(
+        return_value=_resp(MagicMock(attempt_id="att-123", fileset="test-fileset", output_location=None))
+    )
     mock_jobs.create_job_result = AsyncMock(
         side_effect=NemoTransportError(httpx.ConnectError("Connection refused", request=request))
     )
@@ -285,3 +290,31 @@ async def test_async_result_manager_factory_defaults_unscoped_sdk_workspace(monk
     mgr = rm.async_result_manager_factory(job_name="test-job", sdk=sdk)
 
     assert mgr.workspace == "default"
+
+
+@pytest.mark.asyncio
+@patch("nmp.common.jobs.result_manager.async_result_manager_factory")
+@patch("nmp.common.jobs.result_manager.get_async_platform_sdk")
+async def test_download_from_result_info_defaults_sdk(mock_get_sdk, mock_factory, tmp_path, mock_async_nmp_sdk):
+    """Test that download_from_result_info auto-creates SDK when sdk is None."""
+    mock_get_sdk.return_value = mock_async_nmp_sdk
+
+    test_file = tmp_path / "artifact.bin"
+    test_file.write_bytes(b"test content")
+    mock_mgr = MagicMock()
+    mock_mgr.download_artifact = AsyncMock(return_value=TmpDirPath(tmp_dir=tmp_path, path=test_file))
+    mock_factory.return_value = mock_mgr
+
+    await rm.download_from_result_info(
+        result_name="my-result",
+        job_name="test-job",
+        artifact_url="workspace/fileset#path",
+        workspace="workspace",
+    )
+
+    mock_get_sdk.assert_called_once_with()
+    mock_factory.assert_called_once_with(
+        job_name="test-job",
+        workspace="workspace",
+        sdk=mock_async_nmp_sdk,
+    )

--- a/packages/nmp_common/tests/nmp_common/test_common_service.py
+++ b/packages/nmp_common/tests/nmp_common/test_common_service.py
@@ -27,20 +27,6 @@ from nmp.common.service import get_nemo_client as facade_get_nemo_client
 from nmp.common.service.dependencies import get_nemo_client
 
 
-def _route_paths(app: FastAPI) -> set[str]:
-    """Collect all route paths, compatible with FastAPI 0.138+ _IncludedRouter."""
-    paths: set[str] = set()
-    queue = list(app.routes)
-    while queue:
-        route = queue.pop()
-        if hasattr(route, "path"):
-            paths.add(route.path)
-        fn = getattr(route, "effective_candidates", None)
-        if callable(fn):
-            queue.extend(fn())  # type: ignore[arg-type]
-    return paths
-
-
 class MockService(Service):
     """Mock implementation of Service for testing."""
 
@@ -55,6 +41,24 @@ class MockService(Service):
             return {"message": "test"}
 
         return [RouterConfig(router, tag="Test", description="Test endpoints")]
+
+
+class NestedRouterService(Service):
+    """Service with an included router nested under its configured router."""
+
+    def __init__(self):
+        super().__init__(name="nested-router", module_name="nmp.test")
+
+    def get_routers(self) -> List[RouterConfig]:
+        child_router = APIRouter()
+
+        @child_router.get("/child")
+        async def child_endpoint():
+            return {"message": "nested"}
+
+        parent_router = APIRouter()
+        parent_router.include_router(child_router, prefix="/nested")
+        return [RouterConfig(parent_router, tag="Nested", description="Nested endpoints")]
 
 
 class TestRouterConfig:
@@ -138,8 +142,42 @@ class TestServiceBase:
         service = MockService()
         app = service.app
 
-        route_paths = _route_paths(app)
-        assert "/test" in route_paths
+        with TestClient(app) as client:
+            response = client.get("/test")
+
+        assert response.status_code == 200
+        assert response.json() == {"message": "test"}
+
+    def test_service_tags_untagged_nested_router_routes_in_openapi(self):
+        service = NestedRouterService()
+
+        openapi = service.app.openapi()
+
+        assert openapi["paths"]["/nested/child"]["get"]["tags"] == ["Nested"]
+
+    def test_service_openapi_schema_is_generated_lazily(self, monkeypatch: pytest.MonkeyPatch):
+        import nmp.common.service.base as service_base
+
+        calls = 0
+
+        def fake_get_openapi(**_kwargs: object) -> dict[str, object]:
+            nonlocal calls
+            calls += 1
+            return {"components": {"schemas": {}}, "paths": {}}
+
+        monkeypatch.setattr(service_base, "get_openapi", fake_get_openapi)
+
+        service = MockService()
+        app = service.app
+
+        assert calls == 0
+        assert app.openapi_schema is None
+
+        first_schema = app.openapi()
+        second_schema = app.openapi()
+
+        assert calls == 1
+        assert first_schema is second_schema
 
 
 class TestServiceAsync:

--- a/packages/nmp_common/tests/sdk_factory/test_sdk.py
+++ b/packages/nmp_common/tests/sdk_factory/test_sdk.py
@@ -2,19 +2,24 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
-import logging
+from collections.abc import AsyncIterator, Iterator
+from contextlib import asynccontextmanager, contextmanager
 from unittest.mock import patch
 
 import httpx
 import pytest
+from nemo_platform import AsyncNeMoPlatform, NeMoPlatform, omit
 from nemo_platform_ext.auth.helpers import NMPOIDCConfig
 from nemo_platform_plugin.client.adapter import client_from_platform
 from nemo_platform_plugin.client.constants import WORKLOAD_IDENTITY_TOKEN_FILE_ENVVAR
 from nemo_platform_plugin.jobs.client import JobsClient
 from nmp.common.config import Configuration, PlatformConfig
 from nmp.common.http_clients import shared_async_http_client, shared_sync_http_client
+from nmp.common.platform_endpoint import (
+    _AsyncPlatformEndpointRoutingTransport,
+    _SyncPlatformEndpointRoutingTransport,
+)
 from nmp.common.sdk_factory import (
-    PlatformRequestRouter,
     get_async_platform_sdk,
     get_async_task_sdk,
     get_entity_parts,
@@ -22,7 +27,6 @@ from nmp.common.sdk_factory import (
     get_request_scoped_sdk,
     get_sdk_on_behalf_of,
     get_task_sdk,
-    resolve_platform_request_url,
 )
 
 
@@ -37,24 +41,25 @@ def _workload_oidc_config() -> NMPOIDCConfig:
     )
 
 
+@contextmanager
+def _platform_sdk_for_test(*, base_url: str = "http://platform:8080") -> Iterator[NeMoPlatform]:
+    with get_platform_sdk(base_url=base_url) as sdk:
+        yield sdk
+
+
+@asynccontextmanager
+async def _async_platform_sdk_for_test(*, base_url: str = "http://platform:8080") -> AsyncIterator[AsyncNeMoPlatform]:
+    async with get_async_platform_sdk(base_url=base_url) as sdk:
+        yield sdk
+
+
 @pytest.fixture(autouse=True)
-def _clear_sdk_factory_test_client():
-    """Clear SDK factory state before each test so config-based SDK behavior is asserted.
-
-    When _test_http_client is set (e.g. by another test's create_test_client), the SDK
-    is created with base_url='http://testserver' and no request router, which breaks tests
-    that assert on base_url or service routing. Clearing it keeps tests order-independent
-    and ensures sdk_factory tests always exercise the config path.
-    """
-    import nmp.common.sdk_factory as sdk_factory_module
-
-    old = sdk_factory_module._test_http_client
-    sdk_factory_module._test_http_client = None
+def _clear_configuration_cache():
+    """Keep SDK factory tests order-independent."""
     Configuration.clear_cache()
     try:
         yield
     finally:
-        sdk_factory_module._test_http_client = old
         Configuration.clear_cache()
 
 
@@ -119,25 +124,22 @@ def test_get_platform_sdk_preserves_api_base_url_for_controller_only_pods(monkey
     assert str(captured_requests[0].url) == "http://nemo-platform-api:8080/apis/jobs/v2/workspaces/default/jobs"
 
 
-def test_get_platform_sdk_routes_local_service_path_to_process_listener(monkeypatch: pytest.MonkeyPatch):
-    """Requests for APIs hosted in this process bypass the platform entrypoint."""
+def test_get_platform_sdk_uses_routing_transport_for_local_services(monkeypatch: pytest.MonkeyPatch):
+    """APIs hosted in this process are routed by the SDK-owned HTTP client."""
     monkeypatch.setenv("NMP_BASE_URL", "https://nemo-gateway:8080")
     monkeypatch.setenv("NMP_SERVICES", "auth")
     monkeypatch.setenv("NMP_SERVICE_HOST", "127.0.0.1")
     monkeypatch.setenv("NMP_SERVICE_PORT", "8080")
     Configuration.clear_cache()
 
-    sdk = get_platform_sdk()
-    prepared = sdk._prepare_url("https://nemo-gateway:8080/apis/auth/v2/authz/allow")
+    with get_platform_sdk() as sdk:
+        transport = sdk._client._transport
 
-    assert prepared.scheme == "http"
-    assert prepared.host == "127.0.0.1"
-    assert prepared.port == 8080
-    assert prepared.path == "/apis/auth/v2/authz/allow"
+    assert isinstance(transport, _SyncPlatformEndpointRoutingTransport)
 
 
 def test_get_platform_sdk_uses_uds_endpoint_from_base_url():
-    config = PlatformConfig(base_url="unix:///tmp/nemo-platform.sock")  # type: ignore[abstract]
+    config = PlatformConfig.model_construct(base_url="unix:///tmp/nemo-platform.sock")
 
     with patch("nmp.common.sdk_factory.Configuration.get_platform_config", return_value=config):
         sdk = get_platform_sdk()
@@ -221,7 +223,7 @@ def test_get_async_platform_sdk():
 
 
 def test_get_async_platform_sdk_uses_uds_endpoint_from_base_url():
-    config = PlatformConfig(base_url="unix:///tmp/nemo-platform.sock")  # type: ignore[abstract]
+    config = PlatformConfig.model_construct(base_url="unix:///tmp/nemo-platform.sock")
 
     with patch("nmp.common.sdk_factory.Configuration.get_platform_config", return_value=config):
         sdk = get_async_platform_sdk()
@@ -230,26 +232,13 @@ def test_get_async_platform_sdk_uses_uds_endpoint_from_base_url():
 
 
 @pytest.mark.asyncio
-async def test_get_async_platform_sdk_workload_identity_reuses_test_http_client(
-    monkeypatch: pytest.MonkeyPatch, tmp_path
-):
-    import nmp.common.sdk_factory as sdk_factory_module
-
-    subject_token_file = tmp_path / "workload-token"
-    subject_token_file.write_text("subject-token-from-file\n", encoding="utf-8")
-    monkeypatch.setenv("NMP_BASE_URL", "http://nmp.example.test")
-    monkeypatch.setenv(WORKLOAD_IDENTITY_TOKEN_FILE_ENVVAR, str(subject_token_file))
-
+async def test_get_async_platform_sdk_uses_explicit_http_client() -> None:
     transport = httpx.MockTransport(lambda _request: httpx.Response(200, json={}))
     async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as http_client:
-        sdk_factory_module._test_http_client = http_client
-        try:
-            sdk = get_async_platform_sdk()
+        sdk = get_async_platform_sdk(base_url="http://nmp.example.test", http_client=http_client)
 
-            assert sdk._client is http_client
-            assert str(sdk.base_url).rstrip("/") == "http://nmp.example.test"
-        finally:
-            sdk_factory_module._test_http_client = None
+        assert sdk._client is http_client
+        assert str(sdk.base_url).rstrip("/") == "http://nmp.example.test"
 
 
 def test_get_async_platform_sdk_with_service_principal():
@@ -423,6 +412,23 @@ def test_get_task_sdk_uses_explicit_sync_http_client(monkeypatch: pytest.MonkeyP
         assert sdk._client is client
 
 
+def test_platform_sdk_test_context_closes_factory_client() -> None:
+    with _platform_sdk_for_test() as sdk:
+        http_client = sdk._client
+        assert not http_client.is_closed
+
+    assert http_client.is_closed
+
+
+@pytest.mark.asyncio
+async def test_async_platform_sdk_test_context_closes_factory_client() -> None:
+    async with _async_platform_sdk_for_test() as sdk:
+        http_client = sdk._client
+        assert not http_client.is_closed
+
+    assert http_client.is_closed
+
+
 def test_get_request_scoped_sdk_merges_otel_and_auth_headers():
     """Test that get_request_scoped_sdk merges OTEL and auth headers."""
     base_sdk = get_async_platform_sdk()
@@ -450,8 +456,8 @@ def test_get_request_scoped_sdk_merges_otel_and_auth_headers():
     assert scoped_sdk.default_headers["X-NMP-Principal-Groups"] == "group1,group2"
 
 
-def test_get_request_scoped_sdk_preserves_request_router(monkeypatch: pytest.MonkeyPatch):
-    """Derived request SDKs must keep the base SDK's path-aware platform request router."""
+def test_get_request_scoped_sdk_reuses_base_sdk_http_client(monkeypatch: pytest.MonkeyPatch):
+    """Derived request SDKs keep the base SDK's routed HTTP client."""
     monkeypatch.setenv("NMP_BASE_URL", "https://nemo-gateway:8080")
     monkeypatch.setenv("NMP_SERVICES", "entities")
     monkeypatch.setenv("NMP_SERVICE_HOST", "127.0.0.1")
@@ -468,18 +474,16 @@ def test_get_request_scoped_sdk_preserves_request_router(monkeypatch: pytest.Mon
             ):
                 scoped_sdk = get_request_scoped_sdk(base_sdk)
 
-        prepared = scoped_sdk._prepare_url("https://nemo-gateway:8080/apis/entities/v2/workspaces")
+        transport = base_sdk._client._transport
 
-        assert prepared.scheme == "http"
-        assert prepared.host == "127.0.0.1"
-        assert prepared.port == 8080
-        assert prepared.path == "/apis/entities/v2/workspaces"
+        assert isinstance(transport, _AsyncPlatformEndpointRoutingTransport)
+        assert scoped_sdk._client is base_sdk._client
     finally:
         Configuration.clear_cache()
 
 
-def test_get_sdk_on_behalf_of_preserves_request_router(monkeypatch: pytest.MonkeyPatch):
-    """SDKs derived with on-behalf-of headers must still keep platform request routing."""
+def test_get_sdk_on_behalf_of_reuses_base_sdk_http_client(monkeypatch: pytest.MonkeyPatch):
+    """SDKs derived with on-behalf-of headers keep the base SDK's routed HTTP client."""
     monkeypatch.setenv("NMP_BASE_URL", "https://nemo-gateway:8080")
     monkeypatch.setenv("NMP_SERVICES", "entities")
     monkeypatch.setenv("NMP_SERVICE_HOST", "127.0.0.1")
@@ -490,12 +494,10 @@ def test_get_sdk_on_behalf_of_preserves_request_router(monkeypatch: pytest.Monke
         base_sdk = get_async_platform_sdk(as_service="models", internal=True)
         scoped_sdk = get_sdk_on_behalf_of(base_sdk, "user@example.com")
 
-        prepared = scoped_sdk._prepare_url("https://nemo-gateway:8080/apis/entities/v2/workspaces")
+        transport = base_sdk._client._transport
 
-        assert prepared.scheme == "http"
-        assert prepared.host == "127.0.0.1"
-        assert prepared.port == 8080
-        assert prepared.path == "/apis/entities/v2/workspaces"
+        assert isinstance(transport, _AsyncPlatformEndpointRoutingTransport)
+        assert scoped_sdk._client is base_sdk._client
     finally:
         Configuration.clear_cache()
 
@@ -585,6 +587,23 @@ def test_get_request_scoped_sdk_auth_headers_override_otel_headers():
     assert scoped_sdk.default_headers["X-Custom-Header"] == "auth-value"
 
 
+def test_get_request_scoped_sdk_preserves_base_default_headers_with_scoped_headers():
+    """Request-scoped SDKs keep base service headers while adding request headers."""
+    base_sdk = get_async_platform_sdk(as_service="jobs", internal=True)
+
+    mock_otel_headers = {"traceparent": "00-trace-id-span-id-01"}
+    mock_auth_headers = {"X-NMP-Principal-On-Behalf-Of": "user@example.com"}
+
+    with patch("nmp.common.sdk_factory.get_otel_headers", return_value=mock_otel_headers):
+        with patch("nmp.common.sdk_factory.get_principal_auth_headers", return_value=mock_auth_headers):
+            scoped_sdk = get_request_scoped_sdk(base_sdk)
+
+    assert scoped_sdk.default_headers["X-NMP-Internal"] == "true"
+    assert scoped_sdk.default_headers["X-NMP-Principal-Id"] == "service:jobs"
+    assert scoped_sdk.default_headers["X-NMP-Principal-On-Behalf-Of"] == "user@example.com"
+    assert scoped_sdk.default_headers["traceparent"] == "00-trace-id-span-id-01"
+
+
 def test_get_request_scoped_sdk_preserves_base_sdk_http_client():
     """Test that get_request_scoped_sdk reuses the base SDK's HTTP client."""
     import httpx
@@ -664,7 +683,19 @@ def test_get_request_scoped_sdk_service_principal_with_on_behalf_of():
     assert scoped_sdk.default_headers["X-NMP-Principal-On-Behalf-Of"] == "user@example.com"
 
 
-# --- Dynamic routing (service discovery map) tests ---
+def test_get_sdk_on_behalf_of_preserves_omitted_default_headers() -> None:
+    with NeMoPlatform(
+        base_url="http://nmp.example.test",
+        default_headers={"Content-Type": omit, "X-Base": "base"},
+    ) as base_sdk:
+        delegated_sdk = get_sdk_on_behalf_of(base_sdk, "user@example.com")
+
+    assert delegated_sdk.default_headers["Content-Type"] is omit
+    assert delegated_sdk.default_headers["X-Base"] == "base"
+    assert delegated_sdk.default_headers["X-NMP-Principal-On-Behalf-Of"] == "user@example.com"
+
+
+# --- SDK routing client tests ---
 
 
 @pytest.fixture
@@ -679,204 +710,146 @@ def platform_config_with_service_discovery():
     )
 
 
-def test_resolve_platform_request_url_routes_api_path_to_service_url(platform_config_with_service_discovery):
-    """The named request router policy owns per-service routing."""
-
-    def default_resolver(url: str) -> httpx.URL:
-        if url.startswith("/"):
-            return httpx.URL(f"http://platform:8080{url}")
-        return httpx.URL(url)
-
-    prepared = resolve_platform_request_url(
-        "/apis/entities/v2/workspaces?limit=10",
-        platform_config=platform_config_with_service_discovery,
-        default_resolver=default_resolver,
+@pytest.fixture
+def platform_config_with_uds_service_route() -> PlatformConfig:
+    return PlatformConfig(  # type: ignore[abstract]
+        base_url="https://platform:8443",
+        service_discovery={"entities": "unix:///tmp/entities.sock"},
     )
 
-    assert prepared.scheme == "http"
-    assert prepared.host == "entities-service"
-    assert prepared.port == 8080
-    assert prepared.path == "/apis/entities/v2/workspaces"
-    assert prepared.query == b"limit=10"
 
-
-def test_resolve_platform_request_url_logs_path_without_raw_url(
-    caplog: pytest.LogCaptureFixture,
+def test_get_platform_sdk_uses_routing_transport_for_service_discovery(
     platform_config_with_service_discovery,
 ):
-    """Routing logs expose the resolved path without query parameters."""
-
-    def default_resolver(url: str) -> httpx.URL:
-        if url.startswith("/"):
-            return httpx.URL(f"http://platform:8080{url}")
-        return httpx.URL(url)
-
-    caplog.set_level(logging.DEBUG, logger="nmp.common.sdk_factory")
-
-    resolve_platform_request_url(
-        "/health/ready?token=secret",
-        platform_config=platform_config_with_service_discovery,
-        default_resolver=default_resolver,
-    )
-    resolve_platform_request_url(
-        "/apis/entities/v2/workspaces?token=secret",
-        platform_config=platform_config_with_service_discovery,
-        default_resolver=default_resolver,
-    )
-
-    original_record = next(record for record in caplog.records if record.message == "Routing URL to original URL")
-    service_record = next(record for record in caplog.records if record.message == "Routing URL to service URL")
-
-    assert not hasattr(original_record, "url")
-    assert original_record.service == "unknown"
-    assert original_record.path == "/health/ready"
-    assert original_record.host == "platform"
-    assert original_record.port == 8080
-
-    assert not hasattr(service_record, "url")
-    assert service_record.service == "entities"
-    assert service_record.path == "/apis/entities/v2/workspaces"
-    assert service_record.host == "entities-service"
-    assert service_record.port == 8080
-
-    for record in (original_record, service_record):
-        assert "token=secret" not in str(record.__dict__)
-
-
-def test_platform_request_router_uses_default_resolver_for_non_api_paths(platform_config_with_service_discovery):
-    """Non-API paths follow the SDK's normal URL preparation."""
-    router = PlatformRequestRouter(
-        platform_config=platform_config_with_service_discovery,
-        default_resolver=lambda url: httpx.URL(f"http://platform:8080{url}"),
-    )
-
-    prepared = router.resolve("/health/ready")
-
-    assert str(prepared) == "http://platform:8080/health/ready"
-
-
-def test_get_platform_sdk_routes_entities_path_to_entities_service(
-    platform_config_with_service_discovery,
-):
-    """Routes /apis/entities/v2/workspaces to the entities service URL."""
+    """Service discovery routing belongs to the SDK-owned HTTP client."""
     with patch(
         "nmp.common.sdk_factory.Configuration.get_platform_config",
         return_value=platform_config_with_service_discovery,
     ):
-        sdk = get_platform_sdk()
-        request_url = "http://platform:8080/apis/entities/v2/workspaces"
-        prepared = sdk._prepare_url(request_url)
+        with get_platform_sdk() as sdk:
+            transport = sdk._client._transport
 
-    assert prepared.host == "entities-service"
-    assert prepared.port == 8080
-    assert prepared.scheme == "http"
-    assert "/apis/entities/v2/workspaces" in str(prepared.path)
+    assert isinstance(transport, _SyncPlatformEndpointRoutingTransport)
 
 
-def test_get_platform_sdk_routes_service_path_to_env_override(
+def test_platform_sdk_copy_reuses_routing_transport(
+    platform_config_with_service_discovery,
+):
+    """SDK clones remain routed by reusing the base HTTP client."""
+    with patch(
+        "nmp.common.sdk_factory.Configuration.get_platform_config",
+        return_value=platform_config_with_service_discovery,
+    ):
+        with get_platform_sdk() as sdk:
+            copied_sdk = sdk.copy(workspace="copy-workspace")
+
+            assert copied_sdk._client is sdk._client
+
+
+def test_get_platform_sdk_base_url_preserves_routing_transport_for_uds_service(
+    platform_config_with_uds_service_route: PlatformConfig,
+) -> None:
+    with patch(
+        "nmp.common.sdk_factory.Configuration.get_platform_config",
+        return_value=platform_config_with_uds_service_route,
+    ):
+        with get_platform_sdk(base_url="https://override.example.test") as sdk:
+            transport = sdk._client._transport
+
+    assert isinstance(transport, _SyncPlatformEndpointRoutingTransport)
+
+
+def test_get_platform_sdk_workload_identity_uses_routing_transport_for_uds_service(
     monkeypatch: pytest.MonkeyPatch,
+    platform_config_with_uds_service_route: PlatformConfig,
+    tmp_path,
+) -> None:
+    subject_token_file = tmp_path / "workload-token"
+    subject_token_file.write_text("subject-token-from-file\n", encoding="utf-8")
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("{}\n", encoding="utf-8")
+
+    monkeypatch.setenv("NMP_CONFIG_FILE", str(config_file))
+    monkeypatch.setenv(WORKLOAD_IDENTITY_TOKEN_FILE_ENVVAR, str(subject_token_file))
+    monkeypatch.delenv("NMP_ACCESS_TOKEN", raising=False)
+
+    with patch(
+        "nmp.common.sdk_factory.Configuration.get_platform_config",
+        return_value=platform_config_with_uds_service_route,
+    ):
+        with get_platform_sdk() as sdk:
+            transport = sdk._client._transport
+
+    assert isinstance(transport, _SyncPlatformEndpointRoutingTransport)
+
+
+@pytest.mark.asyncio
+async def test_get_async_platform_sdk_uses_routing_transport_for_service_discovery(
     platform_config_with_service_discovery,
-):
-    monkeypatch.setenv("NMP_ENTITIES_URL", "http://entities-env:9090")
+) -> None:
+    """Async service discovery routing belongs to the SDK-owned HTTP client."""
     with patch(
         "nmp.common.sdk_factory.Configuration.get_platform_config",
         return_value=platform_config_with_service_discovery,
     ):
-        sdk = get_platform_sdk()
-        request_url = "http://platform:8080/apis/entities/v2/workspaces"
-        prepared = sdk._prepare_url(request_url)
+        async with get_async_platform_sdk() as sdk:
+            transport = sdk._client._transport
 
-    assert prepared.host == "entities-env"
-    assert prepared.port == 9090
-    assert prepared.scheme == "http"
+    assert isinstance(transport, _AsyncPlatformEndpointRoutingTransport)
 
 
-def test_get_platform_sdk_routes_jobs_path_to_jobs_service(
+@pytest.mark.asyncio
+async def test_get_async_platform_sdk_workload_identity_uses_routing_transport_for_uds_service(
+    monkeypatch: pytest.MonkeyPatch,
+    platform_config_with_uds_service_route: PlatformConfig,
+    tmp_path,
+) -> None:
+    subject_token_file = tmp_path / "workload-token"
+    subject_token_file.write_text("subject-token-from-file\n", encoding="utf-8")
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("{}\n", encoding="utf-8")
+
+    monkeypatch.setenv("NMP_CONFIG_FILE", str(config_file))
+    monkeypatch.setenv(WORKLOAD_IDENTITY_TOKEN_FILE_ENVVAR, str(subject_token_file))
+    monkeypatch.delenv("NMP_ACCESS_TOKEN", raising=False)
+
+    with patch(
+        "nmp.common.sdk_factory.Configuration.get_platform_config",
+        return_value=platform_config_with_uds_service_route,
+    ):
+        async with get_async_platform_sdk() as sdk:
+            transport = sdk._client._transport
+
+    assert isinstance(transport, _AsyncPlatformEndpointRoutingTransport)
+
+
+@pytest.mark.asyncio
+async def test_async_platform_sdk_copy_reuses_routing_transport(
     platform_config_with_service_discovery,
-):
-    """Routes /apis/jobs/v2/workspaces/jobs to the jobs service URL."""
+) -> None:
+    """Async SDK clones remain routed by reusing the base HTTP client."""
     with patch(
         "nmp.common.sdk_factory.Configuration.get_platform_config",
         return_value=platform_config_with_service_discovery,
     ):
-        sdk = get_platform_sdk()
-        request_url = "http://platform:8080/apis/jobs/v2/workspaces/jobs"
-        prepared = sdk._prepare_url(request_url)
+        async with get_async_platform_sdk() as sdk:
+            copied_sdk = sdk.copy(workspace="copy-workspace")
 
-    assert prepared.host == "jobs-service"
-    assert prepared.port == 8080
-    assert prepared.scheme == "http"
-    assert "/apis/jobs/v2/workspaces/jobs" in str(prepared.path)
+            assert copied_sdk._client is sdk._client
 
 
-def test_get_platform_sdk_routing_fallback_to_base_url_when_no_match(
-    platform_config_with_service_discovery,
-):
-    """When the path does not match /apis/{service-name}/ (lowercase+dashes), use the original URL (base)."""
+@pytest.mark.asyncio
+async def test_get_async_platform_sdk_base_url_preserves_routing_transport_for_uds_service(
+    platform_config_with_uds_service_route: PlatformConfig,
+) -> None:
     with patch(
         "nmp.common.sdk_factory.Configuration.get_platform_config",
-        return_value=platform_config_with_service_discovery,
+        return_value=platform_config_with_uds_service_route,
     ):
-        sdk = get_platform_sdk()
-        # Path that does not match /apis/{service-name}/ (e.g. /api/ singular, or no such prefix)
-        request_url = "http://platform:8080/api/other/v1/thing"
-        prepared = sdk._prepare_url(request_url)
+        async with get_async_platform_sdk(base_url="https://override.example.test") as sdk:
+            transport = sdk._client._transport
 
-    # Should pass through to original behavior: same host as request
-    assert prepared.host == "platform"
-    assert prepared.port == 8080
-
-
-def test_get_async_platform_sdk_routes_entities_path_to_entities_service(
-    platform_config_with_service_discovery,
-):
-    """Routes /apis/entities/v2/workspaces to the entities service URL (async SDK)."""
-    with patch(
-        "nmp.common.sdk_factory.Configuration.get_platform_config",
-        return_value=platform_config_with_service_discovery,
-    ):
-        sdk = get_async_platform_sdk()
-        request_url = "http://platform:8080/apis/entities/v2/workspaces"
-        prepared = sdk._prepare_url(request_url)
-
-    assert prepared.host == "entities-service"
-    assert prepared.port == 8080
-    assert prepared.scheme == "http"
-    assert "/apis/entities/v2/workspaces" in str(prepared.path)
-
-
-def test_get_async_platform_sdk_routes_jobs_path_to_jobs_service(
-    platform_config_with_service_discovery,
-):
-    """Routes /apis/jobs/v2/workspaces/jobs to the jobs service URL (async SDK)."""
-    with patch(
-        "nmp.common.sdk_factory.Configuration.get_platform_config",
-        return_value=platform_config_with_service_discovery,
-    ):
-        sdk = get_async_platform_sdk()
-        request_url = "http://platform:8080/apis/jobs/v2/workspaces/jobs"
-        prepared = sdk._prepare_url(request_url)
-
-    assert prepared.host == "jobs-service"
-    assert prepared.port == 8080
-    assert prepared.scheme == "http"
-    assert "/apis/jobs/v2/workspaces/jobs" in str(prepared.path)
-
-
-def test_get_async_platform_sdk_routing_fallback_to_base_url_when_no_match(
-    platform_config_with_service_discovery,
-):
-    """When the path does not match /apis/{service-name}/, use the original URL (async SDK)."""
-    with patch(
-        "nmp.common.sdk_factory.Configuration.get_platform_config",
-        return_value=platform_config_with_service_discovery,
-    ):
-        sdk = get_async_platform_sdk()
-        request_url = "http://platform:8080/api/other/v1/thing"
-        prepared = sdk._prepare_url(request_url)
-
-    assert prepared.host == "platform"
-    assert prepared.port == 8080
+    assert isinstance(transport, _AsyncPlatformEndpointRoutingTransport)
 
 
 # --- get_entity_parts tests ---

--- a/packages/nmp_common/tests/test_immutable_http_client.py
+++ b/packages/nmp_common/tests/test_immutable_http_client.py
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from types import MappingProxyType
+
+import httpx
+import pytest
+from nmp.common.immutable_http_client import ImmutableHttpClientMixin
+
+
+def _noop_request_hook(request: httpx.Request) -> None:
+    pass
+
+
+class _FrozenClient(ImmutableHttpClientMixin, httpx.Client):
+    def __init__(self) -> None:
+        super().__init__(
+            headers={"X-Initial": "true"},
+            event_hooks={"request": [_noop_request_hook]},
+        )
+        self._freeze_http_client()
+
+
+class _FrozenAsyncClient(ImmutableHttpClientMixin, httpx.AsyncClient):
+    def __init__(self) -> None:
+        super().__init__(
+            headers={"X-Initial": "true"},
+            event_hooks={"request": [_noop_request_hook]},
+        )
+        self._freeze_http_client()
+
+
+def test_immutable_sdk_client_still_builds_requests() -> None:
+    with _FrozenClient() as client:
+        request = client.build_request("GET", "http://nmp.example.test/health")
+
+    assert request.url == "http://nmp.example.test/health"
+    assert request.headers["X-Initial"] == "true"
+
+
+def test_immutable_sdk_client_blocks_client_configuration_assignment() -> None:
+    with _FrozenClient() as client:
+        with pytest.raises(AttributeError, match="SDK HTTP clients are immutable"):
+            client.headers = httpx.Headers({"Authorization": "Bearer stale"})
+
+        with pytest.raises(AttributeError, match="SDK HTTP clients are immutable"):
+            client.base_url = httpx.URL("http://other.example.test")
+
+        with pytest.raises(AttributeError, match="SDK HTTP clients are immutable"):
+            client.params = {"debug": "true"}
+
+
+def test_immutable_sdk_client_blocks_transport_assignment() -> None:
+    with _FrozenClient() as client:
+        with pytest.raises(AttributeError, match="SDK HTTP clients are immutable"):
+            client._transport = httpx.HTTPTransport()
+
+        with pytest.raises(AttributeError, match="SDK HTTP clients are immutable"):
+            client._mounts = {}
+
+        assert isinstance(client._mounts, MappingProxyType)
+
+
+@pytest.mark.asyncio
+async def test_immutable_async_sdk_client_blocks_transport_assignment() -> None:
+    async with _FrozenAsyncClient() as client:
+        with pytest.raises(AttributeError, match="SDK HTTP clients are immutable"):
+            client._transport = httpx.AsyncHTTPTransport()
+
+        with pytest.raises(AttributeError, match="SDK HTTP clients are immutable"):
+            client._mounts = {}
+
+        assert isinstance(client._mounts, MappingProxyType)
+
+
+def test_immutable_sdk_client_blocks_header_mutation() -> None:
+    with _FrozenClient() as client:
+        with pytest.raises(TypeError, match="SDK HTTP clients are immutable"):
+            client.headers["Authorization"] = "Bearer stale"
+
+        with pytest.raises(TypeError, match="SDK HTTP clients are immutable"):
+            client.headers.update({"Authorization": "Bearer stale"})
+
+        with pytest.raises(TypeError, match="SDK HTTP clients are immutable"):
+            client.headers.pop("X-Initial")
+
+
+def test_immutable_sdk_client_blocks_cookie_mutation_and_ignores_response_cookies() -> None:
+    with _FrozenClient() as client:
+        with pytest.raises(TypeError, match="SDK HTTP clients are immutable"):
+            client.cookies["session"] = "stale"
+
+        request = client.build_request("GET", "http://nmp.example.test/health")
+        response = httpx.Response(200, headers={"Set-Cookie": "session=stale"}, request=request)
+
+        client.cookies.extract_cookies(response)
+
+        assert "session" not in client.cookies
+
+
+def test_immutable_sdk_client_blocks_event_hook_mutation() -> None:
+    with _FrozenClient() as client:
+        with pytest.raises(AttributeError):
+            client.event_hooks["request"].append(_noop_request_hook)
+
+        with pytest.raises(TypeError):
+            client.event_hooks["request"] = [_noop_request_hook]

--- a/packages/nmp_common/tests/test_platform_endpoint.py
+++ b/packages/nmp_common/tests/test_platform_endpoint.py
@@ -1,12 +1,42 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
+import os
+from collections.abc import Iterator
 from pathlib import Path
 from unittest.mock import patch
 
+import httpx
 import pytest
-from nmp.common.config import PlatformConfig
-from nmp.common.platform_endpoint import UDS_BASE_URL, parse_platform_endpoint, resolve_service_endpoint
+from nmp.common.config import Configuration, PlatformConfig, get_common_service_config
+from nmp.common.platform_endpoint import (
+    UDS_BASE_URL,
+    PlatformEndpoint,
+    _AsyncPlatformEndpointRoutingTransport,
+    _SyncPlatformEndpointRoutingTransport,
+    parse_platform_endpoint,
+    resolve_platform_endpoint,
+    resolve_service_endpoint,
+)
+
+
+def _assert_log_record_extra(record: logging.LogRecord, expected: dict[str, str | int]) -> None:
+    fields = vars(record)
+    for name, value in expected.items():
+        assert fields[name] == value
+
+
+@pytest.fixture(autouse=True)
+def clear_platform_url_env_vars(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    Configuration.clear_cache()
+    for key in tuple(os.environ):
+        if key.startswith("NMP_") and key.endswith("_URL"):
+            monkeypatch.delenv(key, raising=False)
+    try:
+        yield
+    finally:
+        Configuration.clear_cache()
 
 
 def test_parse_tcp_endpoint() -> None:
@@ -69,6 +99,31 @@ def test_resolve_service_endpoint_falls_back_to_base_url(monkeypatch: pytest.Mon
     assert endpoint.connect_base_url == "http://platform:8080"
 
 
+def test_resolve_service_endpoint_skips_invalid_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    config = PlatformConfig(base_url="http://platform:8080")
+    monkeypatch.setenv("NMP_SECRETS_URL", "not-a-url")
+
+    endpoint = resolve_service_endpoint("secrets", config)
+
+    assert endpoint.transport == "tcp"
+    assert endpoint.connect_base_url == "http://platform:8080"
+
+
+def test_resolve_service_endpoint_skips_invalid_env_override_and_uses_configured_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = PlatformConfig(
+        base_url="http://platform:8080",
+        service_discovery={"secrets": "http://secrets-service:8080"},
+    )
+    monkeypatch.setenv("NMP_SECRETS_URL", "not-a-url")
+
+    endpoint = resolve_service_endpoint("secrets", config)
+
+    assert endpoint.transport == "tcp"
+    assert endpoint.connect_base_url == "http://secrets-service:8080"
+
+
 def test_endpoint_env_family_is_not_part_of_contract(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("NMP_SECRETS_ENDPOINT", "unix:///tmp/secrets.sock")
     monkeypatch.delenv("NMP_SECRETS_URL", raising=False)
@@ -78,6 +133,272 @@ def test_endpoint_env_family_is_not_part_of_contract(monkeypatch: pytest.MonkeyP
 
     assert endpoint.transport == "tcp"
     assert endpoint.connect_base_url == "http://platform:8080"
+
+
+@pytest.fixture
+def platform_config_with_service_discovery() -> PlatformConfig:
+    return PlatformConfig(  # type: ignore[abstract]
+        base_url="http://platform:8080",
+        service_discovery={
+            "entities": "http://entities-service:8080",
+            "jobs": "http://jobs-service:8080",
+        },
+    )
+
+
+def test_resolve_platform_endpoint_carries_service_routes(
+    platform_config_with_service_discovery: PlatformConfig,
+) -> None:
+    endpoint = resolve_platform_endpoint(platform_config_with_service_discovery)
+
+    assert endpoint.connect_base_url == "http://platform:8080"
+    assert endpoint.service_endpoints["entities"].connect_base_url == "http://entities-service:8080"
+    assert endpoint.service_endpoints["jobs"].connect_base_url == "http://jobs-service:8080"
+
+
+def test_resolve_platform_endpoint_rejects_malformed_service_route() -> None:
+    config = PlatformConfig(  # type: ignore[abstract]
+        base_url="http://platform:8080",
+        service_discovery={
+            "entities": "http://entities-service:8080",
+            "jobs": "not-a-url",
+        },
+    )
+
+    with pytest.raises(ValueError, match="Unsupported platform endpoint URL 'not-a-url'"):
+        resolve_platform_endpoint(config)
+
+
+def test_resolve_platform_endpoint_rejects_malformed_base_url() -> None:
+    config = PlatformConfig(  # type: ignore[abstract]
+        base_url="not-a-url",
+        service_discovery={"entities": "http://entities-service:8080"},
+    )
+
+    with pytest.raises(ValueError, match="Unsupported platform endpoint URL 'not-a-url'"):
+        resolve_platform_endpoint(config)
+
+
+def test_platform_endpoint_routes_api_path_to_service_url(
+    platform_config_with_service_discovery: PlatformConfig,
+) -> None:
+    endpoint = resolve_platform_endpoint(platform_config_with_service_discovery)
+
+    routed = endpoint.route_request_url("http://platform:8080/apis/entities/v2/workspaces?limit=10")
+
+    assert routed.endpoint.connect_base_url == "http://entities-service:8080"
+    assert routed.url.scheme == "http"
+    assert routed.url.host == "entities-service"
+    assert routed.url.port == 8080
+    assert routed.url.path == "/apis/entities/v2/workspaces"
+    assert routed.url.query == b"limit=10"
+
+
+def test_platform_endpoint_preserves_request_path_when_service_url_has_path_prefix() -> None:
+    config = PlatformConfig(  # type: ignore[abstract]
+        base_url="http://platform:8080",
+        service_discovery={"entities": "http://entities-service:8080/entities-prefix"},
+    )
+    endpoint = resolve_platform_endpoint(config)
+
+    routed = endpoint.route_request_url("http://platform:8080/apis/entities/v2/workspaces?limit=10")
+
+    assert routed.endpoint.connect_base_url == "http://entities-service:8080/entities-prefix"
+    assert routed.url.scheme == "http"
+    assert routed.url.host == "entities-service"
+    assert routed.url.port == 8080
+    assert routed.url.path == "/apis/entities/v2/workspaces"
+    assert routed.url.query == b"limit=10"
+
+
+def test_platform_endpoint_routes_service_discovery_with_underscore_configured_name() -> None:
+    config = PlatformConfig(
+        base_url="http://platform:8080",
+        service_discovery={"my_service": "http://my-service:8080"},
+    )
+
+    endpoint = resolve_platform_endpoint(config)
+    routed = endpoint.route_request_url("http://platform:8080/apis/my-service/v2/workspaces/default/items")
+
+    assert routed.endpoint.connect_base_url == "http://my-service:8080"
+    assert str(routed.url) == "http://my-service:8080/apis/my-service/v2/workspaces/default/items"
+
+
+def test_platform_endpoint_uses_env_override(
+    monkeypatch: pytest.MonkeyPatch,
+    platform_config_with_service_discovery: PlatformConfig,
+) -> None:
+    monkeypatch.setenv("NMP_ENTITIES_URL", "http://entities-env:9090")
+    endpoint = resolve_platform_endpoint(platform_config_with_service_discovery)
+
+    routed = endpoint.route_request_url("http://platform:8080/apis/entities/v2/workspaces")
+
+    assert routed.endpoint.connect_base_url == "http://entities-env:9090"
+    assert routed.url.host == "entities-env"
+    assert routed.url.port == 9090
+
+
+def test_platform_endpoint_routes_env_only_service_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    config = PlatformConfig(base_url="http://platform:8080")  # type: ignore[abstract]
+    monkeypatch.setenv("NMP_ENTITIES_URL", "http://entities-env:9090")
+
+    endpoint = resolve_platform_endpoint(config)
+    routed = endpoint.route_request_url("http://platform:8080/apis/entities/v2/workspaces/default?limit=1")
+
+    assert "entities" in endpoint.service_endpoints
+    assert "entities" not in config.service_discovery
+    assert routed.endpoint.connect_base_url == "http://entities-env:9090"
+    assert str(routed.url) == "http://entities-env:9090/apis/entities/v2/workspaces/default?limit=1"
+
+
+@pytest.mark.parametrize("service_url", ["not-a-url", "http://", "unix://relative.sock"])
+def test_platform_endpoint_skips_invalid_env_only_service_url(
+    monkeypatch: pytest.MonkeyPatch,
+    service_url: str,
+) -> None:
+    monkeypatch.setenv("NMP_FILES_URL", service_url)
+    config = PlatformConfig(base_url="http://platform:8080")
+
+    endpoint = resolve_platform_endpoint(config)
+    routed = endpoint.route_request_url("http://platform:8080/apis/files/v2/workspaces/default/filesets")
+
+    assert "files" not in endpoint.service_endpoints
+    assert str(routed.url) == "http://platform:8080/apis/files/v2/workspaces/default/filesets"
+
+
+def test_platform_endpoint_skips_invalid_unrelated_service_url_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NMP_NOT_A_SERVICE_URL", "not-a-url")
+    config = PlatformConfig(base_url="http://platform:8080")
+
+    endpoint = resolve_platform_endpoint(config)
+
+    assert "not-a-service" not in endpoint.service_endpoints
+
+
+def test_platform_endpoint_keeps_configured_local_service_on_local_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    config = PlatformConfig(base_url="http://platform:8080", services="hello-world")  # type: ignore[abstract]
+    monkeypatch.setenv("NMP_HELLO_WORLD_URL", "http://hello-world-service:8080")
+    endpoint = resolve_platform_endpoint(config)
+
+    routed = endpoint.route_request_url("http://platform:8080/apis/hello-world/v2/workspaces/default/hello")
+
+    assert routed.endpoint.connect_base_url == get_common_service_config().get_host_url()
+    assert routed.url.host == "127.0.0.1"
+
+
+def test_platform_endpoint_keeps_local_service_with_underscore_configured_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = PlatformConfig(base_url="http://platform:8080", services="my_service")
+    monkeypatch.setenv("NMP_SERVICE_HOST", "127.0.0.1")
+    monkeypatch.setenv("NMP_SERVICE_PORT", "8080")
+
+    endpoint = resolve_platform_endpoint(config)
+    routed = endpoint.route_request_url("http://platform:8080/apis/my-service/v2/workspaces/default/items")
+
+    assert routed.endpoint.connect_base_url == "http://127.0.0.1:8080"
+    assert str(routed.url) == "http://127.0.0.1:8080/apis/my-service/v2/workspaces/default/items"
+
+
+def test_platform_endpoint_keeps_local_service_when_env_override_exists(monkeypatch: pytest.MonkeyPatch) -> None:
+    config = PlatformConfig(base_url="http://platform:8080", services="hello-world")  # type: ignore[abstract]
+    monkeypatch.setenv("NMP_SERVICE_HOST", "127.0.0.1")
+    monkeypatch.setenv("NMP_SERVICE_PORT", "8080")
+    monkeypatch.setenv("NMP_HELLO_WORLD_URL", "http://hello-world-env:9090")
+
+    endpoint = resolve_platform_endpoint(config)
+    routed = endpoint.route_request_url("http://platform:8080/apis/hello-world/v2/workspaces/default/hello")
+
+    assert routed.endpoint.connect_base_url == "http://127.0.0.1:8080"
+    assert str(routed.url) == "http://127.0.0.1:8080/apis/hello-world/v2/workspaces/default/hello"
+
+
+def test_platform_endpoint_ignores_unrelated_service_url_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    config = PlatformConfig(base_url="http://platform:8080")  # type: ignore[abstract]
+    monkeypatch.setenv("NMP_NOT_A_SERVICE_URL", "http://not-a-service:8080")
+
+    endpoint = resolve_platform_endpoint(config)
+    routed = endpoint.route_request_url("http://platform:8080/apis/entities/v2/workspaces/default")
+
+    assert routed.endpoint.connect_base_url == "http://platform:8080"
+    assert routed.url.host == "platform"
+
+
+def test_platform_endpoint_routes_uds_service() -> None:
+    config = PlatformConfig(  # type: ignore[abstract]
+        base_url="http://platform:8080",
+        service_discovery={"entities": "unix:///tmp/entities.sock"},
+    )
+    endpoint = resolve_platform_endpoint(config)
+
+    routed = endpoint.route_request_url("http://platform:8080/apis/entities/v2/workspaces")
+
+    assert routed.endpoint.transport == "uds"
+    assert routed.endpoint.socket_path == Path("/tmp/entities.sock")
+    assert str(routed.url) == "http://nemo-platform.local/apis/entities/v2/workspaces"
+
+
+def test_platform_endpoint_keeps_non_api_path_on_default_endpoint(
+    platform_config_with_service_discovery: PlatformConfig,
+) -> None:
+    endpoint = resolve_platform_endpoint(platform_config_with_service_discovery)
+
+    routed = endpoint.route_request_url("http://platform:8080/health/ready")
+
+    assert routed.endpoint.connect_base_url == "http://platform:8080"
+    assert str(routed.url) == "http://platform:8080/health/ready"
+
+
+def test_platform_endpoint_keeps_non_api_service_url(
+    platform_config_with_service_discovery: PlatformConfig,
+) -> None:
+    endpoint = resolve_platform_endpoint(platform_config_with_service_discovery)
+
+    routed = endpoint.route_request_url("http://entities-service:8080/status")
+
+    assert routed.endpoint.connect_base_url == "http://platform:8080"
+    assert str(routed.url) == "http://entities-service:8080/status"
+
+
+def test_platform_endpoint_logs_path_without_raw_url(
+    caplog: pytest.LogCaptureFixture,
+    platform_config_with_service_discovery: PlatformConfig,
+) -> None:
+    caplog.set_level(logging.DEBUG, logger="nmp.common.platform_endpoint")
+    endpoint = resolve_platform_endpoint(platform_config_with_service_discovery)
+
+    endpoint.route_request_url("http://platform:8080/health/ready?token=secret")
+    endpoint.route_request_url("http://platform:8080/apis/entities/v2/workspaces?token=secret")
+
+    default_record = next(
+        record for record in caplog.records if record.message == "Routing SDK URL to default endpoint"
+    )
+    service_record = next(
+        record for record in caplog.records if record.message == "Routing SDK URL to service endpoint"
+    )
+
+    assert "url" not in vars(default_record)
+    _assert_log_record_extra(
+        default_record,
+        {
+            "service": "unknown",
+            "path": "/health/ready",
+        },
+    )
+
+    assert "url" not in vars(service_record)
+    _assert_log_record_extra(
+        service_record,
+        {
+            "service": "entities",
+            "path": "/apis/entities/v2/workspaces",
+            "host": "entities-service",
+            "port": 8080,
+        },
+    )
+
+    for record in (default_record, service_record):
+        assert "token=secret" not in str(vars(record))
 
 
 def test_sync_http_client_omits_unset_timeout() -> None:
@@ -101,7 +422,7 @@ def test_sync_http_client_passes_explicit_timeout() -> None:
 def test_sync_sdk_http_client_uses_sdk_default_for_tcp() -> None:
     endpoint = parse_platform_endpoint("http://127.0.0.1:8080")
 
-    with patch("nmp.common.platform_endpoint.DefaultHttpxClient") as client:
+    with patch("nmp.common.platform_endpoint.ImmutableDefaultHttpxClient") as client:
         endpoint.sync_sdk_http_client()
 
     client.assert_called_once_with()
@@ -110,7 +431,7 @@ def test_sync_sdk_http_client_uses_sdk_default_for_tcp() -> None:
 def test_sync_sdk_http_client_passes_explicit_timeout() -> None:
     endpoint = parse_platform_endpoint("http://127.0.0.1:8080")
 
-    with patch("nmp.common.platform_endpoint.DefaultHttpxClient") as client:
+    with patch("nmp.common.platform_endpoint.ImmutableDefaultHttpxClient") as client:
         endpoint.sync_sdk_http_client(timeout=2.0)
 
     client.assert_called_once_with(timeout=2.0)
@@ -132,8 +453,8 @@ def test_uds_sync_sdk_http_client_keeps_transport_and_omits_unset_timeout() -> N
     endpoint = parse_platform_endpoint("unix:///tmp/nemo-platform.sock")
 
     with (
-        patch("nmp.common.platform_endpoint.DefaultHttpxClient") as sdk_client,
-        patch("nmp.common.platform_endpoint.httpx.Client") as client,
+        patch("nmp.common.platform_endpoint.ImmutableDefaultHttpxClient") as sdk_client,
+        patch("nmp.common.platform_endpoint.ImmutableHttpxClient") as client,
     ):
         endpoint.sync_sdk_http_client()
 
@@ -142,6 +463,219 @@ def test_uds_sync_sdk_http_client_keeps_transport_and_omits_unset_timeout() -> N
     assert kwargs["follow_redirects"] is True
     assert "transport" in kwargs
     assert "timeout" not in kwargs
+
+
+def test_sync_routing_transport_prebuilds_uds_service_transports() -> None:
+    service_endpoint = parse_platform_endpoint("unix:///tmp/entities.sock")
+    constructed_transports: list[object] = []
+    closed_transports: list[object] = []
+
+    class FakeHTTPTransport:
+        def __init__(self, *, uds: str | None = None, **kwargs: object) -> None:
+            self.uds = uds
+            if uds is not None:
+                constructed_transports.append(self)
+
+        def close(self) -> None:
+            if self.uds is not None:
+                closed_transports.append(self)
+
+    with patch("nmp.common.platform_endpoint.httpx.HTTPTransport", FakeHTTPTransport):
+        routing_transport = _SyncPlatformEndpointRoutingTransport(
+            endpoint=PlatformEndpoint(
+                connect_base_url="http://platform:8080",
+                socket_path=None,
+                transport="tcp",
+                service_endpoints={"entities": service_endpoint},
+            )
+        )
+        returned_transport = routing_transport._transport_for_endpoint(service_endpoint)
+
+    routing_transport.close()
+
+    assert len(constructed_transports) == 1
+    assert returned_transport is constructed_transports[0]
+    assert closed_transports == constructed_transports
+
+
+def test_sync_routing_transport_routes_api_path_to_service_url(
+    platform_config_with_service_discovery: PlatformConfig,
+) -> None:
+    captured_urls: list[str] = []
+    captured_hosts: list[str] = []
+
+    class FakeHTTPTransport:
+        def __init__(self, **kwargs: object) -> None:
+            pass
+
+        def handle_request(self, request: httpx.Request) -> httpx.Response:
+            captured_urls.append(str(request.url))
+            captured_hosts.append(request.headers["host"])
+            return httpx.Response(200, request=request)
+
+        def close(self) -> None:
+            pass
+
+    endpoint = resolve_platform_endpoint(platform_config_with_service_discovery)
+    with patch("nmp.common.platform_endpoint.httpx.HTTPTransport", FakeHTTPTransport):
+        routing_transport = _SyncPlatformEndpointRoutingTransport(endpoint=endpoint)
+        request = httpx.Request("GET", "http://platform:8080/apis/entities/v2/workspaces")
+        routing_transport.handle_request(request)
+
+    assert captured_urls == ["http://entities-service:8080/apis/entities/v2/workspaces"]
+    assert captured_hosts == ["entities-service:8080"]
+
+
+def test_sync_routing_transport_preserves_non_api_service_status_url(
+    platform_config_with_service_discovery: PlatformConfig,
+) -> None:
+    captured_urls: list[str] = []
+
+    class FakeHTTPTransport:
+        def __init__(self, **kwargs: object) -> None:
+            pass
+
+        def handle_request(self, request: httpx.Request) -> httpx.Response:
+            captured_urls.append(str(request.url))
+            return httpx.Response(200, request=request)
+
+        def close(self) -> None:
+            pass
+
+    endpoint = resolve_platform_endpoint(platform_config_with_service_discovery)
+    with patch("nmp.common.platform_endpoint.httpx.HTTPTransport", FakeHTTPTransport):
+        routing_transport = _SyncPlatformEndpointRoutingTransport(endpoint=endpoint)
+        request = httpx.Request("GET", "http://entities-service:8080/status")
+        routing_transport.handle_request(request)
+
+    assert captured_urls == ["http://entities-service:8080/status"]
+
+
+def test_sync_sdk_http_client_routes_explicit_client_without_owning_it(
+    platform_config_with_service_discovery: PlatformConfig,
+) -> None:
+    captured_requests: list[httpx.Request] = []
+
+    def capture_request(request: httpx.Request) -> httpx.Response:
+        captured_requests.append(request)
+        return httpx.Response(200, request=request)
+
+    endpoint = resolve_platform_endpoint(platform_config_with_service_discovery)
+    with httpx.Client(
+        transport=httpx.MockTransport(capture_request),
+        follow_redirects=False,
+        headers={"x-test": "sync"},
+        max_redirects=7,
+        params={"debug": "true"},
+    ) as explicit_client:
+        with endpoint.sync_sdk_http_client(http_client=explicit_client) as routed_client:
+            assert routed_client.follow_redirects is False
+            assert routed_client.max_redirects == 7
+            routed_client.get("http://platform:8080/apis/entities/v2/workspaces")
+
+        assert not explicit_client.is_closed
+
+    assert len(captured_requests) == 1
+    assert str(captured_requests[0].url) == "http://entities-service:8080/apis/entities/v2/workspaces?debug=true"
+    assert captured_requests[0].headers["x-test"] == "sync"
+
+
+@pytest.mark.asyncio
+async def test_async_sdk_http_client_routes_explicit_client_without_owning_it(
+    platform_config_with_service_discovery: PlatformConfig,
+) -> None:
+    captured_requests: list[httpx.Request] = []
+
+    async def capture_request(request: httpx.Request) -> httpx.Response:
+        captured_requests.append(request)
+        return httpx.Response(200, request=request)
+
+    endpoint = resolve_platform_endpoint(platform_config_with_service_discovery)
+    transport = httpx.MockTransport(capture_request)
+    async with httpx.AsyncClient(
+        transport=transport,
+        follow_redirects=False,
+        headers={"x-test": "async"},
+        max_redirects=7,
+        params={"debug": "true"},
+    ) as explicit_client:
+        async with endpoint.async_sdk_http_client(http_client=explicit_client) as routed_client:
+            assert routed_client.follow_redirects is False
+            assert routed_client.max_redirects == 7
+            await routed_client.get("http://platform:8080/apis/jobs/v2/workspaces/default/jobs")
+
+        assert not explicit_client.is_closed
+
+    assert len(captured_requests) == 1
+    assert str(captured_requests[0].url) == "http://jobs-service:8080/apis/jobs/v2/workspaces/default/jobs?debug=true"
+    assert captured_requests[0].headers["x-test"] == "async"
+
+
+@pytest.mark.asyncio
+async def test_async_routing_transport_routes_api_path_to_service_url(
+    platform_config_with_service_discovery: PlatformConfig,
+) -> None:
+    captured_urls: list[str] = []
+    captured_hosts: list[str] = []
+
+    class FakeAsyncHTTPTransport:
+        def __init__(self, **kwargs: object) -> None:
+            pass
+
+        async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+            captured_urls.append(str(request.url))
+            captured_hosts.append(request.headers["host"])
+            return httpx.Response(200, request=request)
+
+        async def aclose(self) -> None:
+            pass
+
+    endpoint = resolve_platform_endpoint(platform_config_with_service_discovery)
+    with patch("nmp.common.platform_endpoint.httpx.AsyncHTTPTransport", FakeAsyncHTTPTransport):
+        routing_transport = _AsyncPlatformEndpointRoutingTransport(endpoint=endpoint)
+        request = httpx.Request("GET", "http://platform:8080/apis/jobs/v2/workspaces/default/jobs")
+        await routing_transport.handle_async_request(request)
+
+    assert captured_urls == ["http://jobs-service:8080/apis/jobs/v2/workspaces/default/jobs"]
+    assert captured_hosts == ["jobs-service:8080"]
+
+
+def test_routing_transports_pass_custom_ca_to_tcp_transport(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    cert_file = tmp_path / "ca.pem"
+    cert_file.write_text("certificate", encoding="utf-8")
+    monkeypatch.setenv("NMP_CLIENT_SSL_CERT_FILE", str(cert_file))
+    sync_kwargs: list[dict[str, object]] = []
+    async_kwargs: list[dict[str, object]] = []
+
+    class FakeHTTPTransport:
+        def __init__(self, **kwargs: object) -> None:
+            sync_kwargs.append(kwargs)
+
+        def close(self) -> None:
+            pass
+
+    class FakeAsyncHTTPTransport:
+        def __init__(self, **kwargs: object) -> None:
+            async_kwargs.append(kwargs)
+
+        async def aclose(self) -> None:
+            pass
+
+    endpoint = resolve_platform_endpoint(
+        PlatformConfig(  # type: ignore[abstract]
+            base_url="https://platform:8443",
+            service_discovery={"entities": "https://entities-service:9443"},
+        )
+    )
+    with (
+        patch("nmp.common.platform_endpoint.httpx.HTTPTransport", FakeHTTPTransport),
+        patch("nmp.common.platform_endpoint.httpx.AsyncHTTPTransport", FakeAsyncHTTPTransport),
+    ):
+        _SyncPlatformEndpointRoutingTransport(endpoint=endpoint)
+        _AsyncPlatformEndpointRoutingTransport(endpoint=endpoint)
+
+    assert sync_kwargs[0] == {"verify": str(cert_file)}
+    assert async_kwargs[0] == {"verify": str(cert_file)}
 
 
 def test_async_http_client_omits_unset_timeout() -> None:
@@ -165,7 +699,7 @@ def test_async_http_client_passes_explicit_timeout() -> None:
 def test_async_sdk_http_client_uses_sdk_default_for_tcp() -> None:
     endpoint = parse_platform_endpoint("http://127.0.0.1:8080")
 
-    with patch("nmp.common.platform_endpoint.DefaultAsyncHttpxClient") as client:
+    with patch("nmp.common.platform_endpoint.ImmutableDefaultAsyncHttpxClient") as client:
         endpoint.async_sdk_http_client()
 
     client.assert_called_once_with()
@@ -174,7 +708,7 @@ def test_async_sdk_http_client_uses_sdk_default_for_tcp() -> None:
 def test_async_sdk_http_client_passes_explicit_timeout() -> None:
     endpoint = parse_platform_endpoint("http://127.0.0.1:8080")
 
-    with patch("nmp.common.platform_endpoint.DefaultAsyncHttpxClient") as client:
+    with patch("nmp.common.platform_endpoint.ImmutableDefaultAsyncHttpxClient") as client:
         endpoint.async_sdk_http_client(timeout=2.0)
 
     client.assert_called_once_with(timeout=2.0)
@@ -196,8 +730,8 @@ def test_uds_async_sdk_http_client_keeps_transport_and_omits_unset_timeout() -> 
     endpoint = parse_platform_endpoint("unix:///tmp/nemo-platform.sock")
 
     with (
-        patch("nmp.common.platform_endpoint.DefaultAsyncHttpxClient") as sdk_client,
-        patch("nmp.common.platform_endpoint.httpx.AsyncClient") as client,
+        patch("nmp.common.platform_endpoint.ImmutableDefaultAsyncHttpxClient") as sdk_client,
+        patch("nmp.common.platform_endpoint.ImmutableAsyncHttpxClient") as client,
     ):
         endpoint.async_sdk_http_client()
 

--- a/packages/nmp_platform_runner/tests/test_server.py
+++ b/packages/nmp_platform_runner/tests/test_server.py
@@ -19,6 +19,7 @@ from nemo_platform_plugin.jobs.openapi_utils import clear_query_param_schemas, g
 from nmp.common.config import AuthConfig, Configuration
 from nmp.common.config.base import OIDCConfig
 from nmp.common.controller import ControllerManager
+from nmp.common.platform_endpoint import _SyncPlatformEndpointRoutingTransport
 from nmp.common.service import RouterConfig, Service
 from nmp.platform_runner import config as runner_config
 from nmp.platform_runner import server
@@ -262,13 +263,11 @@ def test_create_app_mounted_services_drive_sdk_local_routing_without_services_en
 
         server.create_app(services=[PluginService()])
 
-        sdk = get_platform_sdk()
-        prepared = sdk._prepare_url("https://nemo-gateway:8080/apis/agents/v2/example")
+        with get_platform_sdk() as sdk:
+            transport = sdk._client._transport
 
         assert platform_cfg.services == "agents"
-        assert prepared.scheme == "http"
-        assert prepared.host == "127.0.0.1"
-        assert prepared.port == 8080
+        assert isinstance(transport, _SyncPlatformEndpointRoutingTransport)
     finally:
         Configuration.clear_cache()
 

--- a/packages/nmp_testing/src/nmp/testing/client.py
+++ b/packages/nmp_testing/src/nmp/testing/client.py
@@ -24,7 +24,7 @@ from nemo_platform_plugin.workspaces.types import CreateWorkspaceRequest
 from nmp.common.config.base import AuthConfig, Configuration, DatabaseConfig, PlatformConfig, ServiceConfig
 from nmp.common.entities.client import EntityClient
 from nmp.common.service import Service
-from nmp.common.service.dependencies import get_entity_client, get_sdk_client
+from nmp.common.service.dependencies import get_entity_client, get_sdk_client, get_sync_sdk_client
 from nmp.core.entities.config import EntitiesConfig
 from nmp.core.entities.service import EntitiesService
 from nmp.core.inference_gateway.config import InferenceGatewayConfig
@@ -176,23 +176,16 @@ def _create_svc(
     return svc
 
 
-def _install_asgi_files_resource(sdk: NeMoPlatform, async_http_client: httpx.AsyncClient) -> None:
+def _install_asgi_files_resource(sdk: NeMoPlatform) -> None:
     """Route sync SDK file uploads through the in-process test app."""
     from filesets.resources import FilesResource
     from nemo_platform_plugin.client.adapter import client_from_platform
-    from nemo_platform_plugin.files.client import AsyncFilesClient, FilesClient
+    from nemo_platform_plugin.files.client import FilesClient
 
-    base_url = str(sdk.base_url).rstrip("/")
     files_client = client_from_platform(sdk, FilesClient)
     sdk.__dict__["files"] = FilesResource(
         sdk,
         files_client=files_client,
-        async_files_client=AsyncFilesClient(
-            base_url=base_url,
-            workspace=sdk.workspace,
-            default_headers=files_client._default_headers or None,
-            http_client=async_http_client,
-        ),
     )
     original_copy: Callable[..., NeMoPlatform] = sdk.copy
 
@@ -200,6 +193,7 @@ def _install_asgi_files_resource(sdk: NeMoPlatform, async_http_client: httpx.Asy
         *,
         workspace: str | None = None,
         base_url: str | httpx.URL | None = None,
+        inference_base_url: str | httpx.URL | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = not_given,
         http_client: httpx.Client | None = None,
         max_retries: int | NotGiven = not_given,
@@ -212,6 +206,7 @@ def _install_asgi_files_resource(sdk: NeMoPlatform, async_http_client: httpx.Asy
         clone = original_copy(
             workspace=workspace,
             base_url=base_url,
+            inference_base_url=inference_base_url,
             timeout=timeout,
             http_client=http_client,
             max_retries=max_retries,
@@ -221,7 +216,7 @@ def _install_asgi_files_resource(sdk: NeMoPlatform, async_http_client: httpx.Asy
             set_default_query=set_default_query,
             _extra_kwargs={} if _extra_kwargs is None else _extra_kwargs,
         )
-        _install_asgi_files_resource(clone, async_http_client)
+        _install_asgi_files_resource(clone)
         return clone
 
     sdk.__dict__["copy"] = copy_with_asgi_files
@@ -445,12 +440,6 @@ def create_test_client(
         services_to_start = [_create_svc(svc, configs) for svc in services_to_create]
         services_to_start = order_services_by_dependencies(services_to_start)
 
-        # Clear any stale SDK client from previous tests BEFORE creating app.
-        # This prevents service startup code from using a previous test's http transport.
-        from nmp.common import sdk_factory as sdk_factory_module
-
-        sdk_factory_module._test_http_client = None
-
         # Create transport and http_client BEFORE the app, so we can inject the client
         # into create_app() for middleware (AuthorizationMiddleware). We set transport.app
         # after app creation - this works because no requests are made until setup completes.
@@ -461,9 +450,7 @@ def create_test_client(
         pdp_timeout = Configuration.get_service_config(AuthConfig).policy_decision_point_request_timeout_seconds
         async_http_client = httpx.AsyncClient(transport=transport, base_url="http://testserver", timeout=pdp_timeout)
 
-        # Both callouts target this in-process ASGI app in tests. Pass them
-        # explicitly so production callers never assume the PDP transport can
-        # also reach the auth-service lifecycle endpoint.
+        # Both auth callouts target this in-process ASGI app in tests.
         app = create_app(
             services_to_start,
             http_client=async_http_client,
@@ -484,15 +471,12 @@ def create_test_client(
             # Store on app.state so tests can access it via test_client.app.state.access_log
             app.state.access_log = access_log_instance
 
-        # Configure module-level http client as FALLBACK for direct callers of
-        # get_async_platform_sdk()/get_platform_sdk() that don't use DependencyProvider.
-        # The primary injection path is through DependencyProvider (see below). These
-        # module-level variables will be removed once all direct callers are migrated.
-        # See architecture/docs/http-client-injection.md for details.
-        sdk_factory_module._test_http_client = async_http_client
-        stack.callback(lambda: setattr(sdk_factory_module, "_test_http_client", None))
+        from nmp.common.sdk_factory import get_async_platform_sdk
 
-        async_sdk = AsyncNeMoPlatform(base_url="http://testserver", http_client=async_http_client, workspace=workspace)
+        async_sdk = get_async_platform_sdk(
+            base_url="http://testserver",
+            http_client=async_http_client,
+        ).copy(workspace=workspace)
 
         # Create the EntityClient (used for DI and optionally yielded)
         entity_client = EntityClient(client_from_platform(async_sdk, AsyncEntitiesClient))
@@ -551,7 +535,19 @@ def create_test_client(
                 http_client=sdk_http_client,
                 max_retries=0,
             )
-            _install_asgi_files_resource(sdk, async_http_client)
+            _install_asgi_files_resource(sdk)
+
+            for svc in services_to_start:
+                svc.dependency_provider._sync_http_client = sdk_http_client
+                svc.dependency_provider._sync_sdk_client = sdk
+
+            if get_sync_sdk_client not in all_overrides:
+                from nmp.common.sdk_factory import get_request_scoped_sync_sdk
+
+                def _get_request_scoped_sync_test_sdk() -> NeMoPlatform:
+                    return get_request_scoped_sync_sdk(sdk)
+
+                app.dependency_overrides[get_sync_sdk_client] = _get_request_scoped_sync_test_sdk
 
             # Trigger middleware stack build with a health check (which skips auth).
             client.get("/health")

--- a/plugins/nemo-agent-hardener/src/nemo_agent_hardener_plugin/filesets.py
+++ b/plugins/nemo-agent-hardener/src/nemo_agent_hardener_plugin/filesets.py
@@ -21,7 +21,6 @@ import zipfile
 from fnmatch import fnmatch
 from pathlib import Path
 
-import fsspec.asyn
 from filesets import FilesetFileSystem
 from nemo_agents_plugin.container.template import DOCKERIGNORE_TEMPLATE
 from nemo_platform import NeMoPlatform
@@ -57,7 +56,7 @@ def download_fileset(sdk: NeMoPlatform, ref: str, dest: Path) -> Path:
     fs = FilesetFileSystem(client=client_from_platform(sdk, FilesClient))
     dest.mkdir(parents=True, exist_ok=True)
     source = ref.rstrip("/") + "/"
-    fsspec.asyn.sync(fs.loop, fs._get, source, str(dest), True)
+    fs.get(source, str(dest), recursive=True)
     return dest
 
 

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/app/input.py
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/app/input.py
@@ -14,7 +14,7 @@ from urllib.parse import urlparse
 
 from anonymizer.config.anonymizer_config import AnonymizerInput
 from anyio import to_thread
-from filesets import FilesetFileSystem, FilesetPathError, build_fileset_ref, parse_fileset_ref
+from filesets import AsyncFilesetFileSystem, FilesetFileSystem, FilesetPathError, build_fileset_ref, parse_fileset_ref
 from nemo_anonymizer_plugin.app.errors import AnonymizerInvalidConfigError
 from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
 from nemo_platform_plugin.client.adapter import client_from_platform
@@ -149,7 +149,7 @@ async def _download_fileset_input_async(
     manager = AsyncFilesetFileManager(
         workspace=workspace_name,
         fileset_name=fileset_name,
-        filesystem=FilesetFileSystem(client=client_from_platform(sdk, AsyncFilesClient)),
+        filesystem=AsyncFilesetFileSystem(client=client_from_platform(sdk, AsyncFilesClient)),
         ensure_fileset_exists=False,
     )
     return await _download_fileset_input_async_inner(manager, workspace_name, fileset_name, file_path)

--- a/plugins/nemo-anonymizer/tests/unit/test_input.py
+++ b/plugins/nemo-anonymizer/tests/unit/test_input.py
@@ -47,6 +47,7 @@ def _patch_files_client(monkeypatch: pytest.MonkeyPatch) -> None:
         return AsyncFilesClient(base_url=base_url, workspace=sdk.workspace)
 
     monkeypatch.setattr(input_module, "FilesetFileSystem", FakeFilesetFileSystem)
+    monkeypatch.setattr(input_module, "AsyncFilesetFileSystem", FakeFilesetFileSystem)
     monkeypatch.setattr(input_module, "client_from_platform", client_from_platform)
 
 

--- a/plugins/nemo-auditor/tests/test_api_artifacts.py
+++ b/plugins/nemo-auditor/tests/test_api_artifacts.py
@@ -202,13 +202,19 @@ class TestDownloadAuditArtifacts:
 
         with (
             patch.object(artifacts_module, "client_from_platform", return_value=mock_jobs),
-            patch.object(artifacts_module, "async_result_manager_factory", return_value=mock_rm),
+            patch.object(artifacts_module, "async_result_manager_factory", return_value=mock_rm) as factory,
         ):
             client.get("/apis/auditor/v2/workspaces/prod/jobs/audit/my-job/results/artifacts/download")
 
         first_call = mock_jobs.get_job_result.await_args_list[0]
         assert first_call.kwargs["workspace"] == "prod"
         assert first_call.kwargs["job"] == "my-job"
+        factory.assert_called_once_with(
+            job_name="my-job",
+            workspace="prod",
+            files_client=mock_jobs,
+            jobs_client=mock_jobs,
+        )
 
 
 class TestArtifactsRouteWiring:

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/_data_designer.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/_data_designer.py
@@ -8,14 +8,14 @@ from pathlib import Path
 import data_designer.config as dd
 import data_designer.interface.data_designer as data_designer_interface
 from data_designer.interface.data_designer import DataDesigner
-from data_designer_nemo.context import DataDesignerContext
+from data_designer_nemo.context import DataDesignerExecutionContext
 
 
 def create_data_designer(
     *,
     artifact_path: Path | str,
     model_providers: list[dd.ModelProvider],
-    dd_ctx: DataDesignerContext,
+    dd_ctx: DataDesignerExecutionContext,
 ) -> DataDesigner:
     """Create the library interface without letting it reconfigure process logging."""
     data_designer_interface.configure_logging = _noop_configure_logging  # ty: ignore[invalid-assignment]

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/functions/preview.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/functions/preview.py
@@ -16,7 +16,7 @@ from anyio.lowlevel import current_token
 from data_designer.config.utils.io_helpers import serialize_data
 from data_designer.errors import DataDesignerError
 from data_designer.interface.data_designer import DataDesigner
-from data_designer_nemo.context import create_data_designer_context
+from data_designer_nemo.context import create_execution_context, create_validation_context
 from data_designer_nemo.errors import NDDInternalError, NDDInvalidConfigError, raise_if_errors
 from data_designer_nemo.fileset_file_seed_reader import workspace_cvar
 from data_designer_nemo.runnable import resolve_runnable_config
@@ -31,7 +31,7 @@ from nemo_data_designer_plugin.functions._types import (
     PreviewSpec,
     ProcessorOutputFrame,
 )
-from nemo_platform import AsyncNeMoPlatform
+from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
 from nemo_platform_plugin.function import NemoFunction
 from nemo_platform_plugin.function_context import FunctionContext
 from nemo_platform_plugin.functions.frames import Done, Error
@@ -52,14 +52,20 @@ class PreviewFunction(NemoFunction[PreviewSpec]):
         spec: PreviewSpec,
         *,
         ctx: FunctionContext,
+        sdk: NeMoPlatform,
         async_sdk: AsyncNeMoPlatform,
     ) -> AsyncIterator[BaseModel]:
         # Fail fast on request shape (``num_records``) before doing any config-validation work.
         num_records = _validate_and_get_num_records(spec.num_records)
 
-        dd_ctx = create_data_designer_context(async_sdk, ctx.workspace)
-        errors, _, model_providers = await resolve_runnable_config(dd_ctx, spec.config)
+        validation_ctx = create_validation_context(async_sdk, ctx.workspace)
+        errors, _, model_providers = await resolve_runnable_config(validation_ctx, spec.config)
         raise_if_errors(errors)
+        execution_ctx = create_execution_context(
+            sdk,
+            ctx.workspace,
+            validated_roots=validation_ctx.validated_filesystem_roots,
+        )
 
         workspace_cvar.set(ctx.workspace)
 
@@ -79,7 +85,7 @@ class PreviewFunction(NemoFunction[PreviewSpec]):
             data_designer = create_data_designer(
                 artifact_path=artifact_storage_tmpdir,
                 model_providers=model_providers,
-                dd_ctx=dd_ctx,
+                dd_ctx=execution_ctx,
             )
 
             try:
@@ -139,10 +145,9 @@ def _make_preview_dataset(
 ) -> None:
     """
     Synchronous function that runs on a worker thread under
-    :func:`anyio.to_thread.run_sync`. SDK calls bridge back to the API
-    process's event loop via :func:`anyio.from_thread.run` inside the
-    helpers. Sends frames back to the async context via the
-    ``send_frame`` callback.
+    :func:`anyio.to_thread.run_sync`. The Data Designer engine and its
+    filesystem readers use sync APIs here; ``send_frame`` is the only bridge
+    back to the async request context.
     """
     with forward_data_designer_logs(send_frame):
         preview_results = data_designer.preview(config_builder, num_records=num_records)

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/functions/retrieval_preview.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/functions/retrieval_preview.py
@@ -9,8 +9,7 @@ from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import ClassVar, Literal
 
-from data_designer_nemo.context import create_data_designer_context
-from data_designer_nemo.sdk_translation import async_to_sync_sdk
+from data_designer_nemo.context import create_validation_context
 from nemo_data_designer_plugin.jobs.retrieval_spec import RetrievalPreviewSpec
 from nemo_data_designer_plugin.retrieval.corpus import materialize_corpus
 from nemo_data_designer_plugin.retrieval.providers import build_retrieval_model_configs, resolve_retrieval_providers
@@ -37,11 +36,12 @@ class RetrievalPreviewFunction(NemoFunction[RetrievalPreviewSpec]):
         self,
         spec: RetrievalPreviewSpec,
         ctx: FunctionContext,
+        sdk: NeMoPlatform,
         async_sdk: AsyncNeMoPlatform,
         is_local: bool = False,
     ) -> AsyncIterator[BaseModel]:
         job = spec.generate
-        dd_ctx = create_data_designer_context(async_sdk, ctx.workspace)
+        validation_ctx = create_validation_context(async_sdk, ctx.workspace)
         model_configs = build_retrieval_model_configs(
             provider=job.provider,
             chat_provider=job.chat_provider,
@@ -52,7 +52,7 @@ class RetrievalPreviewFunction(NemoFunction[RetrievalPreviewSpec]):
             embed_model=job.embed_model,
         )
         try:
-            model_providers = await resolve_retrieval_providers(dd_ctx, model_configs)
+            model_providers = await resolve_retrieval_providers(validation_ctx, model_configs)
         except Exception as exc:
             yield Error(message=str(exc), details={"type": type(exc).__name__})
             return
@@ -63,7 +63,6 @@ class RetrievalPreviewFunction(NemoFunction[RetrievalPreviewSpec]):
                 execute_generation,
             )
 
-            sdk = async_sdk if isinstance(async_sdk, NeMoPlatform) else async_to_sync_sdk(async_sdk)
             with tempfile.TemporaryDirectory() as tmp:
                 tmp_path = Path(tmp)
                 corpus_dir = materialize_corpus(

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/jobs/create.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/jobs/create.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from typing import ClassVar, cast
 
-from data_designer_nemo.context import create_data_designer_context
+from data_designer_nemo.context import create_validation_context
 from data_designer_nemo.errors import raise_if_errors
 from data_designer_nemo.runnable import resolve_runnable_config
 from nemo_data_designer_plugin.jobs.run import run_step_config_result
@@ -49,7 +49,7 @@ class CreateJob(NemoJob):
         async_sdk = cast(AsyncNeMoPlatform, async_sdk)
         input_spec = cast(DataDesignerJobConfig, input_spec)
 
-        dd_ctx = create_data_designer_context(async_sdk, workspace)
+        dd_ctx = create_validation_context(async_sdk, workspace)
         errors, model_configs, model_providers = await resolve_runnable_config(dd_ctx, input_spec.config)
         raise_if_errors(errors)
 

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/jobs/retrieval_generate.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/jobs/retrieval_generate.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from typing import ClassVar, cast
 
-from data_designer_nemo.context import create_data_designer_context
+from data_designer_nemo.context import create_validation_context
 from nemo_data_designer_plugin.jobs.retrieval_common import retrieval_step, work_dir
 from nemo_data_designer_plugin.jobs.retrieval_spec import RetrievalGenerateJobConfig, RetrievalGenerateStepConfig
 from nemo_data_designer_plugin.retrieval.corpus import materialize_corpus
@@ -37,7 +37,7 @@ class RetrievalGenerateJob(NemoJob):
     ) -> BaseModel:
         async_sdk = cast(AsyncNeMoPlatform, async_sdk)
         job_config = cast(RetrievalGenerateJobConfig, input_spec)
-        dd_ctx = create_data_designer_context(async_sdk, workspace)
+        dd_ctx = create_validation_context(async_sdk, workspace)
         model_configs = build_retrieval_model_configs(
             provider=job_config.provider,
             chat_provider=job_config.chat_provider,

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/jobs/run.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/jobs/run.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import data_designer.config as dd
 from data_designer.logging import _make_json_formatter
-from data_designer_nemo.context import create_data_designer_context
+from data_designer_nemo.context import create_execution_context
 from data_designer_nemo.fileset_file_seed_reader import workspace_cvar
 from nemo_data_designer_plugin._data_designer import create_data_designer
 from nemo_data_designer_plugin.jobs.result_manager import DataDesignerResultManager
@@ -60,7 +60,7 @@ def _run_step_config(
     workspace = ctx.workspace
     workspace_cvar.set(workspace)
 
-    dd_ctx = create_data_designer_context(sdk, workspace)
+    dd_ctx = create_execution_context(sdk, workspace)
 
     config_builder = dd.DataDesignerConfigBuilder.from_config(step_config.job_config.config.to_dict())
 

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/retrieval/providers.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/retrieval/providers.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import data_designer.config as dd
-from data_designer_nemo.context import DataDesignerContext
+from data_designer_nemo.context import DataDesignerValidationContext
 from data_designer_nemo.errors import NDDInvalidConfigError
 
 
@@ -51,7 +51,7 @@ def build_retrieval_model_configs(
 
 
 async def resolve_retrieval_providers(
-    dd_ctx: DataDesignerContext,
+    dd_ctx: DataDesignerValidationContext,
     model_configs: list[dd.ModelConfig],
 ) -> list[dd.ModelProvider]:
     """Resolve Inference Gateway providers for retrieval model configs."""

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/sdk/validation.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/sdk/validation.py
@@ -22,7 +22,7 @@ import tempfile
 
 import data_designer.config as dd
 from data_designer.config.errors import InvalidConfigError
-from data_designer_nemo.context import create_data_designer_context
+from data_designer_nemo.context import create_execution_context, create_validation_context
 from data_designer_nemo.errors import NDDInternalError, NDDInvalidConfigError
 from data_designer_nemo.runnable import resolve_runnable_config
 from data_designer_nemo.sdk_translation import sync_to_async_sdk
@@ -65,15 +65,14 @@ async def validate_config(
 
     Mirrors the work ``CreateJob.to_spec`` and ``PreviewFunction.run`` do at
     submit/preview time — via the shared :func:`resolve_runnable_config` —
-    and additionally runs an engine-level compile check that the runtime
-    callers defer to library-execution time. Never short-circuits: every
-    sub-check that *can* be run is run, so a single pass surfaces every
-    problem.
+    and additionally runs an engine-level compile check when a sync SDK is
+    available. Never short-circuits: every sub-check that *can* be run is run,
+    so a single pass surfaces every problem.
 
     Args:
         config_builder: The Data Designer config to validate.
-        sdk: Sync NeMoPlatform SDK. Used as a fallback to derive ``async_sdk``
-            when one is not supplied.
+        sdk: Sync NeMoPlatform SDK. Used for engine-level compile validation
+            and as a fallback to derive ``async_sdk`` when one is not supplied.
         async_sdk: Async NeMoPlatform SDK. If omitted but ``sdk`` is supplied,
             an async wrapper is built via ``sync_to_async_sdk``.
         workspace: Workspace used to resolve provider references and seed
@@ -95,10 +94,10 @@ async def validate_config(
 
     config = config_builder.build()
 
-    dd_ctx = create_data_designer_context(async_sdk, workspace)
+    validation_ctx = create_validation_context(async_sdk, workspace)
 
     # First run the same resolution that the job and function execute.
-    runnable_errors, _model_configs, model_providers = await resolve_runnable_config(dd_ctx, config)
+    runnable_errors, _model_configs, model_providers = await resolve_runnable_config(validation_ctx, config)
     errors: list[ValidationError] = [_to_validation_error(e) for e in runnable_errors]
 
     # Next additionally run engine-level compile via upstream ``DataDesigner.validate``,
@@ -111,13 +110,18 @@ async def validate_config(
     # 'df'``) when the config is already known to be malformed. Skip the
     # engine check in that case so the user-facing diagnostics stay focused
     # on the actionable problems we've already found.
-    if not errors:
+    if not errors and sdk is not None:
+        execution_ctx = create_execution_context(
+            sdk,
+            workspace,
+            validated_roots=validation_ctx.validated_filesystem_roots,
+        )
         try:
             with tempfile.TemporaryDirectory() as artifact_path:
                 data_designer = create_data_designer(
                     artifact_path=artifact_path,
                     model_providers=model_providers,
-                    dd_ctx=dd_ctx,
+                    dd_ctx=execution_ctx,
                 )
                 # Engine validate is sync; run it on a worker thread so the
                 # event loop stays unblocked.

--- a/plugins/nemo-data-designer/tests/integration/test_job_task.py
+++ b/plugins/nemo-data-designer/tests/integration/test_job_task.py
@@ -154,7 +154,7 @@ async def test_exiting_with_error() -> None:
 
     with (
         capture_job_log_messages() as log_messages,
-        patch("nemo_data_designer_plugin.jobs.run.create_data_designer_context", side_effect=RuntimeError("Yuck")),
+        patch("nemo_data_designer_plugin.jobs.run.create_execution_context", side_effect=RuntimeError("Yuck")),
     ):
         async with u.task_context(job_config, job_name) as ctx:
             result = ctx.run_task()

--- a/plugins/nemo-data-designer/tests/unit/test_context.py
+++ b/plugins/nemo-data-designer/tests/unit/test_context.py
@@ -9,7 +9,7 @@ import data_designer.config as dd
 import nemo_data_designer_plugin.testing.utils as u
 import pandas as pd
 import pytest
-from data_designer_nemo.context import DataDesignerContext
+from data_designer_nemo.context import DataDesignerValidationContext
 from data_designer_nemo.errors import NDDInvalidConfigError
 from nemo_platform import AsyncNeMoPlatform
 
@@ -78,7 +78,7 @@ async def test_remote_validate_runs_remote_validators(monkeypatch: pytest.Monkey
     monkeypatch.setattr("data_designer_nemo.context.validate_seed", validate_seed)
     monkeypatch.setattr("data_designer_nemo.context.ensure_nemotron_personas_filesets", validate_personas)
 
-    errors = await DataDesignerContext(sdk, u.WORKSPACE_NAME).validate(config)
+    errors = await DataDesignerValidationContext(sdk, u.WORKSPACE_NAME).validate(config)
 
     assert errors == []
     assert calls == ["tools", "seed", "personas"]
@@ -86,7 +86,7 @@ async def test_remote_validate_runs_remote_validators(monkeypatch: pytest.Monkey
 
 async def test_remote_validate_rejects_unsupported_seed_config() -> None:
     config = _simple_config(seed_source=dd.DataFrameSeedSource(df=pd.DataFrame(data={"a": [1, 2, 3]})))
-    dd_ctx = DataDesignerContext(AsyncMock(spec=AsyncNeMoPlatform), u.WORKSPACE_NAME)
+    dd_ctx = DataDesignerValidationContext(AsyncMock(spec=AsyncNeMoPlatform), u.WORKSPACE_NAME)
 
     errors = await dd_ctx.validate(config)
 
@@ -102,7 +102,7 @@ async def test_remote_validate_aggregates_multiple_failures() -> None:
         seed_source=dd.DataFrameSeedSource(df=pd.DataFrame(data={"a": [1, 2, 3]})),
     )
     sdk = AsyncMock(spec=AsyncNeMoPlatform)
-    dd_ctx = DataDesignerContext(sdk, u.WORKSPACE_NAME)
+    dd_ctx = DataDesignerValidationContext(sdk, u.WORKSPACE_NAME)
 
     errors = await dd_ctx.validate(config)
 

--- a/plugins/nemo-data-designer/tests/unit/test_create_job.py
+++ b/plugins/nemo-data-designer/tests/unit/test_create_job.py
@@ -305,7 +305,7 @@ async def test_to_spec_pure_internal_errors_raise_internal_error(monkeypatch: py
         return [NDDInternalError("simulated internal failure")]
 
     monkeypatch.setattr(
-        "data_designer_nemo.context.DataDesignerContext.validate",
+        "data_designer_nemo.context.DataDesignerValidationContext.validate",
         _internal_only,
     )
 

--- a/plugins/nemo-data-designer/tests/unit/test_preview_function.py
+++ b/plugins/nemo-data-designer/tests/unit/test_preview_function.py
@@ -10,13 +10,14 @@ from collections.abc import Callable
 
 import data_designer.config as dd
 import pytest
+from data_designer_nemo.errors import NDDError
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from nemo_data_designer_plugin.functions import preview as preview_module
 from nemo_data_designer_plugin.functions._types import LogFrame, PreviewSpec
 from nemo_data_designer_plugin.functions.preview import PreviewFunction
-from nemo_platform import AsyncNeMoPlatform
-from nemo_platform_plugin.dependencies import get_sdk_client
+from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
+from nemo_platform_plugin.dependencies import get_sdk_client, get_sync_sdk_client
 from nemo_platform_plugin.function_context import FunctionContext
 from nemo_platform_plugin.functions.routes import NDJSON_MEDIA_TYPE, add_function_routes
 from pydantic import BaseModel
@@ -36,15 +37,40 @@ def _config() -> dd.DataDesignerConfig:
     return builder.build()
 
 
+def _sync_sdk() -> NeMoPlatform:
+    return NeMoPlatform(base_url="http://testserver", workspace="default")
+
+
+def _async_sdk() -> AsyncNeMoPlatform:
+    return AsyncNeMoPlatform(base_url="http://testserver", workspace="default")
+
+
+async def _resolve_runnable_config(
+    *_args: object,
+) -> tuple[list[NDDError], list[dd.ModelConfig], list[dd.ModelProvider]]:
+    return [], [], []
+
+
+class FakeDataDesigner:
+    def check_models(self, _config_builder: dd.DataDesignerConfigBuilder) -> None:
+        pass
+
+
+def _fake_data_designer(*_args: object, **_kwargs: object) -> FakeDataDesigner:
+    return FakeDataDesigner()
+
+
 @pytest.mark.asyncio
 async def test_preview_function_streams_worker_frames_and_done(monkeypatch: pytest.MonkeyPatch) -> None:
 
     def fake_worker(
         send_frame: Callable[[BaseModel], None],
-        *args,
+        *_args: object,
     ) -> None:
         send_frame(LogFrame(level="info", message="generated"))
 
+    monkeypatch.setattr(preview_module, "create_data_designer", _fake_data_designer)
+    monkeypatch.setattr(preview_module, "resolve_runnable_config", _resolve_runnable_config)
     monkeypatch.setattr(preview_module, "_make_preview_dataset", fake_worker)
 
     frames = [
@@ -52,7 +78,8 @@ async def test_preview_function_streams_worker_frames_and_done(monkeypatch: pyte
         async for frame in PreviewFunction().run(
             PreviewSpec(config=_config(), num_records=2),
             ctx=FunctionContext(workspace="team-a"),
-            async_sdk=AsyncNeMoPlatform(base_url="http://testserver", workspace="default"),
+            sdk=_sync_sdk(),
+            async_sdk=_async_sdk(),
         )
     ]
 
@@ -64,18 +91,19 @@ async def test_preview_function_runs_model_health_check_off_event_loop(monkeypat
     event_loop_thread = threading.current_thread()
     check_models_thread: threading.Thread | None = None
 
-    class FakeDataDesigner:
+    class RecordingFakeDataDesigner:
         def check_models(self, _config_builder: dd.DataDesignerConfigBuilder) -> None:
             nonlocal check_models_thread
             check_models_thread = threading.current_thread()
 
-    def fake_create_data_designer(*args, **kwargs) -> FakeDataDesigner:
-        return FakeDataDesigner()
+    def fake_create_data_designer(*_args: object, **_kwargs: object) -> RecordingFakeDataDesigner:
+        return RecordingFakeDataDesigner()
 
-    def fake_worker(*args) -> None:
+    def fake_worker(*_args: object) -> None:
         pass
 
     monkeypatch.setattr(preview_module, "create_data_designer", fake_create_data_designer)
+    monkeypatch.setattr(preview_module, "resolve_runnable_config", _resolve_runnable_config)
     monkeypatch.setattr(preview_module, "_make_preview_dataset", fake_worker)
 
     frames = [
@@ -83,7 +111,8 @@ async def test_preview_function_runs_model_health_check_off_event_loop(monkeypat
         async for frame in PreviewFunction().run(
             PreviewSpec(config=_config(), num_records=2),
             ctx=FunctionContext(workspace="team-a"),
-            async_sdk=AsyncNeMoPlatform(base_url="http://testserver", workspace="default"),
+            sdk=_sync_sdk(),
+            async_sdk=_async_sdk(),
         )
     ]
 
@@ -96,18 +125,19 @@ def test_preview_route_streams_ndjson_and_heartbeats(monkeypatch: pytest.MonkeyP
 
     def slow_worker(
         send_frame: Callable[[BaseModel], None],
-        *args,
+        *_args: object,
     ) -> None:
         send_frame(LogFrame(level="info", message="started"))
         time.sleep(0.05)
         send_frame(LogFrame(level="info", message="more work has been done"))
 
     monkeypatch.setattr(preview_module, "_make_preview_dataset", slow_worker)
+    monkeypatch.setattr(preview_module, "create_data_designer", _fake_data_designer)
+    monkeypatch.setattr(preview_module, "resolve_runnable_config", _resolve_runnable_config)
 
     app = FastAPI()
-    app.dependency_overrides[get_sdk_client] = lambda: AsyncNeMoPlatform(
-        base_url="http://testserver", workspace="default"
-    )
+    app.dependency_overrides[get_sdk_client] = _async_sdk
+    app.dependency_overrides[get_sync_sdk_client] = _sync_sdk
     app.include_router(
         add_function_routes(PreviewFunction, heartbeat_interval_seconds=0.01),
         prefix="/apis/data-designer/v2/workspaces/{workspace}",

--- a/plugins/nemo-data-designer/tests/unit/test_retrieval_jobs.py
+++ b/plugins/nemo-data-designer/tests/unit/test_retrieval_jobs.py
@@ -139,7 +139,7 @@ async def test_retrieval_prepare_compile_uses_one_container_profile() -> None:
     dd_ctx = AsyncMock()
     dd_ctx.get_model_providers = AsyncMock(return_value=providers)
     with patch(
-        "nemo_data_designer_plugin.jobs.retrieval_generate.create_data_designer_context",
+        "nemo_data_designer_plugin.jobs.retrieval_generate.create_validation_context",
         return_value=dd_ctx,
     ):
         step = await RetrievalGenerateJob.to_spec(
@@ -346,7 +346,7 @@ async def test_retrieval_run_compile_chains_generate_then_prepare() -> None:
         prepare=RetrievalPrepareJobConfig(enable_mining=False),
     )
     with patch(
-        "nemo_data_designer_plugin.jobs.retrieval_generate.create_data_designer_context",
+        "nemo_data_designer_plugin.jobs.retrieval_generate.create_validation_context",
         return_value=dd_ctx,
     ):
         compiled = await RetrievalRunJob.compile(

--- a/plugins/nemo-data-designer/tests/unit/test_retrieval_preview.py
+++ b/plugins/nemo-data-designer/tests/unit/test_retrieval_preview.py
@@ -40,19 +40,21 @@ async def test_retrieval_preview_uses_preview_generation(tmp_path) -> None:
     frames = []
     with (
         patch(
-            "nemo_data_designer_plugin.functions.retrieval_preview.create_data_designer_context",
+            "nemo_data_designer_plugin.functions.retrieval_preview.create_validation_context",
             return_value=dd_ctx,
         ),
         patch(
             "nemo_data_designer_plugin.retrieval.generation.execute_generation",
             return_value=preview_result,
         ) as execute,
-        patch(
-            "nemo_data_designer_plugin.functions.retrieval_preview.async_to_sync_sdk",
-            return_value=Mock(),
-        ),
     ):
-        async for frame in RetrievalPreviewFunction().run(spec, ctx=ctx, async_sdk=AsyncMock(), is_local=True):
+        async for frame in RetrievalPreviewFunction().run(
+            spec,
+            ctx=ctx,
+            sdk=Mock(),
+            async_sdk=AsyncMock(),
+            is_local=True,
+        ):
             frames.append(frame)
     execute.assert_called_once()
     assert execute.call_args.kwargs["preview"] is True
@@ -72,16 +74,12 @@ async def test_retrieval_preview_returns_error_frame_for_worker_failure(tmp_path
 
     with (
         patch(
-            "nemo_data_designer_plugin.functions.retrieval_preview.create_data_designer_context",
+            "nemo_data_designer_plugin.functions.retrieval_preview.create_validation_context",
             return_value=dd_ctx,
         ),
         patch(
             "nemo_data_designer_plugin.functions.retrieval_preview.materialize_corpus",
             side_effect=ValueError("bad corpus"),
-        ),
-        patch(
-            "nemo_data_designer_plugin.functions.retrieval_preview.async_to_sync_sdk",
-            return_value=Mock(),
         ),
     ):
         frames = [
@@ -89,6 +87,7 @@ async def test_retrieval_preview_returns_error_frame_for_worker_failure(tmp_path
             async for frame in RetrievalPreviewFunction().run(
                 spec,
                 ctx=ctx,
+                sdk=Mock(),
                 async_sdk=AsyncMock(),
                 is_local=True,
             )

--- a/plugins/nemo-evaluator/src/nemo_evaluator/filesets.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/filesets.py
@@ -8,8 +8,7 @@ from __future__ import annotations
 from fnmatch import fnmatchcase
 from pathlib import Path
 
-import fsspec.asyn
-from filesets import FilesetFileSystem
+from filesets import AsyncFilesetFileSystem, FilesetFileSystem
 from nemo_evaluator_sdk.retrieval.beir import BeirDataset
 from nemo_platform_plugin.client.client import AsyncNemoClient, NemoClient
 from nemo_platform_plugin.files.client import AsyncFilesClient, FilesClient
@@ -96,7 +95,7 @@ async def download_dataset(
 ) -> Path:
     """Download a FilesetRef dataset to a local directory."""
     files_client = AsyncFilesClient.from_client(client)
-    fs = FilesetFileSystem(client=files_client)
+    fs = AsyncFilesetFileSystem(client=files_client)
     return await _download_fileset_ref(dataset, destination, recursive=recursive, fs=fs)
 
 
@@ -136,7 +135,7 @@ async def _download_fileset_ref(
     destination: str,
     recursive: bool = True,
     *,
-    fs: FilesetFileSystem,
+    fs: AsyncFilesetFileSystem,
 ) -> Path:
     ref = dataset.root
 
@@ -188,7 +187,53 @@ def _download_fileset_ref_sync(
 ) -> Path:
     files_client = FilesClient.from_client(client)
     fs = FilesetFileSystem(client=files_client)
-    result = fsspec.asyn.sync(fs.loop, _download_fileset_ref, dataset, destination, recursive, fs=fs)
-    if result is None:
-        raise RuntimeError(f"FilesetRef download returned no path for dataset {dataset.root!r}")
-    return result
+    return _download_fileset_ref_with_sync_filesystem(dataset, destination, recursive=recursive, fs=fs)
+
+
+def _download_fileset_ref_with_sync_filesystem(
+    dataset: FilesetRef,
+    destination: str,
+    recursive: bool = True,
+    *,
+    fs: FilesetFileSystem,
+) -> Path:
+    ref = dataset.root
+
+    if "#" in ref:
+        base_path, pattern = ref.split("#", 1)
+        pattern = pattern.lstrip("/")
+
+        if not pattern:
+            return _download_fileset_ref_with_sync_filesystem(
+                FilesetRef(root=base_path),
+                destination,
+                recursive=recursive,
+                fs=fs,
+            )
+
+        base_dest = _safe_child_path(Path(destination), base_path)
+        base_dest.mkdir(parents=True, exist_ok=True)
+
+        if is_fileset_glob_pattern(pattern):
+            all_files = fs.find(base_path)
+            for file_path in all_files:
+                if "#" in file_path:
+                    relative_path = file_path.split("#", 1)[1]
+                else:
+                    relative_path = file_path.replace(f"{base_path}/", "", 1)
+                if matches_fileset_glob(relative_path, pattern):
+                    file_dest = _safe_child_path(base_dest, relative_path)
+                    file_dest.parent.mkdir(parents=True, exist_ok=True)
+                    fs.get_file(file_path, str(file_dest))
+            return base_dest
+
+        full_remote_path = f"{base_path}/{pattern}"
+        file_dest = _safe_child_path(base_dest, pattern)
+        file_dest.parent.mkdir(parents=True, exist_ok=True)
+        fs.get_file(full_remote_path, str(file_dest))
+        return file_dest
+
+    dest = _safe_child_path(Path(destination), normalize_fileset_path(ref))
+    source = ref.rstrip("/") + "/"
+    fs.get(source, str(dest), recursive=recursive)
+    return dest

--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/environment_stage.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/environment_stage.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import shutil
 from pathlib import Path
 
-import fsspec.asyn
 from filesets import FilesetFileSystem, FilesetPathError, parse_fileset_ref
 from nemo_evaluator.filesets import FilesetRef
 from nemo_platform_plugin.client.client import NemoClient
@@ -46,7 +45,7 @@ def _download_fileset_contents(*, sdk: NemoClient, workspace: str, fileset: str,
     """Download a FileSet root's contents directly into ``destination``."""
     files_client = FilesClient.from_client(sdk)
     fs = FilesetFileSystem(client=files_client)
-    fsspec.asyn.sync(fs.loop, fs._get, f"{workspace}/{fileset}/", str(destination), True)
+    fs.get(f"{workspace}/{fileset}/", str(destination), recursive=True)
 
 
 class EnvironmentStageJob(NemoJob):

--- a/plugins/nemo-evaluator/tests/test_filesets.py
+++ b/plugins/nemo-evaluator/tests/test_filesets.py
@@ -38,7 +38,7 @@ class _FakeFilesetFileSystem:
 @pytest.mark.asyncio
 async def test_download_dataset_rejects_fragment_path_escape(mocker: MockerFixture, tmp_path: Path) -> None:
     """Fileset fragments should not write outside the requested destination."""
-    mocker.patch("nemo_evaluator.filesets.FilesetFileSystem", _FakeFilesetFileSystem)
+    mocker.patch("nemo_evaluator.filesets.AsyncFilesetFileSystem", _FakeFilesetFileSystem)
 
     with pytest.raises(ValueError, match="Fileset path escapes destination"):
         await download_dataset(
@@ -51,7 +51,7 @@ async def test_download_dataset_rejects_fragment_path_escape(mocker: MockerFixtu
 @pytest.mark.asyncio
 async def test_download_dataset_rejects_absolute_root_path(mocker: MockerFixture, tmp_path: Path) -> None:
     """Fileset roots should not be able to become absolute local paths."""
-    mocker.patch("nemo_evaluator.filesets.FilesetFileSystem", _FakeFilesetFileSystem)
+    mocker.patch("nemo_evaluator.filesets.AsyncFilesetFileSystem", _FakeFilesetFileSystem)
 
     with pytest.raises(ValueError, match="Fileset path escapes destination"):
         await download_dataset(

--- a/plugins/nemo-guardrails/src/nemo_guardrails_plugin/middleware.py
+++ b/plugins/nemo-guardrails/src/nemo_guardrails_plugin/middleware.py
@@ -79,7 +79,6 @@ from nemo_platform_plugin.inference_middleware import (
     VirtualModel,
 )
 from nemo_platform_plugin.refs import parse_entity_ref
-from nemo_platform_plugin.sdk_provider import get_async_platform_sdk
 from nemoguardrails.rails.llm.llmrails import LLMRails
 from nemoguardrails.rails.llm.options import GenerationResponse
 from nemoguardrails.types import LLMModel
@@ -190,23 +189,18 @@ class GuardrailsMiddleware(NemoInferenceMiddleware):
         # Use our custom header-aware NIM provider adapter for library-initiated model calls.
         register_header_aware_nim_provider()
 
-        self._sdk = get_async_platform_sdk(as_service=PLUGIN_NAME, internal=True)
+        self._sdk = self._get_platform_sdk("on_startup")
         self._rails_cache = LLMRailsCache(builder=DefaultLLMRailsBuilder())
         self._stable_cache = StabilizedRailsConfigCache()
 
     async def on_shutdown(self) -> None:
         # Detach attributes before awaiting close so a partial close can't
-        # leave a half-torn-down cache visible to a later request. The
-        # try/finally ensures SDK close runs even if cache close raises.
+        # leave a half-torn-down cache visible to a later request.
         cache, self._rails_cache = self._rails_cache, None
-        sdk, self._sdk = self._sdk, None
+        self._sdk = None
         self._stable_cache = None
-        try:
-            if cache is not None:
-                await cache.close()
-        finally:
-            if sdk is not None:
-                await sdk.close()
+        if cache is not None:
+            await cache.close()
 
     async def on_virtual_model_upserted(self, virtual_model: VirtualModel) -> None:
         """Warm the cache for each guardrails config the VM references.

--- a/plugins/nemo-guardrails/tests/unit/test_middleware.py
+++ b/plugins/nemo-guardrails/tests/unit/test_middleware.py
@@ -293,15 +293,15 @@ async def middleware() -> AsyncIterator[GuardrailsMiddleware]:
     """A started middleware with a mocked SDK and a real cache.
 
     Owns startup AND shutdown so any pool-owned resources are released
-    between tests. The platform SDK is an :class:`AsyncMock` so
-    ``await self._sdk.close()`` succeeds in shutdown.
+    between tests. The platform SDK is injected the same way IGW injects
+    its caller-owned SDK at runtime.
     """
     instance = GuardrailsMiddleware()
     instance._inject_cache(MagicMock())
     mock_sdk = AsyncMock()
     mock_sdk._custom_headers = {}
-    with patch("nemo_guardrails_plugin.middleware.get_async_platform_sdk", return_value=mock_sdk):
-        await instance.on_startup()
+    instance._inject_platform_sdk(mock_sdk)
+    await instance.on_startup()
     try:
         yield instance
     finally:
@@ -2125,9 +2125,9 @@ class TestLifecycle:
 
         mock_sdk = AsyncMock()
         mock_sdk._custom_headers = {}
+        instance._inject_platform_sdk(mock_sdk)
         try:
             with (
-                patch("nemo_guardrails_plugin.middleware.get_async_platform_sdk", return_value=mock_sdk),
                 patch(
                     "nemo_guardrails_plugin.middleware.get_common_service_config",
                     return_value=SimpleNamespace(log_level=log_level),
@@ -2141,36 +2141,36 @@ class TestLifecycle:
             if instance._sdk is not None:
                 await instance.on_shutdown()
 
-    async def test_on_shutdown_closes_sdk_and_cache(self) -> None:
+    async def test_on_shutdown_detaches_sdk_and_closes_cache(self) -> None:
         instance = GuardrailsMiddleware()
         instance._inject_cache(MagicMock())
 
         mock_sdk = AsyncMock()
-        with patch("nemo_guardrails_plugin.middleware.get_async_platform_sdk", return_value=mock_sdk):
-            await instance.on_startup()
+        instance._inject_platform_sdk(mock_sdk)
+        await instance.on_startup()
 
         assert instance._rails_cache is not None
         assert instance._stable_cache is not None
         await instance.on_shutdown()
 
-        mock_sdk.close.assert_awaited_once()
+        mock_sdk.close.assert_not_awaited()
         assert instance._rails_cache is None
         assert instance._stable_cache is None
 
-    async def test_on_shutdown_closes_sdk_even_when_cache_close_raises(self) -> None:
+    async def test_on_shutdown_detaches_sdk_even_when_cache_close_raises(self) -> None:
         instance = GuardrailsMiddleware()
         instance._inject_cache(MagicMock())
 
         mock_sdk = AsyncMock()
-        with patch("nemo_guardrails_plugin.middleware.get_async_platform_sdk", return_value=mock_sdk):
-            await instance.on_startup()
+        instance._inject_platform_sdk(mock_sdk)
+        await instance.on_startup()
 
         assert instance._rails_cache is not None
         with patch.object(instance._rails_cache, "close", new=AsyncMock(side_effect=RuntimeError("cache boom"))):
             with pytest.raises(RuntimeError, match="cache boom"):
                 await instance.on_shutdown()
 
-        mock_sdk.close.assert_awaited_once()
+        mock_sdk.close.assert_not_awaited()
         assert instance._sdk is None
         assert instance._rails_cache is None
         assert instance._stable_cache is None

--- a/sdk/python/nemo-platform/src/nemo_platform/_base_client.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/_base_client.py
@@ -393,7 +393,7 @@ class BaseClient(Generic[_HttpxClientT, _DefaultStreamT]):
         _strict_response_validation: bool,
         max_retries: int = DEFAULT_MAX_RETRIES,
         timeout: float | Timeout | None = DEFAULT_TIMEOUT,
-        custom_headers: Mapping[str, str] | None = None,
+        custom_headers: Headers | None = None,
         custom_query: Mapping[str, object] | None = None,
     ) -> None:
         self._version = version
@@ -869,7 +869,7 @@ class SyncAPIClient(BaseClient[httpx.Client, Stream[Any]]):
         max_retries: int = DEFAULT_MAX_RETRIES,
         timeout: float | Timeout | None | NotGiven = not_given,
         http_client: httpx.Client | None = None,
-        custom_headers: Mapping[str, str] | None = None,
+        custom_headers: Headers | None = None,
         custom_query: Mapping[str, object] | None = None,
         _strict_response_validation: bool,
     ) -> None:
@@ -1452,7 +1452,7 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient, AsyncStream[Any]]):
         max_retries: int = DEFAULT_MAX_RETRIES,
         timeout: float | Timeout | None | NotGiven = not_given,
         http_client: httpx.AsyncClient | None = None,
-        custom_headers: Mapping[str, str] | None = None,
+        custom_headers: Headers | None = None,
         custom_query: Mapping[str, object] | None = None,
     ) -> None:
         if not is_given(timeout):

--- a/sdk/python/nemo-platform/src/nemo_platform/_client.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/_client.py
@@ -150,7 +150,7 @@ class NeMoPlatform(SyncAPIClient):
         access_token: str | None = None,
         timeout: float | Timeout | None | NotGiven = not_given,
         max_retries: int = DEFAULT_MAX_RETRIES,
-        default_headers: Mapping[str, str] | None = None,
+        default_headers: Mapping[str, str | Omit] | None = None,
         default_query: Mapping[str, object] | None = None,
         # Configure a custom httpx client.
         # We provide a `DefaultHttpxClient` class that you can pass to retain the default values we use for `limits`, `timeout` & `follow_redirects`.
@@ -411,8 +411,8 @@ class NeMoPlatform(SyncAPIClient):
         timeout: float | Timeout | None | NotGiven = not_given,
         http_client: httpx.Client | None = None,
         max_retries: int | NotGiven = not_given,
-        default_headers: Mapping[str, str] | None = None,
-        set_default_headers: Mapping[str, str] | None = None,
+        default_headers: Mapping[str, str | Omit] | None = None,
+        set_default_headers: Mapping[str, str | Omit] | None = None,
         default_query: Mapping[str, object] | None = None,
         set_default_query: Mapping[str, object] | None = None,
         _extra_kwargs: Mapping[str, Any] = {},
@@ -536,7 +536,7 @@ class AsyncNeMoPlatform(AsyncAPIClient):
         access_token: str | None = None,
         timeout: float | Timeout | None | NotGiven = not_given,
         max_retries: int = DEFAULT_MAX_RETRIES,
-        default_headers: Mapping[str, str] | None = None,
+        default_headers: Mapping[str, str | Omit] | None = None,
         default_query: Mapping[str, object] | None = None,
         # Configure a custom httpx client.
         # We provide a `DefaultAsyncHttpxClient` class that you can pass to retain the default values we use for `limits`, `timeout` & `follow_redirects`.
@@ -819,8 +819,8 @@ class AsyncNeMoPlatform(AsyncAPIClient):
         timeout: float | Timeout | None | NotGiven = not_given,
         http_client: httpx.AsyncClient | None = None,
         max_retries: int | NotGiven = not_given,
-        default_headers: Mapping[str, str] | None = None,
-        set_default_headers: Mapping[str, str] | None = None,
+        default_headers: Mapping[str, str | Omit] | None = None,
+        set_default_headers: Mapping[str, str | Omit] | None = None,
         default_query: Mapping[str, object] | None = None,
         set_default_query: Mapping[str, object] | None = None,
         _extra_kwargs: Mapping[str, Any] = {},

--- a/services/core/files/src/nmp/core/files/api/endpoint_helpers.py
+++ b/services/core/files/src/nmp/core/files/api/endpoint_helpers.py
@@ -19,7 +19,7 @@ from nemo_platform_plugin.secrets.client import AsyncSecretsClient
 from nmp.common.auth import AuthClient
 from nmp.common.entities.client import EntityClient, EntityNotFoundError
 from nmp.common.entities.utils import parse_entity_ref
-from nmp.common.sdk_factory import get_async_platform_sdk
+from nmp.common.observability import MARK_INTERNAL_REQUEST_HEADERS
 from nmp.common.secrets.exceptions import SecretAccessDeniedError, SecretNotFoundError
 from nmp.core.files.app.backends import FileInfo, StorageConfig
 from nmp.core.files.app.backends.base import ByteRange, StorageImpl
@@ -302,7 +302,17 @@ async def resolve_storage_secrets_for_user(
     auth_client: AuthClient,
 ) -> dict[str, str]:
     """Resolve storage secrets using delegated headers on request-scoped SDK."""
-    service_sdk = get_async_platform_sdk(as_service="files", internal=True, on_behalf_of=auth_client.principal.id)
+    effective_principal = auth_client.principal.effective_principal
+    headers = {
+        **MARK_INTERNAL_REQUEST_HEADERS,
+        "X-NMP-Principal-Id": "service:files",
+        "X-NMP-Principal-On-Behalf-Of": effective_principal.id,
+    }
+    if effective_principal.email:
+        headers["X-NMP-Principal-On-Behalf-Of-Email"] = effective_principal.email
+    if effective_principal.groups:
+        headers["X-NMP-Principal-On-Behalf-Of-Groups"] = ",".join(effective_principal.groups)
+    service_sdk = sdk.with_options(set_default_headers=headers)
     return await resolve_storage_secrets(storage, workspace, service_sdk)
 
 

--- a/services/core/files/tests/integration/conftest.py
+++ b/services/core/files/tests/integration/conftest.py
@@ -7,9 +7,8 @@ This conftest provides fixtures for integration tests that require
 external services (like Huggingface Hub).
 """
 
-from collections.abc import Callable, Iterator
+from collections.abc import AsyncIterator, Callable, Iterator
 
-import anyio
 import httpx
 import huggingface_hub
 import pytest
@@ -58,30 +57,11 @@ def _get_auth_client_from_request(request: Request) -> AuthClient:
     )
 
 
-def _create_asgi_async_files_client(sdk: NeMoPlatform) -> tuple[httpx.AsyncClient, AsyncFilesClient]:
-    sdk_http_client = sdk._client
-    assert isinstance(sdk_http_client, SDKTestClientAdapter)
-    base_url = str(sdk.base_url).rstrip("/")
-    http_client = httpx.AsyncClient(
-        transport=httpx.ASGITransport(app=sdk_http_client.asgi_app),
-        base_url=base_url,
-        headers=dict(sdk_http_client.headers),
-    )
-    return http_client, AsyncFilesClient(
-        base_url=base_url,
-        workspace=sdk.workspace,
-        http_client=http_client,
-    )
-
-
-def _install_asgi_files_resource(sdk: NeMoPlatform) -> httpx.AsyncClient:
-    http_client, async_files_client = _create_asgi_async_files_client(sdk)
+def _install_asgi_files_resource(sdk: NeMoPlatform) -> None:
     sdk.__dict__["files"] = FilesResource(
         sdk,
         files_client=client_from_platform(sdk, FilesClient),
-        async_files_client=async_files_client,
     )
-    return http_client
 
 
 @pytest.fixture
@@ -110,8 +90,6 @@ def sdk_user_and_service() -> Iterator[tuple[NeMoPlatform, NeMoPlatform]]:
             base_url=base_url,
             headers={"x-nmp-principal-id": "service:customizer"},
         )
-        user_async_http_client: httpx.AsyncClient | None = None
-        service_async_http_client: httpx.AsyncClient | None = None
         try:
             sdk_user = NeMoPlatform(
                 base_url=base_url,
@@ -123,14 +101,10 @@ def sdk_user_and_service() -> Iterator[tuple[NeMoPlatform, NeMoPlatform]]:
                 http_client=SDKTestClientAdapter(client_service),
                 max_retries=0,
             )
-            user_async_http_client = _install_asgi_files_resource(sdk_user)
-            service_async_http_client = _install_asgi_files_resource(sdk_service)
+            _install_asgi_files_resource(sdk_user)
+            _install_asgi_files_resource(sdk_service)
             yield (sdk_user, sdk_service)
         finally:
-            if user_async_http_client is not None:
-                anyio.run(user_async_http_client.aclose)
-            if service_async_http_client is not None:
-                anyio.run(service_async_http_client.aclose)
             client_user.close()
             client_service.close()
 
@@ -143,11 +117,8 @@ def sdk() -> Iterator[NeMoPlatform]:
         SecretsService,
         dependency_overrides=FILESET_AUTH_DEPENDENCY_OVERRIDES,
     ) as sdk:
-        async_http_client = _install_asgi_files_resource(sdk)
-        try:
-            yield sdk
-        finally:
-            anyio.run(async_http_client.aclose)
+        _install_asgi_files_resource(sdk)
+        yield sdk
 
 
 @pytest.fixture
@@ -157,11 +128,24 @@ def files_client(sdk: NeMoPlatform) -> FilesClient:
 
 
 @pytest.fixture
-def async_files_client(sdk: NeMoPlatform) -> AsyncFilesClient:
-    """Provide the SDK fixture's in-memory AsyncFilesClient."""
-    client = sdk.files.fsspec._client
-    assert isinstance(client, AsyncFilesClient)
-    return client
+async def async_files_client(sdk: NeMoPlatform) -> AsyncIterator[AsyncFilesClient]:
+    """Provide an AsyncFilesClient backed by the SDK fixture's in-memory app."""
+    sdk_http_client = sdk._client
+    assert isinstance(sdk_http_client, SDKTestClientAdapter)
+    base_url = str(sdk.base_url).rstrip("/")
+    http_client = httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=sdk_http_client.asgi_app),
+        base_url=base_url,
+        headers=dict(sdk_http_client.headers),
+    )
+    try:
+        yield AsyncFilesClient(
+            base_url=base_url,
+            workspace=sdk.workspace,
+            http_client=http_client,
+        )
+    finally:
+        await http_client.aclose()
 
 
 @pytest.fixture
@@ -184,11 +168,8 @@ def sdk_allow_user_local_storage(tmp_path) -> Iterator[NeMoPlatform]:
         tmp_dir=tmp_path,
         dependency_overrides=FILESET_AUTH_DEPENDENCY_OVERRIDES,
     ) as sdk:
-        async_http_client = _install_asgi_files_resource(sdk)
-        try:
-            yield sdk
-        finally:
-            anyio.run(async_http_client.aclose)
+        _install_asgi_files_resource(sdk)
+        yield sdk
 
 
 @pytest.fixture

--- a/services/core/files/tests/integration/external_storage/test_huggingface_storage.py
+++ b/services/core/files/tests/integration/external_storage/test_huggingface_storage.py
@@ -23,7 +23,7 @@ from huggingface_hub import snapshot_download
 from nemo_platform import NeMoPlatform
 from nemo_platform_plugin.client.adapter import client_from_platform
 from nemo_platform_plugin.client.errors import NemoHTTPError as ClientBadRequestError
-from nemo_platform_plugin.files.client import AsyncFilesClient, FilesClient
+from nemo_platform_plugin.files.client import FilesClient
 from nemo_platform_plugin.files.types import CreateFilesetRequest, ListFilesQueryParams
 from nmp.core.files.app.backends.base import StorageImpl
 from nmp.core.files.app.streaming import download_url_streaming
@@ -236,7 +236,7 @@ class TestHuggingfaceStorageBackend:
             assert len(range_content) == 50
             assert range_content == full_content[:50]
 
-    def test_file_exists_with_file_path(self, sdk: NeMoPlatform, async_files_client: AsyncFilesClient):
+    def test_file_exists_with_file_path(self, sdk: NeMoPlatform):
         """Test _exists with a file path returns True for existing files.
 
         This tests the fix for HuggingFace's list_repo_tree which expects directory
@@ -256,10 +256,7 @@ class TestHuggingfaceStorageBackend:
                 "repo_type": "model",
             },
         ) as fileset:
-            fs = FilesetFileSystem(
-                client=client_from_platform(sdk, FilesClient),
-                async_client=async_files_client,
-            )
+            fs = FilesetFileSystem(client=client_from_platform(sdk, FilesClient))
             file_path = f"{fileset.workspace}/{fileset.name}#config.json"
 
             # This would fail with EntryNotFoundError before the fix
@@ -270,7 +267,6 @@ class TestHuggingfaceStorageBackend:
     def test_file_exists_with_nonexistent_path_returns_false(
         self,
         sdk: NeMoPlatform,
-        async_files_client: AsyncFilesClient,
     ):
         """Test _exists with a non-existent path returns False."""
         name = f"hf-test-{uuid.uuid4().hex[:8]}"
@@ -284,10 +280,7 @@ class TestHuggingfaceStorageBackend:
                 "repo_type": "model",
             },
         ) as fileset:
-            fs = FilesetFileSystem(
-                client=client_from_platform(sdk, FilesClient),
-                async_client=async_files_client,
-            )
+            fs = FilesetFileSystem(client=client_from_platform(sdk, FilesClient))
             file_path = f"{fileset.workspace}/{fileset.name}#nonexistent/file/path.txt"
 
             # Should return False, not raise an error
@@ -298,7 +291,6 @@ class TestHuggingfaceStorageBackend:
     def test_get_downloads_single_file(
         self,
         sdk: NeMoPlatform,
-        async_files_client: AsyncFilesClient,
         tmp_path,
     ):
         """Test _get downloads a single file correctly.
@@ -318,14 +310,11 @@ class TestHuggingfaceStorageBackend:
                 "repo_type": "model",
             },
         ) as fileset:
-            fs = FilesetFileSystem(
-                client=client_from_platform(sdk, FilesClient),
-                async_client=async_files_client,
-            )
+            fs = FilesetFileSystem(client=client_from_platform(sdk, FilesClient))
             file_path = f"{fileset.workspace}/{fileset.name}#config.json"
 
             # Download single file
-            asyncio.run(fs._get(file_path, str(tmp_path)))
+            fs.get(file_path, str(tmp_path))
 
             # File should be at tmp_path/config.json
             downloaded_file = tmp_path / "config.json"
@@ -338,7 +327,6 @@ class TestHuggingfaceStorageBackend:
     def test_get_downloads_directory_with_trailing_slash(
         self,
         sdk: NeMoPlatform,
-        async_files_client: AsyncFilesClient,
         tmp_path,
     ):
         """Test _get with trailing slash copies contents directly into dest.
@@ -358,14 +346,11 @@ class TestHuggingfaceStorageBackend:
                 "repo_type": "model",
             },
         ) as fileset:
-            fs = FilesetFileSystem(
-                client=client_from_platform(sdk, FilesClient),
-                async_client=async_files_client,
-            )
+            fs = FilesetFileSystem(client=client_from_platform(sdk, FilesClient))
             # Trailing slash on source - copy contents directly
             dir_path = f"{fileset.workspace}/{fileset.name}#/"
 
-            asyncio.run(fs._get(dir_path, str(tmp_path)))
+            fs.get(dir_path, str(tmp_path))
 
             # config.json should be directly in tmp_path (not tmp_path/<fileset_name>/)
             assert (tmp_path / "config.json").exists()
@@ -373,7 +358,6 @@ class TestHuggingfaceStorageBackend:
     def test_get_downloads_directory_without_trailing_slash(
         self,
         sdk: NeMoPlatform,
-        async_files_client: AsyncFilesClient,
         tmp_path,
     ):
         """Test _get for fileset root copies contents directly.
@@ -394,14 +378,11 @@ class TestHuggingfaceStorageBackend:
                 "repo_type": "model",
             },
         ) as fileset:
-            fs = FilesetFileSystem(
-                client=client_from_platform(sdk, FilesClient),
-                async_client=async_files_client,
-            )
+            fs = FilesetFileSystem(client=client_from_platform(sdk, FilesClient))
             # No trailing slash on source - for fileset root, copies contents directly
             dir_path = f"{fileset.workspace}/{fileset.name}#"
 
-            asyncio.run(fs._get(dir_path, str(tmp_path)))
+            fs.get(dir_path, str(tmp_path))
 
             # Files should be directly in tmp_path/ (no fileset subfolder)
             assert (tmp_path / "config.json").exists()

--- a/services/core/files/tests/integration/test_fileset_filesystem.py
+++ b/services/core/files/tests/integration/test_fileset_filesystem.py
@@ -23,6 +23,7 @@ import fsspec
 import pandas as pd
 import pytest
 from filesets import (
+    AsyncFilesetFileSystem,
     FilesetFileSystem,
     FilesetPathError,
     build_fileset_ref,
@@ -296,12 +297,9 @@ class TestFilesetFileSystem:
     """Test fsspec operations via FilesetFileSystem."""
 
     @pytest.fixture
-    def fs(self, sdk: NeMoPlatform, async_files_client: AsyncFilesClient) -> FilesetFileSystem:
+    def fs(self, sdk: NeMoPlatform) -> FilesetFileSystem:
         """Create a FilesetFileSystem backed by the test SDK."""
-        return FilesetFileSystem(
-            client=client_from_platform(sdk, FilesClient),
-            async_client=async_files_client,
-        )
+        return FilesetFileSystem(client=client_from_platform(sdk, FilesClient))
 
     def test_ls_empty_fileset(self, fs: FilesetFileSystem, fileset: FilesetOutput):
         """Test listing an empty fileset."""
@@ -533,7 +531,6 @@ class TestFilesetFileSystem:
     def test_fsspec_filesystem_registration(
         self,
         sdk: NeMoPlatform,
-        async_files_client: AsyncFilesClient,
         fileset: FilesetOutput,
     ):
         """Test that FilesetFileSystem can be instantiated via fsspec.filesystem()."""
@@ -541,7 +538,6 @@ class TestFilesetFileSystem:
         fs = fsspec.filesystem(
             "fileset",
             client=client_from_platform(sdk, FilesClient),
-            async_client=async_files_client,
             skip_instance_cache=True,
         )
 
@@ -999,16 +995,16 @@ class TestFilesetFileSystem:
         download_dir.mkdir()
 
         call_count = 0
-        original_get_file = fs._get_file
+        original_get_file = fs.get_file
 
-        async def failing_get_file(rpath, lpath, **kwargs):
+        def failing_get_file(rpath, lpath, **kwargs):
             nonlocal call_count
             call_count += 1
             if call_count == 2:  # Fail on the second file
                 raise RuntimeError("Simulated failure in concurrent download")
-            return await original_get_file(rpath, lpath, **kwargs)
+            return original_get_file(rpath, lpath, **kwargs)
 
-        with patch.object(fs, "_get_file", side_effect=failing_get_file):
+        with patch.object(fs, "get_file", side_effect=failing_get_file):
             # _run_coros_in_chunks re-raises the first exception for fsspec compatibility
             with pytest.raises(RuntimeError, match="Simulated failure"):
                 fs.get(base + "/", str(download_dir) + "/", recursive=True)
@@ -1029,16 +1025,16 @@ class TestFilesetFileSystem:
         base = f"{fileset.workspace}/{fileset.name}"
 
         call_count = 0
-        original_put_file = fs._put_file
+        original_put_file = fs.put_file
 
-        async def failing_put_file(lpath, rpath, **kwargs):
+        def failing_put_file(lpath, rpath, **kwargs):
             nonlocal call_count
             call_count += 1
             if call_count == 2:  # Fail on the second file
                 raise RuntimeError("Simulated failure in concurrent upload")
-            return await original_put_file(lpath, rpath, **kwargs)
+            return original_put_file(lpath, rpath, **kwargs)
 
-        with patch.object(fs, "_put_file", side_effect=failing_put_file):
+        with patch.object(fs, "put_file", side_effect=failing_put_file):
             with pytest.raises(RuntimeError, match="Simulated failure"):
                 fs.put(str(upload_dir) + "/", base + "/", recursive=True)
 
@@ -1098,21 +1094,21 @@ class TestFilesetFileSystem:
         assert (download_dir / "file3.txt").read_bytes() == b"content3"
 
 
-class TestFilesetFileSystemAsync:
-    """Test async fsspec operations via FilesetFileSystem."""
+class TestAsyncFilesetFileSystem:
+    """Test async fsspec operations via AsyncFilesetFileSystem."""
 
     @pytest.fixture
-    def fs(self, async_files_client: AsyncFilesClient) -> FilesetFileSystem:
-        """Create a FilesetFileSystem backed by the test SDK."""
-        return FilesetFileSystem(client=async_files_client, skip_instance_cache=True)
+    def fs(self, async_files_client: AsyncFilesClient) -> AsyncFilesetFileSystem:
+        """Create an AsyncFilesetFileSystem backed by the test SDK."""
+        return AsyncFilesetFileSystem(client=async_files_client, skip_instance_cache=True)
 
-    async def test_ls_empty_fileset(self, fs: FilesetFileSystem, fileset: FilesetOutput):
+    async def test_ls_empty_fileset(self, fs: AsyncFilesetFileSystem, fileset: FilesetOutput):
         """Test listing an empty fileset."""
         path = f"{fileset.workspace}/{fileset.name}"
         result = await fs._ls(path)
         assert result == []
 
-    async def test_ls_with_files(self, fs: FilesetFileSystem, fileset: FilesetOutput):
+    async def test_ls_with_files(self, fs: AsyncFilesetFileSystem, fileset: FilesetOutput):
         """Test listing a fileset with files."""
         base = f"{fileset.workspace}/{fileset.name}"
         await fs._pipe_file(f"{base}/file1.txt", b"content1")
@@ -1125,7 +1121,7 @@ class TestFilesetFileSystemAsync:
         assert f"{base}#file1.txt" in names
         assert f"{base}#file2.txt" in names
 
-    async def test_ls_with_directories(self, fs: FilesetFileSystem, fileset: FilesetOutput):
+    async def test_ls_with_directories(self, fs: AsyncFilesetFileSystem, fileset: FilesetOutput):
         """Test that nested files show as directories in listing."""
         base = f"{fileset.workspace}/{fileset.name}"
         await fs._pipe_file(f"{base}/root.txt", b"root")
@@ -1139,7 +1135,7 @@ class TestFilesetFileSystemAsync:
         assert types[f"{base}#root.txt"] == "file"
         assert types[f"{base}#subdir"] == "directory"
 
-    async def test_ls_subdirectory(self, fs: FilesetFileSystem, fileset: FilesetOutput):
+    async def test_ls_subdirectory(self, fs: AsyncFilesetFileSystem, fileset: FilesetOutput):
         """Test listing files in a subdirectory."""
         base = f"{fileset.workspace}/{fileset.name}"
         await fs._pipe_file(f"{base}/subdir/file1.txt", b"content1")
@@ -1151,7 +1147,7 @@ class TestFilesetFileSystemAsync:
         assert f"{base}#subdir/file1.txt" in result
         assert f"{base}#subdir/file2.txt" in result
 
-    async def test_cat_file(self, fs: FilesetFileSystem, fileset: FilesetOutput):
+    async def test_cat_file(self, fs: AsyncFilesetFileSystem, fileset: FilesetOutput):
         """Test reading file content with cat."""
         content = b"Hello, fsspec!"
         path = f"{fileset.workspace}/{fileset.name}/test.txt"
@@ -1161,7 +1157,7 @@ class TestFilesetFileSystemAsync:
 
         assert result == content
 
-    async def test_cat_file_with_range(self, fs: FilesetFileSystem, fileset: FilesetOutput):
+    async def test_cat_file_with_range(self, fs: AsyncFilesetFileSystem, fileset: FilesetOutput):
         """Test reading partial file content with byte range."""
         content = b"0123456789ABCDEF"
         path = f"{fileset.workspace}/{fileset.name}/test.txt"
@@ -1171,7 +1167,7 @@ class TestFilesetFileSystemAsync:
 
         assert result == b"456789"
 
-    async def test_pipe_file(self, fs: FilesetFileSystem, fileset: FilesetOutput):
+    async def test_pipe_file(self, fs: AsyncFilesetFileSystem, fileset: FilesetOutput):
         """Test writing file content with pipe."""
         path = f"{fileset.workspace}/{fileset.name}/piped.txt"
         content = b"Piped content"
@@ -1181,7 +1177,7 @@ class TestFilesetFileSystemAsync:
         result = await fs._cat_file(path)
         assert result == content
 
-    async def test_put_file(self, fs: FilesetFileSystem, fileset: FilesetOutput, tmp_path: Path):
+    async def test_put_file(self, fs: AsyncFilesetFileSystem, fileset: FilesetOutput, tmp_path: Path):
         """Test uploading a local file with _put_file."""
         # Create a local file
         local_file = tmp_path / "upload.txt"
@@ -1196,7 +1192,7 @@ class TestFilesetFileSystemAsync:
         result = await fs._cat_file(remote_path)
         assert result == content
 
-    async def test_put_file_nested_path(self, fs: FilesetFileSystem, fileset: FilesetOutput, tmp_path: Path):
+    async def test_put_file_nested_path(self, fs: AsyncFilesetFileSystem, fileset: FilesetOutput, tmp_path: Path):
         """Test uploading a file to a nested path with _put_file."""
         # Create a local file
         local_file = tmp_path / "nested_upload.txt"
@@ -1215,7 +1211,7 @@ class TestFilesetFileSystemAsync:
         parent_info = await fs._info(f"{fileset.workspace}/{fileset.name}/subdir/nested")
         assert parent_info["type"] == "directory"
 
-    async def test_rm_file(self, fs: FilesetFileSystem, fileset: FilesetOutput):
+    async def test_rm_file(self, fs: AsyncFilesetFileSystem, fileset: FilesetOutput):
         """Test deleting a file."""
         path = f"{fileset.workspace}/{fileset.name}/to_delete.txt"
         await fs._pipe_file(path, b"delete me")
@@ -1228,7 +1224,7 @@ class TestFilesetFileSystemAsync:
         with pytest.raises(FileNotFoundError):
             await fs._info(path)
 
-    async def test_info(self, fs: FilesetFileSystem, fileset: FilesetOutput):
+    async def test_info(self, fs: AsyncFilesetFileSystem, fileset: FilesetOutput):
         """Test getting file info."""
         content = b"Content for info test"
         path = f"{fileset.workspace}/{fileset.name}/info.txt"
@@ -1242,14 +1238,14 @@ class TestFilesetFileSystemAsync:
         assert info["size"] == len(content)
         assert info["type"] == "file"
 
-    async def test_info_directory(self, fs: FilesetFileSystem, fileset: FilesetOutput):
+    async def test_info_directory(self, fs: AsyncFilesetFileSystem, fileset: FilesetOutput):
         """Test getting info for fileset root (directory)."""
         path = f"{fileset.workspace}/{fileset.name}"
         info = await fs._info(path)
 
         assert info["type"] == "directory"
 
-    async def test_protocol_url(self, fs: FilesetFileSystem, fileset: FilesetOutput):
+    async def test_protocol_url(self, fs: AsyncFilesetFileSystem, fileset: FilesetOutput):
         """Test that protocol prefix is handled correctly."""
         content = b"Protocol test"
         base = f"{fileset.workspace}/{fileset.name}"
@@ -1262,7 +1258,7 @@ class TestFilesetFileSystemAsync:
         assert await fs._cat_file(path_no_proto) == content
         assert await fs._cat_file(path_with_proto) == content
 
-    async def test_find(self, fs: FilesetFileSystem, fileset: FilesetOutput):
+    async def test_find(self, fs: AsyncFilesetFileSystem, fileset: FilesetOutput):
         """Test recursive file discovery with find (async)."""
         base = f"{fileset.workspace}/{fileset.name}"
         await fs._pipe_file(f"{base}/root.txt", b"root")
@@ -1279,7 +1275,7 @@ class TestFilesetFileSystemAsync:
         assert f"{base}#dir1/file1.txt" in result
         assert f"{base}#dir1/subdir/nested.txt" in result
 
-    async def test_glob(self, fs: FilesetFileSystem, fileset: FilesetOutput):
+    async def test_glob(self, fs: AsyncFilesetFileSystem, fileset: FilesetOutput):
         """Test pattern matching with glob (async)."""
         base = f"{fileset.workspace}/{fileset.name}"
         await fs._pipe_file(f"{base}/data.csv", b"csv")
@@ -1300,7 +1296,7 @@ class TestFilesetFileSystemAsync:
         # All json files including nested
         assert len(json_all) == 3
 
-    async def test_isdir_isfile(self, fs: FilesetFileSystem, fileset: FilesetOutput):
+    async def test_isdir_isfile(self, fs: AsyncFilesetFileSystem, fileset: FilesetOutput):
         """Test isdir and isfile type checking (async)."""
         base = f"{fileset.workspace}/{fileset.name}"
         await fs._pipe_file(f"{base}/file.txt", b"content")
@@ -1316,7 +1312,7 @@ class TestFilesetFileSystemAsync:
         # Subdirectory checks
         assert await fs._isdir(f"{base}/subdir")
 
-    async def test_cat_multiple_files(self, fs: FilesetFileSystem, fileset: FilesetOutput):
+    async def test_cat_multiple_files(self, fs: AsyncFilesetFileSystem, fileset: FilesetOutput):
         """Test reading multiple files at once with cat (async)."""
         base = f"{fileset.workspace}/{fileset.name}"
         await fs._pipe_file(f"{base}/file1.txt", b"content1")
@@ -1332,7 +1328,7 @@ class TestFilesetFileSystemAsync:
         assert result[f"{base}#file2.txt"] == b"content2"
         assert result[f"{base}#file3.txt"] == b"content3"
 
-    async def test_head_tail(self, fs: FilesetFileSystem, fileset: FilesetOutput):
+    async def test_head_tail(self, fs: AsyncFilesetFileSystem, fileset: FilesetOutput):
         """Test reading first/last bytes of a file (async)."""
         content = b"0123456789ABCDEFGHIJ"
         path = f"{fileset.workspace}/{fileset.name}/test.txt"
@@ -1346,7 +1342,7 @@ class TestFilesetFileSystemAsync:
         result = await fs._cat_file(path, start=15, end=20)
         assert result == b"FGHIJ"
 
-    async def test_get_single_file(self, fs: FilesetFileSystem, fileset: FilesetOutput, tmp_path: Path):
+    async def test_get_single_file(self, fs: AsyncFilesetFileSystem, fileset: FilesetOutput, tmp_path: Path):
         """Test downloading a single file with _get() (async version).
 
         Tests three behaviors:
@@ -1380,7 +1376,7 @@ class TestFilesetFileSystemAsync:
 
     async def test_download_entire_fileset(
         self,
-        fs: FilesetFileSystem,
+        fs: AsyncFilesetFileSystem,
         fileset: FilesetOutput,
         sample_dataset: Path,
         tmp_path: Path,
@@ -1438,7 +1434,7 @@ class TestFilesetFileSystemAsync:
         assert not (download_without_slash / fileset.name).exists()
 
     async def test_concurrent_download_failure_hang(
-        self, fs: FilesetFileSystem, fileset: FilesetOutput, tmp_path: Path
+        self, fs: AsyncFilesetFileSystem, fileset: FilesetOutput, tmp_path: Path
     ):
         """Test that a failure in one concurrent download doesn't cause a hang.
 
@@ -1474,7 +1470,9 @@ class TestFilesetFileSystemAsync:
 
         # If we get here without hanging, the test passes
 
-    async def test_concurrent_upload_failure_hang(self, fs: FilesetFileSystem, fileset: FilesetOutput, tmp_path: Path):
+    async def test_concurrent_upload_failure_hang(
+        self, fs: AsyncFilesetFileSystem, fileset: FilesetOutput, tmp_path: Path
+    ):
         """Test that a failure in one concurrent upload doesn't cause a hang.
 
         Similar to test_concurrent_download_failure_hang, this ensures that the
@@ -1523,7 +1521,7 @@ class TestFilesetFileSystemAsync:
         total_files = 8
 
         # Create filesystem with limited concurrency
-        fs = FilesetFileSystem(client=async_files_client, batch_size=batch_size)
+        fs = AsyncFilesetFileSystem(client=async_files_client, batch_size=batch_size)
 
         # Upload files
         base = f"{fileset.workspace}/{fileset.name}"
@@ -1578,7 +1576,7 @@ class TestFilesetFileSystemAsync:
         downloaded_files = list(download_dir.iterdir())
         assert len(downloaded_files) == total_files
 
-    async def test_get_callback_hooks(self, fs: FilesetFileSystem, fileset: FilesetOutput, tmp_path: Path):
+    async def test_get_callback_hooks(self, fs: AsyncFilesetFileSystem, fileset: FilesetOutput, tmp_path: Path):
         """Test that _get properly calls callback hooks for progress tracking.
 
         This test demonstrates two callback features:
@@ -1640,7 +1638,7 @@ class TestFilesetFileSystemAsync:
         assert (download_dir / "file2.txt").read_bytes() == b"content2"
         assert (download_dir / "file3.txt").read_bytes() == b"content3"
 
-    async def test_get_per_chunk_callbacks(self, fs: FilesetFileSystem, fileset: FilesetOutput, tmp_path: Path):
+    async def test_get_per_chunk_callbacks(self, fs: AsyncFilesetFileSystem, fileset: FilesetOutput, tmp_path: Path):
         """Test that _get passes branched callbacks to _get_file for per-chunk progress.
 
         This test verifies the full callback hierarchy:
@@ -1729,7 +1727,7 @@ class TestFilesetFileSystemAsync:
         # Verify file was actually downloaded correctly
         assert (download_dir / "large_file.bin").read_bytes() == large_content
 
-    async def test_put_per_chunk_callbacks(self, fs: FilesetFileSystem, fileset: FilesetOutput, tmp_path: Path):
+    async def test_put_per_chunk_callbacks(self, fs: AsyncFilesetFileSystem, fileset: FilesetOutput, tmp_path: Path):
         """Test that _put passes branched callbacks to _put_file for per-chunk progress.
 
         This test verifies the full callback hierarchy for uploads:
@@ -1833,7 +1831,6 @@ class TestDuckDBIntegration:
     def test_duckdb_parquet_query(
         self,
         sdk: NeMoPlatform,
-        async_files_client: AsyncFilesClient,
         fileset: FilesetOutput,
     ):
         """Test querying a parquet file with DuckDB via fileset:// protocol."""
@@ -1854,7 +1851,6 @@ class TestDuckDBIntegration:
         fs = fsspec.filesystem(
             "fileset",
             client=client_from_platform(sdk, FilesClient),
-            async_client=async_files_client,
         )
         fs.pipe(f"{fileset.workspace}/{fileset.name}#{file_path}", parquet_bytes)
 
@@ -1883,7 +1879,6 @@ class TestDuckDBIntegration:
     def test_duckdb_parquet_range_read(
         self,
         sdk: NeMoPlatform,
-        async_files_client: AsyncFilesClient,
         fileset: FilesetOutput,
     ):
         """Test that DuckDB performs efficient range reads on parquet files.
@@ -1911,7 +1906,6 @@ class TestDuckDBIntegration:
         fs = fsspec.filesystem(
             "fileset",
             client=client_from_platform(sdk, FilesClient),
-            async_client=async_files_client,
         )
         fs.pipe(f"{fileset.workspace}/{fileset.name}#{file_path}", parquet_bytes)
         fileset_url = f"fileset://{fileset.workspace}/{fileset.name}#{file_path}"
@@ -1928,7 +1922,6 @@ class TestDuckDBIntegration:
     def test_duckdb_legacy_path_format(
         self,
         sdk: NeMoPlatform,
-        async_files_client: AsyncFilesClient,
         fileset: FilesetOutput,
     ):
         """Test DuckDB queries using legacy workspace/fileset/path format.
@@ -1951,7 +1944,6 @@ class TestDuckDBIntegration:
         fs = fsspec.filesystem(
             "fileset",
             client=client_from_platform(sdk, FilesClient),
-            async_client=async_files_client,
         )
         fs.pipe(f"{fileset.workspace}/{fileset.name}#{file_path}", parquet_bytes)
 
@@ -1973,12 +1965,9 @@ class TestDirCache:
     """
 
     @pytest.fixture
-    def fs(self, sdk: NeMoPlatform, async_files_client: AsyncFilesClient) -> FilesetFileSystem:
+    def fs(self, sdk: NeMoPlatform) -> FilesetFileSystem:
         """Create a FilesetFileSystem backed by the test SDK."""
-        return FilesetFileSystem(
-            client=client_from_platform(sdk, FilesClient),
-            async_client=async_files_client,
-        )
+        return FilesetFileSystem(client=client_from_platform(sdk, FilesClient))
 
     def test_ls_populates_cache_for_nested_dirs(self, fs: FilesetFileSystem, fileset: FilesetOutput):
         """_ls should populate cache for all directory levels in the response."""
@@ -2187,15 +2176,11 @@ class TestDirCache:
     def test_cache_disabled(
         self,
         sdk: NeMoPlatform,
-        async_files_client: AsyncFilesClient,
         fileset: FilesetOutput,
     ):
         """When use_listings_cache=False, cache should not be used."""
         # Create filesystem with cache disabled
-        fs = FilesetFileSystem(
-            client=client_from_platform(sdk, FilesClient),
-            async_client=async_files_client,
-        )
+        fs = FilesetFileSystem(client=client_from_platform(sdk, FilesClient))
         fs.dircache.use_listings_cache = False
 
         base = f"{fileset.workspace}/{fileset.name}"

--- a/services/core/files/tests/test_endpoint_helpers.py
+++ b/services/core/files/tests/test_endpoint_helpers.py
@@ -6,8 +6,12 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from nemo_platform import AsyncNeMoPlatform, Omit
 from nemo_platform_plugin.client.errors import NotFoundError as ClientNotFoundError
 from nmp.common.api.common import SecretRef
+from nmp.common.auth import AuthClient, Principal
+from nmp.common.config import AuthConfig
+from nmp.common.observability import MARK_INTERNAL_REQUEST_HEADERS
 from nmp.common.secrets.exceptions import SecretNotFoundError
 from nmp.core.files.api.endpoint_helpers import (
     CacheContext,
@@ -16,6 +20,7 @@ from nmp.core.files.api.endpoint_helpers import (
     get_file_info,
     list_storage_files,
     resolve_storage_secrets,
+    resolve_storage_secrets_for_user,
     stream_file_download,
 )
 from nmp.core.files.app.backends.base import FileInfo
@@ -122,6 +127,45 @@ async def test_resolve_storage_secrets_propagates_not_found(mock_sdk):
 
     with pytest.raises(SecretNotFoundError):
         await resolve_storage_secrets(config, "default", mock_sdk)
+
+
+async def test_resolve_storage_secrets_for_user_delegates_effective_principal_claims():
+    config = HuggingfaceStorageConfig(
+        repo_id="org/repo",
+        token_secret=SecretRef(root="my-hf-token"),
+    )
+    auth_client = AuthClient(
+        config=AuthConfig(),
+        principal=Principal(
+            id="service:jobs",
+            groups=["system:serviceaccounts"],
+            on_behalf_of="creator@example.com",
+            on_behalf_of_email="creator@example.com",
+            on_behalf_of_groups=["workspace-editors", "ml-team"],
+        ),
+    )
+    sdk = AsyncNeMoPlatform(base_url="http://testserver")
+    captured_headers: dict[str, str | Omit] = {}
+    secrets_client = MagicMock()
+    secrets_client.access_secret = AsyncMock(return_value=_access_result("hf_token_value"))
+
+    def capture_service_sdk(service_sdk: AsyncNeMoPlatform, _client_type: type[object]) -> MagicMock:
+        captured_headers.update(service_sdk.default_headers)
+        return secrets_client
+
+    try:
+        with patch("nmp.core.files.api.endpoint_helpers.client_from_platform", side_effect=capture_service_sdk):
+            secrets = await resolve_storage_secrets_for_user(config, "my-workspace", sdk, auth_client)
+    finally:
+        await sdk.close()
+
+    assert secrets == {"token": "hf_token_value"}
+    for header, value in MARK_INTERNAL_REQUEST_HEADERS.items():
+        assert captured_headers[header] == value
+    assert captured_headers["X-NMP-Principal-Id"] == "service:files"
+    assert captured_headers["X-NMP-Principal-On-Behalf-Of"] == "creator@example.com"
+    assert captured_headers["X-NMP-Principal-On-Behalf-Of-Email"] == "creator@example.com"
+    assert captured_headers["X-NMP-Principal-On-Behalf-Of-Groups"] == "workspace-editors,ml-team"
 
 
 # Tests for get_cache_status_for_files

--- a/services/core/inference-gateway/src/nmp/core/inference_gateway/api/middleware_registry.py
+++ b/services/core/inference-gateway/src/nmp/core/inference_gateway/api/middleware_registry.py
@@ -13,9 +13,10 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import Any, NamedTuple
+from typing import Any, Callable, NamedTuple
 
 from fastapi import HTTPException
+from nemo_platform import AsyncNeMoPlatform
 from nemo_platform.types.inference.middleware_call import MiddlewareCall as SDKMiddlewareCall
 from nemo_platform.types.inference.virtual_model import VirtualModel as SDKVirtualModel
 from nemo_platform_plugin.discovery import discover_inference_middleware
@@ -734,6 +735,8 @@ def _sdk_vm_to_plugin_vm(vm: SDKVirtualModel) -> PluginVirtualModel:
 async def load_middleware_plugins(
     model_cache: Any,  # ModelCache
     virtual_model_cache: Any,  # VirtualModelCache
+    *,
+    plugin_sdk_factory: Callable[[str], AsyncNeMoPlatform] | None = None,
 ) -> MiddlewareRegistry:
     """Discover ``nemo.inference_middleware`` entry-points, load, and start each plugin.
 
@@ -748,6 +751,7 @@ async def load_middleware_plugins(
     Args:
         model_cache: The IGW's :class:`~nmp.core.inference_gateway.api.model_cache.ModelCache`.
         virtual_model_cache: The IGW's :class:`~nmp.core.inference_gateway.api.virtual_model_cache.VirtualModelCache`.
+        plugin_sdk_factory: Optional factory for caller-owned service SDKs keyed by plugin name.
 
     Returns:
         A :class:`MiddlewareRegistry` containing all successfully loaded plugins.
@@ -764,6 +768,8 @@ async def load_middleware_plugins(
         try:
             instance = cls()
             instance._inject_cache(accessor)
+            if plugin_sdk_factory is not None:
+                instance._inject_platform_sdk(plugin_sdk_factory(name))
             await instance.on_startup()
             plugins[name] = instance
             logger.info("Loaded inference middleware plugin %r (%s)", name, cls.__qualname__)

--- a/services/core/inference-gateway/src/nmp/core/inference_gateway/service.py
+++ b/services/core/inference-gateway/src/nmp/core/inference_gateway/service.py
@@ -10,7 +10,7 @@ from typing import ClassVar, List, Optional, Set
 import aiohttp
 from fastapi import Request
 from fastapi.exceptions import RequestValidationError
-from nmp.common.sdk_factory import get_async_platform_sdk
+from nemo_platform import AsyncNeMoPlatform
 from nmp.common.service import RouterConfig, Service
 from starlette import status
 from starlette.responses import JSONResponse
@@ -96,7 +96,10 @@ class InferenceGatewayService(Service):
         from nmp.core.inference_gateway.api.virtual_model_cache import VirtualModelCache
         from nmp.core.inference_gateway.config import config as inference_gateway_config
 
-        sdk = get_async_platform_sdk(as_service="inference-gateway", internal=True)
+        sdk = self.dependency_provider.get_sdk_client(as_service="inference-gateway")
+
+        def plugin_sdk_factory(plugin_name: str) -> AsyncNeMoPlatform:
+            return self.dependency_provider.get_sdk_client(as_service=plugin_name)
 
         # Initialize caches
         model_cache = set_global_model_cache(ModelCache(secret_value_ttl=inference_gateway_config.secrets_ttl_sec))
@@ -104,7 +107,7 @@ class InferenceGatewayService(Service):
 
         # Discover and load inference middleware plugins
         middleware_registry = set_global_middleware_registry(
-            await load_middleware_plugins(model_cache, virtual_model_cache)
+            await load_middleware_plugins(model_cache, virtual_model_cache, plugin_sdk_factory=plugin_sdk_factory)
         )
         self._middleware_registry = middleware_registry
 

--- a/services/core/inference-gateway/src/nmp/core/inference_gateway/testing/fixtures.py
+++ b/services/core/inference-gateway/src/nmp/core/inference_gateway/testing/fixtures.py
@@ -66,23 +66,16 @@ def _build_app_context(
 ) -> Generator[ClientContext, None, None]:
     """Yield an IGW + Models + extras :class:`ClientContext` (module-lived).
 
-    Two module-scope hazards are neutralised here:
+    One module-scope hazard is neutralised here:
 
-    1. The 3-second background ``refresh_model_cache_task``. ``on_startup``
-       reads ``refresh_model_cache_interval_sec`` from the module-level
-       config snapshot (captured at first import), so a ``service_configs``
-       override is too late. Patch the snapshot field to 0 *before*
-       entering ``create_test_client`` and ``on_startup`` never schedules
-       the loop.
-    2. The shared SDK HTTP client's ``aclose``. Plugins like
-       ``nemo-guardrails`` call ``await sdk.close()`` in ``on_shutdown``,
-       which would close the shared client for every later test in the
-       module. Patch ``aclose`` to a no-op for the module's lifetime;
-       ``ASGITransport`` is in-process so nothing actually leaks.
+    The 3-second background ``refresh_model_cache_task`` reads
+    ``refresh_model_cache_interval_sec`` from the module-level config snapshot
+    (captured at first import), so a ``service_configs`` override is too late.
+    Patch the snapshot field to 0 *before* entering ``create_test_client`` and
+    ``on_startup`` never schedules the loop.
     """
     from unittest.mock import patch
 
-    from nmp.common import sdk_factory as sdk_factory_module
     from nmp.core.inference_gateway import config as igw_config_module
     from nmp.core.inference_gateway.service import InferenceGatewayService
     from nmp.core.models.service import ModelsService
@@ -95,21 +88,7 @@ def _build_app_context(
             client_type=ClientContext,
             igw_mock_provider_mode=False,
         ) as client_context:
-            shared_async_client = sdk_factory_module._test_http_client
-            if shared_async_client is None:
-                yield client_context
-                return
-
-            original_aclose = shared_async_client.aclose
-
-            async def _noop_aclose() -> None:
-                return None
-
-            shared_async_client.aclose = _noop_aclose  # type: ignore[method-assign]
-            try:
-                yield client_context
-            finally:
-                shared_async_client.aclose = original_aclose  # type: ignore[method-assign]
+            yield client_context
 
 
 @pytest.fixture(scope="module")

--- a/services/core/inference-gateway/src/nmp/core/inference_gateway/testing/harness.py
+++ b/services/core/inference-gateway/src/nmp/core/inference_gateway/testing/harness.py
@@ -41,6 +41,8 @@ from nemo_platform_plugin.inference_middleware import NemoInferenceMiddleware
 from nemo_platform_plugin.secrets.client import SecretsClient
 from nemo_platform_plugin.secrets.types import PlatformSecretCreateRequest
 from nmp.common.entities.client import EntityClient
+from nmp.common.observability import MARK_INTERNAL_REQUEST_HEADERS
+from nmp.common.service.headers import build_downstream_service_headers
 from nmp.core.inference_gateway.api.dependencies import (
     global_middleware_registry,
     global_model_cache,
@@ -287,6 +289,12 @@ class IGWPluginHarness:
     # Plugin registration (context-managed)
     # ------------------------------------------------------------------
 
+    def _plugin_sdk(self, name: str) -> AsyncNeMoPlatform:
+        headers = dict(self.async_sdk.default_headers)
+        headers.update(MARK_INTERNAL_REQUEST_HEADERS)
+        headers.update(build_downstream_service_headers(name))
+        return self.async_sdk.with_options(set_default_headers=headers)
+
     @contextmanager
     def use_plugin(
         self,
@@ -321,6 +329,7 @@ class IGWPluginHarness:
         original = self._registry.plugins.get(name)
 
         plugin._inject_cache(self._cache_accessor)
+        plugin._inject_platform_sdk(self._plugin_sdk(name))
         if call_lifecycle:
             asyncio.run(plugin.on_startup())
         self._registry.plugins[name] = plugin
@@ -328,7 +337,8 @@ class IGWPluginHarness:
             yield plugin
         finally:
             if original_present:
-                self._registry.plugins[name] = original  # type: ignore[assignment]
+                assert original is not None
+                self._registry.plugins[name] = original
             else:
                 self._registry.plugins.pop(name, None)
             if call_lifecycle:
@@ -363,6 +373,7 @@ class IGWPluginHarness:
         original = self._registry.plugins.get(name)
 
         plugin._inject_cache(self._cache_accessor)
+        plugin._inject_platform_sdk(self._plugin_sdk(name))
         if call_lifecycle:
             await plugin.on_startup()
         self._registry.plugins[name] = plugin
@@ -370,7 +381,8 @@ class IGWPluginHarness:
             yield plugin
         finally:
             if original_present:
-                self._registry.plugins[name] = original  # type: ignore[assignment]
+                assert original is not None
+                self._registry.plugins[name] = original
             else:
                 self._registry.plugins.pop(name, None)
             if call_lifecycle:

--- a/services/core/inference-gateway/tests/integration/conftest.py
+++ b/services/core/inference-gateway/tests/integration/conftest.py
@@ -352,7 +352,11 @@ def controller_with_docker_and_igw(
             return_value=mock_platform_config,
         ),
         patch("nmp.core.models.controllers.models_controller.get_async_platform_sdk") as mock_sdk_factory,
+        patch("nemo_deployments_plugin.controller.get_async_platform_sdk") as mock_deployments_controller_sdk,
         patch("nemo_platform_plugin.sdk_provider.get_async_platform_sdk") as mock_sdk,
+        patch(
+            "nmp.core.models.controllers.backends.deployments_plugin.backend.get_async_platform_sdk"
+        ) as mock_deployments_backend_sdk,
         patch("nemo_deployments_plugin.config.DeploymentsConfig.get", return_value=deployments_config),
         patch(
             "nemo_platform_plugin.jobs.image.get_qualified_image",
@@ -360,7 +364,9 @@ def controller_with_docker_and_igw(
         ),
     ):
         mock_sdk_factory.return_value = test_clients.async_sdk
+        mock_deployments_controller_sdk.return_value = test_clients.async_sdk
         mock_sdk.return_value = test_clients.async_sdk
+        mock_deployments_backend_sdk.return_value = test_clients.async_sdk
 
         controller = ModelsController(
             backend_registry=backend_registry,

--- a/services/core/inference-gateway/tests/unit/conftest.py
+++ b/services/core/inference-gateway/tests/unit/conftest.py
@@ -106,7 +106,7 @@ def autoprovisioned_vms_for_cache(model_cache: ModelCache) -> list[VirtualModel]
     keying plus the request-side rewrite of ``parse_model_entity_ref`` to surface composite
     LoRA ids through whichever VirtualModel the operator manually associated with them.
     """
-    now = "2026-01-01T00:00:00Z"
+    now = datetime.fromisoformat("2026-01-01T00:00:00+00:00")
     return [
         VirtualModel(
             id=f"{workspace}/{name}",
@@ -170,9 +170,8 @@ def app_and_client(
         ],
     )
 
-    mocker.patch("nmp.core.inference_gateway.service.get_async_platform_sdk", return_value=mock_nmp_sdk)
-
     service = InferenceGatewayService()
+    mocker.patch.object(service.dependency_provider, "get_sdk_client", return_value=mock_nmp_sdk)
     app = service.app
     app.dependency_overrides[global_http_client] = lambda: mock_proxy_client
     app.dependency_overrides[global_model_cache] = lambda: model_cache

--- a/services/core/inference-gateway/tests/unit/test_service.py
+++ b/services/core/inference-gateway/tests/unit/test_service.py
@@ -17,7 +17,6 @@ async def test_debug_startup_hydrates_model_entity_metadata(mocker):
     http_client = Mock()
     http_client.close = AsyncMock()
 
-    mocker.patch("nmp.core.inference_gateway.service.get_async_platform_sdk", return_value=sdk)
     mocker.patch(
         "nmp.core.inference_gateway.api.middleware_registry.load_middleware_plugins",
         AsyncMock(return_value=MiddlewareRegistry()),
@@ -38,8 +37,11 @@ async def test_debug_startup_hydrates_model_entity_metadata(mocker):
     )
 
     service = InferenceGatewayService()
+    mocker.patch.object(service.dependency_provider, "get_sdk_client", return_value=sdk)
     await service.on_startup()
     await service.on_shutdown()
 
     refresh_model_cache.assert_awaited_once()
-    assert refresh_model_cache.await_args.kwargs["model_entity_getter"] is model_entity_getter
+    await_args = refresh_model_cache.await_args
+    assert await_args is not None
+    assert await_args.kwargs["model_entity_getter"] is model_entity_getter

--- a/services/core/jobs/src/nmp/core/jobs/api/dependencies.py
+++ b/services/core/jobs/src/nmp/core/jobs/api/dependencies.py
@@ -3,32 +3,16 @@
 
 """FastAPI dependencies for the Jobs API."""
 
-from fastapi import Depends, Request
+from fastapi import Depends
 from nemo_platform import AsyncNeMoPlatform
 from nmp.common.entities.client import EntityClient
-from nmp.common.sdk_factory import get_async_platform_sdk
-from nmp.common.service.dependencies import get_entity_client
+from nmp.common.service.dependencies import get_entity_client, get_sdk_client
 from nmp.core.jobs.app.dispatcher import JobDispatcher
-
-
-async def get_sdk_with_auth(request: Request) -> AsyncNeMoPlatform:
-    """Get SDK client with current request's auth headers.
-
-    This dependency creates a new SDK instance with the current user's
-    auth context propagated. This is needed for internal service calls
-    that require authorization (e.g., creating filesets).
-
-    Args:
-        request: The FastAPI request object (needed to ensure we're in request context)
-    """
-    # By taking request as parameter, we ensure this runs in request context
-    # where auth headers are available via context vars
-    return get_async_platform_sdk()
 
 
 async def dep_dispatcher(
     entity_client: EntityClient = Depends(get_entity_client),
-    sdk: AsyncNeMoPlatform = Depends(get_sdk_with_auth),
+    sdk: AsyncNeMoPlatform = Depends(get_sdk_client),
 ) -> JobDispatcher:
     """Dependency to get the job dispatcher with EntityClient and SDK client."""
     return JobDispatcher(

--- a/services/core/jobs/src/nmp/core/jobs/api/v2/jobs/endpoints.py
+++ b/services/core/jobs/src/nmp/core/jobs/api/v2/jobs/endpoints.py
@@ -31,7 +31,6 @@ from nmp.common.jobs.schemas import (
     PlatformJobStatusResponse,
 )
 from nmp.common.observability import scoped_app_ctx
-from nmp.common.sdk_factory import with_options_preserving_request_router
 from nmp.common.service.dependencies import get_sdk_client
 from nmp.core.jobs.api.dependencies import dep_dispatcher
 from nmp.core.jobs.api.v2.jobs.schemas import (
@@ -739,8 +738,9 @@ async def download_job_result(
         filename, tmp_dir_path = await download_from_result_info(
             result_name=name,
             job_name=job,
+            workspace=workspace,
             artifact_url=result.artifact_url,
-            sdk=with_options_preserving_request_router(sdk, workspace=workspace),
+            sdk=sdk,
         )
         background_tasks.add_task(lambda: tmp_dir_path.cleanup_tmp_dir())
         return FileResponse(path=tmp_dir_path.path, filename=filename, background=background_tasks)

--- a/services/core/jobs/tests/test_jobs_api.py
+++ b/services/core/jobs/tests/test_jobs_api.py
@@ -1096,8 +1096,8 @@ async def test_job_result_download(
 
     call_kwargs = factory.call_args.kwargs
     assert call_kwargs["job_name"] == sdk_job_resp.name
-    assert "workspace" not in call_kwargs
-    assert call_kwargs["sdk"].workspace == DEFAULT_WORKSPACE
+    assert call_kwargs["workspace"] == DEFAULT_WORKSPACE
+    assert call_kwargs["sdk"]._client is test_sdk._client
 
     # make sure we deleted the temp files on the server
     assert not tmp_dir.exists()

--- a/services/core/models/src/nmp/core/models/api/dependencies.py
+++ b/services/core/models/src/nmp/core/models/api/dependencies.py
@@ -17,16 +17,18 @@ from nmp.core.models.api.service.prompt_service import PromptService
 
 def get_model_entity_service(
     entity_client: EntityClient = Depends(get_entity_client),
+    nmp_sdk: AsyncNeMoPlatform = Depends(get_sdk_client),
 ) -> ModelEntityService:
     """Dependency to get ModelEntityService instance."""
-    return ModelEntityService(entity_client)
+    return ModelEntityService(entity_client, sdk=nmp_sdk)
 
 
 def get_adapter_entity_service(
     entity_client: EntityClient = Depends(get_entity_client),
+    nmp_sdk: AsyncNeMoPlatform = Depends(get_sdk_client),
 ) -> AdapterEntityService:
     """Dependency to get AdapterEntityService instance."""
-    return AdapterEntityService(entity_client)
+    return AdapterEntityService(entity_client, sdk=nmp_sdk)
 
 
 def get_model_provider_service(

--- a/services/core/models/tests/integration/conftest.py
+++ b/services/core/models/tests/integration/conftest.py
@@ -444,10 +444,16 @@ def controller_with_deployments_plugin(
             "nmp.core.models.controllers.backends.deployments_plugin.resolve.get_platform_config",
             return_value=mock_platform_config,
         ),
+        patch(
+            "nmp.core.models.controllers.backends.deployments_plugin.backend.get_async_platform_sdk"
+        ) as mock_deployments_backend_sdk,
         patch("nmp.core.models.controllers.models_controller.get_async_platform_sdk") as mock_models_sdk,
+        patch("nemo_deployments_plugin.controller.get_async_platform_sdk") as mock_deployments_controller_sdk,
         patch("nemo_platform_plugin.sdk_provider.get_async_platform_sdk") as mock_sdk,
         patch("nemo_deployments_plugin.config.DeploymentsConfig.get", return_value=deployments_config),
     ):
+        mock_deployments_backend_sdk.return_value = test_clients.async_sdk
+        mock_deployments_controller_sdk.return_value = test_clients.async_sdk
         mock_models_sdk.return_value = test_clients.async_sdk
         mock_sdk.return_value = test_clients.async_sdk
 

--- a/uv.lock
+++ b/uv.lock
@@ -5894,7 +5894,7 @@ requires-dist = [
     { name = "fastapi", extras = ["standard"], marker = "extra == 'auth-service'", specifier = ">=0.115.4" },
     { name = "fastapi", extras = ["standard"], marker = "extra == 'core-service'", specifier = ">=0.115.4" },
     { name = "fastapi", extras = ["standard"], marker = "extra == 'hello-world-service'", specifier = ">=0.115.4" },
-    { name = "fastapi", extras = ["standard"], marker = "extra == 'nmp-common'", specifier = ">=0.115.4" },
+    { name = "fastapi", extras = ["standard"], marker = "extra == 'nmp-common'", specifier = ">=0.137.2" },
     { name = "fastapi", extras = ["standard"], marker = "extra == 'services'", specifier = ">=0.115.4" },
     { name = "fastapi", extras = ["standard"], marker = "extra == 'studio-service'", specifier = ">=0.115.4" },
     { name = "fastmcp", marker = "extra == 'all'", specifier = ">=3.2.0" },
@@ -7882,7 +7882,7 @@ dev-dependencies = [
 requires-dist = [
     { name = "aiofiles", specifier = ">=24.1.0" },
     { name = "base58", specifier = ">=2.1.1" },
-    { name = "fastapi", extras = ["standard"], specifier = ">=0.115.4" },
+    { name = "fastapi", extras = ["standard"], specifier = ">=0.137.2" },
     { name = "huggingface-hub", specifier = ">=1.0.1,<2.0.0" },
     { name = "hvac", specifier = ">=2.3.0" },
     { name = "kubernetes", specifier = ">=30.1.0" },


### PR DESCRIPTION
## TL;DR

This PR moves platform SDK and typed-client routing into endpoint-owned HTTP clients/transports instead of patching SDK URL preparation. That keeps service-discovery, local-service, and Unix-socket routing intact across SDK clones, explicit clients, workload identity, and request-scoped headers.

It also tightens client lifecycle and delegated identity propagation for jobs, files, inference middleware plugins, Data Designer file access, and generated SDK header typing.

## Details

The platform endpoint model now builds a fixed routing table from local service config, `service_discovery`, and valid `NMP_<SERVICE>_URL` environment overrides. Requests under `/apis/{service}/...` are routed to the matching TCP or Unix-socket endpoint while preserving the original path and query string. Invalid service URL overrides are ignored when a safe fallback exists, and routing logs avoid recording full URLs with query values.

SDK creation now uses endpoint-aware sync and async HTTP clients for default, explicit, and workload-identity clients. SDK-owned clients are immutable after construction so headers, cookies, transports, and event hooks cannot be mutated after the client is shared through `copy()`/`with_options()` or typed-client adapters. Explicit caller-owned clients are wrapped for routing without transferring close ownership.

Request-scoped and delegated SDKs now rely on normal SDK `with_options()` cloning while preserving existing default headers, including omitted headers. Principal propagation now carries delegated principal ID, email, and groups through the platform SDK provider, file storage-secret resolution, task SDKs, and downstream service calls.

Jobs result and artifact downloads now pass workspace context explicitly and reuse the request SDK client rather than creating ad hoc scoped SDKs. The common result-manager wrapper can create its own async SDK when needed, and Data Designer file-system setup now provides both sync and async files clients when starting from an async platform SDK.

Inference Gateway now injects caller-owned service SDKs into middleware plugins before startup. The guardrails middleware uses that injected SDK and no longer creates or closes its own platform SDK, which keeps SDK lifecycle ownership inside IGW and avoids closing shared test/runtime clients.

Service route tagging now handles nested FastAPI routers through route contexts and the OpenAPI schema is registered eagerly. The FastAPI minimum for `nmp-common` is raised to `>=0.137.0` for that route-context support, and the vendored/generated SDK types now accept `Omit`/`Headers` values for default headers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added service-aware platform request routing, including Unix socket support and endpoint-specific clients.
  - Added workspace-aware job result downloads with automatic SDK creation when needed.
  - Added support for omitting selected default headers.
  - Added injectable HTTP clients and plugin-specific SDK injection for inference middleware.
  - Improved delegated identity propagation across platform and storage operations.

- **Bug Fixes**
  - Prevented SDK-owned HTTP client settings, headers, cookies, and hooks from being modified unexpectedly.
  - Improved handling of delegated identities and related headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->