### PR TITLE
fix(eval-author): bind publication review and gate trace environment readiness

### DIFF
--- a/plugins/nemo-eval-author/skills/eval-author-trace-environment/SKILL.md
+++ b/plugins/nemo-eval-author/skills/eval-author-trace-environment/SKILL.md
@@ -59,6 +59,8 @@ Use one workspace per task:
     private/source.atif.json
     private/canonical.atif.json
     private/privacy-audit.json
+    private/publications/<digest>/
+    private/publication-review.json
     private/ground-truth/
     safe/trace.atif.json
     safe/privacy.json
@@ -168,8 +170,9 @@ and user home paths.
 The helper also writes `private/privacy-audit.json`: a complete string-field and
 character denominator, URL hosts, and candidate name, organization, and street
 address findings. These are contextual leads, not automatic claims. Review every
-text field in `safe/trace.atif.json`, every audit finding and host, and the
-generalized task files, then record who performed the review:
+text field in `safe/trace.atif.json`, every audit finding and host, then record
+who performed this trace review. Generated task files do not exist yet; review
+the complete publication separately after finalization.
 
 ```bash
 python <skill_dir>/scripts/trace_environment.py review-privacy \
@@ -461,7 +464,8 @@ python <skill_dir>/scripts/trace_environment.py check \
 
 The helper derives environment status rather than accepting a claimed status:
 failed technical proof becomes `failed`; passed proof with the required separate
-no-network verification and `--human-reviewed` becomes `ready`; every other
+no-network verification, `--human-reviewed`, and no required software whose
+availability is `unknown` becomes `ready`; every other
 candidate is `unproven`. A shared verifier is a contract error rather than an
 unproven candidate. The human-review flag means a human supplied or reviewed
 Relevant experience and the generalized task. It is distinct from the earlier
@@ -494,22 +498,13 @@ python <skill_dir>/scripts/trace_environment.py batch-status \
 `denominator` must equal the selected source set. Never report only candidates
 or successes. A malformed workspace remains in the `batch-status` report with
 status `invalid` and makes the report invalid without hiding other member rows.
-For publication, export each finalized workspace to a new,
-nonexistent destination:
 
-```bash
-python <skill_dir>/scripts/trace_environment.py export \
-  --task-dir <task-dir> \
-  --output-dir <dataset-product-dir>
-```
-
-The command runs `check` and copies only `candidate.json`, the generalized
-`task/` and `reproducibility.json` when present, and a declassified `result.json`.
-It never copies source, canonical, safe, privacy-audit, ground-truth, validation,
-or Harbor job files. It preserves task-file executable bits while making the
-export readable, so the published task matches its task-tree digest.
-Public results report image pinning separately from unverified dependency
-closure and distinguish distinct jobs from unverified container freshness.
+Before any export, including `no_candidate`, read and follow
+`references/publication-review.md`. Prepare the complete private publication
+preview, review every exported file and path, and attest its exact digest before
+exporting. Trace privacy review and `--human-reviewed` do not replace this gate.
+Any change to the public product requires a new publication review; a successful
+`check` alone is not publication approval.
 
 Report the task ID, `candidate` or `no_candidate`, ground-truth availability and
 artifact count, required software and licensing constraints, environment

--- a/plugins/nemo-eval-author/skills/eval-author-trace-environment/SKILL.md
+++ b/plugins/nemo-eval-author/skills/eval-author-trace-environment/SKILL.md
@@ -145,7 +145,7 @@ and safe files of at most 25 MiB. It may make only two bounded normalizations:
 - insert a missing JSON escape when the parser-implicated quote immediately
   follows a provider-redaction placeholder; and
 - convert string-encoded ATIF image objects into image parts while omitting
-  encoded binary data and oversized image metadata.
+  encoded binary data, including image metadata embedded in text fields.
 
 Every operation, offset, count, and loss is recorded in the canonical ATIF and
 summary. Exact source bytes remain unchanged and hashed. Reject unrelated JSON

--- a/plugins/nemo-eval-author/skills/eval-author-trace-environment/references/environment-integrity.md
+++ b/plugins/nemo-eval-author/skills/eval-author-trace-environment/references/environment-integrity.md
@@ -25,7 +25,7 @@ python <skill_dir>/scripts/trace_environment.py record-reproducibility \
 ```
 
 The manifest hashes every task path, file byte, directory, and executable bit.
-It records a declared source revision, Dockerfile base images, external
+It records a declared source revision, Dockerfile base and `# syntax=` frontend images, external
 `COPY --from` and `RUN --mount=from=...` image dependencies, configured agent,
 verifier and step `docker_image` references, network modes,
 and one image-reference state: `local_only`, `image_pinned_recipe`, or
@@ -34,7 +34,10 @@ and every inventoried external image is pinned by digest. Local named or numeric
 build stages are distinguished from external images. Unresolved variable-based
 references keep the task `local_only`. A configured agent image is immutable
 only when its reference contains a SHA-256 digest and all inventoried image
-dependencies are immutable. Use Harbor's `docker_image` field, not `image`.
+dependencies are immutable. Mutable or unresolved frontend references keep the
+recipe `local_only`; pin an external frontend by digest too. Only active parser
+directives before a blank line, ordinary comment, or build instruction count.
+Use Harbor's `docker_image` field, not `image`.
 These states describe image pinning only. The manifest and public result
 explicitly report `dependency_closure: "unverified"`: arbitrary package
 downloads, tool installations, and external build inputs are not proven

--- a/plugins/nemo-eval-author/skills/eval-author-trace-environment/references/environment-integrity.md
+++ b/plugins/nemo-eval-author/skills/eval-author-trace-environment/references/environment-integrity.md
@@ -5,6 +5,34 @@
 
 Apply this protocol to every candidate before finalization.
 
+## Existing Harbor runtime preflight
+
+Before building images or starting proof jobs, run this read-only check in the
+existing Harbor Python environment. Run it again when that environment changes;
+do not infer compatibility from a minimum version or a previous result:
+
+```bash
+python <skill_dir>/scripts/trace_environment.py check-runtime
+python <skill_dir>/scripts/trace_environment.py check-runtime --task-dir <task-dir>
+```
+
+The first command probes provider-declared configuration and result fields; the
+second also makes Harbor validate the authored task and compute its checksum.
+Exit code 1 / `valid: false` means do not launch proof jobs with that runtime.
+Keep the report private with construction evidence. Use the same interpreter's
+Harbor installation for receipts and jobs, not an unrelated `harbor` on PATH.
+The reported version is provenance, not an allowlist: development builds and
+future versions must retain the required capabilities too. If unavailable, use
+another already-installed compatible runtime when present; do not automatically
+install, upgrade or patch the provider, or synthesize missing result fields.
+
+This preflight does not start Docker, download anything, or prove execution.
+It checks only the single-step proof shape understood by this helper. Multi-step
+trial results may omit trial-level verifier mode even when their task config
+accepts separate verification; the task-specific preflight fails closed there.
+Do not flatten a multi-step task just to pass. Every actual job must still pass
+the existing checksum, identity, reward and separate-mode result checks.
+
 ## Network isolation
 
 In addition to the separate no-network verifier contract, require the agent

--- a/plugins/nemo-eval-author/skills/eval-author-trace-environment/references/publication-review.md
+++ b/plugins/nemo-eval-author/skills/eval-author-trace-environment/references/publication-review.md
@@ -14,7 +14,7 @@ python <skill_dir>/scripts/trace_environment.py prepare-publication \
 
 Inspect every file in the returned `preview_dir`: all candidate notes,
 uncertainties, software and ground-truth provenance, the generated task and
-manifest when present, and the derived `result.json`. Check paths as well as
+`reproducibility.json` when present, and the derived `result.json`. Check paths as well as
 contents for private identifiers, internal locators, proprietary material, and
 other information not authorized for publication. The preview contains only the
 publication whitelist; source evidence and review notes are not part of it.

