### PR TITLE
chore: carry plugin shared-data into the nemo-platform wheel

### DIFF
--- a/packages/nemo_platform/hatch_build.py
+++ b/packages/nemo_platform/hatch_build.py
@@ -17,6 +17,9 @@
 
 - Wheel builds: reads [tool.bundle-package] from pyproject.toml and generates
   force-include mappings dynamically, merged with static wheel force-includes.
+  Bundle entries declaring `shared_data` also contribute wheel shared-data, so
+  files a bundled package would install under the environment prefix survive
+  bundling.
   Also attempts to build the Studio UI bundle so it is picked up by the
   force-include.
 - Editable installs: suppresses force-include so workspace packages stay resolved
@@ -34,6 +37,7 @@ from pathlib import Path
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 from nmp_build_tools.hatch import (
     apply_bundle_force_include,
+    apply_bundle_shared_data,
     disable_bundle_force_include_for_editable,
     rewrite_bundled_dependencies_in_wheel,
 )
@@ -49,6 +53,9 @@ class CustomBuildHook(BuildHookInterface):
         # This replaces the hardcoded [tool.hatch.build.targets.wheel.force-include]
         # section that was previously in pyproject.toml.
         apply_bundle_force_include(self.root, build_data)
+        # Prefix-installed data files (<sys.prefix>/share/...) that a bundled
+        # package would otherwise ship as its own distribution's shared-data.
+        apply_bundle_shared_data(self.root, build_data)
 
         self._build_studio_ui()
 

