### PR TITLE
fix(evaluator): provision storage for retrieve eval

### DIFF
--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/retrieve_eval.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/retrieve_eval.py
@@ -167,7 +167,6 @@ class RetrieveEvalJob(NemoJob):
         """Compile a CPU task that calls the embedding target through IGW."""
         del workspace, entity_client, job_name, async_sdk, options
         canonical = RetrieveEvalSpec.model_validate(spec.model_dump())
-        environment = []
         secret_refs = [
             (model.api_key_env, model.api_key_secret.root)
             for retrieval in (canonical.target, canonical.baseline)
@@ -175,8 +174,7 @@ class RetrieveEvalJob(NemoJob):
             for model in (retrieval.embeddings, retrieval.reranker)
             if model is not None and model.api_key_secret is not None and model.api_key_env
         ]
-        if secret_refs:
-            environment = build_task_environment(secret_refs)
+        environment = build_task_environment(secret_refs)
         return PlatformJobSpec(
             steps=[
                 PlatformJobStep(

--- a/plugins/nemo-evaluator/tests/test_retrieve_eval_job.py
+++ b/plugins/nemo-evaluator/tests/test_retrieve_eval_job.py
@@ -27,6 +27,7 @@ from nemo_platform_plugin.client.client import NemoClient
 from nemo_platform_plugin.job_context import JobContext, StoragePaths
 from nemo_platform_plugin.job_results import LocalJobResults
 from nemo_platform_plugin.jobs.api_factory import CPUExecutionProviderSpec
+from nemo_platform_plugin.jobs.constants import PERSISTENT_JOB_STORAGE_PATH_ENVVAR
 from pydantic import ValidationError
 from pytest_mock import MockerFixture
 
@@ -139,6 +140,7 @@ async def test_compile_builds_cpu_retrieve_eval_task() -> None:
     assert step.name == "retrieve-eval"
     assert isinstance(step.executor, CPUExecutionProviderSpec)
     assert step.executor.container.command == ["nemo_evaluator.tasks.retrieve_eval"]
+    assert [variable.name for variable in step.environment] == [PERSISTENT_JOB_STORAGE_PATH_ENVVAR]
 
 
 def test_run_validates_fileset_and_persists_nemotron_keys(tmp_path: Path, mocker: MockerFixture) -> None:


### PR DESCRIPTION
## Summary
- always provision persistent job storage for retrieve-eval, including ModelRef targets without endpoint secrets
- add a compiler regression assertion for the required storage environment

## Root cause
`RetrieveEvalJob.run()` writes datasets and result artifacts through `ctx.storage.persistent`, but `compile()` only called `build_task_environment()` when endpoint SecretRefs existed. ModelRef/IGW submissions therefore compiled with an empty environment and failed before dataset validation.

## Validation
- `.venv/bin/pytest -q plugins/nemo-evaluator/tests/test_retrieve_eval_job.py` (10 passed)
- `.venv/bin/ruff check ...`
- `.venv/bin/ruff format --check ...`

Live release/0.6 BEIR rerun evidence will be added after rebuilding and deploying the source image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved evaluation job setup so collected secret references are consistently applied.
  - Ensured generated executors expose the persistent job storage environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->