### PR TITLE
fix(agents): refuse only a contradicting compute driver in the executor mode check

### DIFF
--- a/plugins/nemo-agents/src/nemo_agents_plugin/runner/deployments_backend.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/runner/deployments_backend.py
@@ -368,22 +368,23 @@ def executor_backend(name: str | None) -> str | None:
 
 
 def require_executor_matches_mode(executor: str | None, mode: DeploymentMode) -> None:
-    """Refuse a container mode that would run somewhere other than it names.
+    """Refuse a container mode that would run on the other compute driver.
 
     ``executor_for_mode`` falls back to ``default_executor``, so asking for k8s
     where none is configured silently lands on docker: the deployment reports
     running while nothing exists in the cluster, and a k8s-only failure cannot
-    reproduce. The backend keys and the deployment modes share a vocabulary, so
-    the mismatch is checkable here rather than discoverable by counting pods.
+    reproduce. The docker and k8s backend keys share a vocabulary with the
+    deployment modes, so that mismatch is checkable here rather than discoverable
+    by counting pods. Only those two backends can contradict a mode; any other
+    backend is a substrate layered over one of them and is accepted by default.
     """
     backend = executor_backend(executor)
-    if backend is None or backend == mode:
+    if backend not in CONTAINER_DEPLOYMENT_MODES or backend == mode:
         return
-    alternative = f", or deploy with deployment_mode {backend!r}" if backend in CONTAINER_DEPLOYMENT_MODES else ""
     raise ValueError(
         f"deployment_mode {mode!r} resolved to executor {executor!r}, which runs on "
         f"{backend!r}. Set 'deployments.{mode}_executor' to an executor whose backend "
-        f"is {mode!r}{alternative}."
+        f"is {mode!r}, or deploy with deployment_mode {backend!r}."
     )
 
 

--- a/plugins/nemo-agents/tests/unit/test_runner_deployments.py
+++ b/plugins/nemo-agents/tests/unit/test_runner_deployments.py
@@ -244,17 +244,37 @@ def test_k8s_mode_on_a_docker_executor_is_refused(monkeypatch: pytest.MonkeyPatc
         require_executor_matches_mode("default-exec", "k8s")
 
 
-def test_k8s_mode_on_a_non_deployable_backend_omits_the_mode_suggestion(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_docker_mode_on_a_k8s_executor_is_refused(monkeypatch: pytest.MonkeyPatch) -> None:
     from nemo_deployments_plugin.config import DeploymentsConfig
 
-    # 'openshell' is a deployments-plugin backend but not a DeploymentMode, so
-    # the error must not suggest deploying with a mode that can't validate.
-    cfg = _executors(("default-exec", "openshell"))
+    cfg = _executors(("default-exec", "k8s"))
     monkeypatch.setattr(DeploymentsConfig, "get", classmethod(lambda cls: cfg))
 
-    with pytest.raises(ValueError, match="runs on 'openshell'") as exc_info:
+    with pytest.raises(ValueError, match="runs on 'k8s'"):
+        require_executor_matches_mode("default-exec", "docker")
+
+
+def test_refusal_names_the_mode_that_would_have_worked(monkeypatch: pytest.MonkeyPatch) -> None:
+    from nemo_deployments_plugin.config import DeploymentsConfig
+
+    cfg = _executors(("default-exec", "docker"))
+    monkeypatch.setattr(DeploymentsConfig, "get", classmethod(lambda cls: cfg))
+
+    with pytest.raises(ValueError, match="deploy with deployment_mode 'docker'"):
         require_executor_matches_mode("default-exec", "k8s")
-    assert "deploy with deployment_mode" not in str(exc_info.value)
+
+
+@pytest.mark.parametrize("mode", ["docker", "k8s"])
+@pytest.mark.parametrize("backend", ["openshell", "nomad"])
+def test_container_modes_accept_any_non_driver_backend(
+    backend: str, mode: DeploymentMode, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from nemo_deployments_plugin.config import DeploymentsConfig
+
+    cfg = _executors(("substrate-exec", backend))
+    monkeypatch.setattr(DeploymentsConfig, "get", classmethod(lambda cls: cfg))
+
+    require_executor_matches_mode("substrate-exec", mode)
 
 
 def test_k8s_mode_accepts_a_k8s_capable_default(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
`nemo agents deploy --mode k8s` (or `docker`) is refused when the operator points `agents.deployments.k8s_executor` at an executor whose backend is not literally the mode name, for example `openshell`. That configuration is the documented way to sandbox agent deployments, and a user-supplied substrate registered under any other backend key hits the same wall. The mode check now refuses only a docker or k8s executor that contradicts the requested mode and accepts every other backend.

## Changes
- `require_executor_matches_mode` refuses exactly the case #1786 was written for: k8s mode resolving to the docker driver, or the reverse, where "running" means nothing exists where you looked. Only those two backends can contradict a mode, so nothing else is refused and the platform never has to learn a new backend's name.
- The mode suggestion in the error is unconditional, since the refused backend is always itself a deployable mode.
- Tests: docker-on-k8s and k8s-on-docker still refused with the suggestion; `openshell` and an unknown `nomad` backend accepted for both container modes.

Verified live: with `agents.deployments.k8s_executor: openshell`, `nemo agents deploy --mode k8s` lands a Fabric agent in an OpenShell sandbox on a k3d cluster and `nemo agents invoke` answers (together with #TBD-1135 for the invoke hop).

Closes AIRCORE-1160.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: removes a refusal of an already-documented configuration; the sandboxed-deployments docs land separately (AIRCORE-1162/1163).

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `uv run --frozen pytest plugins/nemo-agents/tests/unit/test_runner_deployments.py -q`: 91 passed
- `uv run --frozen pytest plugins/nemo-agents/tests/unit -q -k "deploy or executor"`: 267 passed
- `uv run --frozen ruff check` and `ruff format --check` on the two changed files: clean
- `uv run --frozen ty check` on the two changed files: clean
- `uv run pre-commit run -a`: not run locally (full-repo hooks); CI covers it


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved deployment-mode validation for Docker and Kubernetes executor mismatches.
  - Non-container backends, including OpenShell and Nomad, are now accepted with either container deployment mode.
  - Error messages now suggest the compatible deployment mode when a container backend mismatch occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->