### PR TITLE
fix(agents): cherry pick k8s deployment fixes

### DIFF
--- a/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/deployments.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/deployments.py
@@ -108,6 +108,18 @@ async def create_deployment(
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
+    # The runner fails the deployment for this; the answer is already available here.
+    if is_container_deployment_mode(body.deployment_mode) and not (
+        body.image or AgentsConfig.get().deployments.default_image
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"deployment_mode '{body.deployment_mode}' requires a container image. "
+                "Set 'image' on the request, or configure 'deployments.default_image'."
+            ),
+        )
+
     # 3. Resolve deployment-time config. NAT workflows need legacy injection;
     # Platform-owned agent configs stay strict and are translated by the runner.
     resolved_config = _resolve_deployment_config(agent, workspace=workspace)

--- a/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/deployments.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/deployments.py
@@ -25,6 +25,7 @@ from nemo_agents_plugin.agent_config_formats import AgentConfigFormatError, reso
 from nemo_agents_plugin.api.v2._perms import DeploymentPerms
 from nemo_agents_plugin.api.v2.dependencies import get_entity_client
 from nemo_agents_plugin.authz import scope
+from nemo_agents_plugin.config import AgentsConfig
 from nemo_agents_plugin.entities import (
     Agent,
     AgentDeployment,
@@ -38,6 +39,10 @@ from nemo_agents_plugin.environment_resolution import (
     ResolvedEnvironment,
     merge_environment_spec_into_agent_config,
     resolve_environment,
+)
+from nemo_agents_plugin.runner.deployments_backend import (
+    executor_for_mode,
+    require_executor_matches_mode,
 )
 from nemo_agents_plugin.schema import (
     CreateDeploymentRequest,
@@ -93,6 +98,15 @@ async def create_deployment(
             status_code=400,
             detail="use_image_entrypoint requires deployment_mode 'docker' or 'k8s'.",
         )
+
+    # The controller refuses this too, but only on its next reconcile — by which
+    # point a pending deployment exists and the caller has had its 201.
+    if is_container_deployment_mode(body.deployment_mode):
+        runner_config = AgentsConfig.get().deployments
+        try:
+            require_executor_matches_mode(executor_for_mode(runner_config, body.deployment_mode), body.deployment_mode)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     # 3. Resolve deployment-time config. NAT workflows need legacy injection;
     # Platform-owned agent configs stay strict and are translated by the runner.

--- a/plugins/nemo-agents/src/nemo_agents_plugin/fabric/environment.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/fabric/environment.py
@@ -3,9 +3,66 @@
 
 """Prepare Platform-owned environment paths before Fabric runtime startup."""
 
+import logging
+import os
+import shutil
+import stat
+import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 
 from nemo_agents_plugin.agent_config import AgentConfig
+
+logger = logging.getLogger(__name__)
+
+#: Prefix for the directory an agent tree is copied to when its mounted location
+#: cannot be written to.
+RUNTIME_BASE_DIR_PREFIX = "nemo-agent-runtime"
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeBaseDir:
+    """An agent root the runtime can write to, and whether this process created it."""
+
+    path: Path
+    staged: bool
+
+
+def resolve_runtime_base_dir(config_path: Path) -> RuntimeBaseDir:
+    """Return an agent root the runtime can write to, copying the tree out if it cannot.
+
+    Fabric resolves everything against the agent root — skills and prompts to
+    read, but also the workspace and artifacts to write. In k8s the agent config
+    arrives on a read-only ConfigMap ``subPath`` whose parent kubelet creates as
+    root, so the runtime user can read its agent but cannot create anything
+    beside it. Docker has no such mount and is unaffected.
+
+    A staged copy belongs to one process lifecycle: it goes to a fresh directory
+    and :func:`release_runtime_base_dir` removes it at shutdown, so a later
+    runtime can never read skills or prompts left behind by an earlier one. The
+    tree is bounded by the spec-fileset staging limits, so copying it is cheap
+    next to starting a runtime.
+    """
+    source = config_path.parent
+    if os.access(source, os.W_OK):
+        return RuntimeBaseDir(path=source, staged=False)
+
+    target = Path(tempfile.mkdtemp(prefix=f"{RUNTIME_BASE_DIR_PREFIX}-"))
+    logger.info("Agent root %s is not writable; staging it to %s for the runtime.", source, target)
+    shutil.copytree(source, target, dirs_exist_ok=True)
+    # copytree carries the source's mode across, so the copy of a read-only mount
+    # is read-only too — restore write access on the directories we just made.
+    for directory in (target, *(path for path in target.rglob("*") if path.is_dir())):
+        directory.chmod(directory.stat().st_mode | stat.S_IRWXU)
+    return RuntimeBaseDir(path=target, staged=True)
+
+
+def release_runtime_base_dir(base_dir: RuntimeBaseDir) -> None:
+    """Remove a staged agent root. A root used in place is left alone."""
+    if not base_dir.staged:
+        return
+    shutil.rmtree(base_dir.path, ignore_errors=True)
+    logger.info("Removed staged agent root %s.", base_dir.path)
 
 
 def ensure_local_workspace_dir(agent_config: AgentConfig, base_dir: Path) -> None:

--- a/plugins/nemo-agents/src/nemo_agents_plugin/fabric/server.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/fabric/server.py
@@ -19,6 +19,7 @@ from typing import Annotated, Any
 from fastapi import FastAPI, Header, HTTPException, Response
 from fastapi.responses import StreamingResponse
 from nemo_agents_plugin.agent_config import AgentConfig, load_agent_config
+from nemo_agents_plugin.fabric.environment import release_runtime_base_dir, resolve_runtime_base_dir
 from nemo_agents_plugin.fabric.runtime import (
     FabricInvocationRequest,
     FabricRuntimeExecutionError,
@@ -245,37 +246,45 @@ def create_fabric_serving_app(
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         agent_config = load_agent_config(config_path)
-        validation_result = await _validate_agent_config(agent_config, base_dir=config_path.parent)
-        app.state.agent_config = agent_config
-        app.state.base_dir = config_path.parent
-        app.state.validation_result = validation_result
-        session_registry = FabricSessionRegistry()
-        app.state.session_registry = session_registry
-        session_manager = FabricSessionManager(
-            agent_config,
-            base_dir=config_path.parent,
-            session_registry=session_registry,
-            max_concurrent_invocations=settings.max_concurrent_invocations,
-        )
-        app.state.session_manager = session_manager
-        cleanup_shutdown = asyncio.Event()
-        cleanup_task = asyncio.create_task(
-            _run_idle_session_cleanup(
-                session_manager,
-                idle_timeout_seconds=settings.idle_session_timeout_seconds,
-                cleanup_interval_seconds=settings.session_cleanup_interval_seconds,
-                shutdown_event=cleanup_shutdown,
-            )
-        )
-        logger.info("Validated Fabric-backed agent config at %s", config_path)
+        runtime_base_dir = await asyncio.to_thread(resolve_runtime_base_dir, config_path)
+        base_dir = runtime_base_dir.path
+        # Startup can still fail past this point, and a staged root must not outlive
+        # the process that made it even when the runtime never comes up.
         try:
-            yield
-        finally:
-            cleanup_shutdown.set()
+            validation_result = await _validate_agent_config(agent_config, base_dir=base_dir)
+            app.state.agent_config = agent_config
+            app.state.base_dir = base_dir
+            app.state.validation_result = validation_result
+            session_registry = FabricSessionRegistry()
+            app.state.session_registry = session_registry
+            session_manager = FabricSessionManager(
+                agent_config,
+                base_dir=base_dir,
+                session_registry=session_registry,
+                max_concurrent_invocations=settings.max_concurrent_invocations,
+            )
+            app.state.session_manager = session_manager
+            cleanup_shutdown = asyncio.Event()
+            cleanup_task = asyncio.create_task(
+                _run_idle_session_cleanup(
+                    session_manager,
+                    idle_timeout_seconds=settings.idle_session_timeout_seconds,
+                    cleanup_interval_seconds=settings.session_cleanup_interval_seconds,
+                    shutdown_event=cleanup_shutdown,
+                )
+            )
+            logger.info("Validated Fabric-backed agent config at %s", config_path)
             try:
-                await cleanup_task
+                yield
             finally:
-                await session_manager.close_all_sessions()
+                cleanup_shutdown.set()
+                try:
+                    await cleanup_task
+                finally:
+                    # A staged root is only safe to remove once no runtime can still write to it.
+                    await session_manager.close_all_sessions()
+        finally:
+            await asyncio.to_thread(release_runtime_base_dir, runtime_base_dir)
 
     app = FastAPI(title="NeMo Agents Fabric Server", lifespan=lifespan)
 

--- a/plugins/nemo-agents/src/nemo_agents_plugin/runner/deployments_backend.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/runner/deployments_backend.py
@@ -337,6 +337,45 @@ def executor_for_mode(config: DeploymentsRunnerConfig, mode: DeploymentMode) -> 
     return config.default_executor
 
 
+def executor_backend(name: str | None) -> str | None:
+    """Return the backend key the deployments plugin would run *name* on.
+
+    An unset name is not "no executor": ``ExecutorRegistry.resolve`` falls back to
+    the deployments plugin's own ``default_executor``, so resolving it here is what
+    makes the mode check see the executor that will actually run.
+    """
+    from nemo_deployments_plugin.config import DeploymentsConfig
+
+    config = DeploymentsConfig.get()
+    resolved = name or config.default_executor
+    if not resolved:
+        return None
+    for entry in config.executors:
+        if entry.name == resolved:
+            return entry.backend
+    return None
+
+
+def require_executor_matches_mode(executor: str | None, mode: DeploymentMode) -> None:
+    """Refuse a container mode that would run somewhere other than it names.
+
+    ``executor_for_mode`` falls back to ``default_executor``, so asking for k8s
+    where none is configured silently lands on docker: the deployment reports
+    running while nothing exists in the cluster, and a k8s-only failure cannot
+    reproduce. The backend keys and the deployment modes share a vocabulary, so
+    the mismatch is checkable here rather than discoverable by counting pods.
+    """
+    backend = executor_backend(executor)
+    if backend is None or backend == mode:
+        return
+    alternative = f", or deploy with deployment_mode {backend!r}" if backend in CONTAINER_DEPLOYMENT_MODES else ""
+    raise ValueError(
+        f"deployment_mode {mode!r} resolved to executor {executor!r}, which runs on "
+        f"{backend!r}. Set 'deployments.{mode}_executor' to an executor whose backend "
+        f"is {mode!r}{alternative}."
+    )
+
+
 _HTTP_PROTOCOLS = frozenset({"http", "https"})
 
 
@@ -549,6 +588,12 @@ class DeploymentsRunnerBackend(RunnerBackend):
                 status="failed",
                 error=f"DeploymentsRunnerBackend does not support deployment_mode={deployment_mode!r}.",
             )
+
+        try:
+            require_executor_matches_mode(executor_for_mode(self._config, deployment_mode), deployment_mode)
+        except ValueError as exc:
+            logger.error("Refusing to deploy agent %r: %s", name, exc)
+            return DeploymentInfo(name=name, status="failed", error=str(exc))
 
         resolved_image = image or self._config.default_image
         if not resolved_image:

--- a/plugins/nemo-agents/tests/unit/test_deployments_api.py
+++ b/plugins/nemo-agents/tests/unit/test_deployments_api.py
@@ -178,6 +178,66 @@ class TestCreateDeployment:
         # The controller would have failed this on reconcile; nothing should persist.
         mock_entity_client.create.assert_not_called()
 
+    def test_create_rejects_container_deployment_with_no_resolvable_image(self) -> None:
+        mock_entity_client = AsyncMock()
+        mock_entity_client.get = AsyncMock(return_value=_make_agent())
+        client = _test_client(mock_entity_client)
+
+        resp = client.post(
+            "/apis/agents/v2/workspaces/default/deployments",
+            json={"agent": "fabric-agent", "name": "fabric-dep", "deployment_mode": "docker"},
+        )
+
+        assert resp.status_code == 400
+        assert "requires a container image" in resp.json()["detail"]
+        assert "deployments.default_image" in resp.json()["detail"]
+        mock_entity_client.create.assert_not_called()
+
+    def test_create_allows_container_deployment_without_image_when_a_default_is_configured(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config = AgentsConfig.get()
+        monkeypatch.setattr(config.deployments, "default_image", "registry.example/agent:pinned")
+        monkeypatch.setattr(AgentsConfig, "get", classmethod(lambda cls: config))
+        mock_entity_client = AsyncMock()
+        mock_entity_client.get = AsyncMock(return_value=_make_agent())
+
+        async def _save_deployment(deployment: AgentDeployment) -> AgentDeployment:
+            deployment._id = f"deployment-{deployment.name}-id"
+            deployment._created_at = NOW
+            return deployment
+
+        mock_entity_client.create = AsyncMock(side_effect=_save_deployment)
+        client = _test_client(mock_entity_client)
+
+        resp = client.post(
+            "/apis/agents/v2/workspaces/default/deployments",
+            json={"agent": "fabric-agent", "name": "fabric-dep", "deployment_mode": "docker"},
+        )
+
+        assert resp.status_code == 201
+        created_deployment: AgentDeployment = mock_entity_client.create.call_args[0][0]
+        assert created_deployment.image == ""
+
+    def test_create_allows_subprocess_deployment_without_an_image(self) -> None:
+        mock_entity_client = AsyncMock()
+        mock_entity_client.get = AsyncMock(return_value=_make_agent())
+
+        async def _save_deployment(deployment: AgentDeployment) -> AgentDeployment:
+            deployment._id = f"deployment-{deployment.name}-id"
+            deployment._created_at = NOW
+            return deployment
+
+        mock_entity_client.create = AsyncMock(side_effect=_save_deployment)
+        client = _test_client(mock_entity_client)
+
+        resp = client.post(
+            "/apis/agents/v2/workspaces/default/deployments",
+            json={"agent": "fabric-agent", "name": "fabric-dep", "deployment_mode": "subprocess"},
+        )
+
+        assert resp.status_code == 201
+
     def test_create_rejects_image_entrypoint_for_subprocess(self) -> None:
         mock_entity_client = AsyncMock()
         mock_entity_client.get = AsyncMock(return_value=_make_agent())

--- a/plugins/nemo-agents/tests/unit/test_deployments_api.py
+++ b/plugins/nemo-agents/tests/unit/test_deployments_api.py
@@ -9,10 +9,12 @@ from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import AsyncMock
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from nemo_agents_plugin.api.v2 import deployments as deployments_router_module
 from nemo_agents_plugin.api.v2.dependencies import get_entity_client
+from nemo_agents_plugin.config import AgentsConfig
 from nemo_agents_plugin.entities import (
     NEMO_AGENTS_SPEC_CONFIG_FORMAT,
     Agent,
@@ -20,6 +22,7 @@ from nemo_agents_plugin.entities import (
     AgentDeployment,
     AgentEnvironment,
     AgentEnvironmentSpec,
+    ComputeResources,
     DeploymentStatus,
 )
 from nemo_platform_plugin.entity_client import NemoEntityConflictError, NemoEntityNotFoundError
@@ -145,6 +148,36 @@ class TestCreateDeployment:
         assert created_deployment.image == "hand-built-agent:latest"
         assert created_deployment.use_image_entrypoint is True
 
+    def test_create_rejects_a_mode_the_executor_will_not_honour(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from nemo_deployments_plugin.config import DeploymentsConfig, ExecutorConfigEntry
+
+        # A standalone config: DeploymentsConfig.get() is a cached singleton, and
+        # assigning to it would outlive this test.
+        deployments_cfg = DeploymentsConfig(executors=[ExecutorConfigEntry(name="default-exec", backend="docker")])
+        monkeypatch.setattr(DeploymentsConfig, "get", classmethod(lambda cls: deployments_cfg))
+        agents_cfg = AgentsConfig.get()
+        monkeypatch.setattr(agents_cfg.deployments, "default_executor", "default-exec")
+        monkeypatch.setattr(agents_cfg.deployments, "k8s_executor", None)
+        monkeypatch.setattr(AgentsConfig, "get", classmethod(lambda cls: agents_cfg))
+        mock_entity_client = AsyncMock()
+        mock_entity_client.get = AsyncMock(return_value=_make_agent())
+        client = _test_client(mock_entity_client)
+
+        resp = client.post(
+            "/apis/agents/v2/workspaces/default/deployments",
+            json={
+                "agent": "fabric-agent",
+                "name": "fabric-dep",
+                "deployment_mode": "k8s",
+                "image": "registry.example/agent:1.0",
+            },
+        )
+
+        assert resp.status_code == 400
+        assert "runs on 'docker'" in resp.json()["detail"]
+        # The controller would have failed this on reconcile; nothing should persist.
+        mock_entity_client.create.assert_not_called()
+
     def test_create_rejects_image_entrypoint_for_subprocess(self) -> None:
         mock_entity_client = AsyncMock()
         mock_entity_client.get = AsyncMock(return_value=_make_agent())
@@ -173,7 +206,7 @@ class TestCreateDeployment:
             env={"CUSTOM": "from-spec"},
             secrets={"APP_TOKEN": "default/app-token"},
         )
-        cspec = AgentComputeSpec(name="cspec", workspace="default", resources={"limits": {"cpu": "2"}})
+        cspec = AgentComputeSpec(name="cspec", workspace="default", resources=ComputeResources(limits={"cpu": "2"}))
 
         mock_entity_client = AsyncMock()
         # get order: agent (route), then AgentEnvironment, env spec, compute spec (resolver).

--- a/plugins/nemo-agents/tests/unit/test_environment_resolution.py
+++ b/plugins/nemo-agents/tests/unit/test_environment_resolution.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+import os
+from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock
 
@@ -15,6 +17,7 @@ from nemo_agents_plugin.entities import (
     AgentEnvironment,
     AgentEnvironmentInline,
     AgentEnvironmentSpec,
+    ComputeResources,
     ComputeSpecInline,
     EnvironmentSpecInline,
     McpFulfillment,
@@ -57,7 +60,7 @@ async def test_resolve_none_returns_empty() -> None:
 async def test_resolve_inline_environment_with_inline_specs() -> None:
     environment = AgentEnvironmentInline(
         environment_spec=EnvironmentSpecInline(env={"FOO": "bar"}),
-        compute_spec=ComputeSpecInline(resources={"limits": {"cpu": "2"}}),
+        compute_spec=ComputeSpecInline(resources=ComputeResources(limits={"cpu": "2"})),
     )
     resolved = await resolve_environment(environment, workspace="default", entity_client=AsyncMock())
     assert resolved.environment_spec is not None
@@ -75,7 +78,7 @@ async def test_resolve_environment_ref_dereferences_all_entities() -> None:
         compute_spec="default/cspec",
     )
     espec = AgentEnvironmentSpec(name="espec", workspace="default", env={"A": "1"})
-    cspec = AgentComputeSpec(name="cspec", workspace="default", resources={"requests": {"cpu": "1"}})
+    cspec = AgentComputeSpec(name="cspec", workspace="default", resources=ComputeResources(requests={"cpu": "1"}))
 
     entity_client = AsyncMock()
     entity_client.get = AsyncMock(side_effect=[env_entity, espec, cspec])
@@ -299,3 +302,121 @@ def test_merge_no_environment_reference_is_identical_to_today() -> None:
     result = merge_environment_spec_into_agent_config(config, None)
     assert result.config == config
     assert result.secrets == {}
+
+
+class TestRuntimeBaseDir:
+    """Fabric resolves both reads and writes against the agent root, so a root the
+    runtime cannot write to breaks session startup rather than config loading."""
+
+    @staticmethod
+    def _unwritable_root(tmp_path: Path, name: str = "mounted") -> Path:
+        mounted = tmp_path / name
+        (mounted / "skills").mkdir(parents=True)
+        (mounted / "agent.yaml").write_text("config_format: nemo-agents-spec-v1\n")
+        (mounted / "skills" / "SKILL.md").write_text(f"# {name}\n")
+        # Mirrors a ConfigMap subPath parent: readable and executable, not writable.
+        mounted.chmod(0o555)
+        return mounted
+
+    def test_a_writable_agent_root_is_used_as_is(self, tmp_path: Path) -> None:
+        from nemo_agents_plugin.fabric.environment import resolve_runtime_base_dir
+
+        config = tmp_path / "agent.yaml"
+        config.write_text("config_format: nemo-agents-spec-v1\n")
+
+        base_dir = resolve_runtime_base_dir(config)
+
+        assert base_dir.path == tmp_path
+        assert base_dir.staged is False
+
+    def test_an_unwritable_agent_root_is_staged_somewhere_writable(self, tmp_path: Path) -> None:
+        from nemo_agents_plugin.fabric.environment import resolve_runtime_base_dir
+
+        mounted = self._unwritable_root(tmp_path)
+        try:
+            base_dir = resolve_runtime_base_dir(mounted / "agent.yaml")
+
+            assert base_dir.path != mounted
+            assert base_dir.staged is True
+            assert os.access(base_dir.path, os.W_OK)
+            # Sibling artifacts must survive the move or skills.paths stops resolving.
+            assert (base_dir.path / "skills" / "SKILL.md").read_text() == "# mounted\n"
+            assert (base_dir.path / "agent.yaml").exists()
+        finally:
+            mounted.chmod(0o755)
+
+    def test_each_lifecycle_stages_to_its_own_directory(self, tmp_path: Path) -> None:
+        from nemo_agents_plugin.fabric.environment import resolve_runtime_base_dir
+
+        mounted = self._unwritable_root(tmp_path)
+        try:
+            first = resolve_runtime_base_dir(mounted / "agent.yaml")
+            second = resolve_runtime_base_dir(mounted / "agent.yaml")
+
+            assert first.path != second.path
+        finally:
+            mounted.chmod(0o755)
+
+    def test_a_staged_root_never_inherits_an_earlier_pass(self, tmp_path: Path) -> None:
+        from nemo_agents_plugin.fabric.environment import (
+            release_runtime_base_dir,
+            resolve_runtime_base_dir,
+        )
+
+        mounted = self._unwritable_root(tmp_path)
+        try:
+            first = resolve_runtime_base_dir(mounted / "agent.yaml")
+            (first.path / "skills" / "STALE.md").write_text("# dropped skill\n")
+            release_runtime_base_dir(first)
+
+            second = resolve_runtime_base_dir(mounted / "agent.yaml")
+
+            assert not (second.path / "skills" / "STALE.md").exists()
+            assert (second.path / "skills" / "SKILL.md").exists()
+        finally:
+            mounted.chmod(0o755)
+
+    def test_two_agent_roots_stage_to_separate_directories(self, tmp_path: Path) -> None:
+        from nemo_agents_plugin.fabric.environment import resolve_runtime_base_dir
+
+        roots = [self._unwritable_root(tmp_path, name) for name in ("first", "second")]
+        try:
+            first = resolve_runtime_base_dir(roots[0] / "agent.yaml")
+            second = resolve_runtime_base_dir(roots[1] / "agent.yaml")
+
+            assert first.path != second.path
+            assert (first.path / "skills" / "SKILL.md").read_text() == "# first\n"
+            assert (second.path / "skills" / "SKILL.md").read_text() == "# second\n"
+        finally:
+            for mounted in roots:
+                mounted.chmod(0o755)
+
+    def test_releasing_a_staged_root_removes_it(self, tmp_path: Path) -> None:
+        from nemo_agents_plugin.fabric.environment import (
+            release_runtime_base_dir,
+            resolve_runtime_base_dir,
+        )
+
+        mounted = self._unwritable_root(tmp_path)
+        try:
+            base_dir = resolve_runtime_base_dir(mounted / "agent.yaml")
+            release_runtime_base_dir(base_dir)
+
+            assert not base_dir.path.exists()
+        finally:
+            mounted.chmod(0o755)
+
+    def test_releasing_an_in_place_root_leaves_the_agent_alone(self, tmp_path: Path) -> None:
+        from nemo_agents_plugin.fabric.environment import (
+            release_runtime_base_dir,
+            resolve_runtime_base_dir,
+        )
+
+        config = tmp_path / "agent.yaml"
+        config.write_text("config_format: nemo-agents-spec-v1\n")
+
+        base_dir = resolve_runtime_base_dir(config)
+        release_runtime_base_dir(base_dir)
+
+        assert config.exists()
+        assert tmp_path.exists()

--- a/plugins/nemo-agents/tests/unit/test_fabric_server.py
+++ b/plugins/nemo-agents/tests/unit/test_fabric_server.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from collections.abc import AsyncGenerator
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
@@ -18,6 +19,7 @@ from nemo_agents_plugin.fabric import server
 from nemo_agents_plugin.fabric.runtime import (
     FabricRuntimeExecutionError,
     FabricRuntimeResult,
+    FabricRuntimeStream,
     FabricRuntimeTimeoutError,
 )
 from nemo_agents_plugin.fabric.server import SESSION_ID_HEADER, FabricServingSettings, create_fabric_serving_app
@@ -113,6 +115,61 @@ def _sse_line_payload(line: str) -> dict[str, object]:
     return json.loads(line.removeprefix("data: "))
 
 
+def test_shutdown_removes_a_staged_agent_root(
+    tmp_path: Path,
+    mock_validate_agent_config: list[tuple[AgentConfig, Path]],
+) -> None:
+    mounted = tmp_path / "mounted"
+    mounted.mkdir()
+    config_path = _write_agent_config(mounted)
+    mounted.chmod(0o555)
+    app = create_fabric_serving_app(config_path)
+    try:
+        with TestClient(app) as client:
+            assert client.get("/health").status_code == 200
+            staged = Path(app.state.base_dir)
+
+            assert staged != mounted
+            assert (staged / "agent.yaml").exists()
+
+        assert not staged.exists()
+        assert config_path.exists()
+    finally:
+        mounted.chmod(0o755)
+
+
+def test_failed_startup_removes_a_staged_agent_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mounted = tmp_path / "mounted"
+    mounted.mkdir()
+    config_path = _write_agent_config(mounted)
+    mounted.chmod(0o555)
+    staged: list[Path] = []
+    real_resolve = server.resolve_runtime_base_dir
+
+    def record(path: Path) -> Any:
+        base_dir = real_resolve(path)
+        staged.append(base_dir.path)
+        return base_dir
+
+    async def fail(config: AgentConfig, *, base_dir: Path) -> object:
+        raise AgentConfigLoadError("invalid agent")
+
+    monkeypatch.setattr(server, "resolve_runtime_base_dir", record)
+    monkeypatch.setattr(server, "_validate_agent_config", fail)
+    app = create_fabric_serving_app(config_path)
+    try:
+        with pytest.raises(AgentConfigLoadError), TestClient(app):
+            pass
+
+        assert len(staged) == 1
+        assert not staged[0].exists()
+    finally:
+        mounted.chmod(0o755)
+
+
 def test_startup_loads_and_validates_agent_config(
     tmp_path: Path,
     mock_validate_agent_config: list[tuple[AgentConfig, Path]],
@@ -178,6 +235,7 @@ def test_shutdown_stops_all_registered_runtimes(
         async def register_runtime() -> None:
             await registry.register(cast(Any, runtime), session_id="session-1")
 
+        assert client.portal is not None
         client.portal.call(register_runtime)
 
     assert runtime.stop_calls == 1
@@ -513,7 +571,7 @@ async def test_streaming_chat_completion_emits_sse_error_and_closes_stream() -> 
         event
         async for event in server._iter_streaming_chat_completion(
             stream_context,
-            fabric_stream,
+            cast(FabricRuntimeStream, fabric_stream),
             completion_id="chatcmpl-test",
             model="test-model",
         )
@@ -536,14 +594,14 @@ async def test_streaming_chat_completion_closes_stream_on_generator_close() -> N
     stream_context = _FakeStreamContext(fabric_stream)
     events = server._iter_streaming_chat_completion(
         stream_context,
-        fabric_stream,
+        cast(FabricRuntimeStream, fabric_stream),
         completion_id="chatcmpl-test",
         model="test-model",
     )
 
     assert _sse_payload(await events.__anext__())["choices"] == [{"index": 0, "delta": {"role": "assistant"}}]
 
-    await events.aclose()
+    await cast(AsyncGenerator[str], events).aclose()
 
     assert fabric_stream.aclose_calls == 1
     assert stream_context.exit_calls == 1
@@ -555,12 +613,12 @@ async def test_streaming_chat_completion_closes_stream_before_first_event() -> N
     stream_context = _FakeStreamContext(fabric_stream)
     events = server._iter_streaming_chat_completion(
         stream_context,
-        fabric_stream,
+        cast(FabricRuntimeStream, fabric_stream),
         completion_id="chatcmpl-test",
         model="test-model",
     )
 
-    await events.aclose()
+    await cast(AsyncGenerator[str], events).aclose()
 
     assert fabric_stream.aclose_calls == 1
     assert stream_context.exit_calls == 1

--- a/plugins/nemo-agents/tests/unit/test_runner_deployments.py
+++ b/plugins/nemo-agents/tests/unit/test_runner_deployments.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 import yaml
 from nemo_agents_plugin.config import AgentsConfig, DeploymentsRunnerConfig
-from nemo_agents_plugin.entities import ComputeResources, Endpoint
+from nemo_agents_plugin.entities import ComputeResources, DeploymentMode, Endpoint
 from nemo_agents_plugin.fabric.gateway_credentials import PLATFORM_IGW_API_KEY_ENV, PLATFORM_IGW_API_KEY_PLACEHOLDER
 from nemo_agents_plugin.runner.deployments_backend import (
     DeploymentsRunnerBackend,
@@ -21,6 +21,7 @@ from nemo_agents_plugin.runner.deployments_backend import (
     build_deployment_config,
     executor_for_mode,
     map_status,
+    require_executor_matches_mode,
     resolve_agent_gateway_url,
     rewrite_config_base_urls,
     rewrite_fabric_config_base_urls,
@@ -218,6 +219,100 @@ def test_executor_for_mode_prefers_mode_specific() -> None:
     assert executor_for_mode(cfg, "k8s") == "k8s-exec"
 
 
+def _executors(*pairs: tuple[str, str], default: str | None = None) -> Any:
+    """A standalone DeploymentsConfig.
+
+    Not ``DeploymentsConfig.get()``: that is a cached singleton, and assigning to
+    it outlives the test that did so.
+    """
+    from nemo_deployments_plugin.config import DeploymentsConfig, ExecutorConfigEntry
+
+    return DeploymentsConfig(
+        executors=[ExecutorConfigEntry(name=n, backend=b) for n, b in pairs],
+        default_executor=default,
+    )
+
+
+def test_k8s_mode_on_a_docker_executor_is_refused(monkeypatch: pytest.MonkeyPatch) -> None:
+    from nemo_deployments_plugin.config import DeploymentsConfig
+
+    cfg = _executors(("default-exec", "docker"))
+    monkeypatch.setattr(DeploymentsConfig, "get", classmethod(lambda cls: cfg))
+
+    with pytest.raises(ValueError, match="runs on 'docker'"):
+        require_executor_matches_mode("default-exec", "k8s")
+
+
+def test_k8s_mode_on_a_non_deployable_backend_omits_the_mode_suggestion(monkeypatch: pytest.MonkeyPatch) -> None:
+    from nemo_deployments_plugin.config import DeploymentsConfig
+
+    # 'openshell' is a deployments-plugin backend but not a DeploymentMode, so
+    # the error must not suggest deploying with a mode that can't validate.
+    cfg = _executors(("default-exec", "openshell"))
+    monkeypatch.setattr(DeploymentsConfig, "get", classmethod(lambda cls: cfg))
+
+    with pytest.raises(ValueError, match="runs on 'openshell'") as exc_info:
+        require_executor_matches_mode("default-exec", "k8s")
+    assert "deploy with deployment_mode" not in str(exc_info.value)
+
+
+def test_k8s_mode_accepts_a_k8s_capable_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    from nemo_deployments_plugin.config import DeploymentsConfig
+
+    # The naive check — "is k8s_executor set" — would reject this, but a default
+    # executor backed by k8s honours the requested mode.
+    cfg = _executors(("default-exec", "k8s"))
+    monkeypatch.setattr(DeploymentsConfig, "get", classmethod(lambda cls: cfg))
+
+    require_executor_matches_mode("default-exec", "k8s")
+
+
+def test_k8s_mode_with_no_runner_executors_still_checks_the_plugin_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from nemo_deployments_plugin.config import DeploymentsConfig
+
+    # executor_for_mode returns None here, but ExecutorRegistry.resolve falls back
+    # to the plugin's own default — so None is not "nothing will run".
+    cfg = _executors(("plugin-default", "docker"), default="plugin-default")
+    monkeypatch.setattr(DeploymentsConfig, "get", classmethod(lambda cls: cfg))
+
+    with pytest.raises(ValueError, match="runs on 'docker'"):
+        require_executor_matches_mode(None, "k8s")
+
+
+def test_no_executor_anywhere_is_left_to_the_deployments_plugin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from nemo_deployments_plugin.config import DeploymentsConfig
+
+    cfg = _executors()
+    monkeypatch.setattr(DeploymentsConfig, "get", classmethod(lambda cls: cfg))
+
+    # Nothing to run it on at all is ExecutorNotFoundError's message to give.
+    require_executor_matches_mode(None, "k8s")
+
+
+def test_docker_mode_on_a_docker_executor_is_allowed(monkeypatch: pytest.MonkeyPatch) -> None:
+    from nemo_deployments_plugin.config import DeploymentsConfig
+
+    cfg = _executors(("docker-exec", "docker"))
+    monkeypatch.setattr(DeploymentsConfig, "get", classmethod(lambda cls: cfg))
+
+    require_executor_matches_mode("docker-exec", "docker")
+
+
+def test_an_unknown_executor_is_left_to_the_deployments_plugin(monkeypatch: pytest.MonkeyPatch) -> None:
+    from nemo_deployments_plugin.config import DeploymentsConfig
+
+    # Naming an executor that is not configured is the deployments plugin's error
+    # to report; guessing here would turn its message into a worse one.
+    cfg = _executors(("something-else", "docker"))
+    monkeypatch.setattr(DeploymentsConfig, "get", classmethod(lambda cls: cfg))
+
+    require_executor_matches_mode("not-configured", "k8s")
+
+
 def test_config_mount_path_default_is_under_writable_workspace() -> None:
     assert DeploymentsRunnerConfig().config_mount_path == "/tmp/nemo/config.yaml"
 
@@ -363,7 +458,9 @@ def test_build_deployment_config_no_secrets_adds_no_secret_env() -> None:
     "reserved_name",
     ["NMP_WORKSPACE", "NMP_AGENT_NAME", "NMP_BASE_URL", "PYTHONPATH", "AGENT_CONFIG_PATH", "NAT_CONFIG_PATH"],
 )
-def test_build_deployment_config_rejects_secret_name_colliding_with_reserved(reserved_name: str, mode: str) -> None:
+def test_build_deployment_config_rejects_secret_name_colliding_with_reserved(
+    reserved_name: str, mode: DeploymentMode
+) -> None:
     # A secret env var whose name collides with a platform-generated container
     # env var is rejected up front (behavior would otherwise differ by substrate).
     with pytest.raises(ReservedSecretEnvVarError, match=reserved_name):


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary

Prepares the agent fixes for the `release/0.5` patch release. The changeset
hardens the local-wheel packaging support in NVIDIA-NeMo/nemo-platform#1804
and backports the Kubernetes runtime and deployment-validation fixes from
NVIDIA-NeMo/nemo-platform#1697, NVIDIA-NeMo/nemo-platform#1727, and
NVIDIA-NeMo/nemo-platform#1786.

The wheel hardening is stacked on `ASTD-535-backport-wheel-support/mmogallapall`.
The three deployment fixes are collected on
`backport-agent-deployment-fixes/mmogallapall`, based on `origin/release/0.5`.

## Changes

- Include the selected wheel's SHA-256 digest in the agent identity so wheels
  with the same version but different contents receive different IDs and tags.
- Create `Dockerfile.generated.dockerignore` exclusively and track ownership
  before writing, preventing an existing or concurrently created file from
  being overwritten and deleted during cleanup.
- Fix the renderer test wrapper so it always invokes the real Dockerfile
  renderer.
- Add regression coverage for wheel-content identity and scoped-ignore file
  collisions.
- Backport #1697 so Kubernetes agents stage their configuration and source into
  a writable temporary agent root instead of trying to write under a read-only
  ConfigMap mount.
- Backport #1786 so deployment requests fail clearly when the selected executor
  cannot honor the requested deployment mode.
- Backport #1727 so container deployment is rejected when no usable image can be
  resolved, instead of allowing an invalid deployment to proceed.

## Backported Commits

- `2297231c1` - #1697: run Kubernetes agents from a writable agent root.
- `cc2734ab2` - #1786: reject deployment modes unsupported by the executor.
- `5f709dff9` - #1727: reject container deployments without a resolvable image.

## Type of Change

- [x] Bug fix
- [x] Packaging safety and correctness
- [x] Kubernetes runtime compatibility
- [x] Deployment validation
- [x] Unit tests

## Verification

- [x] Focused packaging, validation, and subprocess tests pass: 237 passed.
- [x] Full NeMo Agents unit suite passes for the deployment backports: 1,427
  passed.
- [x] Ruff lint and formatting checks pass for both changed files.
- [x] Ruff lint and formatting checks pass for all eight files changed by the
  deployment backports.
- [x] Focused type checking passes.
- [x] All commit hooks and DCO checks pass.
- [x] `git diff --check` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Deployment creation now rejects incompatible Docker or Kubernetes executor configurations before deployment begins.
  - Container deployments without a request image or configured default image now return a clear validation error.
  - Subprocess deployments can be created without requiring a container image.

- **Reliability**
  - Agent runtimes can operate with read-only configuration locations by using a temporary writable workspace.
  - Temporary runtime workspaces are cleaned up reliably during shutdown, including when startup validation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->