--- a/plugins/nemo-eval-author/skills/eval-author-trace-environment/references/publication-review.md
+++ b/plugins/nemo-eval-author/skills/eval-author-trace-environment/references/publication-review.md
@@ -1,0 +1,62 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Review and publish an exact product
+
+Every export requires a separate publication review, including `no_candidate`.
+The earlier trace review and `--human-reviewed` flag do not authorize publication.
+First prepare an owner-private preview of the exact files that will be exported:
+
+```bash
+python <skill_dir>/scripts/trace_environment.py prepare-publication \
+  --task-dir <task-dir>
+```
+
+Inspect every file in the returned `preview_dir`: all candidate notes,
+uncertainties, software and ground-truth provenance, the generated task and
+manifest when present, and the derived `result.json`. Check paths as well as
+contents for private identifiers, internal locators, proprietary material, and
+other information not authorized for publication. The preview contains only the
+publication whitelist; source evidence and review notes are not part of it.
+Do not approve a product that still contains private details. Correct the source
+artifacts in a new workspace if finalization prevents revision, regenerate any
+affected proof, finalize, and prepare a new preview. Never edit just the preview.
+
+After reviewing it, supply the exact returned digest and directory:
+
+```bash
+python <skill_dir>/scripts/trace_environment.py review-publication \
+  --task-dir <task-dir> \
+  --preview-dir <preview-dir> \
+  --sha256 <reviewed-sha256> \
+  --reviewer-kind <agent|human> \
+  --note "<scope reviewed and disposition, without private values>"
+```
+
+This records a contextual attestation, not an automatic safety verdict or a
+cryptographic proof that a reviewer read the files. It is bound to every exported
+byte, path, and entry permission; the private preview root itself stays owner-only.
+Re-review a newly prepared preview after any publication change. Superseded
+previews remain private. `check` establishes workspace consistency, not
+publication approval. Historical workspaces also require this new review before
+export; existing trace-review records are not upgraded into publication approval.
+
+Then export the reviewed product to a new, nonexistent destination:
+
+```bash
+python <skill_dir>/scripts/trace_environment.py export \
+  --task-dir <task-dir> \
+  --output-dir <dataset-product-dir>
+```
+
+The command runs `check`, verifies the publication review against a newly staged
+snapshot, and copies only `candidate.json`, the generalized `task/` and
+`reproducibility.json` when present, and a declassified `result.json`.
+It never copies source, canonical, safe, privacy-audit, ground-truth, validation,
+or Harbor job files. It preserves task-file executable bits while making the
+export readable, so the published task matches its task-tree digest.
+Public results report image pinning separately from unverified dependency
+closure and distinguish distinct jobs from unverified container freshness.
+Publication previews and the versioned review receipt remain private. The public
+product schema is unchanged; the new receipt does not imply that older products
+were publication-reviewed.

--- a/plugins/nemo-eval-author/skills/eval-author-trace-environment/references/publication-review.md
+++ b/plugins/nemo-eval-author/skills/eval-author-trace-environment/references/publication-review.md
@@ -36,6 +36,9 @@ python <skill_dir>/scripts/trace_environment.py review-publication \
 This records a contextual attestation, not an automatic safety verdict or a
 cryptographic proof that a reviewer read the files. It is bound to every exported
 byte, path, and entry permission; the private preview root itself stays owner-only.
+Staging and export copy file contents and normalized executable bits only, not
+source extended attributes or other source filesystem metadata. Directory
+metadata is not copied either; keep private context out of publication contents.
 Re-review a newly prepared preview after any publication change. Superseded
 previews remain private. `check` establishes workspace consistency, not
 publication approval. Historical workspaces also require this new review before

--- a/plugins/nemo-eval-author/skills/eval-author-trace-environment/scripts/trace_environment.py
+++ b/plugins/nemo-eval-author/skills/eval-author-trace-environment/scripts/trace_environment.py
@@ -1127,8 +1127,23 @@ def _dockerfile_images(task_dir: Path) -> list[dict[str, Any]]:
         logical_line = ""
         first_line = 1
         escape = "\\"
+        parser_directives = True
+        frontend_seen = False
         for line_number, line in enumerate(lines, start=1):
             stripped = line.strip()
+            if parser_directives:
+                directive = re.fullmatch(r"#\s*(syntax|escape|check)\s*=\s*(.*?)\s*", stripped, re.IGNORECASE)
+                if directive is None:
+                    parser_directives = False
+                elif directive[1].casefold() == "syntax":
+                    if frontend_seen or not directive[2] or len(directive[2].split()) != 1:
+                        raise ContractError(
+                            f"{path.relative_to(task_dir)}:{line_number} has an invalid syntax directive"
+                        )
+                    frontend_seen = True
+                    frontend = _image_reference(path, task_dir, line_number, "frontend", directive[2], set())
+                    frontend["immutable"] = _IMAGE_DIGEST.fullmatch(directive[2]) is not None
+                    images.append(frontend)
             if stripped.lower().startswith("# escape="):
                 escape = stripped.split("=", 1)[1].strip()
             if not stripped or stripped.startswith("#"):
@@ -2108,6 +2123,30 @@ def _reject_symlinks(root: Path) -> None:
             raise ContractError(f"safe export refuses symlink: {path.relative_to(root.parent)}")
 
 
+def _copy_publication_file(source: Path, destination: Path) -> None:
+    """Copy only file bytes and normalized executable bits, never source metadata."""
+
+    if source.is_symlink() or not source.is_file():
+        raise ContractError("publication source must be a regular file")
+    with source.open("rb") as incoming, destination.open("xb") as outgoing:
+        shutil.copyfileobj(incoming, outgoing)
+    destination.chmod(0o644 | (stat.S_IMODE(source.stat().st_mode) & 0o111))
+
+
+def _copy_publication_tree(source: Path, destination: Path) -> None:
+    """Keep the new root private while copying; do not propagate directory xattrs."""
+
+    _reject_symlinks(source)
+    destination.mkdir(mode=0o700, parents=True, exist_ok=False)
+    for path in sorted(source.iterdir()):
+        target = destination / path.name
+        if path.is_dir():
+            _copy_publication_tree(path, target)
+            target.chmod(0o755)
+        else:
+            _copy_publication_file(path, target)
+
+
 def _write_publication(task_dir: Path, output_dir: Path) -> None:
     """Render the complete publication inside an owner-private staging directory."""
 
@@ -2119,12 +2158,12 @@ def _write_publication(task_dir: Path, output_dir: Path) -> None:
         raise ContractError(f"task workspace check failed: {'; '.join(checked['errors'])}")
     _reject_symlinks(task_dir / "candidate.json")
     candidate = _load_object(task_dir / "candidate.json", label="candidate")
-    shutil.copy2(task_dir / "candidate.json", output_dir / "candidate.json")
+    _copy_publication_file(task_dir / "candidate.json", output_dir / "candidate.json")
     if summary["status"] == "candidate":
         _reject_symlinks(task_dir / "task")
         _reject_symlinks(task_dir / "reproducibility.json")
-        shutil.copytree(task_dir / "task", output_dir / "task")
-        shutil.copy2(task_dir / "reproducibility.json", output_dir / "reproducibility.json")
+        _copy_publication_tree(task_dir / "task", output_dir / "task")
+        _copy_publication_file(task_dir / "reproducibility.json", output_dir / "reproducibility.json")
     reproducibility_summary = None
     if summary["status"] == "candidate":
         reproducibility = _validate_reproducibility(task_dir)
@@ -2290,7 +2329,7 @@ def _export(args: argparse.Namespace) -> dict[str, Any]:
         if _publication_inventory(staged) != review["publication"]:
             raise ContractError("publication review is stale; prepare and review the current product")
         # Publish the checked snapshot, never reread mutable source files after review.
