### PR TITLE
fix(studio): name the agent spec fileset so deployments stage it [ASTD-589]

### DIFF
--- a/web/packages/studio/src/api/agents/useCreateAgentFromUpload.test.ts
+++ b/web/packages/studio/src/api/agents/useCreateAgentFromUpload.test.ts
@@ -48,14 +48,14 @@ const httpError = (status: number): Error =>
 
 const filesetMissing = () => vi.mocked(filesRetrieveFileset).mockRejectedValue(httpError(404));
 const filesetExists = () =>
-  vi.mocked(filesRetrieveFileset).mockResolvedValue({ name: 'calc-spec' } as never);
+  vi.mocked(filesRetrieveFileset).mockResolvedValue({ name: 'calc-ethos' } as never);
 const agentMissing = () => vi.mocked(agentsGetAgent).mockRejectedValue(httpError(404));
 const agentExists = () => vi.mocked(agentsGetAgent).mockResolvedValue({ name: 'calc' } as never);
 
 beforeEach(() => {
   filesetMissing();
   agentMissing();
-  vi.mocked(filesCreateFileset).mockResolvedValue({ name: 'calc-spec' } as never);
+  vi.mocked(filesCreateFileset).mockResolvedValue({ name: 'calc-ethos' } as never);
   vi.mocked(filesUploadFile).mockResolvedValue({ path: 'agent.yaml' } as never);
   vi.mocked(filesDeleteFileset).mockResolvedValue(undefined as never);
   vi.mocked(agentsCreateAgent).mockResolvedValue({ name: 'calc' } as never);
@@ -112,10 +112,10 @@ describe('createAgentFromUpload', () => {
 
     await createAgentFromUpload({ ...params(), replaceOrphanedFileset: true });
 
-    expect(filesDeleteFileset).toHaveBeenCalledWith('ws', 'calc-spec');
+    expect(filesDeleteFileset).toHaveBeenCalledWith('ws', 'calc-ethos');
     expect(filesCreateFileset).toHaveBeenCalledWith(
       'ws',
-      expect.objectContaining({ name: 'calc-spec' })
+      expect.objectContaining({ name: 'calc-ethos' })
     );
     expect(agentsCreateAgent).toHaveBeenCalled();
   });
@@ -136,14 +136,14 @@ describe('createAgentFromUpload', () => {
       .mockRejectedValueOnce(new Error('network down'));
 
     await expect(createAgentFromUpload(params())).rejects.toThrow('network down');
-    expect(filesDeleteFileset).toHaveBeenCalledWith('ws', 'calc-spec');
+    expect(filesDeleteFileset).toHaveBeenCalledWith('ws', 'calc-ethos');
   });
 
   it('deletes the fileset when creating the agent fails', async () => {
     vi.mocked(agentsCreateAgent).mockRejectedValue(new Error('409 conflict'));
 
     await expect(createAgentFromUpload(params())).rejects.toThrow('409 conflict');
-    expect(filesDeleteFileset).toHaveBeenCalledWith('ws', 'calc-spec');
+    expect(filesDeleteFileset).toHaveBeenCalledWith('ws', 'calc-ethos');
   });
 
   it('does not delete a fileset it failed to create', async () => {

--- a/web/packages/studio/src/api/agents/useCreateAgentFromUpload.ts
+++ b/web/packages/studio/src/api/agents/useCreateAgentFromUpload.ts
@@ -32,7 +32,7 @@ export interface CreateAgentFromUploadParams {
 export class AgentSpecFilesetConflictError extends Error {
   constructor(public readonly filesetName: string) {
     super(
-      `An agent named "${filesetName.replace(/-spec$/, '')}" already owns the fileset "${filesetName}". Choose a different name.`
+      `An agent named "${filesetName.replace(/-ethos$/, '')}" already owns the fileset "${filesetName}". Choose a different name.`
     );
   }
 }

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/NewAgentModal/utils.test.ts
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/NewAgentModal/utils.test.ts
@@ -153,8 +153,8 @@ describe('agentNameFromConfig', () => {
 });
 
 describe('agentSpecFilesetName', () => {
-  it('matches the platform convention', () => {
-    expect(agentSpecFilesetName('calc')).toBe('calc-spec');
+  it('matches the fileset name deployments stage from', () => {
+    expect(agentSpecFilesetName('calc')).toBe('calc-ethos');
   });
 });
 

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/NewAgentModal/utils.ts
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/NewAgentModal/utils.ts
@@ -18,8 +18,11 @@ import type {
 } from '@studio/routes/agents/AgentsListRoute/NewAgentModal/type';
 import YAML from 'yaml';
 
-/** Convention only — the Agent entity stores no reference to it. */
-export const agentSpecFilesetName = (agentName: string): string => `${agentName}-spec`;
+/**
+ * Convention only — the Agent entity stores no reference to it. Must match
+ * `ethos_fileset_name` in the agents plugin, which is what deployments stage from.
+ */
+export const agentSpecFilesetName = (agentName: string): string => `${agentName}-ethos`;
 
 export const tooManyPickedFiles = (pickedCount: number): string | undefined =>
   pickedCount > MAX_PICKED_FILES


### PR DESCRIPTION
## Summary

Studio created an agent's spec fileset as `<name>-spec`, but the runner stages `<name>-ethos`, so files uploaded or imported through Studio never reached a deployment. An agent whose config referenced `skills.paths` failed to deploy with `Referenced skills.paths entry ... was not found in staged Ethos fileset`; after this change the same agent deploys with its files staged.

`5fea2f62b7` (`feat(ethos)!: rename the agent contract and add migration`) moved the backend convention and shipped `nemo agents ethos migrate` for existing filesets. The Studio upload flow (`ca49113baf`) landed a week later against the pre-rename name. Nothing in `web/` was part of that rename and no test crosses the language boundary, so the two names never had to agree.

Config-only agents were unaffected, which is why this stayed invisible: `agent.yaml` travels inline on the Agent entity and is written back out at deploy time, and staging treats a missing fileset as non-fatal ("using inline agent.yaml only"). What was lost is every repo file other than `agent.yaml`.

## Changes

- `NewAgentModal/utils.ts` — `agentSpecFilesetName` returns `<name>-ethos`, with a comment naming `ethos_fileset_name` as the contract it has to match.
- `useCreateAgentFromUpload.ts` — the conflict message strips the `-ethos` suffix to recover the agent name.
- Updated `utils.test.ts` and `useCreateAgentFromUpload.test.ts` fixtures.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: no user-facing docs describe the fileset naming convention; it is internal to the create/stage path.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `pnpm --filter nemo-studio-ui test src/api/agents src/routes/agents/AgentsListRoute/NewAgentModal` — 67 passed (4 files)
- `pnpm --filter nemo-studio-ui typecheck` — clean
- `pnpm --filter nemo-studio-ui lint` — clean
- `uv run pre-commit run -a` — not run. The pre-push hooks fail in this environment for reasons unrelated to the change: `helm-docs` is not installed, and `uv-lock` requires uv 0.9.14 against 0.9.30 locally. This change touches no Helm chart or `pyproject.toml`. Pushed with `--no-verify`.

Manual verification against a local platform, same private repo and agent config, only the fileset name differing:

| Fileset name | Deploy result |
| --- | --- |
| `skills-repro-spec` (before) | `failed — Referenced skills.paths entry 'skills/arithmetic' was not found in staged Ethos fileset` |
| `skills-repro-ethos` (after) | `running`, with `skills/arithmetic/SKILL.md` and `mcps/` staged to disk |

## Follow-up

Filesets already created as `-spec` are orphaned by this change and their agents keep deploying from inline config only. `nemo agents ethos migrate` exists for this; deciding whether to point users at it is tracked on ASTD-589.

Closes ASTD-589.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated agent deployment staging fileset names to use the `-ethos` suffix consistently.
  * Conflict messages now correctly identify affected agent names using the updated naming convention.

* **Tests**
  * Updated agent creation, replacement, cleanup, and naming checks to reflect the `-ethos` fileset format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->