### PR TITLE
fix: remove lint-python-sdk from CI lint suite

### DIFF
--- a/tools/lint/lint-all.sh
+++ b/tools/lint/lint-all.sh
@@ -18,7 +18,6 @@ declare -a scripts=(
   "lint-config-reference-docs:tools/lint/lint-config-reference-docs.sh"
   "lint-python-style:tools/lint/lint-python-style.sh"
   "lint-python-types:tools/lint/lint-python-types.sh"
-  "lint-python-sdk:tools/lint/lint-python-sdk.sh"
   "lint-sdk-vendored:tools/lint/lint-sdk-vendored.sh"
   "lint-web-sdk:tools/lint/lint-web-sdk.sh"
   "lint-cli:tools/lint/lint-cli.sh"


### PR DESCRIPTION
## Summary
- Removes the `lint-python-sdk` check from `tools/lint/lint-all.sh`. This check runs `nemo-platform-sdk-tools is-up-to-date`, which compares the OpenAPI spec against the Stainless-generated SDK snapshot.
- Stainless builds are currently stuck queued for this project — verified via `stl builds list --project nemo-platform`: the last several builds sit at `not_started` for every target until a newer build supersedes and cancels them, so none complete. This blocks the check independent of any actual spec/SDK drift, and is currently failing unrelated PRs (e.g. #1890). 

## Test plan
- [x] `tools/lint/lint-all.sh` no longer includes `lint-python-sdk` in its script list
- [x] Confirmed no other references to `lint-python-sdk` remain in the repo
- [x] `lint-sdk-vendored` (separate, unaffected check) still runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the linting workflow by removing one Python SDK lint check from the serial execution list.
  * All remaining lint checks and summary behavior are unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->