-        shutil.copytree(staged, output_dir)
+        _copy_publication_tree(staged, output_dir)
     output_dir.chmod(0o755)
     return {
         "task_id": task_dir.name,

--- a/plugins/nemo-eval-author/skills/eval-author-trace-environment/scripts/trace_environment.py
+++ b/plugins/nemo-eval-author/skills/eval-author-trace-environment/scripts/trace_environment.py
@@ -26,6 +26,7 @@ CANDIDATE_SCHEMA = "nemo.eval_author.trace_environment_candidate.v2"
 VALIDATION_SCHEMA = "nemo.eval_author.trace_environment_validation.v5"
 RUN_INPUT_SCHEMA = "nemo.eval_author.trace_environment_run_input.v1"
 PRIVACY_AUDIT_SCHEMA = "nemo.eval_author.trace_environment_privacy_audit.v1"
+PUBLICATION_REVIEW_SCHEMA = "nemo.eval_author.trace_environment_publication_review.v1"
 REPRODUCIBILITY_SCHEMA = "nemo.eval_author.trace_environment_reproducibility.v3"
 EXPORT_SCHEMA = "nemo.eval_author.trace_environment_product.v3"
 BATCH_SCHEMA = "nemo.eval_author.trace_environment_batch.v1"
@@ -928,7 +929,8 @@ def _validate_requirements(value: Any, step_ids: set[int]) -> list[dict[str, Any
         label = f"candidate.requirements[{index}]"
         if not isinstance(requirement, dict) or set(requirement) != _REQUIREMENT_KEYS:
             raise ContractError(f"{label} fields do not match the versioned contract")
-        if not isinstance(requirement.get("description"), str) or not requirement["description"].strip():
+        description = requirement.get("description")
+        if not isinstance(description, str) or not description.strip():
             raise ContractError(f"{label}.description must be nonempty text")
         _evidence_steps(requirement.get("evidence_steps"), step_ids, label=f"{label}.evidence_steps")
     return value
@@ -1658,10 +1660,11 @@ def _validation_from_jobs(
     if len(job_ids) != len(set(job_ids)):
         raise ContractError("validation Harbor config.job_id values must be distinct")
     checksums = {trial.get("task_checksum") for trial in trials}
+    retained_checksum = next(iter(checksums))
     if (
         len(checksums) != 1
-        or not isinstance(next(iter(checksums)), str)
-        or _TASK_CHECKSUM.fullmatch(next(iter(checksums))) is None
+        or not isinstance(retained_checksum, str)
+        or _TASK_CHECKSUM.fullmatch(retained_checksum) is None
     ):
         raise ContractError("all validation Harbor results must have one matching task checksum")
     modes = {trial.get("verifier_environment_mode") for trial in trials}
@@ -1679,7 +1682,7 @@ def _validation_from_jobs(
     return {
         "schema": VALIDATION_SCHEMA,
         "harbor_version": harbor_version,
-        "task_checksum": next(iter(checksums)),
+        "task_checksum": retained_checksum,
         "task_tree_sha256": reproducibility["task_tree_sha256"],
         "verifier_environment_mode": mode,
         "distinct_jobs": True,
@@ -1807,6 +1810,24 @@ def _summary_markdown(summary: dict[str, Any]) -> str:
     )
 
 
+def _environment_status(
+    candidate: dict[str, Any], technical_status: str, isolation_status: str, review_status: str
+) -> str:
+    if technical_status == "failed":
+        return "failed"
+    unknown_required = any(
+        item["required"] and item["availability"] == "unknown" for item in candidate["software_requirements"]
+    )
+    if (
+        technical_status == "passed"
+        and isolation_status == "isolated"
+        and review_status == "human_reviewed"
+        and not unknown_required
+    ):
+        return "ready"
+    return "unproven"
+
+
 def _finalize(args: argparse.Namespace) -> dict[str, Any]:
     task_dir = _ensure_task_dir(args.task_dir)
     summary = _load_summary(task_dir)
@@ -1847,12 +1868,7 @@ def _finalize(args: argparse.Namespace) -> dict[str, Any]:
             technical_status = "passed" if validation["passed"] else "failed"
         else:
             technical_status = "not_run"
-        if technical_status == "failed":
-            environment_status = "failed"
-        elif technical_status == "passed" and isolation_status == "isolated" and args.human_reviewed:
-            environment_status = "ready"
-        else:
-            environment_status = "unproven"
+        environment_status = _environment_status(candidate, technical_status, isolation_status, review_status)
 
     reasons = list(args.reason)
     if args.status == "no_candidate" and not reasons:
@@ -1908,7 +1924,7 @@ def _check(args: argparse.Namespace) -> dict[str, Any]:
     else:
         errors.append("source has not been prepared")
     privacy = summary.get("privacy")
-    if isinstance(privacy, dict):
+    if isinstance(privacy, dict) and isinstance(source, dict):
         try:
             privacy_payload = _load_object(task_dir / privacy["path"], label="privacy report")
             if privacy != {"path": privacy["path"], "audit_path": privacy["audit_path"], **privacy_payload}:
@@ -1952,16 +1968,13 @@ def _check(args: argparse.Namespace) -> dict[str, Any]:
                     expected_technical = "passed" if validation["passed"] else "failed"
                     if environment.get("technical_status") != expected_technical:
                         errors.append("summary technical status does not match Harbor evidence")
-                    expected_status = "failed"
-                    if validation["passed"]:
-                        expected_status = (
-                            "ready"
-                            if task_contract["isolation_status"] == "isolated"
-                            and environment.get("review_status") == "human_reviewed"
-                            else "unproven"
-                        )
+                    expected_status = _environment_status(
+                        candidate, expected_technical, task_contract["isolation_status"], environment["review_status"]
+                    )
                     if environment.get("status") != expected_status:
-                        errors.append("summary environment status does not match proof, review, and isolation")
+                        errors.append(
+                            "summary environment status does not match proof, review, isolation, and software"
+                        )
                     if environment.get("validation") != "validation.json":
                         errors.append("summary omits retained Harbor validation")
                 elif environment.get("technical_status") != "not_run":
@@ -2095,24 +2108,21 @@ def _reject_symlinks(root: Path) -> None:
             raise ContractError(f"safe export refuses symlink: {path.relative_to(root.parent)}")
 
 
-def _export(args: argparse.Namespace) -> dict[str, Any]:
-    task_dir = _ensure_task_dir(args.task_dir)
+def _write_publication(task_dir: Path, output_dir: Path) -> None:
+    """Render the complete publication inside an owner-private staging directory."""
+
     summary = _load_summary(task_dir)
     if summary["status"] == "pending":
         raise ContractError("finalize the task workspace before export")
     checked = _check(argparse.Namespace(task_dir=task_dir))
     if not checked["valid"]:
         raise ContractError(f"task workspace check failed: {'; '.join(checked['errors'])}")
-    output_dir = args.output_dir.resolve()
-    if output_dir.is_relative_to(task_dir) or ".eval-author" in output_dir.parts:
-        raise ContractError("export directory must be outside every private .eval-author workspace")
-    if output_dir.exists():
-        raise ContractError(f"refusing to replace existing export directory: {output_dir}")
-    output_dir.mkdir(parents=True)
+    _reject_symlinks(task_dir / "candidate.json")
     candidate = _load_object(task_dir / "candidate.json", label="candidate")
     shutil.copy2(task_dir / "candidate.json", output_dir / "candidate.json")
     if summary["status"] == "candidate":
         _reject_symlinks(task_dir / "task")
+        _reject_symlinks(task_dir / "reproducibility.json")
         shutil.copytree(task_dir / "task", output_dir / "task")
         shutil.copy2(task_dir / "reproducibility.json", output_dir / "reproducibility.json")
     reproducibility_summary = None
@@ -2184,9 +2194,106 @@ def _export(args: argparse.Namespace) -> dict[str, Any]:
             path.chmod(0o644 | (stat.S_IMODE(path.stat().st_mode) & 0o111))
         elif path.is_dir():
             path.chmod(0o755)
+
+
+def _publication_inventory(root: Path) -> dict[str, Any]:
+    tree = _task_tree_info(root)
+    # The task digest tracks whether a file is executable; publication review
+    # additionally binds exact permission bits for every entry (except the root).
+    modes = {path.relative_to(root).as_posix(): stat.S_IMODE(path.stat().st_mode) for path in sorted(root.rglob("*"))}
+    digest = _sha256(json.dumps({"tree": tree, "modes": modes}, sort_keys=True).encode())
+    return {"sha256": digest, "file_count": tree["file_count"], "total_bytes": tree["total_bytes"]}
+
+
+def _prepare_publication(args: argparse.Namespace) -> dict[str, Any]:
+    task_dir = _ensure_task_dir(args.task_dir)
+    publications = task_dir / "private" / "publications"
+    if (task_dir / "private").is_symlink() or publications.is_symlink():
+        raise ContractError("publication staging directories must not be symlinks")
+    _mkdir_private(task_dir / "private")
+    _mkdir_private(publications)
+    # Keep each preview, including superseded ones, as private review evidence.
+    with tempfile.TemporaryDirectory(prefix="staging-", dir=publications) as temporary:
+        preview = Path(temporary) / "product"
+        _mkdir_private(preview)
+        _write_publication(task_dir, preview)
+        inventory = _publication_inventory(preview)
+        destination = publications / inventory["sha256"].removeprefix("sha256:")
+        if destination.exists():
+            if _publication_inventory(destination) != inventory:
+                raise ContractError("retained publication preview changed; preserve it and prepare a new workspace")
+        else:
+            preview.rename(destination)
+    return {"task_dir": str(task_dir), "preview_dir": str(destination), **inventory}
+
+
+def _review_publication(args: argparse.Namespace) -> dict[str, Any]:
+    task_dir = _ensure_task_dir(args.task_dir)
+    if not args.note.strip():
+        raise ContractError("publication review note must be nonempty")
+    if (task_dir / "private").is_symlink() or (task_dir / "private/publications").is_symlink():
+        raise ContractError("publication staging directories must not be symlinks")
+    preview = args.preview_dir
+    if not preview.is_absolute():
+        preview = task_dir / preview
+    if preview.is_symlink():
+        raise ContractError("publication preview must not be a symlink")
+    preview = preview.resolve()
+    if preview.parent != task_dir / "private/publications":
+        raise ContractError("review requires a retained private publication preview")
+    inventory = _publication_inventory(preview)
+    if inventory["sha256"] != args.sha256 or preview.name != args.sha256.removeprefix("sha256:"):
+        raise ContractError("publication preview does not match the reviewed digest")
+    with tempfile.TemporaryDirectory(dir=task_dir / "private") as temporary:
+        current = Path(temporary)
+        _write_publication(task_dir, current)
+        if _publication_inventory(current) != inventory:
+            raise ContractError("publication preview is stale; prepare and review the current product")
+    _write_json(
+        task_dir / "private/publication-review.json",
+        {
+            "schema": PUBLICATION_REVIEW_SCHEMA,
+            "publication": inventory,
+            "reviewer_kind": args.reviewer_kind,
+            "note": args.note.strip(),
+        },
+    )
+    return {"task_dir": str(task_dir), "reviewed": True, **inventory}
+
+
+def _export(args: argparse.Namespace) -> dict[str, Any]:
+    task_dir = _ensure_task_dir(args.task_dir)
+    if (task_dir / "private").is_symlink():
+        raise ContractError("publication staging directories must not be symlinks")
+    _mkdir_private(task_dir / "private")
+    output_dir = args.output_dir.resolve()
+    if output_dir.is_relative_to(task_dir) or ".eval-author" in output_dir.parts:
+        raise ContractError("export directory must be outside every private .eval-author workspace")
+    if output_dir.exists():
+        raise ContractError(f"refusing to replace existing export directory: {output_dir}")
+    review_path = task_dir / "private/publication-review.json"
+    if not review_path.is_file():
+        raise ContractError("export requires prepare-publication and review-publication for every product")
+    _reject_symlinks(review_path)
+    review = _load_object(review_path, label="publication review")
+    if (
+        set(review) != {"schema", "publication", "reviewer_kind", "note"}
+        or review.get("schema") != PUBLICATION_REVIEW_SCHEMA
+        or review.get("reviewer_kind") not in ("agent", "human")
+        or not isinstance(review.get("note"), str)
+        or not review["note"].strip()
+    ):
+        raise ContractError("publication review does not match the versioned contract")
+    with tempfile.TemporaryDirectory(dir=task_dir / "private") as temporary:
+        staged = Path(temporary)
+        _write_publication(task_dir, staged)
+        if _publication_inventory(staged) != review["publication"]:
+            raise ContractError("publication review is stale; prepare and review the current product")
+        # Publish the checked snapshot, never reread mutable source files after review.
+        shutil.copytree(staged, output_dir)
     output_dir.chmod(0o755)
     return {
-        "task_id": summary["task_id"],
+        "task_id": task_dir.name,
         "output_dir": str(output_dir),
         "files": sorted(str(path.relative_to(output_dir)) for path in output_dir.rglob("*") if path.is_file()),
     }
@@ -2260,6 +2367,20 @@ def _parser() -> argparse.ArgumentParser:
     batch_status.add_argument("--root", type=Path, default=Path(".eval-author/trace-environments"))
     batch_status.add_argument("--manifest", required=True, type=Path)
     batch_status.set_defaults(run=_batch_status)
+
+    publication = subparsers.add_parser("prepare-publication", help="stage the exact public product for private review")
+    publication.add_argument("--task-dir", required=True, type=Path)
+    publication.set_defaults(run=_prepare_publication)
+
+    publication_review = subparsers.add_parser(
+        "review-publication", help="attest review of an exact publication preview"
+    )
+    publication_review.add_argument("--task-dir", required=True, type=Path)
+    publication_review.add_argument("--preview-dir", required=True, type=Path)
+    publication_review.add_argument("--sha256", required=True)
+    publication_review.add_argument("--reviewer-kind", choices=("agent", "human"), required=True)
+    publication_review.add_argument("--note", required=True)
+    publication_review.set_defaults(run=_review_publication)
 
     export = subparsers.add_parser("export", help="publish only the reviewed candidate, task, and result summary")
     export.add_argument("--task-dir", required=True, type=Path)

--- a/plugins/nemo-eval-author/skills/eval-author-trace-environment/scripts/trace_environment.py
+++ b/plugins/nemo-eval-author/skills/eval-author-trace-environment/scripts/trace_environment.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import importlib
+import importlib.metadata
 import ipaddress
 import json
 import os
@@ -1501,6 +1503,116 @@ def _harbor_task_checksum(task_dir: Path) -> str:
         raise ContractError(f"Harbor could not validate the proof task: {error}") from error
 
 
+def _runtime_mode_roundtrip(model: Any) -> bool:
+    """Probe a declared provider field, without constructing a proof result."""
+    from pydantic import TypeAdapter
+
+    field = model.model_fields.get("verifier_environment_mode")
+    if field is None:
+        return False
+    adapter = TypeAdapter(field.annotation)
+    for mode in ("shared", "separate"):
+        value = adapter.validate_python(mode)
+        # Other required trial fields are deliberately absent: this is only a
+        # field serialization probe, never a validated or retained trial.
+        probe = model.model_construct(verifier_environment_mode=value)
+        if probe.model_dump(mode="json", exclude_unset=True).get("verifier_environment_mode") != mode:
+            return False
+    return True
+
+
+def _check_runtime(args: argparse.Namespace) -> dict[str, Any]:
+    """Read-only capability preflight; version labels are informational only."""
+    checks: list[dict[str, Any]] = []
+    report: dict[str, Any] = {
+        "schema": "nemo.eval_author.trace_environment_runtime_check.v1",
+        "valid": False,
+        "scope": "single_step_proof",
+        "harbor_version": None,
+        "python_executable": sys.executable,
+        "checks": checks,
+        "execution_verified": False,
+        "hint": "Use the same existing Harbor Python environment for this check, proof receipts and Harbor jobs. "
+        "Do not install or upgrade Harbor automatically. Actual trial results must still prove separate mode.",
+    }
+
+    def check(name: str, passed: bool, message: str) -> None:
+        checks.append({"name": name, "passed": passed, "message": message})
+
+    try:
+        report["harbor_version"] = importlib.metadata.version("harbor")
+    except importlib.metadata.PackageNotFoundError:
+        # Editable/source installations may have usable APIs without metadata.
+        pass
+    try:
+        config_model = importlib.import_module("harbor.models.task.config").TaskConfig
+        result_model = importlib.import_module("harbor.models.trial.result").TrialResult
+        task_model = importlib.import_module("harbor.models.task.task").Task
+    except Exception as error:
+        # Provider import/validation exception types can change between releases.
+        # Keep an incompatible installation a structured finding, not a traceback.
+        check("provider_imports", False, f"Required Harbor APIs are unavailable ({type(error).__name__}).")
+        return report
+    check("provider_imports", True, "Required Harbor model APIs imported in this interpreter.")
+    check("task_checksum_api", hasattr(task_model, "checksum"), "Proof receipts require Harbor's Task.checksum API.")
+    try:
+        config = config_model.model_validate(
+            {
+                "environment": {"network_mode": "no-network"},
+                "verifier": {
+                    "environment_mode": "separate",
+                    "network_mode": "no-network",
+                    "environment": {"network_mode": "no-network"},
+                },
+            }
+        )
+        for name, model, expected in (
+            ("agent_network_config", config.environment, {"network_mode": "no-network"}),
+            (
+                "separate_verifier_config",
+                config.verifier,
+                {"environment_mode": "separate", "network_mode": "no-network"},
+            ),
+            ("verifier_environment_config", config.verifier.environment, {"network_mode": "no-network"}),
+        ):
+            declared = model is not None and all(key in type(model).model_fields for key in expected)
+            dumped = model.model_dump(mode="json") if declared else {}
+            check(
+                name,
+                all(dumped.get(key) == value for key, value in expected.items()),
+                "Required isolation settings must be declared and retained by Harbor, not ignored extras.",
+            )
+    except Exception as error:
+        check(
+            "isolation_config", False, f"Harbor could not retain required isolation settings ({type(error).__name__})."
+        )
+    try:
+        mode_supported = _runtime_mode_roundtrip(result_model)
+        check(
+            "trial_verifier_mode", mode_supported, "TrialResult must declare and serialize verifier_environment_mode."
+        )
+    except Exception as error:
+        check("trial_verifier_mode", False, f"Verifier-mode serialization is incompatible ({type(error).__name__}).")
+    if args.task_dir is not None:
+        task_dir = _ensure_task_dir(args.task_dir)
+        try:
+            task = task_model(task_dir / "task")
+            single_step = not task.config.steps
+            check(
+                "task_proof_shape",
+                single_step,
+                "The current proof reader requires trial-level verifier mode; multi-step proof is not certified by this preflight.",
+            )
+            checksum = task.checksum
+            check(
+                "task_checksum", isinstance(checksum, str) and bool(checksum), "Harbor must compute the task checksum."
+            )
+        except Exception as error:
+            check("task_validation", False, f"Harbor could not validate this proof task ({type(error).__name__}).")
+    report["valid"] = all(item["passed"] for item in checks)
+    return report
+
+
 def _run_input_path(task_dir: Path, job_dir: Path) -> Path:
     relative = job_dir.relative_to(task_dir).as_posix()
     return task_dir / "private" / "run-inputs" / f"{hashlib.sha256(relative.encode()).hexdigest()}.json"
@@ -2341,6 +2453,10 @@ def _export(args: argparse.Namespace) -> dict[str, Any]:
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="command", required=True)
+
+    runtime = subparsers.add_parser("check-runtime", help="probe the installed Harbor proof APIs without running jobs")
+    runtime.add_argument("--task-dir", type=Path, help="also validate an authored task and its proof shape")
+    runtime.set_defaults(run=_check_runtime)
 
     init = subparsers.add_parser("init", help="create one private, gitignored task workspace")
     init.add_argument("--root", type=Path, default=Path(".eval-author/trace-environments"))

--- a/plugins/nemo-eval-author/skills/eval-author-trace-environment/scripts/trace_environment.py
+++ b/plugins/nemo-eval-author/skills/eval-author-trace-environment/scripts/trace_environment.py
@@ -600,25 +600,50 @@ def _bound_stringified_images(payload: dict[str, Any]) -> dict[str, int]:
             parts.append({"type": "text", "text": content[emitted_cursor:]})
         return parts, converted_count, converted_characters
 
-    def bound_metadata(value: Any) -> None:
+    def bound_metadata(value: Any, *, image_context: bool = False) -> Any:
         if isinstance(value, dict):
-            image_like = value.get("type") in {"image", "base64"} or (
-                isinstance(value.get("media_type"), str) and value["media_type"].startswith("image/")
+            image_like = (
+                image_context
+                or value.get("type") in {"image", "base64"}
+                or (isinstance(value.get("media_type"), str) and value["media_type"].startswith("image/"))
             )
             for key, nested in value.items():
                 if (
                     isinstance(nested, str)
-                    and len(nested) > 100_000
-                    and (key == "base64" or (key == "data" and image_like))
+                    and nested
+                    and ((key in {"base64", "data"} and image_like) or (key == "base64" and len(nested) > 100_000))
                 ):
                     counts["metadata_field_count"] += 1
                     counts["metadata_omitted_characters"] += len(nested)
                     value[key] = ""
                 else:
-                    bound_metadata(nested)
+                    value[key] = bound_metadata(nested, image_context=image_like)
         elif isinstance(value, list):
-            for nested in value:
-                bound_metadata(nested)
+            for index, nested in enumerate(value):
+                value[index] = bound_metadata(nested, image_context=image_context)
+        elif isinstance(value, str):
+            # Tool observations may repeat image metadata as JSON inside a text
+            # part, not as a structured ATIF image. Preserve surrounding prose
+            # and nonbinary metadata; never decode or execute encoded contents.
+            decoder = json.JSONDecoder()
+            fragments: list[str] = []
+            search_cursor = emitted_cursor = 0
+            while match := _IMAGE_OBJECT_START.search(value, search_cursor):
+                try:
+                    metadata, end = decoder.raw_decode(value, match.start())
+                except json.JSONDecodeError:
+                    search_cursor = match.end()
+                    continue
+                previous_count = counts["metadata_field_count"]
+                bound_metadata(metadata)
+                if counts["metadata_field_count"] != previous_count:
+                    fragments.extend((value[emitted_cursor : match.start()], json.dumps(metadata, ensure_ascii=False)))
+                    emitted_cursor = end
+                search_cursor = end
+            if fragments:
+                fragments.append(value[emitted_cursor:])
+                return "".join(fragments)
+        return value
 
     def bound_image_parts(value: Any) -> None:
         if isinstance(value, dict):

--- a/plugins/nemo-eval-author/tests/test_trace_environment.py
+++ b/plugins/nemo-eval-author/tests/test_trace_environment.py
@@ -1351,6 +1351,38 @@ def test_publication_review_rejects_tampered_preview(tmp_path: Path, change: str
     assert not (task_dir / "private/publication-review.json").exists()
 
 
+@pytest.mark.skipif(not hasattr(os, "setxattr"), reason="extended attributes require OS support")
+@pytest.mark.parametrize("status", ["candidate", "no_candidate"])
+def test_publication_omits_source_extended_attributes(tmp_path: Path, status: str) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _candidate(task_dir, status=status)
+    if status == "candidate":
+        _ready_environment(task_dir, record_validation=False)
+    _review_privacy(task_dir)
+    code, result = _run("finalize", "--task-dir", str(task_dir), "--status", status)
+    assert code == 0, result
+    sources = [task_dir / "candidate.json"]
+    if status == "candidate":
+        sources.extend([task_dir / "reproducibility.json", task_dir / "task", task_dir / "task/tests/test.sh"])
+    attribute = "user.fixture_note"
+    for path in sources:
+        os.setxattr(path, attribute, b"fixture metadata before review")
+    preview = _review_publication(task_dir)
+    preview_dir = Path(preview["preview_dir"])
+    for path in sources:
+        assert attribute not in os.listxattr(preview_dir / path.relative_to(task_dir))
+        os.setxattr(path, attribute, b"fixture metadata changed after review")
+    output = tmp_path / "product"
+    code, result = _run("export", "--task-dir", str(task_dir), "--output-dir", str(output))
+    assert code == 0, result
+    for path in sources:
+        assert os.getxattr(path, attribute) == b"fixture metadata changed after review"
+        assert attribute not in os.listxattr(output / path.relative_to(task_dir))
+    for path in output.rglob("*"):
+        if path.is_file():
+            assert path.read_bytes() == (preview_dir / path.relative_to(output)).read_bytes()
+
+
 @pytest.mark.parametrize("executable_bits", [0, stat.S_IXUSR, stat.S_IXGRP, stat.S_IXOTH, 0o111])
 def test_export_preserves_executable_bits_and_task_digest(tmp_path: Path, executable_bits: int) -> None:
     task_dir, _ = _workspace(tmp_path)
@@ -1737,6 +1769,38 @@ def test_portability_tracks_multiple_run_mounts(tmp_path: Path, source: str, pin
     assert report["portability"]["state"] == ("image_pinned_recipe" if pinned else "local_only")
     mounts = [image for image in report["portability"]["container_images"] if image["instruction"] == "run_mount"]
     assert [(item["reference"], item["internal_stage"]) for item in mounts] == [("builder", True), (source, internal)]
+
+
+@pytest.mark.parametrize(
+    "reference,pinned",
+    [("docker/dockerfile:1", False), ("docker/dockerfile@sha256:" + "a" * 64, True), ("${FRONTEND}", False)],
+)
+@pytest.mark.parametrize("location", ["environment", "tests"])
+def test_portability_inventories_dockerfile_frontend(
+    tmp_path: Path, reference: str, pinned: bool, location: str
+) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _ready_environment(task_dir, record_validation=False)
+    (task_dir / f"task/{location}/Dockerfile").write_text(f"# syntax={reference}\nFROM scratch\n")
+    _record_reproducibility(task_dir)
+    report = json.loads((task_dir / "reproducibility.json").read_text())
+    assert report["portability"]["state"] == ("image_pinned_recipe" if pinned else "local_only")
+    frontends = [item for item in report["portability"]["container_images"] if item["instruction"] == "frontend"]
+    assert len(frontends) == 1
+    assert frontends[0]["reference"] == reference
+    assert frontends[0]["immutable"] is pinned
+    assert frontends[0]["internal_stage"] is False
+
+
+@pytest.mark.parametrize("prefix", ["\n", "# ordinary comment\n", "FROM scratch\n"])
+def test_portability_ignores_inactive_syntax_comments(tmp_path: Path, prefix: str) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _ready_environment(task_dir, record_validation=False)
+    (task_dir / "task/environment/Dockerfile").write_text(prefix + "# syntax=docker/dockerfile:1\nFROM scratch\n")
+    _record_reproducibility(task_dir)
+    report = json.loads((task_dir / "reproducibility.json").read_text())
+    assert report["portability"]["state"] == "image_pinned_recipe"
+    assert not any(item["instruction"] == "frontend" for item in report["portability"]["container_images"])
 
 
 @pytest.mark.parametrize(

--- a/plugins/nemo-eval-author/tests/test_trace_environment.py
+++ b/plugins/nemo-eval-author/tests/test_trace_environment.py
@@ -150,6 +150,26 @@ def _record_reproducibility(task_dir: Path) -> None:
     assert code == 0, result
 
 
+def _review_publication(task_dir: Path, *, reviewer_kind: str = "agent") -> dict[str, Any]:
+    code, preview = _run("prepare-publication", "--task-dir", str(task_dir))
+    assert code == 0, preview
+    code, result = _run(
+        "review-publication",
+        "--task-dir",
+        str(task_dir),
+        "--preview-dir",
+        preview["preview_dir"],
+        "--sha256",
+        preview["sha256"],
+        "--reviewer-kind",
+        reviewer_kind,
+        "--note",
+        "Reviewed all files in this synthetic publication preview.",
+    )
+    assert code == 0, result
+    return preview
+
+
 def _ready_environment(
     task_dir: Path,
     *,
@@ -513,6 +533,71 @@ def test_candidate_rejects_required_unavailable_software(tmp_path: Path) -> None
 
     assert code == 1
     assert "candidate requires unavailable software: ExampleCAD" in result["error"]
+
+
+def _software(*, required: bool, availability: str) -> dict[str, Any]:
+    return {
+        "name": "ExampleRuntime",
+        "category": "cli",
+        "required": required,
+        "version": None,
+        "license": "open_source",
+        "availability": availability,
+        "redistributable": True,
+        "provenance": {"kind": "atif_step", "step_ids": [1], "uri": None, "revision": None, "source_id": None},
+        "notes": "Runtime availability recorded from the task evidence.",
+    }
+
+
+@pytest.mark.parametrize(
+    "required,availability,nop_reward,record_validation,expected",
+    [
+        (True, "unknown", 0.0, True, "unproven"),
+        (False, "unknown", 0.0, True, "ready"),
+        (True, "available", 0.0, True, "ready"),
+        (True, "installable", 0.0, True, "ready"),
+        (True, "unknown", 1.0, True, "failed"),
+        (True, "unknown", 0.0, False, "unproven"),
+    ],
+)
+def test_software_availability_gates_readiness(
+    tmp_path: Path, required: bool, availability: str, nop_reward: float, record_validation: bool, expected: str
+) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _candidate(task_dir, software_requirements=[_software(required=required, availability=availability)])
+    _ready_environment(task_dir, nop_reward=nop_reward, record_validation=record_validation)
+    _review_privacy(task_dir)
+    code, result = _run("finalize", "--task-dir", str(task_dir), "--status", "candidate", "--human-reviewed")
+    assert code == 0, result
+    assert result["environment_status"] == expected
+    code, result = _run("check", "--task-dir", str(task_dir))
+    assert code == 0, result
+    _review_publication(task_dir)
+    output = tmp_path / "product"
+    code, result = _run("export", "--task-dir", str(task_dir), "--output-dir", str(output))
+    assert code == 0, result
+    assert json.loads((output / "result.json").read_text())["environment"]["status"] == expected
+
+
+def test_check_rejects_ready_claim_with_unknown_required_software(tmp_path: Path) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _candidate(task_dir, software_requirements=[_software(required=True, availability="unknown")])
+    _ready_environment(task_dir)
+    _review_privacy(task_dir)
+    code, result = _run("finalize", "--task-dir", str(task_dir), "--status", "candidate", "--human-reviewed")
+    assert code == 0, result
+    summary_path = task_dir / "summary.json"
+    summary = json.loads(summary_path.read_text())
+    summary["environment"]["status"] = "ready"
+    _write_json(summary_path, summary)
+    markdown = task_dir / "summary.md"
+    markdown.write_text(markdown.read_text().replace("Environment: `unproven`", "Environment: `ready`"))
+    code, result = _run("check", "--task-dir", str(task_dir))
+    assert code == 1
+    assert any("software" in error for error in result["errors"])
+    code, result = _run("prepare-publication", "--task-dir", str(task_dir))
+    assert code == 1
+    assert "software" in result["error"]
 
 
 def test_ground_truth_digest_must_match_retained_artifact(tmp_path: Path) -> None:
@@ -1095,6 +1180,7 @@ def test_export_uses_a_strict_publication_whitelist(tmp_path: Path) -> None:
     assert code == 0, result
     output = tmp_path / "product"
 
+    _review_publication(task_dir)
     code, result = _run("export", "--task-dir", str(task_dir), "--output-dir", str(output))
 
     assert code == 0, result
@@ -1115,6 +1201,156 @@ def test_export_uses_a_strict_publication_whitelist(tmp_path: Path) -> None:
     assert product["reproducibility"]["dependency_closure"] == "unverified"
 
 
+@pytest.mark.parametrize("status", ["candidate", "no_candidate"])
+def test_export_requires_publication_review_even_after_trace_review(tmp_path: Path, status: str) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _candidate(task_dir, status=status)
+    if status == "candidate":
+        _ready_environment(task_dir, record_validation=False)
+    _review_privacy(task_dir)
+    code, result = _run("finalize", "--task-dir", str(task_dir), "--status", status)
+    assert code == 0, result
+    output = tmp_path / "product"
+    code, result = _run("export", "--task-dir", str(task_dir), "--output-dir", str(output))
+    assert code == 1
+    assert "review-publication" in result["error"]
+    assert not output.exists()
+
+
+@pytest.mark.parametrize("reviewer_kind", ["agent", "human"])
+def test_no_candidate_publication_reviews_exact_product(tmp_path: Path, reviewer_kind: str) -> None:
+    task_dir, _ = _workspace(tmp_path, image_only=True)
+    _candidate(task_dir, status="no_candidate")
+    code, result = _run("finalize", "--task-dir", str(task_dir), "--status", "no_candidate")
+    assert code == 0, result
+    preview = _review_publication(task_dir, reviewer_kind=reviewer_kind)
+    preview_dir = Path(preview["preview_dir"])
+    assert preview["file_count"] == 2
+    assert stat.S_IMODE(preview_dir.stat().st_mode) == 0o700
+    receipt = task_dir / "private/publication-review.json"
+    assert stat.S_IMODE(receipt.stat().st_mode) == 0o600
+    assert json.loads(receipt.read_text())["reviewer_kind"] == reviewer_kind
+    code, second = _run("prepare-publication", "--task-dir", str(task_dir))
+    assert code == 0, second
+    assert second == preview
+    output = tmp_path / "product"
+    code, result = _run("export", "--task-dir", str(task_dir), "--output-dir", str(output))
+    assert code == 0, result
+    assert result["files"] == ["candidate.json", "result.json"]
+    for path in output.iterdir():
+        assert path.read_bytes() == (preview_dir / path.name).read_bytes()
+    product = json.loads((output / "result.json").read_text())
+    assert product["status"] == "no_candidate"
+    assert product["privacy"]["contextual_review_complete"] is False
+
+
+@pytest.mark.parametrize("change", ["candidate", "task", "manifest", "executable", "empty_directory"])
+def test_publication_review_is_invalidated_by_changed_export(tmp_path: Path, change: str) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _candidate(task_dir)
+    _ready_environment(task_dir, record_validation=False)
+    _review_privacy(task_dir)
+    code, result = _run("finalize", "--task-dir", str(task_dir), "--status", "candidate")
+    assert code == 0, result
+    preview = _review_publication(task_dir)
+    if change in {"candidate", "manifest"}:
+        path = task_dir / ("candidate.json" if change == "candidate" else "reproducibility.json")
+        # Equivalent JSON still changes the exact bytes approved for publication.
+        path.write_text(path.read_text() + "\n")
+    elif change == "task":
+        path = task_dir / "task/instruction.md"
+        path.write_text(path.read_text() + "Keep the repair local.\n")
+        _record_reproducibility(task_dir)
+    elif change == "executable":
+        (task_dir / "task/tests/test.sh").chmod(0o744)
+        _record_reproducibility(task_dir)
+    else:
+        (task_dir / "task/empty").mkdir()
+        _record_reproducibility(task_dir)
+    code, result = _run("check", "--task-dir", str(task_dir))
+    assert code == 0, result
+    output = tmp_path / "product"
+    code, result = _run("export", "--task-dir", str(task_dir), "--output-dir", str(output))
+    assert code == 1
+    assert "publication review is stale" in result["error"]
+    assert not output.exists()
+    code, result = _run(
+        "review-publication",
+        "--task-dir",
+        str(task_dir),
+        "--preview-dir",
+        preview["preview_dir"],
+        "--sha256",
+        preview["sha256"],
+        "--reviewer-kind",
+        "agent",
+        "--note",
+        "Old preview",
+    )
+    assert code == 1
+    assert "preview is stale" in result["error"]
+    updated = _review_publication(task_dir)
+    assert updated["sha256"] != preview["sha256"]
+    assert Path(preview["preview_dir"]).is_dir()
+    code, result = _run("export", "--task-dir", str(task_dir), "--output-dir", str(output))
+    assert code == 0, result
+
+
+def test_publication_review_binds_derived_result_json(tmp_path: Path) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _candidate(task_dir, status="no_candidate")
+    code, result = _run("finalize", "--task-dir", str(task_dir), "--status", "no_candidate")
+    assert code == 0, result
+    _review_publication(task_dir)
+    # This changes only the public result, not candidate.json or the safe trace.
+    _review_privacy(task_dir)
+    code, result = _run("check", "--task-dir", str(task_dir))
+    assert code == 0, result
+    output = tmp_path / "product"
+    code, result = _run("export", "--task-dir", str(task_dir), "--output-dir", str(output))
+    assert code == 1
+    assert "publication review is stale" in result["error"]
+    assert not output.exists()
+
+
+@pytest.mark.parametrize("change", ["bytes", "mode", "symlink", "extra_file", "missing_file"])
+def test_publication_review_rejects_tampered_preview(tmp_path: Path, change: str) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _candidate(task_dir, status="no_candidate")
+    code, result = _run("finalize", "--task-dir", str(task_dir), "--status", "no_candidate")
+    assert code == 0, result
+    code, preview = _run("prepare-publication", "--task-dir", str(task_dir))
+    assert code == 0, preview
+    path = Path(preview["preview_dir"]) / "candidate.json"
+    if change == "bytes":
+        path.write_text(path.read_text() + "\n")
+    elif change == "mode":
+        path.chmod(0o744)
+    elif change == "symlink":
+        path.unlink()
+        path.symlink_to(task_dir / "candidate.json")
+    elif change == "extra_file":
+        (path.parent / "extra.txt").write_text("Unreviewed internal project detail.")
+    else:
+        path.unlink()
+    code, result = _run(
+        "review-publication",
+        "--task-dir",
+        str(task_dir),
+        "--preview-dir",
+        preview["preview_dir"],
+        "--sha256",
+        preview["sha256"],
+        "--reviewer-kind",
+        "agent",
+        "--note",
+        "Changed preview",
+    )
+    assert code == 1
+    assert "digest" in result["error"] or "symlink" in result["error"]
+    assert not (task_dir / "private/publication-review.json").exists()
+
+
 @pytest.mark.parametrize("executable_bits", [0, stat.S_IXUSR, stat.S_IXGRP, stat.S_IXOTH, 0o111])
 def test_export_preserves_executable_bits_and_task_digest(tmp_path: Path, executable_bits: int) -> None:
     task_dir, _ = _workspace(tmp_path)
@@ -1128,6 +1364,7 @@ def test_export_preserves_executable_bits_and_task_digest(tmp_path: Path, execut
     code, result = _run("finalize", "--task-dir", str(task_dir), "--status", "candidate")
     assert code == 0, result
     output = tmp_path / "product"
+    _review_publication(task_dir)
     code, result = _run("export", "--task-dir", str(task_dir), "--output-dir", str(output))
     assert code == 0, result
 
@@ -1185,6 +1422,7 @@ def test_image_pinning_does_not_claim_dependency_closure(tmp_path: Path) -> None
     code, result = _run("finalize", "--task-dir", str(task_dir), "--status", "candidate")
     assert code == 0, result
     output = tmp_path / "product"
+    _review_publication(task_dir)
     code, result = _run("export", "--task-dir", str(task_dir), "--output-dir", str(output))
     assert code == 0, result
     manifest = json.loads((output / "reproducibility.json").read_text())
@@ -1321,15 +1559,21 @@ def _record_existing_jobs(task_dir: Path) -> tuple[int, dict[str, Any]]:
     return _run("record-validation", "--task-dir", str(task_dir), *args, "--harbor-version", "0.21.0")
 
 
-@pytest.mark.parametrize("change", ["verifier", "executable"])
+@pytest.mark.parametrize("change", ["verifier", "executable", "instruction", "build_input", "new_file"])
 def test_stale_jobs_cannot_prove_a_changed_task(tmp_path: Path, change: str) -> None:
     task_dir, _ = _workspace(tmp_path)
     _ready_environment(task_dir, record_validation=False)
     verifier = task_dir / "task/tests/test.sh"
     if change == "verifier":
         verifier.write_text("#!/bin/sh\nexit 99\n")
-    else:
+    elif change == "executable":
         verifier.chmod(verifier.stat().st_mode ^ stat.S_IXUSR)
+    elif change == "instruction":
+        (task_dir / "task/instruction.md").write_text("Repair a different fixture.\n")
+    elif change == "build_input":
+        (task_dir / "task/environment/Dockerfile").write_text("FROM scratch\nENV FIXTURE_REVISION=2\n")
+    else:
+        (task_dir / "task/environment/input.txt").write_text("New initial state.\n")
     _record_reproducibility(task_dir)
     code, result = _record_existing_jobs(task_dir)
     assert code == 1
@@ -1373,8 +1617,11 @@ def test_missing_pre_run_inputs_rejects_historical_proof(tmp_path: Path) -> None
     "arm,agent",
     [
         ("nop-1", None),
+        ("oracle-1", None),
         ("oracle-1", {"name": "nop"}),
+        ("nop-1", {"name": "oracle"}),
         ("negative-1", {"name": "nop"}),
+        ("negative-1", {"name": "oracle"}),
         ("negative-1", {"import_path": "harbor.agents.nop:NopAgent"}),
         ("negative-1", {"import_path": "other_agent:WrongControl"}),
         ("nop-1", {"name": "nop", "import_path": "other_agent:WrongControl"}),
@@ -1465,6 +1712,31 @@ def test_portability_tracks_external_copy_sources(tmp_path: Path, copy_source: s
     assert len(copies) == 1
     assert copies[0]["reference"] == copy_source
     assert copies[0]["internal_stage"] == (copy_source in ("builder", "0"))
+
+
+@pytest.mark.parametrize(
+    "source,pinned,internal",
+    [
+        ("example.invalid/tool:latest", False, False),
+        ("example.invalid/tool@sha256:" + "a" * 64, True, False),
+        ("builder", True, True),
+        ("0", True, True),
+        ("${TOOLS_IMAGE}", False, False),
+    ],
+)
+def test_portability_tracks_multiple_run_mounts(tmp_path: Path, source: str, pinned: bool, internal: bool) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _ready_environment(task_dir, record_validation=False)
+    (task_dir / "task/environment/Dockerfile").write_text(
+        "FROM scratch AS builder\nFROM scratch\n"
+        "RUN --mount=type=bind,from=builder,target=/local \\\n"
+        f"    --mount=type=bind,from={source},target=/tool true\n"
+    )
+    _record_reproducibility(task_dir)
+    report = json.loads((task_dir / "reproducibility.json").read_text())
+    assert report["portability"]["state"] == ("image_pinned_recipe" if pinned else "local_only")
+    mounts = [image for image in report["portability"]["container_images"] if image["instruction"] == "run_mount"]
+    assert [(item["reference"], item["internal_stage"]) for item in mounts] == [("builder", True), (source, internal)]
 
 
 @pytest.mark.parametrize(

--- a/plugins/nemo-eval-author/tests/test_trace_environment.py
+++ b/plugins/nemo-eval-author/tests/test_trace_environment.py
@@ -1011,6 +1011,44 @@ def test_prepare_bounds_string_encoded_images_and_audits_context(tmp_path: Path)
     }
 
 
+@pytest.mark.parametrize("encoded_size", [12, 100_001])
+@pytest.mark.parametrize("location", ["observation", "text_part", "extra", "message"])
+def test_prepare_omits_repeated_image_metadata_without_losing_prose(
+    tmp_path: Path, encoded_size: int, location: str
+) -> None:
+    code, initialized = _run("init", "--root", str(tmp_path / ".eval-author"), "--task-id", "image-metadata")
+    assert code == 0, initialized
+    task_dir = Path(initialized["task_dir"])
+    payload = _atif()
+    metadata = {"type": "image", "file": {"base64": "A" * encoded_size, "caption": "synthetic diagram"}}
+    embedded = "before [metadata] " + json.dumps(metadata) + " after"
+    step = payload["steps"][1]
+    result = step["observation"]["results"][0]
+    if location == "observation":
+        result["content"] = embedded
+    elif location == "text_part":
+        result["content"] = [{"type": "text", "text": embedded}]
+    elif location == "extra":
+        result["extra"] = {"image_metadata": metadata}
+    else:
+        step["message"] = embedded
+    source = tmp_path / "source.atif.json"
+    _write_json(source, payload)
+    code, report = _run("prepare", "--task-dir", str(task_dir), "--atif", str(source), "--source-kind", "atif")
+    assert code == 0, report
+    assert (task_dir / "private/source.atif.json").read_bytes() == source.read_bytes()
+    for artifact in ("private/canonical.atif.json", "safe/trace.atif.json"):
+        text = (task_dir / artifact).read_text()
+        assert "A" * encoded_size not in text
+        assert "synthetic diagram" in text
+        if location != "extra":
+            assert "before [metadata]" in text and " after" in text
+    summary = json.loads((task_dir / "summary.json").read_text())
+    operation = summary["source"]["normalizations"][0]
+    assert operation["metadata_field_count"] == 1
+    assert operation["metadata_omitted_characters"] == encoded_size
+
+
 def test_shared_verifier_is_rejected(tmp_path: Path) -> None:
     task_dir, _ = _workspace(tmp_path)
     _candidate(task_dir)

--- a/plugins/nemo-eval-author/tests/test_trace_runtime.py
+++ b/plugins/nemo-eval-author/tests/test_trace_runtime.py
@@ -1,0 +1,182 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Capability probes must judge provider behavior, not version ordering."""
+
+import argparse
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Literal
+
+import pytest
+from harbor.models.task.config import TaskConfig
+from harbor.models.task.task import Task
+from harbor.models.trial.result import TrialResult
+from pydantic import BaseModel, ConfigDict, Field
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "skills/eval-author-trace-environment/scripts/trace_environment.py"
+
+
+class ModeResult(BaseModel):
+    verifier_environment_mode: Literal["shared", "separate"] | None = None
+
+
+class MissingModeResult(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+
+class ExcludedModeResult(BaseModel):
+    verifier_environment_mode: Literal["shared", "separate"] | None = Field(default=None, exclude=True)
+
+
+class SharedOnlyResult(BaseModel):
+    verifier_environment_mode: Literal["shared"] | None = None
+
+
+@pytest.fixture
+def helper() -> Any:
+    spec = importlib.util.spec_from_file_location("trace_runtime_probe_test", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def provider(monkeypatch: pytest.MonkeyPatch, helper: Any, result_model: type[BaseModel], label: str) -> None:
+    original_import = helper.importlib.import_module
+    original_version = helper.importlib.metadata.version
+    modules = {
+        "harbor.models.task.config": SimpleNamespace(TaskConfig=TaskConfig),
+        "harbor.models.trial.result": SimpleNamespace(TrialResult=result_model),
+        "harbor.models.task.task": SimpleNamespace(Task=Task),
+    }
+
+    def load(name: str, package: str | None = None) -> Any:
+        return modules[name] if name in modules else original_import(name, package)
+
+    monkeypatch.setattr(helper.importlib, "import_module", load)
+    monkeypatch.setattr(
+        helper.importlib.metadata, "version", lambda name: label if name == "harbor" else original_version(name)
+    )
+
+
+@pytest.mark.parametrize("label", ["0.1.0", "0.22.0", "99.0.0", "development-build"])
+def test_runtime_accepts_capabilities_independent_of_version(
+    helper: Any, monkeypatch: pytest.MonkeyPatch, label: str
+) -> None:
+    provider(monkeypatch, helper, ModeResult, label)
+    result = helper._check_runtime(argparse.Namespace(task_dir=None))
+    assert result["valid"] is True
+    assert result["harbor_version"] == label
+    assert result["execution_verified"] is False
+    assert result["scope"] == "single_step_proof"
+
+
+@pytest.mark.parametrize("result_model", [MissingModeResult, ExcludedModeResult, SharedOnlyResult])
+def test_runtime_rejects_missing_dropped_or_narrowed_mode(
+    helper: Any, monkeypatch: pytest.MonkeyPatch, result_model: type[BaseModel]
+) -> None:
+    provider(monkeypatch, helper, result_model, "99.0.0")
+    result = helper._check_runtime(argparse.Namespace(task_dir=None))
+    assert result["valid"] is False
+    assert any(check["name"] == "trial_verifier_mode" and not check["passed"] for check in result["checks"])
+
+
+def test_runtime_does_not_treat_unknown_config_extras_as_support(helper: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    provider(monkeypatch, helper, ModeResult, "99.0.0")
+
+    class ExtraConfig(BaseModel):
+        model_config = ConfigDict(extra="allow")
+
+    class PermissiveTaskConfig(BaseModel):
+        environment: ExtraConfig
+        verifier: ExtraConfig
+
+    # An old provider can preserve arbitrary fields while not interpreting them.
+    original_import = helper.importlib.import_module
+    monkeypatch.setattr(
+        helper.importlib,
+        "import_module",
+        lambda name: (
+            SimpleNamespace(TaskConfig=PermissiveTaskConfig)
+            if name == "harbor.models.task.config"
+            else original_import(name)
+        ),
+    )
+    result = helper._check_runtime(argparse.Namespace(task_dir=None))
+    assert result["valid"] is False
+    assert any(not check["passed"] for check in result["checks"] if "config" in check["name"])
+
+
+def test_runtime_missing_provider_is_a_structured_finding(helper: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    def missing(name: str) -> Any:
+        raise ModuleNotFoundError(name)
+
+    monkeypatch.setattr(helper.importlib, "import_module", missing)
+    result = helper._check_runtime(argparse.Namespace(task_dir=None))
+    assert result["valid"] is False
+    assert result["checks"][0]["name"] == "provider_imports"
+
+
+def test_runtime_metadata_absence_does_not_override_capabilities(helper: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    provider(monkeypatch, helper, ModeResult, "development")
+
+    def missing(name: str) -> str:
+        raise helper.importlib.metadata.PackageNotFoundError(name)
+
+    monkeypatch.setattr(helper.importlib.metadata, "version", missing)
+    result = helper._check_runtime(argparse.Namespace(task_dir=None))
+    assert result["harbor_version"] is None
+    assert result["valid"] is True
+
+
+def test_runtime_cli_reports_actual_installed_provider_without_writes(tmp_path: Path) -> None:
+    result = subprocess.run(
+        [sys.executable, str(_SCRIPT), "check-runtime"], cwd=tmp_path, capture_output=True, text=True, check=False
+    )
+    report = json.loads(result.stdout)
+    assert result.returncode == (0 if report["valid"] else 1)
+    mode = next(check for check in report["checks"] if check["name"] == "trial_verifier_mode")
+    if "verifier_environment_mode" not in TrialResult.model_fields:
+        assert mode["passed"] is False
+    assert report["execution_verified"] is False
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_task_preflight_rejects_multistep_shape(helper: Any, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    provider(monkeypatch, helper, ModeResult, "development")
+    original_import = helper.importlib.import_module
+
+    class MultiStepTask:
+        checksum = "probe-checksum"
+        config = SimpleNamespace(steps=[SimpleNamespace(name="step-one")])
+
+        def __init__(self, task_dir: Path):
+            pass
+
+    monkeypatch.setattr(
+        helper.importlib,
+        "import_module",
+        lambda name: (
+            SimpleNamespace(Task=MultiStepTask) if name == "harbor.models.task.task" else original_import(name)
+        ),
+    )
+    workspace = tmp_path / "runtime-probe"
+    workspace.mkdir()
+    result = helper._check_runtime(argparse.Namespace(task_dir=workspace))
+    assert result["valid"] is False
+    assert any(check["name"] == "task_proof_shape" and not check["passed"] for check in result["checks"])
+
+
+def test_runtime_provider_exception_is_not_an_unhandled_traceback(helper: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    def incompatible(name: str) -> Any:
+        raise RuntimeError("provider initialization changed")
+
+    monkeypatch.setattr(helper.importlib, "import_module", incompatible)
+    result = helper._check_runtime(argparse.Namespace(task_dir=None))
+    assert result["valid"] is False
+    assert "RuntimeError" in result["checks"][0]["message"]


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
<!-- In 1-3 plain sentences, explain what changes and why. Describe before-and-after behavior when it applies. -->

Finish the six Astra findings following #1899 and the follow-on publication metadata, Docker frontend, and Harbor compatibility findings. Exports require exact-publication review, readiness claims are narrower, and capability preflight rejects unsupported Harbor proof shapes before jobs. The fresh 89-task reconstruction remains an incomplete experiment, not a completed benchmark rerun.

## Changes
<!-- List the concrete changes included in this pull request. -->

- Bind every candidate/no-candidate export to a reviewed byte/path/permission snapshot; strip source extended attributes during staging/export.
- Inventory active Dockerfile syntax frontend dependencies; mutable or unresolved references prevent image-pinned claims.
- Use consistent software-aware readiness gates; unknown required software blocks readiness.
- Add read-only `check-runtime [--task-dir ...]` for provider configuration/result capabilities and optional task validation/checksum. Version labels are provenance, not an allowlist. Unsupported multi-step proof shape fails closed; no provider upgrades or synthesized result fields.
- Omit duplicate encoded image metadata embedded in text while retaining surrounding text, nonbinary metadata, exact original bytes and omission counts.
- Cover publication mutation, proof identity/task snapshots, software readiness, frontend inventory, provider drift and embedded image metadata with behavioral regressions.
- Clarify privacy review versus publication review. The latest one-line correction explicitly names `reproducibility.json` in publication review scope, matching `_write_publication`'s allowlist; runtime behavior is unchanged.
- No dependency manifests, secret-scanner exclusions/configuration or credential-shaped fixtures changed.

Related [fixtures PR #22](https://github.com/NVIDIA-dev/nemo-eval-author-fixtures/pull/22) retains historical products unchanged and separately labels fresh results.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

<!-- List each command and result. Explain skipped, blocked, or non-successful checks without marking them as passed. -->

- `uv run --project <source-worktree> --no-sync pytest plugins/nemo-eval-author/tests --rootdir=<source-worktree> --confcutdir=plugins/nemo-eval-author/tests -q`: **338 passed**, 94 existing Harbor checksum-deprecation warnings, no skips; rerun for the documentation correction.
- Earlier `uv run --project <existing-harbor-checkout> --no-sync pytest <source-worktree>/plugins/nemo-eval-author/tests/test_trace_runtime.py -q`: **13 passed** with Harbor 0.22.0.
- Targeted `uv run --frozen ruff check`, `ruff format --check`, and `ty check` of the helper and modified Python tests passed for the behavioral changes. Latest change is Markdown only.
- `uv run pre-commit run -a` under existing `tools/lint` Flox with platform-pinned uv on PATH: **all hooks passed again**, including lint, format and type checks. The wrapper rebuilt an existing editable SDK package; no tracked drift or Harbor upgrade.
- `git diff --cached --check` and full PR-range whitespace check: passed. All **five** PR commits passed author-matching DCO audit before push.
- TruffleHog 3.95.3 scan of the full plugin plus fresh fixture products/test: **zero verified/unverified findings**, no exclusions, network or credential verification.
- Generic `skill-creator/scripts/quick_validate.py` still rejects the repository's existing extended frontmatter (`compatibility`, `maturity`, `not-for`, `triggers`, `user-invocable`). Repository-specific tests pass; metadata was not altered to bypass that validator mismatch.

The two-runtime measurement remains attributed to source commit `752864e8a`: existing Harbor 0.20.0 lacks serialized trial verifier mode, while existing 0.22.0 passes the required probes. Actual retained trial evidence remains mandatory; capability preflight does not prove execution, future-version support, dependency closure or container freshness.

Fresh checkpoint: **89 prepared; 8 technically passing candidates, 7 no-candidates, 74 pending; 40 accepted Harbor 0.22 jobs** and 15 retained/rejected earlier 0.20 jobs. Every candidate has two NOP=0, two Oracle=1 and a task-specific negative=0, separate no-network verification and pre-run receipts. No human-reviewed or ready environments are claimed. This is not a new model-agent benchmark score or full-batch yield measurement.

Public source recovery is distinct from benchmark reuse: Bottle's trace-observed blob IDs identify an upstream commit matching the benchmark Dockerfile only checked after freezing. Token counting uses revision/hash-pinned trace-named public inputs and independently computes the expected integer through two tokenizer interfaces; both frozen Oracle outputs agree with the later-inspected original expected value. Public upstream verification inputs are explicitly inventoried; benchmark archives remain comparison-only. No original benchmark grader has been executed or copied into a fresh task.

All 89 traces name GLM-5.2 as primary, but 57 also contain Opus agent steps (2,852 GLM and 535 Opus steps overall). This is not a pure single-model comparison. The normalization fix was applied to ten pending preparations with originals and prior preparations preserved privately.

Head `246b136965a32e13d03457fd499069e800df31bd` is the documentation correction. Previous head `5109e88be` completed all CI/security/title/DCO checks successfully or was intentionally skipped; new-head CI must finish independently. Preserve the PR's current ready-for-review state; human approval is still required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime capability checks before proof jobs, including fail-closed handling for unsupported runtimes and task types.
  * Added publication staging and dedicated review workflows with preview, digest, directory, and export validation.
  * Added command-line actions for runtime checks and publication preparation and review.
  * Improved image metadata normalization and privacy-safe publication handling.

* **Bug Fixes**
  * Environment readiness now detects unavailable required software.
  * Improved reproducibility checks for Dockerfile frontend images and immutable references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->