--- a/packages/nemo_platform/pyproject.toml
+++ b/packages/nemo_platform/pyproject.toml
@@ -866,7 +866,9 @@ nemo-data-designer-plugin = { source = "../../plugins/nemo-data-designer/src/nem
 nemo-deployments-plugin = { source = "../../plugins/nemo-deployments/src/nemo_deployments_plugin", module = "nemo_deployments_plugin", inherit = { "entry-points" = ["nemo.*"] } }
 nemo-evaluator-plugin = { source = "../../plugins/nemo-evaluator/src/nemo_evaluator", module = "nemo_evaluator", inherit = { "entry-points" = ["nemo.*"] } }
 nemo-experimentalist-plugin = { source = "../../plugins/nemo-experimentalist/src/nemo_experimentalist_plugin", module = "nemo_experimentalist_plugin", inherit = { "entry-points" = ["nemo.*"] } }
-nemo-insights-plugin = { source = "../../plugins/nemo-insights/src/nemo_insights_plugin", module = "nemo_insights_plugin", inherit = { "entry-points" = ["nemo.*"] } }
+# shared_data mirrors the standalone plugin's wheel shared-data: Fabric resolves
+# adapter descriptors from <sys.prefix>/share/nemo-fabric/adapters at runtime.
+nemo-insights-plugin = { source = "../../plugins/nemo-insights/src/nemo_insights_plugin", module = "nemo_insights_plugin", inherit = { "entry-points" = ["nemo.*"] }, shared_data = { "../../insights-analyst.fabric-adapter.json" = "share/nemo-fabric/adapters/insights-analyst/insights-analyst.fabric-adapter.json" } }
 # Required by agents.optimize (OptimizeJob lives here; agents plugin imports it at router setup).
 nemo-optimization-plugin = { source = "../../plugins/nemo-optimization/src/nemo_optimization", module = "nemo_optimization", inherit = { "entry-points" = ["nemo.*"] } }
 nemo-guardrails-plugin = { source = "../../plugins/nemo-guardrails/src/nemo_guardrails_plugin", module = "nemo_guardrails_plugin", inherit = { "entry-points" = ["nemo.*"] } }

--- a/packages/nmp_build_tools/src/nmp_build_tools/hatch.py
+++ b/packages/nmp_build_tools/src/nmp_build_tools/hatch.py
@@ -104,8 +104,37 @@ def read_bundle_force_include(root: str) -> dict[str, str]:
     return force_include
 
 
+def read_bundle_shared_data(root: str) -> dict[str, str]:
+    """Return Hatch shared-data mappings for bundled packages.
+
+    A bundled package that installs data files under the environment prefix
+    (``<sys.prefix>/share/...``) cannot express that through ``force_include``:
+    force-includes land in site-packages, while shared-data lands in the wheel's
+    ``.data`` directory and is unpacked relative to the install prefix. Bundle
+    entries therefore declare ``shared_data`` separately, with source paths
+    resolved relative to that entry's ``source`` directory.
+    """
+    pyproject_path = Path(root) / "pyproject.toml"
+    with open(pyproject_path, "rb") as f:
+        config = tomllib.load(f)
+
+    bundle_packages = config.get("tool", {}).get("bundle-package", {})
+
+    shared_data: dict[str, str] = {}
+    for pkg_config in bundle_packages.values():
+        source_path = (Path(root) / pkg_config["source"]).resolve()
+        for extra_source, target in pkg_config.get("shared_data", {}).items():
+            shared_data[str((source_path / extra_source).resolve())] = target
+
+    return shared_data
+
+
 def apply_bundle_force_include(root: str, build_data: dict[str, Any]) -> None:
     build_data["force_include"] = read_bundle_force_include(root)
+
+
+def apply_bundle_shared_data(root: str, build_data: dict[str, Any]) -> None:
+    build_data["shared_data"] = {**build_data.get("shared_data", {}), **read_bundle_shared_data(root)}
 
 
 def disable_bundle_force_include_for_editable(build_data: dict[str, Any]) -> None:

--- a/packages/nmp_build_tools/tests/test_hatch.py
+++ b/packages/nmp_build_tools/tests/test_hatch.py
@@ -10,6 +10,7 @@ from nmp_build_tools.hatch import (
     _rewrite_metadata,
     nmp_dynamic_versioning_config,
     read_bundle_force_include,
+    read_bundle_shared_data,
 )
 
 
@@ -126,6 +127,35 @@ pkg = { source = "pkg/src/pkg", module = "pkg", force_include = { "../../**/*.ym
 
     with pytest.raises(ValueError, match="Glob force_include target collision"):
         read_bundle_force_include(str(root))
+
+
+def test_read_bundle_shared_data_resolves_paths_relative_to_the_bundle_source(tmp_path: Path) -> None:
+    root = tmp_path / "wrapper"
+    (root / "pkg" / "src" / "pkg").mkdir(parents=True)
+    (root / "pkg" / "adapter.json").write_text("{}")
+    (root / "pyproject.toml").write_text(
+        """
+[tool.bundle-package]
+pkg = { source = "pkg/src/pkg", module = "pkg", shared_data = { "../../adapter.json" = "share/x/adapter.json" } }
+"""
+    )
+
+    assert read_bundle_shared_data(str(root)) == {
+        str(root / "pkg" / "adapter.json"): "share/x/adapter.json",
+    }
+
+
+def test_read_bundle_shared_data_is_empty_without_declarations(tmp_path: Path) -> None:
+    root = tmp_path / "wrapper"
+    (root / "pkg" / "src" / "pkg").mkdir(parents=True)
+    (root / "pyproject.toml").write_text(
+        """
+[tool.bundle-package]
+pkg = { source = "pkg/src/pkg", module = "pkg" }
+"""
+    )
+
+    assert read_bundle_shared_data(str(root)) == {}
 
 
 def test_rewrite_metadata_replaces_bundled_requirements_with_self_extras() -> None:

--- a/tests/unit/test_wrapper_distribution.py
+++ b/tests/unit/test_wrapper_distribution.py
@@ -29,3 +29,72 @@ def test_all_extra_bundles_default_deployments_backend() -> None:
     assert project["entry-points"]["nemo.controllers"]["deployments"].startswith("nemo_deployments_plugin.")
     assert project["entry-points"]["nemo.sandbox_profiles"]["openshell"].startswith("nemo_deployments_plugin.")
     assert project["entry-points"]["nemo.skills"]["deployments"].startswith("nemo_deployments_plugin.")
+
+
+def test_bundled_shared_data_is_carried_into_the_wrapper_wheel() -> None:
+    """Every bundled package's shared-data must be re-declared on its bundle entry.
+
+    Bundled packages are not installed as their own distribution in a packaged
+    ``nemo-platform`` install, so anything they would install under the
+    environment prefix is lost unless the wrapper bundle entry declares it too.
+    """
+    pyproject_path = ROOT / "packages/nemo_platform/pyproject.toml"
+    with open(pyproject_path, "rb") as pyproject:
+        bundles = tomllib.load(pyproject)["tool"]["bundle-package"]
+
+    for name, bundle in bundles.items():
+        source = (pyproject_path.parent / bundle["source"]).resolve()
+        bundled_pyproject = _owning_pyproject(source)
+        if bundled_pyproject is None:
+            continue
+
+        with open(bundled_pyproject, "rb") as pyproject:
+            config = tomllib.load(pyproject)
+        shared_data = (
+            config.get("tool", {})
+            .get("hatch", {})
+            .get("build", {})
+            .get("targets", {})
+            .get("wheel", {})
+            .get("shared-data", {})
+        )
+        if not shared_data:
+            continue
+
+        expected = {
+            (bundled_pyproject.parent / relative_source).resolve(): target
+            for relative_source, target in shared_data.items()
+        }
+        actual = {
+            (source / relative_source).resolve(): target
+            for relative_source, target in bundle.get("shared_data", {}).items()
+        }
+        assert actual == expected, f"bundle entry '{name}' does not carry the shared-data of {bundled_pyproject}"
+        for path in actual:
+            assert path.is_file()
+
+
+def test_insights_analyst_fabric_descriptor_ships_in_the_wrapper_wheel() -> None:
+    """Fabric resolves ``nvidia.fabric.insights-analyst`` from the install prefix."""
+    pyproject_path = ROOT / "packages/nemo_platform/pyproject.toml"
+    with open(pyproject_path, "rb") as pyproject:
+        bundle = tomllib.load(pyproject)["tool"]["bundle-package"]["nemo-insights-plugin"]
+
+    source = (pyproject_path.parent / bundle["source"]).resolve()
+    shared_data = {(source / key).resolve(): value for key, value in bundle["shared_data"].items()}
+
+    descriptor = (ROOT / "plugins/nemo-insights/insights-analyst.fabric-adapter.json").resolve()
+    assert shared_data[descriptor] == (
+        "share/nemo-fabric/adapters/insights-analyst/insights-analyst.fabric-adapter.json"
+    )
+
+
+def _owning_pyproject(source: Path) -> Path | None:
+    """Return the ``pyproject.toml`` of the distribution owning a bundled source tree."""
+    for parent in source.parents:
+        candidate = parent / "pyproject.toml"
+        if candidate.is_file():
+            return candidate
+        if parent == ROOT:
+            break
+    return None


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
Ensure that plugin's `shared-data` defined in their pyproject.toml is carried into the `nemo-platform` wheel.

This addresses [this comment](https://github.com/NVIDIA-NeMo/nemo-platform/pull/1863#discussion_r3972245745) from @benmccown (which was caught on that PR but really traces back to #1598)


## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [x] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

<!-- List each command and result. Explain skipped, blocked, or non-successful checks without marking them as passed. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wheel builds now package declared shared-data files from bundled packages.
  * The Insights Analyst Fabric adapter descriptor is included at its expected installation path.

* **Bug Fixes**
  * Corrected packaging so shared-data files are available in prefix-installed wheels.

* **Tests**
  * Added coverage for shared-data path resolution and wrapper bundle distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->