### PR TITLE
fix(evaluator): persist agent runtime evidence in result bundle

### DIFF
--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/agent_evaluate.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/agent_evaluate.py
@@ -616,12 +616,14 @@ class AgentEvalJob(NemoJob):
         spec = AgentEvalSpec.model_validate(config)
         tasks = [_to_runtime_task(task) for task in spec.tasks]
         target, prompt_template, params = self._resolve_target(spec.target, ctx)
+        bundle_dir = ctx.storage.persistent / AGENT_BUNDLE_DIR
         run_config = AgentEvalRunConfig(
             params=params,
             prompt_template=prompt_template,
             parallelism=spec.max_concurrent_tasks,
             labels=spec.labels,
             fail_fast=spec.fail_fast,
+            work_dir=bundle_dir,
         )
         # `run` may be injected a sync `sdk` (submitted jobs, via get_task_nemo_client) and/or an
         # `async_sdk`; forward whichever identity is present, preferring async when both are — the

--- a/plugins/nemo-evaluator/tests/test_agent_evaluate.py
+++ b/plugins/nemo-evaluator/tests/test_agent_evaluate.py
@@ -63,6 +63,7 @@ from nemo_evaluator_sdk.agent_eval.trials import (
 from nemo_evaluator_sdk.enums import AgentFormat
 from nemo_evaluator_sdk.metrics.exact_match import ExactMatchMetric
 from nemo_evaluator_sdk.values import Agent, GenericAgent, Model, RunConfigOnline, RunConfigOnlineModel, SecretRef
+from nemo_evaluator_sdk.values.evidence import CandidateEvidence, EvidenceDescriptor
 from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
 from nemo_platform_plugin.client.client import AsyncNemoClient, NemoClient
 from nemo_platform_plugin.client.errors import InternalServerError, NemoResponseValidationError, NemoTransportError
@@ -257,9 +258,48 @@ def test_agent_eval_job_reconstructs_tasks_and_persists_bundle(tmp_path: Path, m
     assert (bundle / "trials.jsonl").exists()
     assert (bundle / "scores.jsonl").exists()
     assert (bundle / "summary.json").exists()
+    assert fake.received_config is not None
+    assert fake.received_config.work_dir == bundle
     assert (ctx.storage.persistent / "results" / DEFAULT_RESULT_NAME).exists()
     assert (ctx.storage.persistent / "results" / SUMMARY_RESULT_NAME).exists()
     assert result["artifact"]["name"] == DEFAULT_RESULT_NAME
+
+
+def test_agent_eval_job_keeps_runtime_evidence_inside_downloadable_bundle(
+    tmp_path: Path, mocker: MockerFixture
+) -> None:
+    class EvidenceWritingEvaluator(_FakeEvaluator):
+        def run_sync(
+            self,
+            *,
+            tasks: Sequence[AgentEvalTask],
+            trials: Sequence[AgentEvalTrial] | None = None,
+            target: AgentEvalTarget | None = None,
+            config: AgentEvalRunConfig | None = None,
+        ) -> AgentEvalResult:
+            assert config is not None and config.work_dir is not None
+            capture = Path(config.work_dir) / "gym_run" / "model_calls" / "0-0.capture.jsonl"
+            capture.parent.mkdir(parents=True)
+            capture.write_text('{"model_call_id":"call-1"}\n', encoding="utf-8")
+            result = super().run_sync(tasks=tasks, trials=trials, target=target, config=config)
+            result.trials[0].evidence = CandidateEvidence(
+                descriptors={"ng_trajectory": EvidenceDescriptor(kind="filesystem", format="file", ref=str(capture))}
+            )
+            return result
+
+    fake = EvidenceWritingEvaluator()
+    mocker.patch.object(AgentEvalJob, "_build_evaluator", return_value=fake)
+    ctx = _job_context(tmp_path)
+
+    spec = AgentEvalSpec(tasks=[_task_spec()], target=_runner_target("openai/gpt-5.4"))
+    AgentEvalJob().run(spec.model_dump(), ctx=ctx)
+
+    bundle = ctx.storage.persistent / AGENT_BUNDLE_DIR
+    capture_rel = Path("gym_run/model_calls/0-0.capture.jsonl")
+    assert (bundle / capture_rel).read_text(encoding="utf-8") == '{"model_call_id":"call-1"}\n'
+    persisted_trial = json.loads((bundle / "trials.jsonl").read_text(encoding="utf-8"))
+    assert persisted_trial["evidence"]["descriptors"]["ng_trajectory"]["ref"] == capture_rel.as_posix()
+    assert (ctx.storage.persistent / "results" / DEFAULT_RESULT_NAME / capture_rel).exists()
 
 
 def test_agent_eval_job_survives_result_persistence_failure(tmp_path: Path, mocker: MockerFixture) -> None:


### PR DESCRIPTION
## Summary

Agent evaluation jobs did not pass a working directory to the evaluator, so Gym runtime evidence was created under a temporary `/tmp/gym_sandboxed_run_*` directory outside persistent Job storage. Downloaded result bundles therefore omitted raw captures and rollouts while retaining unusable absolute references. This change places runtime evidence directly inside the canonical downloadable `agent-eval` bundle.

## Changes

- Pass the persistent `agent-eval` bundle directory as `AgentEvalRunConfig.work_dir`.
- Verify generated evidence is stored in the bundle and persisted references are relative and portable.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: This restores the documented downloadable-result behavior without changing the public API.

## Verification

- [x] Pull request title follows the repositorys Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `pytest plugins/nemo-evaluator/tests/test_agent_evaluate.py`: 77 passed.
- `ruff check` and `ruff format --check` for both changed files: passed.
- `ty check` for both changed files in a clean Flox/uv environment: passed.
- Rebuilt `my-registry/nmp-cpu-tasks:local` from this commit and imported it into the live QA k3d cluster.
- Real model-backed Gym Job against the release/0.6 Platform deployment: raw-capture persistence and persisted-secret redaction cases both passed (2/2).
- Downloaded artifact verification: `gym_run/model_calls/0-0.capture.jsonl` and `gym_run/rollouts.jsonl` are present, and `trials.jsonl` contains portable relative references to both.
- Full repository pre-commit was not run; focused lint, format, type, unit, image, and live end-to-end gates above passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Runtime evidence files are now preserved in downloadable agent-evaluation bundles.
  * Evidence references remain valid when evaluation results are persisted and retrieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->