### PR TITLE
fix(evaluator): support NVIDIA hosted rerank contract

### DIFF
--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/retrieval/nim_ranking.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/retrieval/nim_ranking.py
@@ -16,6 +16,8 @@ from pydantic import BaseModel, ConfigDict, Field
 
 __all__ = ["NimRankingClient", "NimRankingError"]
 
+_NVIDIA_HOSTED_INFERENCE_HOSTS = frozenset({"inference-api.nvidia.com", "integrate.api.nvidia.com"})
+
 
 class NimRankingError(RuntimeError):
     """Raised when NIM returns an unusable ranking response."""
@@ -46,15 +48,24 @@ class NimRankingClient(BaseModel):
             client = httpx.AsyncClient(timeout=self.timeout)
         try:
             for attempt in range(self.max_retries + 1):
+                hosted_contract = _uses_nvidia_hosted_contract(self.model)
                 response = await client.post(
-                    _ranking_url(self.model.url),
+                    _rerank_url(self.model.url) if hosted_contract else _ranking_url(self.model.url),
                     headers=_headers(self.model),
-                    json={
-                        "model": self.model.name,
-                        "query": {"text": query},
-                        "passages": [{"text": passage} for passage in passages],
-                        "truncate": truncate,
-                    },
+                    json=(
+                        {
+                            "model": self.model.name,
+                            "query": query,
+                            "documents": passages,
+                        }
+                        if hosted_contract
+                        else {
+                            "model": self.model.name,
+                            "query": {"text": query},
+                            "passages": [{"text": passage} for passage in passages],
+                            "truncate": truncate,
+                        }
+                    ),
                 )
                 response.raise_for_status()
                 ranked = _parse_rankings(response, expected_count=len(passages))
@@ -83,6 +94,23 @@ def _ranking_url(url: str) -> str:
     return urlunparse(parsed._replace(path=path))
 
 
+def _rerank_url(url: str) -> str:
+    parsed = urlparse(url)
+    path = parsed.path.rstrip("/")
+    for suffix in ("/chat/completions", "/completions", "/embeddings", "/reranking", "/ranking"):
+        if path.endswith(suffix):
+            path = path[: -len(suffix)]
+            break
+    if not path.endswith("/rerank"):
+        path = f"{path}/rerank"
+    return urlunparse(parsed._replace(path=path))
+
+
+def _uses_nvidia_hosted_contract(model: Model) -> bool:
+    endpoint = model.host_url or model.url
+    return urlparse(endpoint).hostname in _NVIDIA_HOSTED_INFERENCE_HOSTS
+
+
 def _headers(model: Model) -> dict[str, str]:
     return {
         "Authorization": f"Bearer {model.api_key or PLACEHOLDER_INFERENCE_API_KEY}",
@@ -99,7 +127,10 @@ def _parse_rankings(response: httpx.Response, expected_count: int) -> list[tuple
         rankings = payload.get("rankings", payload.get("results"))
         if not isinstance(rankings, list):
             raise TypeError("ranking response must include a rankings list")
-        parsed = [(int(item["index"]), float(item.get("logit", item.get("score")))) for item in rankings]
+        parsed = [
+            (int(item["index"]), float(item.get("logit", item.get("score", item.get("relevance_score")))))
+            for item in rankings
+        ]
     except (KeyError, TypeError, ValueError) as error:
         raise NimRankingError("ranking endpoint returned an invalid response") from error
     if len(parsed) != expected_count:

--- a/packages/nemo_evaluator_sdk/tests/retrieval/test_nim_ranking.py
+++ b/packages/nemo_evaluator_sdk/tests/retrieval/test_nim_ranking.py
@@ -56,6 +56,45 @@ async def test_ranking_client_rewrites_reranking_and_embeddings_routes() -> None
 
 
 @pytest.mark.asyncio
+async def test_ranking_client_uses_nvidia_hosted_rerank_contract() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            request=request,
+            content=json.dumps(
+                {
+                    "results": [
+                        {"index": 1, "relevance_score": 0.8},
+                        {"index": 0, "relevance_score": 0.1},
+                    ]
+                }
+            ),
+            headers={"content-type": "application/json"},
+        )
+
+    model = Model(
+        url="https://platform.test/apis/inference-gateway/v2/workspaces/default/model/reranker/-/v1",
+        host_url="https://inference-api.nvidia.com/v1",
+        name="nvidia-nvidia-llama-nemotron-rerank-vl-1b-v2",
+    )
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        ranked = await NimRankingClient(model=model).rank("q", ["first", "second"], client=client)
+
+    assert ranked == [(1, 0.8), (0, 0.1)]
+    assert requests[0].url == (
+        "https://platform.test/apis/inference-gateway/v2/workspaces/default/model/reranker/-/v1/rerank"
+    )
+    assert json.loads(requests[0].content) == {
+        "model": "nvidia-nvidia-llama-nemotron-rerank-vl-1b-v2",
+        "query": "q",
+        "documents": ["first", "second"],
+    }
+
+
+@pytest.mark.asyncio
 async def test_ranking_client_retries_non_finite_logits() -> None:
     attempts = 0
 


### PR DESCRIPTION
## Summary

- use the NVIDIA hosted `/v1/rerank` request contract for ModelRefs backed by `inference-api.nvidia.com` or `integrate.api.nvidia.com`
- parse hosted `results[].relevance_score` responses
- preserve the existing `/v1/ranking` NIM contract for self-hosted rerankers

## Why

The hosted rerank models discovered by the NVIDIA provider reject the legacy NIM `/v1/ranking` route with a backend 404. The same ModelRefs work through the inference gateway when called with `/v1/rerank`, `query`, and `documents`.

## Validation

- `uv run --frozen pytest -q packages/nemo_evaluator_sdk/tests/retrieval` — 23 passed
- `uv run --frozen ruff check ...` — passed
- `uv run --frozen ruff format --check ...` — passed
- `uv run --frozen ty check packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/retrieval/nim_ranking.py` — passed
- rebuilt `my-registry/nmp-cpu-tasks:local` from this change combined with the retrieve-eval persistent-storage fix
- real K8s BEIR retrieve-eval, DevTest template 3949036:
  - `default/nvidia-nvidia-llama-nemotron-rerank-vl-1b-v2` — passed
  - `default/nvidia-qwen-qwen3-reranker-8b` — passed

No mocked service was used for the live validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reranking support for NVIDIA-hosted inference endpoints.
  * Hosted endpoints now use the appropriate `/rerank` route and request format.
  * Added support for responses using `relevance_score` values.
  * Existing behavior for other endpoints remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->