### PR TITLE
feat(files): serve filesets from GitHub and refresh a tracked revision [ASTD-592]

### DIFF
--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -1357,6 +1357,7 @@ nemo files filesets [OPTIONS] COMMAND [ARGS]...
 * `create`: Create a new fileset.
 * `delete`: Delete Fileset.
 * `list`: List Filesets endpoint with filtering and pagination.
+* `refresh`: Re-resolve a fileset's tracked revision against its source.
 * `get`: Get Fileset by Workspace and Name.
 * `update`: Update Fileset Metadata.
 
@@ -1422,8 +1423,8 @@ Delete Fileset.
 Permanently deletes an unreferenced fileset from the platform.
 
 Referencing model
-or adapter entities must be relinked or deleted first. For local storage backends, this also deletes the
-underlying files.
+or adapter entities must be relinked or deleted first. For local storage
+backends, this also deletes the underlying files.
 
 **Usage:**
 
@@ -1487,6 +1488,40 @@ Filter filesets by name, description, purpose, storage_type, created_at, and upd
 * `--no-truncate`: Don't truncate long values in table/markdown/csv output.
 * `--output-columns, -c`: Columns to display: 'default', 'all', or comma-separated names. Only affects table/csv/markdown formats.
 * `--stream`: Emit newline-delimited JSON, one record per line. Requires JSON or raw output.
+
+##### nemo files filesets refresh
+
+Re-resolve a fileset's tracked revision against its source.
+
+A fileset created from a mutable ref is pinned to an immutable id so its
+contents cannot shift under a deployment. This re-resolves that same ref and
+repoints the fileset at whatever it names now. Everything else about the storage
+config, including the repository and directory, is left alone.
+
+Deployments stage the fileset when they are created, so existing deployments
+keep serving the revision they were staged from.
+
+**Usage:**
+
+```shell
+nemo files filesets refresh [OPTIONS] NAME
+```
+
+**Arguments:**
+
+* `<NAME>`
+
+**Options:**
+
+* `--workspace`
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+**Output Options:**
+
+* `--output-format, --output, -f <CHOICE>`: Output format for an entity. [possible values: json, yaml, raw, code]
 
 ##### nemo files filesets get
 

--- a/docs/set-up/config-reference.mdx
+++ b/docs/set-up/config-reference.mdx
@@ -245,8 +245,8 @@ files:
     path: /data/files_storage
     # How many bytes to buffer before flushing to disk | default: 16777216
     write_buffer_size: 16777216
-  # Comma-separated list of external hosts the Files service is allowed to access. | default: 'https://api.ngc.nvidia.com,https://huggingface.co'
-  allowed_external_hosts: https://api.ngc.nvidia.com,https://huggingface.co
+  # Comma-separated list of external hosts the Files service is allowed to access. | default: 'https://api.ngc.nvidia.com,https://huggingface.co,https://api.github.com'
+  allowed_external_hosts: https://api.ngc.nvidia.com,https://huggingface.co,https://api.github.com
   # Allow users to explicitly create filesets with local storage config. Security-sensitive: enable only in trusted deployments. | default: False
   allow_user_local_storage: false
   # TTL for file locks in seconds (default 5 minutes) | default: 300

--- a/openapi/ga/individual/platform.openapi.yaml
+++ b/openapi/ga/individual/platform.openapi.yaml
@@ -2290,6 +2290,62 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /apis/files/v2/workspaces/{workspace}/filesets/{name}/refresh:
+    post:
+      tags:
+      - Files
+      summary: Refresh Fileset Revision
+      description: 'Re-resolve a fileset''s tracked revision against its source.
+
+
+        A fileset created from a mutable ref is pinned to an immutable id so its
+
+        contents cannot shift under a deployment. This re-resolves that same ref and
+
+        repoints the fileset at whatever it names now. Everything else about the
+
+        storage config, including the repository and directory, is left alone.
+
+
+        Deployments stage the fileset when they are created, so existing deployments
+
+        keep serving the revision they were staged from.'
+      operationId: refresh_fileset_apis_files_v2_workspaces__workspace__filesets__name__refresh_post
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FilesetOutput'
+        '409':
+          description: Fileset does not track a mutable revision
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /apis/guardrails/v2/workspaces/{workspace}/checks:
     post:
       tags:

--- a/openapi/ga/individual/platform.openapi.yaml
+++ b/openapi/ga/individual/platform.openapi.yaml
@@ -2307,9 +2307,10 @@ paths:
         storage config, including the repository and directory, is left alone.
 
 
-        Deployments stage the fileset when they are created, so existing deployments
+        A running deployment keeps serving the revision it staged. It moves to this
+        one
 
-        keep serving the revision they were staged from.'
+        when the runner next stages the fileset, and records the revision it staged.'
       operationId: refresh_fileset_apis_files_v2_workspaces__workspace__filesets__name__refresh_post
       parameters:
       - name: workspace
@@ -2331,8 +2332,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FilesetOutput'
+        '400':
+          description: Storage configuration, secret, or source rejected the refresh
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+        '404':
+          description: Fileset not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
         '409':
           description: Fileset does not track a mutable revision
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+        '502':
+          description: Storage backend unavailable
           content:
             application/json:
               schema:

--- a/openapi/ga/individual/platform.openapi.yaml
+++ b/openapi/ga/individual/platform.openapi.yaml
@@ -10266,6 +10266,7 @@ components:
           - $ref: '#/components/schemas/NGCStorageConfig'
           - $ref: '#/components/schemas/HuggingfaceStorageConfig'
           - $ref: '#/components/schemas/S3StorageConfig'
+          - $ref: '#/components/schemas/GithubStorageConfig'
           title: Storage
           description: The storage configuration for the fileset. If not provided,
             uses default storage.
@@ -12616,6 +12617,7 @@ components:
           - $ref: '#/components/schemas/NGCStorageConfig'
           - $ref: '#/components/schemas/HuggingfaceStorageConfig'
           - $ref: '#/components/schemas/S3StorageConfig'
+          - $ref: '#/components/schemas/GithubStorageConfig'
           title: Storage
         metadata:
           $ref: '#/components/schemas/FilesetMetadata'
@@ -13122,6 +13124,60 @@ components:
         with ``-`` for
 
         descending order.'
+    GithubStorageConfig:
+      properties:
+        read_chunk_size:
+          type: integer
+          title: Read Chunk Size
+          description: 'Chunk size in bytes for reading/streaming files. Larger chunks
+            reduce async overhead but increase memory per concurrent download. Default:
+            1MB.'
+          default: 1048576
+        type:
+          type: string
+          const: github
+          title: Type
+          default: github
+        owner:
+          type: string
+          title: Owner
+          description: GitHub repository owner (user or organization)
+        repo:
+          type: string
+          title: Repo
+          description: GitHub repository name
+        revision:
+          type: string
+          title: Revision
+          description: Branch, tag, or commit SHA. 'HEAD' resolves to the repository's
+            default branch.
+          default: HEAD
+        original_revision:
+          title: Original Revision
+          description: The original revision requested by the user before resolution
+            (e.g., 'main'). The 'revision' field contains the resolved commit SHA.
+          type: string
+        path:
+          type: string
+          title: Path
+          description: Optional directory within the repository. All paths are relative
+            to it.
+          default: ''
+        token_secret:
+          allOf:
+          - $ref: '#/components/schemas/SecretRef'
+          description: GitHub personal access token secret name, required for private
+            repositories
+        api_base_url:
+          type: string
+          title: Api Base Url
+          description: GitHub API base URL. Use for GitHub Enterprise instances.
+          default: https://api.github.com
+      type: object
+      required:
+      - owner
+      - repo
+      title: GithubStorageConfig
     GuardrailCheckRequest:
       properties:
         model:
@@ -19038,6 +19094,7 @@ components:
       - ngc
       - huggingface
       - s3
+      - github
       title: StorageConfigType
       type: string
     StringFilter:

--- a/openapi/ga/openapi.yaml
+++ b/openapi/ga/openapi.yaml
@@ -2290,6 +2290,62 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /apis/files/v2/workspaces/{workspace}/filesets/{name}/refresh:
+    post:
+      tags:
+      - Files
+      summary: Refresh Fileset Revision
+      description: 'Re-resolve a fileset''s tracked revision against its source.
+
+
+        A fileset created from a mutable ref is pinned to an immutable id so its
+
+        contents cannot shift under a deployment. This re-resolves that same ref and
+
+        repoints the fileset at whatever it names now. Everything else about the
+
+        storage config, including the repository and directory, is left alone.
+
+
+        Deployments stage the fileset when they are created, so existing deployments
+
+        keep serving the revision they were staged from.'
+      operationId: refresh_fileset_apis_files_v2_workspaces__workspace__filesets__name__refresh_post
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FilesetOutput'
+        '409':
+          description: Fileset does not track a mutable revision
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /apis/guardrails/v2/workspaces/{workspace}/checks:
     post:
       tags:

--- a/openapi/ga/openapi.yaml
+++ b/openapi/ga/openapi.yaml
@@ -2307,9 +2307,10 @@ paths:
         storage config, including the repository and directory, is left alone.
 
 
-        Deployments stage the fileset when they are created, so existing deployments
+        A running deployment keeps serving the revision it staged. It moves to this
+        one
 
-        keep serving the revision they were staged from.'
+        when the runner next stages the fileset, and records the revision it staged.'
       operationId: refresh_fileset_apis_files_v2_workspaces__workspace__filesets__name__refresh_post
       parameters:
       - name: workspace
@@ -2331,8 +2332,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FilesetOutput'
+        '400':
+          description: Storage configuration, secret, or source rejected the refresh
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+        '404':
+          description: Fileset not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
         '409':
           description: Fileset does not track a mutable revision
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+        '502':
+          description: Storage backend unavailable
           content:
             application/json:
               schema:

--- a/openapi/ga/openapi.yaml
+++ b/openapi/ga/openapi.yaml
@@ -10266,6 +10266,7 @@ components:
           - $ref: '#/components/schemas/NGCStorageConfig'
           - $ref: '#/components/schemas/HuggingfaceStorageConfig'
           - $ref: '#/components/schemas/S3StorageConfig'
+          - $ref: '#/components/schemas/GithubStorageConfig'
           title: Storage
           description: The storage configuration for the fileset. If not provided,
             uses default storage.
@@ -12616,6 +12617,7 @@ components:
           - $ref: '#/components/schemas/NGCStorageConfig'
           - $ref: '#/components/schemas/HuggingfaceStorageConfig'
           - $ref: '#/components/schemas/S3StorageConfig'
+          - $ref: '#/components/schemas/GithubStorageConfig'
           title: Storage
         metadata:
           $ref: '#/components/schemas/FilesetMetadata'
@@ -13122,6 +13124,60 @@ components:
         with ``-`` for
 
         descending order.'
+    GithubStorageConfig:
+      properties:
+        read_chunk_size:
+          type: integer
+          title: Read Chunk Size
+          description: 'Chunk size in bytes for reading/streaming files. Larger chunks
+            reduce async overhead but increase memory per concurrent download. Default:
+            1MB.'
+          default: 1048576
+        type:
+          type: string
+          const: github
+          title: Type
+          default: github
+        owner:
+          type: string
+          title: Owner
+          description: GitHub repository owner (user or organization)
+        repo:
+          type: string
+          title: Repo
+          description: GitHub repository name
+        revision:
+          type: string
+          title: Revision
+          description: Branch, tag, or commit SHA. 'HEAD' resolves to the repository's
+            default branch.
+          default: HEAD
+        original_revision:
+          title: Original Revision
+          description: The original revision requested by the user before resolution
+            (e.g., 'main'). The 'revision' field contains the resolved commit SHA.
+          type: string
+        path:
+          type: string
+          title: Path
+          description: Optional directory within the repository. All paths are relative
+            to it.
+          default: ''
+        token_secret:
+          allOf:
+          - $ref: '#/components/schemas/SecretRef'
+          description: GitHub personal access token secret name, required for private
+            repositories
+        api_base_url:
+          type: string
+          title: Api Base Url
+          description: GitHub API base URL. Use for GitHub Enterprise instances.
+          default: https://api.github.com
+      type: object
+      required:
+      - owner
+      - repo
+      title: GithubStorageConfig
     GuardrailCheckRequest:
       properties:
         model:
@@ -19038,6 +19094,7 @@ components:
       - ngc
       - huggingface
       - s3
+      - github
       title: StorageConfigType
       type: string
     StringFilter:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2290,6 +2290,62 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /apis/files/v2/workspaces/{workspace}/filesets/{name}/refresh:
+    post:
+      tags:
+      - Files
+      summary: Refresh Fileset Revision
+      description: 'Re-resolve a fileset''s tracked revision against its source.
+
+
+        A fileset created from a mutable ref is pinned to an immutable id so its
+
+        contents cannot shift under a deployment. This re-resolves that same ref and
+
+        repoints the fileset at whatever it names now. Everything else about the
+
+        storage config, including the repository and directory, is left alone.
+
+
+        Deployments stage the fileset when they are created, so existing deployments
+
+        keep serving the revision they were staged from.'
+      operationId: refresh_fileset_apis_files_v2_workspaces__workspace__filesets__name__refresh_post
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FilesetOutput'
+        '409':
+          description: Fileset does not track a mutable revision
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /apis/guardrails/v2/workspaces/{workspace}/checks:
     post:
       tags:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2307,9 +2307,10 @@ paths:
         storage config, including the repository and directory, is left alone.
 
 
-        Deployments stage the fileset when they are created, so existing deployments
+        A running deployment keeps serving the revision it staged. It moves to this
+        one
 
-        keep serving the revision they were staged from.'
+        when the runner next stages the fileset, and records the revision it staged.'
       operationId: refresh_fileset_apis_files_v2_workspaces__workspace__filesets__name__refresh_post
       parameters:
       - name: workspace
@@ -2331,8 +2332,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FilesetOutput'
+        '400':
+          description: Storage configuration, secret, or source rejected the refresh
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+        '404':
+          description: Fileset not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
         '409':
           description: Fileset does not track a mutable revision
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+        '502':
+          description: Storage backend unavailable
           content:
             application/json:
               schema:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -10266,6 +10266,7 @@ components:
           - $ref: '#/components/schemas/NGCStorageConfig'
           - $ref: '#/components/schemas/HuggingfaceStorageConfig'
           - $ref: '#/components/schemas/S3StorageConfig'
+          - $ref: '#/components/schemas/GithubStorageConfig'
           title: Storage
           description: The storage configuration for the fileset. If not provided,
             uses default storage.
@@ -12616,6 +12617,7 @@ components:
           - $ref: '#/components/schemas/NGCStorageConfig'
           - $ref: '#/components/schemas/HuggingfaceStorageConfig'
           - $ref: '#/components/schemas/S3StorageConfig'
+          - $ref: '#/components/schemas/GithubStorageConfig'
           title: Storage
         metadata:
           $ref: '#/components/schemas/FilesetMetadata'
@@ -13122,6 +13124,60 @@ components:
         with ``-`` for
 
         descending order.'
+    GithubStorageConfig:
+      properties:
+        read_chunk_size:
+          type: integer
+          title: Read Chunk Size
+          description: 'Chunk size in bytes for reading/streaming files. Larger chunks
+            reduce async overhead but increase memory per concurrent download. Default:
+            1MB.'
+          default: 1048576
+        type:
+          type: string
+          const: github
+          title: Type
+          default: github
+        owner:
+          type: string
+          title: Owner
+          description: GitHub repository owner (user or organization)
+        repo:
+          type: string
+          title: Repo
+          description: GitHub repository name
+        revision:
+          type: string
+          title: Revision
+          description: Branch, tag, or commit SHA. 'HEAD' resolves to the repository's
+            default branch.
+          default: HEAD
+        original_revision:
+          title: Original Revision
+          description: The original revision requested by the user before resolution
+            (e.g., 'main'). The 'revision' field contains the resolved commit SHA.
+          type: string
+        path:
+          type: string
+          title: Path
+          description: Optional directory within the repository. All paths are relative
+            to it.
+          default: ''
+        token_secret:
+          allOf:
+          - $ref: '#/components/schemas/SecretRef'
+          description: GitHub personal access token secret name, required for private
+            repositories
+        api_base_url:
+          type: string
+          title: Api Base Url
+          description: GitHub API base URL. Use for GitHub Enterprise instances.
+          default: https://api.github.com
+      type: object
+      required:
+      - owner
+      - repo
+      title: GithubStorageConfig
     GuardrailCheckRequest:
       properties:
         model:
@@ -19038,6 +19094,7 @@ components:
       - ngc
       - huggingface
       - s3
+      - github
       title: StorageConfigType
       type: string
     StringFilter:

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/files/filesets.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/files/filesets.py
@@ -170,8 +170,8 @@ def delete_filesets(
     Permanently deletes an unreferenced fileset from the platform.
 
     Referencing model
-    or adapter entities must be relinked or deleted first. For local storage backends, this also deletes the
-    underlying files."""
+    or adapter entities must be relinked or deleted first. For local storage
+    backends, this also deletes the underlying files."""
     state: CLIContext = ctx.obj
     client = state.get_client()
 
@@ -279,6 +279,45 @@ def list_filesets(
     )
     if not all_pages:
         warn_if_more_pages(items, pagination_type)
+
+
+@app.command("refresh")
+@collect_warnings
+@handle_errors
+def refresh_filesets(
+    ctx: typer.Context,
+    name: Annotated[str, typer.Argument()],
+    workspace: Annotated[str | None, typer.Option("--workspace")] = None,
+    output_format: EntityOutputFormatOption = None,
+) -> None:
+    """Re-resolve a fileset's tracked revision against its source.
+
+    A fileset created from a mutable ref is pinned to an immutable id so its
+    contents cannot shift under a deployment. This re-resolves that same ref and
+    repoints the fileset at whatever it names now. Everything else about the storage
+    config, including the repository and directory, is left alone.
+
+    Deployments stage the fileset when they are created, so existing deployments
+    keep serving the revision they were staged from."""
+    state: CLIContext = ctx.obj
+    output_format = state.get_output_format(output_format)
+
+    kwargs = build_kwargs(
+        workspace=workspace,
+    )
+    if handle_code_generation(["files", "filesets"], "refresh", kwargs, output_format, state):
+        return
+
+    client = state.get_client()
+    result = client.files.filesets.refresh(name, **kwargs)
+
+    format_output(
+        result,
+        is_list=False,
+        output_format=output_format,
+        no_truncate=state.get_no_truncate(),
+        timestamp_format=state.get_timestamp_format(),
+    )
 
 
 @app.command("get")

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/files/storage_config.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/files/storage_config.py
@@ -27,6 +27,7 @@ class StorageConfigType(StrEnum):
     NGC = "ngc"
     HUGGINGFACE = "huggingface"
     S3 = "s3"
+    GITHUB = "github"
     # AZURE_BLOB = "azure_blob"
     # GCS = "gcs"
     # HTTP = "http"
@@ -146,6 +147,43 @@ class HuggingfaceStorageConfig(BaseStorageConfig):
         return {"token": self.token_secret} if self.token_secret else {}
 
 
+class GithubStorageConfig(BaseStorageConfig):
+    type: Literal[StorageConfigType.GITHUB] = StorageConfigType.GITHUB
+    owner: str = Field(description="GitHub repository owner (user or organization)")
+    repo: str = Field(description="GitHub repository name")
+    revision: str = Field(
+        default="HEAD",
+        description="Branch, tag, or commit SHA. 'HEAD' resolves to the repository's default branch.",
+    )
+    original_revision: str | None = Field(
+        default=None,
+        description="The original revision requested by the user before resolution (e.g., 'main'). "
+        "The 'revision' field contains the resolved commit SHA.",
+    )
+    path: str = Field(
+        default="",
+        description="Optional directory within the repository. All paths are relative to it.",
+    )
+
+    token_secret: SecretRef | None = Field(
+        default=None,
+        description="GitHub personal access token secret name, required for private repositories",
+    )
+
+    api_base_url: str = Field(
+        default="https://api.github.com",
+        description="GitHub API base URL. Use for GitHub Enterprise instances.",
+    )
+
+    @field_validator("path")
+    @classmethod
+    def strip_path_slashes(cls, v: str) -> str:
+        return v.strip("/")
+
+    def get_secret_references(self) -> dict[str, SecretRef]:
+        return {"token": self.token_secret} if self.token_secret else {}
+
+
 class NGCStorageConfig(BaseStorageConfig):
     type: Literal[StorageConfigType.NGC] = StorageConfigType.NGC
     org: str = Field(description="NGC organization name")
@@ -252,6 +290,6 @@ class S3StorageConfig(BaseStorageConfig):
         return self.model_copy(deep=True, update={"prefix": new_prefix})
 
 
-StorageConfig = LocalStorageConfig | NGCStorageConfig | HuggingfaceStorageConfig | S3StorageConfig
+StorageConfig = LocalStorageConfig | NGCStorageConfig | HuggingfaceStorageConfig | S3StorageConfig | GithubStorageConfig
 
 StorageConfigField = Annotated[StorageConfig, Field(discriminator="type")]

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/files/storage_config.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/files/storage_config.py
@@ -19,7 +19,7 @@ from typing import (
 
 from nemo_platform_plugin.config import nmp_user_data_dir
 from nemo_platform_plugin.schema import SecretRef
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, ValidationInfo, field_validator, model_validator
 
 
 class StorageConfigType(StrEnum):
@@ -37,6 +37,27 @@ class StorageConfigType(StrEnum):
 DEFAULT_READ_CHUNK_SIZE = 1 * 1024 * 1024
 
 
+def _tracked_revision(revision: str, original_revision: str | None) -> str | None:
+    """Return the ref *revision* was resolved from, when that ref can still move.
+
+    Resolution records the original revision even when the user pinned an
+    immutable id themselves, and a ref equal to what it resolved to cannot name
+    anything else.
+    """
+    return original_revision if original_revision and original_revision != revision else None
+
+
+def _reject_relative_segments(field: str, value: str) -> str:
+    """Refuse values that would re-point a URL built from them at another resource.
+
+    ``..`` is resolved away by the URL layer before the request is sent, so a
+    dot segment escapes the repository the rest of the config names.
+    """
+    if any(segment in (".", "..") for segment in value.split("/")):
+        raise ValueError(f"{field} must not contain '.' or '..' path segments, got {value!r}")
+    return value
+
+
 class BaseStorageConfig(BaseModel):
     read_chunk_size: int = Field(
         default=DEFAULT_READ_CHUNK_SIZE,
@@ -48,6 +69,20 @@ class BaseStorageConfig(BaseModel):
     def get_secret_references(self) -> dict[str, SecretRef]:
         """Get the secret references for the storage config."""
         return {}
+
+    @property
+    def pinned_revision(self) -> str:
+        """The immutable id this storage is pinned to, empty when it pins nothing."""
+        return ""
+
+    @property
+    def tracked_revision(self) -> str | None:
+        """The mutable ref :attr:`pinned_revision` was resolved from, if it can still move.
+
+        None when the fileset was created from an already-immutable id, which has
+        nothing to move to.
+        """
+        return None
 
     @property
     def owns_storage_data(self) -> bool:
@@ -143,6 +178,14 @@ class HuggingfaceStorageConfig(BaseStorageConfig):
         description="Huggingface Hub endpoint URL. Use for self-hosted instances.",
     )
 
+    @property
+    def pinned_revision(self) -> str:
+        return self.revision
+
+    @property
+    def tracked_revision(self) -> str | None:
+        return _tracked_revision(self.revision, self.original_revision)
+
     def get_secret_references(self) -> dict[str, SecretRef]:
         return {"token": self.token_secret} if self.token_secret else {}
 
@@ -178,7 +221,27 @@ class GithubStorageConfig(BaseStorageConfig):
     @field_validator("path")
     @classmethod
     def strip_path_slashes(cls, v: str) -> str:
-        return v.strip("/")
+        return _reject_relative_segments("path", v.strip("/"))
+
+    @field_validator("owner", "repo")
+    @classmethod
+    def reject_multi_segment_names(cls, v: str, info: ValidationInfo) -> str:
+        if "/" in v:
+            raise ValueError(f"{info.field_name} must name a single path segment, got {v!r}")
+        return _reject_relative_segments(info.field_name or "value", v)
+
+    @field_validator("revision")
+    @classmethod
+    def reject_relative_revision(cls, v: str) -> str:
+        return _reject_relative_segments("revision", v)
+
+    @property
+    def pinned_revision(self) -> str:
+        return self.revision
+
+    @property
+    def tracked_revision(self) -> str | None:
+        return _tracked_revision(self.revision, self.original_revision)
 
     def get_secret_references(self) -> dict[str, SecretRef]:
         return {"token": self.token_secret} if self.token_secret else {}

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/files/storage_config.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/files/storage_config.py
@@ -47,6 +47,17 @@ def _tracked_revision(revision: str, original_revision: str | None) -> str | Non
     return original_revision if original_revision and original_revision != revision else None
 
 
+def _reject_blank(field: str, value: str) -> str:
+    """Refuse a value that would drop out of a URL built from it.
+
+    An empty segment is skipped when the path is joined, so a blank revision turns
+    ``/commits/{revision}`` into the list-commits endpoint rather than failing.
+    """
+    if not value.strip():
+        raise ValueError(f"{field} must not be blank")
+    return value
+
+
 def _reject_relative_segments(field: str, value: str) -> str:
     """Refuse values that would re-point a URL built from them at another resource.
 
@@ -226,14 +237,15 @@ class GithubStorageConfig(BaseStorageConfig):
     @field_validator("owner", "repo")
     @classmethod
     def reject_multi_segment_names(cls, v: str, info: ValidationInfo) -> str:
+        field = info.field_name or "value"
         if "/" in v:
-            raise ValueError(f"{info.field_name} must name a single path segment, got {v!r}")
-        return _reject_relative_segments(info.field_name or "value", v)
+            raise ValueError(f"{field} must name a single path segment, got {v!r}")
+        return _reject_relative_segments(field, _reject_blank(field, v))
 
     @field_validator("revision")
     @classmethod
     def reject_relative_revision(cls, v: str) -> str:
-        return _reject_relative_segments("revision", v)
+        return _reject_relative_segments("revision", _reject_blank("revision", v))
 
     @field_validator("api_base_url")
     @classmethod

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/files/storage_config.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/files/storage_config.py
@@ -235,6 +235,16 @@ class GithubStorageConfig(BaseStorageConfig):
     def reject_relative_revision(cls, v: str) -> str:
         return _reject_relative_segments("revision", v)
 
+    @field_validator("api_base_url")
+    @classmethod
+    def require_https(cls, v: str) -> str:
+        # Every request to this host carries the token, and the external-host
+        # allowlist matches on scheme, so an allowlisted http:// host would send it
+        # in cleartext.
+        if not v.lower().startswith("https://"):
+            raise ValueError(f"api_base_url must use https, got {v!r}")
+        return v
+
     @property
     def pinned_revision(self) -> str:
         return self.revision

--- a/packages/nmp_common/src/nmp/common/files/storage_config.py
+++ b/packages/nmp_common/src/nmp/common/files/storage_config.py
@@ -10,6 +10,7 @@ import …`` statements working without changes.
 
 from nemo_platform_plugin.files.storage_config import DEFAULT_READ_CHUNK_SIZE as DEFAULT_READ_CHUNK_SIZE
 from nemo_platform_plugin.files.storage_config import BaseStorageConfig as BaseStorageConfig
+from nemo_platform_plugin.files.storage_config import GithubStorageConfig as GithubStorageConfig
 from nemo_platform_plugin.files.storage_config import HuggingfaceStorageConfig as HuggingfaceStorageConfig
 from nemo_platform_plugin.files.storage_config import LocalStorageConfig as LocalStorageConfig
 from nemo_platform_plugin.files.storage_config import NGCStorageConfig as NGCStorageConfig

--- a/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
+++ b/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
@@ -2293,6 +2293,62 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /apis/files/v2/workspaces/{workspace}/filesets/{name}/refresh:
+    post:
+      tags:
+      - Files
+      summary: Refresh Fileset Revision
+      description: 'Re-resolve a fileset''s tracked revision against its source.
+
+
+        A fileset created from a mutable ref is pinned to an immutable id so its
+
+        contents cannot shift under a deployment. This re-resolves that same ref and
+
+        repoints the fileset at whatever it names now. Everything else about the
+
+        storage config, including the repository and directory, is left alone.
+
+
+        Deployments stage the fileset when they are created, so existing deployments
+
+        keep serving the revision they were staged from.'
+      operationId: refresh_fileset_apis_files_v2_workspaces__workspace__filesets__name__refresh_post
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FilesetOutput'
+        '409':
+          description: Fileset does not track a mutable revision
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /apis/guardrails/v2/workspaces/{workspace}/checks:
     post:
       tags:
@@ -10269,6 +10325,7 @@ components:
           - $ref: '#/components/schemas/NGCStorageConfig'
           - $ref: '#/components/schemas/HuggingfaceStorageConfig'
           - $ref: '#/components/schemas/S3StorageConfig'
+          - $ref: '#/components/schemas/GithubStorageConfig'
           title: Storage
           description: The storage configuration for the fileset. If not provided,
             uses default storage.
@@ -12619,6 +12676,7 @@ components:
           - $ref: '#/components/schemas/NGCStorageConfig'
           - $ref: '#/components/schemas/HuggingfaceStorageConfig'
           - $ref: '#/components/schemas/S3StorageConfig'
+          - $ref: '#/components/schemas/GithubStorageConfig'
           title: Storage
         metadata:
           $ref: '#/components/schemas/FilesetMetadata'
@@ -13125,6 +13183,60 @@ components:
         with ``-`` for
 
         descending order.'
+    GithubStorageConfig:
+      properties:
+        read_chunk_size:
+          type: integer
+          title: Read Chunk Size
+          description: 'Chunk size in bytes for reading/streaming files. Larger chunks
+            reduce async overhead but increase memory per concurrent download. Default:
+            1MB.'
+          default: 1048576
+        type:
+          type: string
+          const: github
+          title: Type
+          default: github
+        owner:
+          type: string
+          title: Owner
+          description: GitHub repository owner (user or organization)
+        repo:
+          type: string
+          title: Repo
+          description: GitHub repository name
+        revision:
+          type: string
+          title: Revision
+          description: Branch, tag, or commit SHA. 'HEAD' resolves to the repository's
+            default branch.
+          default: HEAD
+        original_revision:
+          title: Original Revision
+          description: The original revision requested by the user before resolution
+            (e.g., 'main'). The 'revision' field contains the resolved commit SHA.
+          type: string
+        path:
+          type: string
+          title: Path
+          description: Optional directory within the repository. All paths are relative
+            to it.
+          default: ''
+        token_secret:
+          allOf:
+          - $ref: '#/components/schemas/SecretRef'
+          description: GitHub personal access token secret name, required for private
+            repositories
+        api_base_url:
+          type: string
+          title: Api Base Url
+          description: GitHub API base URL. Use for GitHub Enterprise instances.
+          default: https://api.github.com
+      type: object
+      required:
+      - owner
+      - repo
+      title: GithubStorageConfig
     GuardrailCheckRequest:
       properties:
         model:
@@ -19041,6 +19153,7 @@ components:
       - ngc
       - huggingface
       - s3
+      - github
       title: StorageConfigType
       type: string
     StringFilter:

--- a/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
+++ b/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
@@ -2310,9 +2310,10 @@ paths:
         storage config, including the repository and directory, is left alone.
 
 
-        Deployments stage the fileset when they are created, so existing deployments
+        A running deployment keeps serving the revision it staged. It moves to this
+        one
 
-        keep serving the revision they were staged from.'
+        when the runner next stages the fileset, and records the revision it staged.'
       operationId: refresh_fileset_apis_files_v2_workspaces__workspace__filesets__name__refresh_post
       parameters:
       - name: workspace
@@ -2334,8 +2335,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FilesetOutput'
+        '400':
+          description: Storage configuration, secret, or source rejected the refresh
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+        '404':
+          description: Fileset not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
         '409':
           description: Fileset does not track a mutable revision
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+        '502':
+          description: Storage backend unavailable
           content:
             application/json:
               schema:

--- a/sdk/python/nemo-platform/.nmpcontext/stainless.yaml
+++ b/sdk/python/nemo-platform/.nmpcontext/stainless.yaml
@@ -240,6 +240,7 @@ resources:
       fileset_file: FilesetFileOutput
       fileset_outputs_page: FilesetOutputsPage
       fileset_purpose: FilesetPurpose
+      github_storage_config: GithubStorageConfig
       huggingface_storage_config: HuggingfaceStorageConfig
       list_fileset_files_response: ListFilesetFilesResponse
       local_storage_config: LocalStorageConfig
@@ -263,6 +264,7 @@ resources:
           retrieve: get /apis/files/v2/workspaces/{workspace}/filesets/{name}
           delete: delete /apis/files/v2/workspaces/{workspace}/filesets/{name}
           update: patch /apis/files/v2/workspaces/{workspace}/filesets/{name}
+          refresh: post /apis/files/v2/workspaces/{workspace}/filesets/{name}/refresh
       otlp:
         subresources:
           logs:

--- a/sdk/python/nemo-platform/src/nemo_platform/resources/files/api.md
+++ b/sdk/python/nemo-platform/src/nemo_platform/resources/files/api.md
@@ -13,6 +13,7 @@ from nemo_platform.types.files import (
     FilesetFile,
     FilesetOutputsPage,
     FilesetPurpose,
+    GitHubStorageConfig,
     HuggingfaceStorageConfig,
     ListFilesetFilesResponse,
     LocalStorageConfig,
@@ -46,6 +47,7 @@ Methods:
 - <code title="patch /apis/files/v2/workspaces/{workspace}/filesets/{name}">client.files.filesets.<a href="./src/nemo_platform/resources/files/filesets.py">update</a>(name, \*, workspace, \*\*<a href="src/nemo_platform/types/files/fileset_update_params.py">params</a>) -> <a href="./src/nemo_platform/types/files/fileset.py">Fileset</a></code>
 - <code title="get /apis/files/v2/workspaces/{workspace}/filesets">client.files.filesets.<a href="./src/nemo_platform/resources/files/filesets.py">list</a>(\*, workspace, \*\*<a href="src/nemo_platform/types/files/fileset_list_params.py">params</a>) -> <a href="./src/nemo_platform/types/files/fileset.py">SyncDefaultPagination[Fileset]</a></code>
 - <code title="delete /apis/files/v2/workspaces/{workspace}/filesets/{name}">client.files.filesets.<a href="./src/nemo_platform/resources/files/filesets.py">delete</a>(name, \*, workspace) -> <a href="./src/nemo_platform/types/files/fileset.py">Fileset</a></code>
+- <code title="post /apis/files/v2/workspaces/{workspace}/filesets/{name}/refresh">client.files.filesets.<a href="./src/nemo_platform/resources/files/filesets.py">refresh</a>(name, \*, workspace) -> <a href="./src/nemo_platform/types/files/fileset.py">Fileset</a></code>
 
 ## Otlp
 

--- a/sdk/python/nemo-platform/src/nemo_platform/resources/files/filesets.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/resources/files/filesets.py
@@ -348,8 +348,8 @@ class FilesetsResource(SyncAPIResource):
         Permanently deletes an unreferenced fileset from the platform.
 
         Referencing model
-        or adapter entities must be relinked or deleted first. For local storage backends, this also deletes the
-        underlying files.
+        or adapter entities must be relinked or deleted first. For local storage
+        backends, this also deletes the underlying files.
 
         Args:
           extra_headers: Send extra headers
@@ -368,6 +368,54 @@ class FilesetsResource(SyncAPIResource):
             raise ValueError(f"Expected a non-empty value for `name` but received {name!r}")
         return self._delete(
             path_template("/apis/files/v2/workspaces/{workspace}/filesets/{name}", workspace=workspace, name=name),
+            options=make_request_options(
+                extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+            ),
+            cast_to=Fileset,
+        )
+
+    def refresh(
+        self,
+        name: str,
+        *,
+        workspace: str | None = None,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> Fileset:
+        """
+        Re-resolve a fileset's tracked revision against its source.
+
+        A fileset created from a mutable ref is pinned to an immutable id so its
+        contents cannot shift under a deployment. This re-resolves that same ref and
+        repoints the fileset at whatever it names now. Everything else about the storage
+        config, including the repository and directory, is left alone.
+
+        Deployments stage the fileset when they are created, so existing deployments
+        keep serving the revision they were staged from.
+
+        Args:
+          extra_headers: Send extra headers
+
+          extra_query: Add additional query parameters to the request
+
+          extra_body: Add additional JSON properties to the request
+
+          timeout: Override the client-level default timeout for this request, in seconds
+        """
+        if workspace is None:
+            workspace = self._client._get_workspace_path_param()
+        if not workspace:
+            raise ValueError(f"Expected a non-empty value for `workspace` but received {workspace!r}")
+        if not name:
+            raise ValueError(f"Expected a non-empty value for `name` but received {name!r}")
+        return self._post(
+            path_template(
+                "/apis/files/v2/workspaces/{workspace}/filesets/{name}/refresh", workspace=workspace, name=name
+            ),
             options=make_request_options(
                 extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
             ),
@@ -674,8 +722,8 @@ class AsyncFilesetsResource(AsyncAPIResource):
         Permanently deletes an unreferenced fileset from the platform.
 
         Referencing model
-        or adapter entities must be relinked or deleted first. For local storage backends, this also deletes the
-        underlying files.
+        or adapter entities must be relinked or deleted first. For local storage
+        backends, this also deletes the underlying files.
 
         Args:
           extra_headers: Send extra headers
@@ -694,6 +742,54 @@ class AsyncFilesetsResource(AsyncAPIResource):
             raise ValueError(f"Expected a non-empty value for `name` but received {name!r}")
         return await self._delete(
             path_template("/apis/files/v2/workspaces/{workspace}/filesets/{name}", workspace=workspace, name=name),
+            options=make_request_options(
+                extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+            ),
+            cast_to=Fileset,
+        )
+
+    async def refresh(
+        self,
+        name: str,
+        *,
+        workspace: str | None = None,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> Fileset:
+        """
+        Re-resolve a fileset's tracked revision against its source.
+
+        A fileset created from a mutable ref is pinned to an immutable id so its
+        contents cannot shift under a deployment. This re-resolves that same ref and
+        repoints the fileset at whatever it names now. Everything else about the storage
+        config, including the repository and directory, is left alone.
+
+        Deployments stage the fileset when they are created, so existing deployments
+        keep serving the revision they were staged from.
+
+        Args:
+          extra_headers: Send extra headers
+
+          extra_query: Add additional query parameters to the request
+
+          extra_body: Add additional JSON properties to the request
+
+          timeout: Override the client-level default timeout for this request, in seconds
+        """
+        if workspace is None:
+            workspace = self._client._get_workspace_path_param()
+        if not workspace:
+            raise ValueError(f"Expected a non-empty value for `workspace` but received {workspace!r}")
+        if not name:
+            raise ValueError(f"Expected a non-empty value for `name` but received {name!r}")
+        return await self._post(
+            path_template(
+                "/apis/files/v2/workspaces/{workspace}/filesets/{name}/refresh", workspace=workspace, name=name
+            ),
             options=make_request_options(
                 extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
             ),
@@ -720,6 +816,9 @@ class FilesetsResourceWithRawResponse:
         self.delete = to_raw_response_wrapper(
             filesets.delete,
         )
+        self.refresh = to_raw_response_wrapper(
+            filesets.refresh,
+        )
 
 
 class AsyncFilesetsResourceWithRawResponse:
@@ -740,6 +839,9 @@ class AsyncFilesetsResourceWithRawResponse:
         )
         self.delete = async_to_raw_response_wrapper(
             filesets.delete,
+        )
+        self.refresh = async_to_raw_response_wrapper(
+            filesets.refresh,
         )
 
 
@@ -762,6 +864,9 @@ class FilesetsResourceWithStreamingResponse:
         self.delete = to_streamed_response_wrapper(
             filesets.delete,
         )
+        self.refresh = to_streamed_response_wrapper(
+            filesets.refresh,
+        )
 
 
 class AsyncFilesetsResourceWithStreamingResponse:
@@ -782,4 +887,7 @@ class AsyncFilesetsResourceWithStreamingResponse:
         )
         self.delete = async_to_streamed_response_wrapper(
             filesets.delete,
+        )
+        self.refresh = async_to_streamed_response_wrapper(
+            filesets.refresh,
         )

--- a/sdk/python/nemo-platform/src/nemo_platform/resources/files/filesets.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/resources/files/filesets.py
@@ -394,8 +394,8 @@ class FilesetsResource(SyncAPIResource):
         repoints the fileset at whatever it names now. Everything else about the storage
         config, including the repository and directory, is left alone.
 
-        Deployments stage the fileset when they are created, so existing deployments
-        keep serving the revision they were staged from.
+        A running deployment keeps serving the revision it staged. It moves to this one
+        when the runner next stages the fileset, and records the revision it staged.
 
         Args:
           extra_headers: Send extra headers
@@ -768,8 +768,8 @@ class AsyncFilesetsResource(AsyncAPIResource):
         repoints the fileset at whatever it names now. Everything else about the storage
         config, including the repository and directory, is left alone.
 
-        Deployments stage the fileset when they are created, so existing deployments
-        keep serving the revision they were staged from.
+        A running deployment keeps serving the revision it staged. It moves to this one
+        when the runner next stages the fileset, and records the revision it staged.
 
         Args:
           extra_headers: Send extra headers

--- a/sdk/python/nemo-platform/src/nemo_platform/types/files/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/files/__init__.py
@@ -31,11 +31,13 @@ from .fileset_outputs_page import FilesetOutputsPage as FilesetOutputsPage
 from .local_storage_config import LocalStorageConfig as LocalStorageConfig
 from .fileset_create_params import FilesetCreateParams as FilesetCreateParams
 from .fileset_update_params import FilesetUpdateParams as FilesetUpdateParams
+from .github_storage_config import GitHubStorageConfig as GitHubStorageConfig
 from .file_list_files_params import FileListFilesParams as FileListFilesParams
 from .file_upload_file_params import FileUploadFileParams as FileUploadFileParams
 from .s3_storage_config_param import S3StorageConfigParam as S3StorageConfigParam
 from .ngc_storage_config_param import NGCStorageConfigParam as NGCStorageConfigParam
 from .huggingface_storage_config import HuggingfaceStorageConfig as HuggingfaceStorageConfig
 from .local_storage_config_param import LocalStorageConfigParam as LocalStorageConfigParam
+from .github_storage_config_param import GitHubStorageConfigParam as GitHubStorageConfigParam
 from .list_fileset_files_response import ListFilesetFilesResponse as ListFilesetFilesResponse
 from .huggingface_storage_config_param import HuggingfaceStorageConfigParam as HuggingfaceStorageConfigParam

--- a/sdk/python/nemo-platform/src/nemo_platform/types/files/fileset.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/files/fileset.py
@@ -23,12 +23,15 @@ from .fileset_purpose import FilesetPurpose
 from .s3_storage_config import S3StorageConfig
 from .ngc_storage_config import NGCStorageConfig
 from .local_storage_config import LocalStorageConfig
+from .github_storage_config import GitHubStorageConfig
 from ..shared.fileset_metadata import FilesetMetadata
 from .huggingface_storage_config import HuggingfaceStorageConfig
 
 __all__ = ["Fileset", "Storage"]
 
-Storage: TypeAlias = Union[LocalStorageConfig, NGCStorageConfig, HuggingfaceStorageConfig, S3StorageConfig]
+Storage: TypeAlias = Union[
+    LocalStorageConfig, NGCStorageConfig, HuggingfaceStorageConfig, S3StorageConfig, GitHubStorageConfig
+]
 
 
 class Fileset(BaseModel):

--- a/sdk/python/nemo-platform/src/nemo_platform/types/files/fileset_create_params.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/files/fileset_create_params.py
@@ -24,6 +24,7 @@ from .fileset_purpose import FilesetPurpose
 from .s3_storage_config_param import S3StorageConfigParam
 from .ngc_storage_config_param import NGCStorageConfigParam
 from .local_storage_config_param import LocalStorageConfigParam
+from .github_storage_config_param import GitHubStorageConfigParam
 from ..shared_params.fileset_metadata import FilesetMetadata
 from .huggingface_storage_config_param import HuggingfaceStorageConfigParam
 
@@ -71,5 +72,9 @@ class FilesetCreateParams(TypedDict, total=False):
 
 
 Storage: TypeAlias = Union[
-    LocalStorageConfigParam, NGCStorageConfigParam, HuggingfaceStorageConfigParam, S3StorageConfigParam
+    LocalStorageConfigParam,
+    NGCStorageConfigParam,
+    HuggingfaceStorageConfigParam,
+    S3StorageConfigParam,
+    GitHubStorageConfigParam,
 ]

--- a/sdk/python/nemo-platform/src/nemo_platform/types/files/github_storage_config.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/files/github_storage_config.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+from typing import Optional
+from typing_extensions import Literal
+
+from ..._models import BaseModel
+from .secret_ref import SecretRef
+
+__all__ = ["GitHubStorageConfig"]
+
+
+class GitHubStorageConfig(BaseModel):
+    owner: str
+    """GitHub repository owner (user or organization)"""
+
+    repo: str
+    """GitHub repository name"""
+
+    api_base_url: Optional[str] = None
+    """GitHub API base URL. Use for GitHub Enterprise instances."""
+
+    original_revision: Optional[str] = None
+    """The original revision requested by the user before resolution (e.g., 'main').
+
+    The 'revision' field contains the resolved commit SHA.
+    """
+
+    path: Optional[str] = None
+    """Optional directory within the repository. All paths are relative to it."""
+
+    read_chunk_size: Optional[int] = None
+    """Chunk size in bytes for reading/streaming files.
+
+    Larger chunks reduce async overhead but increase memory per concurrent download.
+    Default: 1MB.
+    """
+
+    revision: Optional[str] = None
+    """Branch, tag, or commit SHA. 'HEAD' resolves to the repository's default branch."""
+
+    token_secret: Optional[SecretRef] = None
+    """Reference to a secret.
+
+    Format: 'secret_name' (uses request workspace) or 'workspace/secret_name'
+    (explicit workspace).
+    """
+
+    type: Optional[Literal["github"]] = None

--- a/sdk/python/nemo-platform/src/nemo_platform/types/files/github_storage_config_param.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/files/github_storage_config_param.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+from __future__ import annotations
+
+from typing_extensions import Literal, Required, TypedDict
+
+from .secret_ref import SecretRef
+
+__all__ = ["GitHubStorageConfigParam"]
+
+
+class GitHubStorageConfigParam(TypedDict, total=False):
+    owner: Required[str]
+    """GitHub repository owner (user or organization)"""
+
+    repo: Required[str]
+    """GitHub repository name"""
+
+    api_base_url: str
+    """GitHub API base URL. Use for GitHub Enterprise instances."""
+
+    original_revision: str
+    """The original revision requested by the user before resolution (e.g., 'main').
+
+    The 'revision' field contains the resolved commit SHA.
+    """
+
+    path: str
+    """Optional directory within the repository. All paths are relative to it."""
+
+    read_chunk_size: int
+    """Chunk size in bytes for reading/streaming files.
+
+    Larger chunks reduce async overhead but increase memory per concurrent download.
+    Default: 1MB.
+    """
+
+    revision: str
+    """Branch, tag, or commit SHA. 'HEAD' resolves to the repository's default branch."""
+
+    token_secret: SecretRef
+    """Reference to a secret.
+
+    Format: 'secret_name' (uses request workspace) or 'workspace/secret_name'
+    (explicit workspace).
+    """
+
+    type: Literal["github"]

--- a/sdk/python/nemo-platform/src/nemo_platform/types/files/storage_config_type.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/files/storage_config_type.py
@@ -19,4 +19,4 @@ from typing_extensions import Literal, TypeAlias
 
 __all__ = ["StorageConfigType"]
 
-StorageConfigType: TypeAlias = Literal["local", "ngc", "huggingface", "s3"]
+StorageConfigType: TypeAlias = Literal["local", "ngc", "huggingface", "s3", "github"]

--- a/sdk/python/nemo-platform/src/nemo_platform/types/models/model_entity_filter_param.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/models/model_entity_filter_param.py
@@ -26,15 +26,13 @@ from ..shared_params.string_filter import StringFilter
 from .finetuning_type_filter_param import FinetuningTypeFilterParam
 from ..shared_params.datetime_filter import DatetimeFilter
 
-__all__ = ["ModelEntityFilterParam", "Adapters", "BaseModel", "Description", "Fileset", "Name"]
+__all__ = ["ModelEntityFilterParam", "Adapters", "BaseModel", "Description", "Name"]
 
 Adapters: TypeAlias = Union[FinetuningTypeFilterParam, bool]
 
 BaseModel: TypeAlias = Union[BaseModelFilterParam, bool, str]
 
 Description: TypeAlias = Union[StringFilter, str]
-
-Fileset: TypeAlias = Union[bool, str]
 
 Name: TypeAlias = Union[StringFilter, str]
 
@@ -57,7 +55,7 @@ class ModelEntityFilterParam(TypedDict, total=False):
     description: Description
     """Filter by description."""
 
-    fileset: Fileset
+    fileset: Union[bool, str]
     """
     Filter by fileset: true = has a fileset, false = no fileset, string = match
     fileset reference in the form {workspace}/{fileset_name}.

--- a/sdk/python/nemo-platform/tests/api_resources/files/test_filesets.py
+++ b/sdk/python/nemo-platform/tests/api_resources/files/test_filesets.py
@@ -394,6 +394,58 @@ class TestFilesets:
                 workspace="workspace",
             )
 
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    def test_method_refresh(self, client: NeMoPlatform) -> None:
+        fileset = client.files.filesets.refresh(
+            name="name",
+            workspace="workspace",
+        )
+        assert_matches_type(Fileset, fileset, path=["response"])
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    def test_raw_response_refresh(self, client: NeMoPlatform) -> None:
+        response = client.files.filesets.with_raw_response.refresh(
+            name="name",
+            workspace="workspace",
+        )
+
+        assert response.is_closed is True
+        assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+        fileset = response.parse()
+        assert_matches_type(Fileset, fileset, path=["response"])
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    def test_streaming_response_refresh(self, client: NeMoPlatform) -> None:
+        with client.files.filesets.with_streaming_response.refresh(
+            name="name",
+            workspace="workspace",
+        ) as response:
+            assert not response.is_closed
+            assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+
+            fileset = response.parse()
+            assert_matches_type(Fileset, fileset, path=["response"])
+
+        assert cast(Any, response.is_closed) is True
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    def test_path_params_refresh(self, client: NeMoPlatform) -> None:
+        with pytest.raises(ValueError, match=r"Expected a non-empty value for `workspace` but received ''"):
+            client.files.filesets.with_raw_response.refresh(
+                name="name",
+                workspace="",
+            )
+
+        with pytest.raises(ValueError, match=r"Expected a non-empty value for `name` but received ''"):
+            client.files.filesets.with_raw_response.refresh(
+                name="",
+                workspace="workspace",
+            )
+
 
 class TestAsyncFilesets:
     parametrize = pytest.mark.parametrize(
@@ -754,6 +806,58 @@ class TestAsyncFilesets:
 
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `name` but received ''"):
             await async_client.files.filesets.with_raw_response.delete(
+                name="",
+                workspace="workspace",
+            )
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    async def test_method_refresh(self, async_client: AsyncNeMoPlatform) -> None:
+        fileset = await async_client.files.filesets.refresh(
+            name="name",
+            workspace="workspace",
+        )
+        assert_matches_type(Fileset, fileset, path=["response"])
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    async def test_raw_response_refresh(self, async_client: AsyncNeMoPlatform) -> None:
+        response = await async_client.files.filesets.with_raw_response.refresh(
+            name="name",
+            workspace="workspace",
+        )
+
+        assert response.is_closed is True
+        assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+        fileset = await response.parse()
+        assert_matches_type(Fileset, fileset, path=["response"])
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    async def test_streaming_response_refresh(self, async_client: AsyncNeMoPlatform) -> None:
+        async with async_client.files.filesets.with_streaming_response.refresh(
+            name="name",
+            workspace="workspace",
+        ) as response:
+            assert not response.is_closed
+            assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+
+            fileset = await response.parse()
+            assert_matches_type(Fileset, fileset, path=["response"])
+
+        assert cast(Any, response.is_closed) is True
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    async def test_path_params_refresh(self, async_client: AsyncNeMoPlatform) -> None:
+        with pytest.raises(ValueError, match=r"Expected a non-empty value for `workspace` but received ''"):
+            await async_client.files.filesets.with_raw_response.refresh(
+                name="name",
+                workspace="",
+            )
+
+        with pytest.raises(ValueError, match=r"Expected a non-empty value for `name` but received ''"):
+            await async_client.files.filesets.with_raw_response.refresh(
                 name="",
                 workspace="workspace",
             )

--- a/sdk/python/nemo-platform/tests/api_resources/test_models.py
+++ b/sdk/python/nemo-platform/tests/api_resources/test_models.py
@@ -405,7 +405,7 @@ class TestModels:
                     "like": "$like",
                     "nin": ["string"],
                 },
-                "fileset": "fileset",
+                "fileset": True,
                 "finetuning_type": "lora_merged",
                 "lora_enabled": True,
                 "name": {
@@ -890,7 +890,7 @@ class TestAsyncModels:
                     "like": "$like",
                     "nin": ["string"],
                 },
-                "fileset": "fileset",
+                "fileset": True,
                 "finetuning_type": "lora_merged",
                 "lora_enabled": True,
                 "name": {

--- a/sdk/stainless.yaml
+++ b/sdk/stainless.yaml
@@ -240,6 +240,7 @@ resources:
       fileset_file: FilesetFileOutput
       fileset_outputs_page: FilesetOutputsPage
       fileset_purpose: FilesetPurpose
+      github_storage_config: GithubStorageConfig
       huggingface_storage_config: HuggingfaceStorageConfig
       list_fileset_files_response: ListFilesetFilesResponse
       local_storage_config: LocalStorageConfig
@@ -263,6 +264,7 @@ resources:
           retrieve: get /apis/files/v2/workspaces/{workspace}/filesets/{name}
           delete: delete /apis/files/v2/workspaces/{workspace}/filesets/{name}
           update: patch /apis/files/v2/workspaces/{workspace}/filesets/{name}
+          refresh: post /apis/files/v2/workspaces/{workspace}/filesets/{name}/refresh
       otlp:
         subresources:
           logs:

--- a/services/core/auth/src/nmp/core/auth/assets/static-authz.yaml
+++ b/services/core/auth/src/nmp/core/auth/assets/static-authz.yaml
@@ -697,6 +697,15 @@ authz:
         scopes:
         - files:read
         - platform:read
+    # Refresh re-points an existing fileset at a new revision, so it takes the same
+    # permission as PATCH rather than the create permission a POST would default to.
+    /apis/files/v2/workspaces/{workspace}/filesets/{name}/refresh:
+      post:
+        permissions:
+        - filesets.update
+        scopes:
+        - files:write
+        - platform:write
     /apis/files/v2/workspaces/{workspace}/filesets/{name}/otlp/v1/logs:
       post:
         permissions:

--- a/services/core/files/src/nmp/core/files/api/v2/filesets/endpoints.py
+++ b/services/core/files/src/nmp/core/files/api/v2/filesets/endpoints.py
@@ -633,16 +633,18 @@ async def refresh_fileset(
             f"Fileset '{workspace}/{name}' not found",
         ) from exc
 
+    # Decided before secrets are resolved: whether a fileset tracks anything is a
+    # property of its stored config, and resolving first would report a missing or
+    # forbidden secret as 400 for a fileset whose real answer is 409.
+    if not fileset.storage.tracked_revision:
+        raise HTTPException(
+            HTTP_409_CONFLICT,
+            f"Fileset '{workspace}/{name}' does not track a revision that can be refreshed",
+        )
+
     try:
         secrets = await resolve_storage_secrets_for_user(fileset.storage, workspace, sdk, auth_client)
         storage_impl = storage_impl_factory(fileset.storage, secrets)
-
-        if not storage_impl.tracked_revision:
-            raise HTTPException(
-                HTTP_409_CONFLICT,
-                f"Fileset '{workspace}/{name}' does not track a revision that can be refreshed",
-            )
-
         tracked_impl = storage_impl_factory(storage_impl.config_at_tracked_revision(), secrets)
         # The host allowlist is enforced at create time; re-check it here so a host
         # removed from it since then stops being reachable through a refresh.

--- a/services/core/files/src/nmp/core/files/api/v2/filesets/endpoints.py
+++ b/services/core/files/src/nmp/core/files/api/v2/filesets/endpoints.py
@@ -612,7 +612,7 @@ async def refresh_fileset(
     Deployments stage the fileset when they are created, so existing deployments
     keep serving the revision they were staged from.
     """
-    logger.info(f"POST /filesets/{name}/refresh - workspace={workspace}")
+    logger.info("POST /filesets/%s/refresh - workspace=%s", _sanitize_for_log(name), _sanitize_for_log(workspace))
     try:
         fileset = await get_fileset(workspace, name, entity_store)
     except EntityNotFoundError as exc:
@@ -644,7 +644,12 @@ async def refresh_fileset(
     except ExternalHostInvalidError as exc:
         raise HTTPException(HTTP_400_BAD_REQUEST, f"Invalid URL for external host: {exc}") from exc
     except (SecretNotFoundError, SecretAccessDeniedError) as exc:
-        logger.warning(f"Secret unavailable while refreshing {workspace}/{name}: {exc}")
+        logger.warning(
+            "Secret unavailable while refreshing %s/%s: %s",
+            _sanitize_for_log(workspace),
+            _sanitize_for_log(name),
+            exc,
+        )
         raise HTTPException(HTTP_400_BAD_REQUEST, f"Secret unavailable: {exc}") from exc
     except StorageAccessError as exc:
         logger.warning(f"Storage access denied: {exc}")

--- a/services/core/files/src/nmp/core/files/api/v2/filesets/endpoints.py
+++ b/services/core/files/src/nmp/core/files/api/v2/filesets/endpoints.py
@@ -631,12 +631,18 @@ async def refresh_fileset(
                 f"Fileset '{workspace}/{name}' does not track a revision that can be refreshed",
             )
 
-        storage = await storage_impl_factory(storage_impl.config_at_tracked_revision(), secrets).resolve_config()
+        tracked_impl = storage_impl_factory(storage_impl.config_at_tracked_revision(), secrets)
+        # The host allowlist is enforced at create time; re-check it here so a host
+        # removed from it since then stops being reachable through a refresh.
+        await tracked_impl.validate_storage()
+        storage = await tracked_impl.resolve_config()
     except ExternalHostNotAllowedError as exc:
         raise HTTPException(
             HTTP_400_BAD_REQUEST,
             f"Storage host or endpoint not in allowed list: {exc}",
         ) from exc
+    except ExternalHostInvalidError as exc:
+        raise HTTPException(HTTP_400_BAD_REQUEST, f"Invalid URL for external host: {exc}") from exc
     except (SecretNotFoundError, SecretAccessDeniedError) as exc:
         logger.warning(f"Secret unavailable while refreshing {workspace}/{name}: {exc}")
         raise HTTPException(HTTP_400_BAD_REQUEST, f"Secret unavailable: {exc}") from exc

--- a/services/core/files/src/nmp/core/files/api/v2/filesets/endpoints.py
+++ b/services/core/files/src/nmp/core/files/api/v2/filesets/endpoints.py
@@ -582,6 +582,83 @@ async def update_fileset_metadata(
     return fileset_output_from_entity(fileset)
 
 
+@router.post(
+    "/v2/workspaces/{workspace}/filesets/{name}/refresh",
+    summary="Refresh Fileset Revision",
+    response_model=FilesetOutput,
+    status_code=HTTP_200_OK,
+    responses={
+        HTTP_409_CONFLICT: {
+            "description": "Fileset does not track a mutable revision",
+            **_HTTP_EXCEPTION_DETAIL,
+        },
+    },
+)
+async def refresh_fileset(
+    workspace: str,
+    name: str,
+    entity_store: EntityClient = Depends(get_entity_client),
+    sdk: AsyncNeMoPlatform = Depends(get_sdk_client),
+    auth_client: AuthClient = Depends(get_auth_client),
+) -> FilesetOutput:
+    """
+    Re-resolve a fileset's tracked revision against its source.
+
+    A fileset created from a mutable ref is pinned to an immutable id so its
+    contents cannot shift under a deployment. This re-resolves that same ref and
+    repoints the fileset at whatever it names now. Everything else about the
+    storage config, including the repository and directory, is left alone.
+
+    Deployments stage the fileset when they are created, so existing deployments
+    keep serving the revision they were staged from.
+    """
+    logger.info(f"POST /filesets/{name}/refresh - workspace={workspace}")
+    try:
+        fileset = await get_fileset(workspace, name, entity_store)
+    except EntityNotFoundError as exc:
+        raise HTTPException(
+            HTTP_404_NOT_FOUND,
+            f"Fileset '{workspace}/{name}' not found",
+        ) from exc
+
+    try:
+        secrets = await resolve_storage_secrets_for_user(fileset.storage, workspace, sdk, auth_client)
+        storage_impl = storage_impl_factory(fileset.storage, secrets)
+
+        if not storage_impl.tracked_revision:
+            raise HTTPException(
+                HTTP_409_CONFLICT,
+                f"Fileset '{workspace}/{name}' does not track a revision that can be refreshed",
+            )
+
+        storage = await storage_impl_factory(storage_impl.config_at_tracked_revision(), secrets).resolve_config()
+    except ExternalHostNotAllowedError as exc:
+        raise HTTPException(
+            HTTP_400_BAD_REQUEST,
+            f"Storage host or endpoint not in allowed list: {exc}",
+        ) from exc
+    except (SecretNotFoundError, SecretAccessDeniedError) as exc:
+        logger.warning(f"Secret unavailable while refreshing {workspace}/{name}: {exc}")
+        raise HTTPException(HTTP_400_BAD_REQUEST, f"Secret unavailable: {exc}") from exc
+    except StorageAccessError as exc:
+        logger.warning(f"Storage access denied: {exc}")
+        raise HTTPException(HTTP_400_BAD_REQUEST, f"Access denied to storage backend: {exc}") from exc
+    except StorageConfigError as exc:
+        logger.warning(f"Storage config invalid: {exc}")
+        raise HTTPException(HTTP_400_BAD_REQUEST, f"Invalid storage configuration: {exc}") from exc
+    except StorageUnavailableError as exc:
+        logger.warning(f"Storage backend unavailable: {exc}")
+        raise HTTPException(HTTP_502_BAD_GATEWAY, f"Storage backend unavailable: {exc}") from exc
+    except StorageBackendError as exc:
+        logger.warning(f"Storage refresh failed: {exc}")
+        raise HTTPException(HTTP_400_BAD_REQUEST, f"Error refreshing fileset: {exc}") from exc
+
+    fileset = fileset.model_copy(update={"storage": storage})
+    await entity_store.update(fileset)
+
+    return fileset_output_from_entity(fileset)
+
+
 @router.get(
     "/v2/workspaces/{workspace}/filesets/{name}/files",
     summary="List Fileset Files",

--- a/services/core/files/src/nmp/core/files/api/v2/filesets/endpoints.py
+++ b/services/core/files/src/nmp/core/files/api/v2/filesets/endpoints.py
@@ -588,8 +588,20 @@ async def update_fileset_metadata(
     response_model=FilesetOutput,
     status_code=HTTP_200_OK,
     responses={
+        HTTP_400_BAD_REQUEST: {
+            "description": "Storage configuration, secret, or source rejected the refresh",
+            **_HTTP_EXCEPTION_DETAIL,
+        },
+        HTTP_404_NOT_FOUND: {
+            "description": "Fileset not found",
+            **_HTTP_EXCEPTION_DETAIL,
+        },
         HTTP_409_CONFLICT: {
             "description": "Fileset does not track a mutable revision",
+            **_HTTP_EXCEPTION_DETAIL,
+        },
+        HTTP_502_BAD_GATEWAY: {
+            "description": "Storage backend unavailable",
             **_HTTP_EXCEPTION_DETAIL,
         },
     },
@@ -609,8 +621,8 @@ async def refresh_fileset(
     repoints the fileset at whatever it names now. Everything else about the
     storage config, including the repository and directory, is left alone.
 
-    Deployments stage the fileset when they are created, so existing deployments
-    keep serving the revision they were staged from.
+    A running deployment keeps serving the revision it staged. It moves to this one
+    when the runner next stages the fileset, and records the revision it staged.
     """
     logger.info("POST /filesets/%s/refresh - workspace=%s", _sanitize_for_log(name), _sanitize_for_log(workspace))
     try:

--- a/services/core/files/src/nmp/core/files/app/backends/base.py
+++ b/services/core/files/src/nmp/core/files/app/backends/base.py
@@ -27,6 +27,8 @@ class FileInfo:
 
 
 class StorageImpl(ABC):
+    config: BaseStorageConfig
+
     @abstractmethod
     async def list_files(self, path: str | None = None) -> list[FileInfo]: ...
 
@@ -77,11 +79,11 @@ class StorageImpl(ABC):
         """The mutable ref this fileset was created from, if it tracks one.
 
         The counterpart to :meth:`resolve_config`: a backend that pins a mutable
-        ref to an immutable id at create time returns that original ref here, so
+        ref to an immutable id at create time reports that original ref here, so
         the fileset can be re-resolved against it later. None when the fileset was
         created from an already-immutable id, which has nothing to move to.
         """
-        return None
+        return self.config.tracked_revision
 
     def config_at_tracked_revision(self) -> BaseStorageConfig:
         """Return the config pointed back at :attr:`tracked_revision` for re-resolution.

--- a/services/core/files/src/nmp/core/files/app/backends/base.py
+++ b/services/core/files/src/nmp/core/files/app/backends/base.py
@@ -72,6 +72,24 @@ class StorageImpl(ABC):
         """
         return self.config
 
+    @property
+    def tracked_revision(self) -> str | None:
+        """The mutable ref this fileset was created from, if it tracks one.
+
+        The counterpart to :meth:`resolve_config`: a backend that pins a mutable
+        ref to an immutable id at create time returns that original ref here, so
+        the fileset can be re-resolved against it later. None when the fileset was
+        created from an already-immutable id, which has nothing to move to.
+        """
+        return None
+
+    def config_at_tracked_revision(self) -> BaseStorageConfig:
+        """Return the config pointed back at :attr:`tracked_revision` for re-resolution.
+
+        Only meaningful when :attr:`tracked_revision` is set; callers check first.
+        """
+        raise NotImplementedError()
+
     async def get_file(self, path: str) -> FileInfo:
         files = await self.list_files(path)
         if not files:

--- a/services/core/files/src/nmp/core/files/app/backends/base.py
+++ b/services/core/files/src/nmp/core/files/app/backends/base.py
@@ -90,7 +90,10 @@ class StorageImpl(ABC):
 
         Only meaningful when :attr:`tracked_revision` is set; callers check first.
         """
-        raise NotImplementedError()
+        tracked = self.tracked_revision
+        if tracked is None:
+            raise NotImplementedError(f"{type(self.config).__name__} tracks no revision to re-resolve against")
+        return self.config.model_copy(update={"revision": tracked})
 
     async def get_file(self, path: str) -> FileInfo:
         files = await self.list_files(path)

--- a/services/core/files/src/nmp/core/files/app/backends/factory.py
+++ b/services/core/files/src/nmp/core/files/app/backends/factory.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import logging
 
 from nmp.common.files.storage_config import (
+    GithubStorageConfig,
     HuggingfaceStorageConfig,
     LocalStorageConfig,
     NGCStorageConfig,
@@ -49,5 +50,9 @@ def storage_impl_factory(
             from nmp.core.files.app.backends.s3 import S3StorageImpl
 
             return S3StorageImpl(config, secrets)
+        case GithubStorageConfig():
+            from nmp.core.files.app.backends.github import GithubStorageImpl
+
+            return GithubStorageImpl(config, secrets)
         case _:
             raise TypeError(f"Unsupported storage config type: {type(config).__name__}")

--- a/services/core/files/src/nmp/core/files/app/backends/github.py
+++ b/services/core/files/src/nmp/core/files/app/backends/github.py
@@ -1,0 +1,192 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""GitHub storage backend for repositories served over the GitHub REST API."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from typing import Any
+
+import aiohttp
+from nmp.common.files.storage_config import GithubStorageConfig as GithubStorageConfig
+from nmp.core.files.app.backends.base import (
+    ByteRange,
+    FileInfo,
+    StorageImpl,
+)
+from nmp.core.files.app.external_hosts import validate_external_host
+from nmp.core.files.app.http_session import get_http_session
+from nmp.core.files.exceptions import (
+    NotFoundError,
+    StorageAccessError,
+    StorageBackendError,
+    StorageConfigError,
+    StorageUnavailableError,
+)
+
+logger = logging.getLogger(__name__)
+
+JSON_MEDIA_TYPE = "application/vnd.github+json"
+RAW_MEDIA_TYPE = "application/vnd.github.raw"
+
+
+class GithubBackendError(StorageBackendError):
+    """Raised when there's issues talking to GitHub."""
+
+
+class GithubAccessError(StorageAccessError):
+    """Raised when access to a GitHub repository is denied (401, 403)."""
+
+
+class GithubConfigError(StorageConfigError):
+    """Raised when GitHub storage config is invalid (repository or revision not found)."""
+
+
+class GithubUnavailableError(StorageUnavailableError):
+    """Raised when GitHub is unavailable (5xx, 429)."""
+
+
+def raise_for_github_status(status: int, subject: str, headers: dict[str, str] | None = None) -> None:
+    """Map a GitHub response status onto the storage exception hierarchy."""
+    if status < 400:
+        return
+
+    # A private repository is indistinguishable from a missing one without the right
+    # token, so 404 is reported as a config error rather than an access error.
+    if status == 404:
+        raise GithubConfigError(f"GitHub has no {subject}, or the token cannot see it")
+    if status in (401, 403):
+        if headers and headers.get("x-ratelimit-remaining") == "0":
+            raise GithubUnavailableError(f"GitHub rate limit exhausted while reading {subject}")
+        raise GithubAccessError(f"GitHub denied access to {subject}")
+    if status == 429 or status >= 500:
+        raise GithubUnavailableError(f"GitHub is unavailable ({status}) reading {subject}")
+    raise GithubBackendError(f"GitHub returned {status} reading {subject}")
+
+
+@dataclass
+class GithubStorageImpl(StorageImpl):
+    config: GithubStorageConfig
+    secrets: dict[str, str]
+
+    @property
+    def _repo_slug(self) -> str:
+        return f"{self.config.owner}/{self.config.repo}"
+
+    def _headers(self, accept: str) -> dict[str, str]:
+        headers = {"Accept": accept, "X-GitHub-Api-Version": "2022-11-28"}
+        token = self.secrets.get("token")
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        return headers
+
+    def _api_url(self, suffix: str) -> str:
+        return f"{self.config.api_base_url.rstrip('/')}/repos/{self._repo_slug}/{suffix}"
+
+    def _repo_path(self, path: str) -> str:
+        return f"{self.config.path}/{path}" if self.config.path else path
+
+    async def _get_json(self, url: str, subject: str) -> Any:
+        session = get_http_session()
+        try:
+            async with session.get(url, headers=self._headers(JSON_MEDIA_TYPE)) as response:
+                raise_for_github_status(subject=subject, status=response.status, headers=dict(response.headers))
+                return await response.json()
+        except aiohttp.ClientError as exc:
+            raise GithubUnavailableError(f"Could not reach GitHub to read {subject}: {exc}") from exc
+
+    async def resolve_config(self) -> GithubStorageConfig:
+        """Pin the revision to a commit SHA so the fileset cannot shift under a deployment."""
+        commit = await self._get_json(
+            self._api_url(f"commits/{self.config.revision}"),
+            f"revision {self.config.revision} of {self._repo_slug}",
+        )
+        sha = commit.get("sha") if isinstance(commit, dict) else None
+        if not isinstance(sha, str) or not sha:
+            raise GithubConfigError(f"GitHub returned no commit SHA for {self.config.revision} of {self._repo_slug}")
+
+        return self.config.model_copy(
+            update={"revision": sha, "original_revision": self.config.original_revision or self.config.revision}
+        )
+
+    async def list_files(self, path: str | None = None) -> list[FileInfo]:
+        tree = await self._get_json(
+            self._api_url(f"git/trees/{self.config.revision}?recursive=1"),
+            f"{self._repo_slug} at {self.config.revision}",
+        )
+
+        if not isinstance(tree, dict) or not isinstance(tree.get("tree"), list):
+            raise GithubBackendError(f"GitHub returned no file list for {self._repo_slug}")
+        if tree.get("truncated") is True:
+            raise GithubConfigError(
+                f"{self._repo_slug} is too large for GitHub to list in one request; "
+                "point the fileset at a directory within it"
+            )
+
+        prefix = f"{self.config.path}/" if self.config.path else ""
+        wanted = f"{path.strip('/')}" if path else ""
+
+        files: list[FileInfo] = []
+        for entry in tree["tree"]:
+            if not isinstance(entry, dict) or entry.get("type") != "blob":
+                continue
+            entry_path = entry.get("path")
+            if not isinstance(entry_path, str) or (prefix and not entry_path.startswith(prefix)):
+                continue
+
+            relative = entry_path[len(prefix) :]
+            if wanted and relative != wanted and not relative.startswith(f"{wanted}/"):
+                continue
+            size = entry.get("size")
+            files.append(FileInfo(path=relative, size=size if isinstance(size, int) else 0))
+
+        if wanted and not files:
+            raise NotFoundError(f"File not found for path: {path}")
+        return files
+
+    async def download(self, path: str, byte_range: ByteRange | None) -> AsyncIterator[bytes]:
+        """Stream a file's bytes from the contents API, which serves private repos too."""
+        url = self._api_url(f"contents/{self._repo_path(path)}?ref={self.config.revision}")
+        headers = self._headers(RAW_MEDIA_TYPE)
+        if byte_range is not None:
+            headers["Range"] = f"bytes={byte_range.start}-{byte_range.end}"
+
+        async def _download() -> AsyncIterator[bytes]:
+            session = get_http_session()
+            try:
+                async with session.get(url, headers=headers) as response:
+                    raise_for_github_status(
+                        status=response.status,
+                        subject=f"{path} in {self._repo_slug}",
+                        headers=dict(response.headers),
+                    )
+                    async for chunk in response.content.iter_chunked(self.config.read_chunk_size):
+                        yield chunk
+            except aiohttp.ClientError as exc:
+                raise GithubUnavailableError(f"Could not download {path} from GitHub: {exc}") from exc
+
+        return _download()
+
+    async def validate_storage(self):
+        validate_external_host(self.config.api_base_url)
+        await self._get_json(self._api_url("").rstrip("/"), f"repository {self._repo_slug}")
+
+    async def upload(
+        self,
+        path: str,
+        fstream: AsyncIterator[bytes],
+        content_length: int | None = None,
+    ) -> FileInfo:
+        raise NotImplementedError("GitHub upload is not implemented")
+
+    async def delete(self, path: str) -> FileInfo:
+        raise NotImplementedError("GitHub delete is not implemented")
+
+    async def get_cache_path_key(self, path: str | None = None) -> str:
+        prefix = f"cache/github/{self._repo_slug}/{self.config.revision}"
+        if self.config.path:
+            prefix = f"{prefix}/{self.config.path}"
+        return prefix if path is None else f"{prefix}/{path}"

--- a/services/core/files/src/nmp/core/files/app/backends/github.py
+++ b/services/core/files/src/nmp/core/files/app/backends/github.py
@@ -127,9 +127,6 @@ class GithubStorageImpl(StorageImpl):
         except aiohttp.ClientError as exc:
             raise GithubUnavailableError(f"Could not reach GitHub to read {subject}: {exc}") from exc
 
-    def config_at_tracked_revision(self) -> GithubStorageConfig:
-        return self.config.model_copy(update={"revision": self.config.original_revision})
-
     async def resolve_config(self) -> GithubStorageConfig:
         """Pin the revision to a commit SHA so the fileset cannot shift under a deployment."""
         commit = await self._get_json(

--- a/services/core/files/src/nmp/core/files/app/backends/github.py
+++ b/services/core/files/src/nmp/core/files/app/backends/github.py
@@ -98,6 +98,13 @@ class GithubStorageImpl(StorageImpl):
         except aiohttp.ClientError as exc:
             raise GithubUnavailableError(f"Could not reach GitHub to read {subject}: {exc}") from exc
 
+    @property
+    def tracked_revision(self) -> str | None:
+        return self.config.original_revision
+
+    def config_at_tracked_revision(self) -> GithubStorageConfig:
+        return self.config.model_copy(update={"revision": self.config.original_revision})
+
     async def resolve_config(self) -> GithubStorageConfig:
         """Pin the revision to a commit SHA so the fileset cannot shift under a deployment."""
         commit = await self._get_json(

--- a/services/core/files/src/nmp/core/files/app/backends/github.py
+++ b/services/core/files/src/nmp/core/files/app/backends/github.py
@@ -100,7 +100,10 @@ class GithubStorageImpl(StorageImpl):
 
     @property
     def tracked_revision(self) -> str | None:
-        return self.config.original_revision
+        # resolve_config records original_revision even when the user pinned a commit
+        # themselves, and a ref equal to what it resolved to cannot name anything else.
+        tracked = self.config.original_revision
+        return tracked if tracked and tracked != self.config.revision else None
 
     def config_at_tracked_revision(self) -> GithubStorageConfig:
         return self.config.model_copy(update={"revision": self.config.original_revision})

--- a/services/core/files/src/nmp/core/files/app/backends/github.py
+++ b/services/core/files/src/nmp/core/files/app/backends/github.py
@@ -32,7 +32,11 @@ logger = logging.getLogger(__name__)
 
 JSON_MEDIA_TYPE = "application/vnd.github+json"
 RAW_MEDIA_TYPE = "application/vnd.github.raw"
-_SYMLINK_MODE = "120000"
+
+# Git's blob modes. Anything else a tree can hold is a directory (040000, type
+# "tree"), a submodule (160000, type "commit"), or a symlink (120000) — none of
+# which the contents API serves as the bytes the listing described.
+_REGULAR_FILE_MODES = frozenset({"100644", "100755"})
 
 
 class GithubBackendError(StorageBackendError):
@@ -166,11 +170,16 @@ class GithubStorageImpl(StorageImpl):
         for entry in tree["tree"]:
             if not isinstance(entry, dict) or entry.get("type") != "blob":
                 continue
-            # A symlink is a blob whose content is its target path, but the contents
-            # API serves the target instead — a different size, and possibly a file
-            # outside the directory this fileset is scoped to.
-            if entry.get("mode") == _SYMLINK_MODE:
-                logger.debug("Skipping symlink %r in %s", entry.get("path"), self._repo_slug)
+            # A symlink is also a blob, but one whose content is its target path
+            # while the contents API serves the target itself — a different size, and
+            # possibly a file outside the directory this fileset is scoped to.
+            if entry.get("mode") not in _REGULAR_FILE_MODES:
+                logger.debug(
+                    "Skipping %s in %s: mode %s is not a regular file",
+                    entry.get("path"),
+                    self._repo_slug,
+                    entry.get("mode"),
+                )
                 continue
             relative = entry.get("path")
             if not isinstance(relative, str):

--- a/services/core/files/src/nmp/core/files/app/backends/github.py
+++ b/services/core/files/src/nmp/core/files/app/backends/github.py
@@ -9,6 +9,7 @@ import logging
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from typing import Any
+from urllib.parse import quote, urlencode
 
 import aiohttp
 from nmp.common.files.storage_config import GithubStorageConfig as GithubStorageConfig
@@ -83,8 +84,25 @@ class GithubStorageImpl(StorageImpl):
             headers["Authorization"] = f"Bearer {token}"
         return headers
 
-    def _api_url(self, suffix: str) -> str:
-        return f"{self.config.api_base_url.rstrip('/')}/repos/{self._repo_slug}/{suffix}"
+    def _api_url(self, *segments: str, **query: str) -> str:
+        """Build a repository API URL, encoding each segment and query value.
+
+        Encoding is what keeps a ``#`` or ``?`` in a filename or ref from
+        truncating the URL and dropping the revision the fileset is pinned to.
+        """
+        path = "/".join(quote(segment, safe="/:") for segment in segments if segment)
+        url = f"{self.config.api_base_url.rstrip('/')}/repos/{quote(self._repo_slug, safe='/')}"
+        if path:
+            url = f"{url}/{path}"
+        return f"{url}?{urlencode(query)}" if query else url
+
+    def _subject_at_revision(self) -> str:
+        scope = f"{self._repo_slug}/{self.config.path}" if self.config.path else self._repo_slug
+        return f"{scope} at {self.config.revision}"
+
+    def _tree_ref(self) -> str:
+        """Address the configured directory directly, so the listing is scoped to it."""
+        return f"{self.config.revision}:{self.config.path}" if self.config.path else self.config.revision
 
     def _repo_path(self, path: str) -> str:
         return f"{self.config.path}/{path}" if self.config.path else path
@@ -98,20 +116,13 @@ class GithubStorageImpl(StorageImpl):
         except aiohttp.ClientError as exc:
             raise GithubUnavailableError(f"Could not reach GitHub to read {subject}: {exc}") from exc
 
-    @property
-    def tracked_revision(self) -> str | None:
-        # resolve_config records original_revision even when the user pinned a commit
-        # themselves, and a ref equal to what it resolved to cannot name anything else.
-        tracked = self.config.original_revision
-        return tracked if tracked and tracked != self.config.revision else None
-
     def config_at_tracked_revision(self) -> GithubStorageConfig:
         return self.config.model_copy(update={"revision": self.config.original_revision})
 
     async def resolve_config(self) -> GithubStorageConfig:
         """Pin the revision to a commit SHA so the fileset cannot shift under a deployment."""
         commit = await self._get_json(
-            self._api_url(f"commits/{self.config.revision}"),
+            self._api_url("commits", self.config.revision),
             f"revision {self.config.revision} of {self._repo_slug}",
         )
         sha = commit.get("sha") if isinstance(commit, dict) else None
@@ -124,30 +135,30 @@ class GithubStorageImpl(StorageImpl):
 
     async def list_files(self, path: str | None = None) -> list[FileInfo]:
         tree = await self._get_json(
-            self._api_url(f"git/trees/{self.config.revision}?recursive=1"),
-            f"{self._repo_slug} at {self.config.revision}",
+            self._api_url("git", "trees", self._tree_ref(), recursive="1"),
+            self._subject_at_revision(),
         )
 
         if not isinstance(tree, dict) or not isinstance(tree.get("tree"), list):
             raise GithubBackendError(f"GitHub returned no file list for {self._repo_slug}")
         if tree.get("truncated") is True:
             raise GithubConfigError(
-                f"{self._repo_slug} is too large for GitHub to list in one request; "
-                "point the fileset at a directory within it"
+                f"{self._subject_at_revision()} is too large for GitHub to list in one request; "
+                "point the fileset at a smaller directory within it"
             )
 
-        prefix = f"{self.config.path}/" if self.config.path else ""
-        wanted = f"{path.strip('/')}" if path else ""
+        # Entries are relative to the tree that was asked for, which is already the
+        # configured directory.
+        wanted = path.strip("/") if path else ""
 
         files: list[FileInfo] = []
         for entry in tree["tree"]:
             if not isinstance(entry, dict) or entry.get("type") != "blob":
                 continue
-            entry_path = entry.get("path")
-            if not isinstance(entry_path, str) or (prefix and not entry_path.startswith(prefix)):
+            relative = entry.get("path")
+            if not isinstance(relative, str):
                 continue
 
-            relative = entry_path[len(prefix) :]
             if wanted and relative != wanted and not relative.startswith(f"{wanted}/"):
                 continue
             size = entry.get("size")
@@ -159,7 +170,7 @@ class GithubStorageImpl(StorageImpl):
 
     async def download(self, path: str, byte_range: ByteRange | None) -> AsyncIterator[bytes]:
         """Stream a file's bytes from the contents API, which serves private repos too."""
-        url = self._api_url(f"contents/{self._repo_path(path)}?ref={self.config.revision}")
+        url = self._api_url("contents", self._repo_path(path), ref=self.config.revision)
         headers = self._headers(RAW_MEDIA_TYPE)
         if byte_range is not None:
             headers["Range"] = f"bytes={byte_range.start}-{byte_range.end}"
@@ -182,7 +193,14 @@ class GithubStorageImpl(StorageImpl):
 
     async def validate_storage(self):
         validate_external_host(self.config.api_base_url)
-        await self._get_json(self._api_url("").rstrip("/"), f"repository {self._repo_slug}")
+        await self._get_json(self._api_url(), f"repository {self._repo_slug}")
+        if self.config.path:
+            # Without this a directory that is not in the repository reads as an
+            # empty fileset rather than a misconfigured one.
+            await self._get_json(
+                self._api_url("git", "trees", self._tree_ref()),
+                f"directory {self.config.path!r} in {self._repo_slug}",
+            )
 
     async def upload(
         self,

--- a/services/core/files/src/nmp/core/files/app/backends/github.py
+++ b/services/core/files/src/nmp/core/files/app/backends/github.py
@@ -32,6 +32,7 @@ logger = logging.getLogger(__name__)
 
 JSON_MEDIA_TYPE = "application/vnd.github+json"
 RAW_MEDIA_TYPE = "application/vnd.github.raw"
+_SYMLINK_MODE = "120000"
 
 
 class GithubBackendError(StorageBackendError):
@@ -137,9 +138,11 @@ class GithubStorageImpl(StorageImpl):
         if not isinstance(sha, str) or not sha:
             raise GithubConfigError(f"GitHub returned no commit SHA for {self.config.revision} of {self._repo_slug}")
 
-        return self.config.model_copy(
-            update={"revision": sha, "original_revision": self.config.original_revision or self.config.revision}
-        )
+        # Recorded unconditionally: `original_revision` is settable on create, so
+        # carrying a client-supplied value forward would let a fileset pin one commit
+        # and then refresh against an unrelated ref. Refresh re-points `revision` at
+        # the tracked ref before calling this, so nothing is lost.
+        return self.config.model_copy(update={"revision": sha, "original_revision": self.config.revision})
 
     async def list_files(self, path: str | None = None) -> list[FileInfo]:
         tree = await self._get_json(
@@ -163,6 +166,12 @@ class GithubStorageImpl(StorageImpl):
         for entry in tree["tree"]:
             if not isinstance(entry, dict) or entry.get("type") != "blob":
                 continue
+            # A symlink is a blob whose content is its target path, but the contents
+            # API serves the target instead — a different size, and possibly a file
+            # outside the directory this fileset is scoped to.
+            if entry.get("mode") == _SYMLINK_MODE:
+                logger.debug("Skipping symlink %r in %s", entry.get("path"), self._repo_slug)
+                continue
             relative = entry.get("path")
             if not isinstance(relative, str):
                 continue
@@ -175,6 +184,19 @@ class GithubStorageImpl(StorageImpl):
         if wanted and not files:
             raise NotFoundError(f"File not found for path: {path}")
         return files
+
+    async def get_file(self, path: str) -> FileInfo:
+        """Require an exact blob.
+
+        ``list_files`` matches descendants of *path* too, so the inherited
+        implementation would describe a directory with its first child's size while
+        the contents API answers the directory with a JSON listing.
+        """
+        wanted = path.strip("/")
+        for file in await self.list_files(path):
+            if file.path == wanted:
+                return file
+        raise NotFoundError(f"File not found for path: {path}")
 
     async def download(self, path: str, byte_range: ByteRange | None) -> AsyncIterator[bytes]:
         """Stream a file's bytes from the contents API, which serves private repos too."""

--- a/services/core/files/src/nmp/core/files/app/backends/github.py
+++ b/services/core/files/src/nmp/core/files/app/backends/github.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Mapping
 from dataclasses import dataclass
 from typing import Any
 from urllib.parse import quote, urlencode
@@ -50,7 +50,18 @@ class GithubUnavailableError(StorageUnavailableError):
     """Raised when GitHub is unavailable (5xx, 429)."""
 
 
-def raise_for_github_status(status: int, subject: str, headers: dict[str, str] | None = None) -> None:
+def _header(headers: Mapping[str, str] | None, name: str) -> str | None:
+    """Read a header by name regardless of case.
+
+    GitHub capitalizes rate-limit headers over HTTP/1.1, and a plain dict built
+    from the response loses aiohttp's case-insensitive lookup.
+    """
+    if not headers:
+        return None
+    return next((value for key, value in headers.items() if key.lower() == name), None)
+
+
+def raise_for_github_status(status: int, subject: str, headers: Mapping[str, str] | None = None) -> None:
     """Map a GitHub response status onto the storage exception hierarchy."""
     if status < 400:
         return
@@ -60,7 +71,7 @@ def raise_for_github_status(status: int, subject: str, headers: dict[str, str] |
     if status == 404:
         raise GithubConfigError(f"GitHub has no {subject}, or the token cannot see it")
     if status in (401, 403):
-        if headers and headers.get("x-ratelimit-remaining") == "0":
+        if _header(headers, "x-ratelimit-remaining") == "0":
             raise GithubUnavailableError(f"GitHub rate limit exhausted while reading {subject}")
         raise GithubAccessError(f"GitHub denied access to {subject}")
     if status == 429 or status >= 500:
@@ -111,7 +122,7 @@ class GithubStorageImpl(StorageImpl):
         session = get_http_session()
         try:
             async with session.get(url, headers=self._headers(JSON_MEDIA_TYPE)) as response:
-                raise_for_github_status(subject=subject, status=response.status, headers=dict(response.headers))
+                raise_for_github_status(subject=subject, status=response.status, headers=response.headers)
                 return await response.json()
         except aiohttp.ClientError as exc:
             raise GithubUnavailableError(f"Could not reach GitHub to read {subject}: {exc}") from exc
@@ -182,7 +193,7 @@ class GithubStorageImpl(StorageImpl):
                     raise_for_github_status(
                         status=response.status,
                         subject=f"{path} in {self._repo_slug}",
-                        headers=dict(response.headers),
+                        headers=response.headers,
                     )
                     async for chunk in response.content.iter_chunked(self.config.read_chunk_size):
                         yield chunk

--- a/services/core/files/src/nmp/core/files/app/backends/huggingface.py
+++ b/services/core/files/src/nmp/core/files/app/backends/huggingface.py
@@ -336,13 +336,6 @@ class HuggingfaceStorageImpl(StorageImpl):
             endpoint=self.config.endpoint,
         )
 
-    @property
-    def tracked_revision(self) -> str | None:
-        # resolve_config records original_revision even when the user pinned a commit
-        # themselves, and a ref equal to what it resolved to cannot name anything else.
-        tracked = self.config.original_revision
-        return tracked if tracked and tracked != self.config.revision else None
-
     def config_at_tracked_revision(self) -> HuggingfaceStorageConfig:
         return self.config.model_copy(update={"revision": self.config.original_revision})
 

--- a/services/core/files/src/nmp/core/files/app/backends/huggingface.py
+++ b/services/core/files/src/nmp/core/files/app/backends/huggingface.py
@@ -338,7 +338,10 @@ class HuggingfaceStorageImpl(StorageImpl):
 
     @property
     def tracked_revision(self) -> str | None:
-        return self.config.original_revision
+        # resolve_config records original_revision even when the user pinned a commit
+        # themselves, and a ref equal to what it resolved to cannot name anything else.
+        tracked = self.config.original_revision
+        return tracked if tracked and tracked != self.config.revision else None
 
     def config_at_tracked_revision(self) -> HuggingfaceStorageConfig:
         return self.config.model_copy(update={"revision": self.config.original_revision})

--- a/services/core/files/src/nmp/core/files/app/backends/huggingface.py
+++ b/services/core/files/src/nmp/core/files/app/backends/huggingface.py
@@ -336,9 +336,6 @@ class HuggingfaceStorageImpl(StorageImpl):
             endpoint=self.config.endpoint,
         )
 
-    def config_at_tracked_revision(self) -> HuggingfaceStorageConfig:
-        return self.config.model_copy(update={"revision": self.config.original_revision})
-
     async def resolve_config(self) -> HuggingfaceStorageConfig:
         """Resolve the revision to a specific commit SHA.
 

--- a/services/core/files/src/nmp/core/files/app/backends/huggingface.py
+++ b/services/core/files/src/nmp/core/files/app/backends/huggingface.py
@@ -336,6 +336,13 @@ class HuggingfaceStorageImpl(StorageImpl):
             endpoint=self.config.endpoint,
         )
 
+    @property
+    def tracked_revision(self) -> str | None:
+        return self.config.original_revision
+
+    def config_at_tracked_revision(self) -> HuggingfaceStorageConfig:
+        return self.config.model_copy(update={"revision": self.config.original_revision})
+
     async def resolve_config(self) -> HuggingfaceStorageConfig:
         """Resolve the revision to a specific commit SHA.
 

--- a/services/core/files/src/nmp/core/files/config.py
+++ b/services/core/files/src/nmp/core/files/config.py
@@ -28,7 +28,7 @@ class FilesConfig(create_service_config_class("files")):  # type: ignore
     )
 
     allowed_external_hosts: str = Field(
-        default="https://api.ngc.nvidia.com,https://huggingface.co",
+        default="https://api.ngc.nvidia.com,https://huggingface.co,https://api.github.com",
         description="Comma-separated list of external hosts the Files service is allowed to access.",
     )
 

--- a/services/core/files/tests/integration/test_fileset_refresh.py
+++ b/services/core/files/tests/integration/test_fileset_refresh.py
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration tests: refreshing a fileset against the revision it tracks."""
+
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+
+DEFAULT_WORKSPACE = "default"
+FILESETS_URL = f"/apis/files/v2/workspaces/{DEFAULT_WORKSPACE}/filesets"
+
+FIRST_SHA = "1" * 40
+SECOND_SHA = "2" * 40
+
+
+class _FakeResponse:
+    def __init__(self, sha: str):
+        self._sha = sha
+        self.status = 200
+        self.headers: dict[str, str] = {}
+
+    async def json(self) -> dict[str, Any]:
+        return {"sha": self._sha}
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc) -> None:
+        return None
+
+
+class _FakeSession:
+    """Answers every GitHub API read with one commit SHA."""
+
+    def __init__(self, sha: str):
+        self.sha = sha
+
+    def get(self, url: str, **_kwargs):
+        return _FakeResponse(self.sha)
+
+
+@contextmanager
+def _github_at(sha: str) -> Iterator[_FakeSession]:
+    session = _FakeSession(sha)
+    with patch("nmp.core.files.app.backends.github.get_http_session", return_value=session):
+        yield session
+
+
+def _create_github_fileset(client: httpx.Client, name: str, revision: str = "main") -> dict[str, Any]:
+    response = client.post(
+        FILESETS_URL,
+        json={
+            "name": name,
+            "storage": {"type": "github", "owner": "acme", "repo": "agents", "revision": revision},
+        },
+    )
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+class TestRefreshFileset:
+    def test_moves_a_tracked_fileset_to_the_commit_the_ref_names_now(self, client: httpx.Client) -> None:
+        name = f"gh-refresh-{uuid.uuid4().hex[:8]}"
+        with _github_at(FIRST_SHA):
+            created = _create_github_fileset(client, name)
+        assert created["storage"]["revision"] == FIRST_SHA
+
+        with _github_at(SECOND_SHA):
+            response = client.post(f"{FILESETS_URL}/{name}/refresh")
+
+        assert response.status_code == 200, response.text
+        storage = response.json()["storage"]
+        assert storage["revision"] == SECOND_SHA
+        assert storage["original_revision"] == "main"
+
+        # The refreshed revision is what a later read serves, not just what the call returned.
+        assert client.get(f"{FILESETS_URL}/{name}").json()["storage"]["revision"] == SECOND_SHA
+
+    def test_leaves_the_repository_and_directory_alone(self, client: httpx.Client) -> None:
+        name = f"gh-scoped-{uuid.uuid4().hex[:8]}"
+        with _github_at(FIRST_SHA):
+            response = client.post(
+                FILESETS_URL,
+                json={
+                    "name": name,
+                    "storage": {
+                        "type": "github",
+                        "owner": "acme",
+                        "repo": "agents",
+                        "revision": "main",
+                        "path": "agents/calc",
+                    },
+                },
+            )
+            assert response.status_code == 200, response.text
+
+        with _github_at(SECOND_SHA):
+            storage = client.post(f"{FILESETS_URL}/{name}/refresh").json()["storage"]
+
+        assert (storage["owner"], storage["repo"], storage["path"]) == ("acme", "agents", "agents/calc")
+
+    def test_refuses_a_fileset_pinned_to_a_commit(self, client: httpx.Client) -> None:
+        """A revision the user pinned themselves tracks nothing, so there is nowhere to move."""
+        name = f"gh-pinned-{uuid.uuid4().hex[:8]}"
+        with _github_at(FIRST_SHA):
+            _create_github_fileset(client, name, revision=FIRST_SHA)
+
+        response = client.post(f"{FILESETS_URL}/{name}/refresh")
+
+        assert response.status_code == 409
+        assert "does not track a revision" in response.json()["detail"]
+
+    def test_refuses_a_fileset_holding_uploaded_files(self, client: httpx.Client) -> None:
+        name = f"local-{uuid.uuid4().hex[:8]}"
+        assert client.post(FILESETS_URL, json={"name": name}).status_code == 200
+
+        response = client.post(f"{FILESETS_URL}/{name}/refresh")
+
+        assert response.status_code == 409
+
+    def test_reports_a_fileset_that_does_not_exist(self, client: httpx.Client) -> None:
+        response = client.post(f"{FILESETS_URL}/never-created/refresh")
+
+        assert response.status_code == 404

--- a/services/core/files/tests/integration/test_fileset_refresh.py
+++ b/services/core/files/tests/integration/test_fileset_refresh.py
@@ -19,9 +19,9 @@ SECOND_SHA = "2" * 40
 
 
 class _FakeResponse:
-    def __init__(self, sha: str):
+    def __init__(self, sha: str, status: int = 200):
         self._sha = sha
-        self.status = 200
+        self.status = status
         self.headers: dict[str, str] = {}
 
     async def json(self) -> dict[str, Any]:
@@ -37,16 +37,19 @@ class _FakeResponse:
 class _FakeSession:
     """Answers every GitHub API read with one commit SHA."""
 
-    def __init__(self, sha: str):
+    def __init__(self, sha: str, status: int = 200):
         self.sha = sha
+        self.status = status
+        self.requests: list[str] = []
 
     def get(self, url: str, **_kwargs):
-        return _FakeResponse(self.sha)
+        self.requests.append(url)
+        return _FakeResponse(self.sha, status=self.status)
 
 
 @contextmanager
-def _github_at(sha: str) -> Iterator[_FakeSession]:
-    session = _FakeSession(sha)
+def _github_at(sha: str, status: int = 200) -> Iterator[_FakeSession]:
+    session = _FakeSession(sha, status=status)
     with patch("nmp.core.files.app.backends.github.get_http_session", return_value=session):
         yield session
 
@@ -70,13 +73,16 @@ class TestRefreshFileset:
             created = _create_github_fileset(client, name)
         assert created["storage"]["revision"] == FIRST_SHA
 
-        with _github_at(SECOND_SHA):
+        with _github_at(SECOND_SHA) as github:
             response = client.post(f"{FILESETS_URL}/{name}/refresh")
 
         assert response.status_code == 200, response.text
         storage = response.json()["storage"]
         assert storage["revision"] == SECOND_SHA
         assert storage["original_revision"] == "main"
+        # The ref is what gets re-resolved; re-resolving the pinned SHA would report
+        # the same move without ever asking about the branch.
+        assert any(url.endswith("/commits/main") for url in github.requests), github.requests
 
         # The refreshed revision is what a later read serves, not just what the call returned.
         assert client.get(f"{FILESETS_URL}/{name}").json()["storage"]["revision"] == SECOND_SHA
@@ -122,6 +128,28 @@ class TestRefreshFileset:
         response = client.post(f"{FILESETS_URL}/{name}/refresh")
 
         assert response.status_code == 409
+
+    def test_reports_github_being_unavailable(self, client: httpx.Client) -> None:
+        name = f"gh-down-{uuid.uuid4().hex[:8]}"
+        with _github_at(FIRST_SHA):
+            _create_github_fileset(client, name)
+
+        with _github_at(SECOND_SHA, status=503):
+            response = client.post(f"{FILESETS_URL}/{name}/refresh")
+
+        assert response.status_code == 502
+        assert client.get(f"{FILESETS_URL}/{name}").json()["storage"]["revision"] == FIRST_SHA
+
+    def test_reports_a_ref_github_no_longer_has(self, client: httpx.Client) -> None:
+        name = f"gh-gone-{uuid.uuid4().hex[:8]}"
+        with _github_at(FIRST_SHA):
+            _create_github_fileset(client, name)
+
+        with _github_at(SECOND_SHA, status=404):
+            response = client.post(f"{FILESETS_URL}/{name}/refresh")
+
+        assert response.status_code == 400
+        assert client.get(f"{FILESETS_URL}/{name}").json()["storage"]["revision"] == FIRST_SHA
 
     def test_reports_a_fileset_that_does_not_exist(self, client: httpx.Client) -> None:
         response = client.post(f"{FILESETS_URL}/never-created/refresh")

--- a/services/core/files/tests/integration/test_fileset_refresh.py
+++ b/services/core/files/tests/integration/test_fileset_refresh.py
@@ -121,6 +121,24 @@ class TestRefreshFileset:
         assert response.status_code == 409
         assert "does not track a revision" in response.json()["detail"]
 
+    def test_refuses_a_pinned_fileset_without_resolving_its_secrets(self, client: httpx.Client) -> None:
+        """Eligibility is a property of the stored config, so it is decided first.
+
+        Resolving secrets first would report a missing or forbidden secret as 400
+        for a fileset whose real answer is 409.
+        """
+        name = f"gh-pinned-secret-{uuid.uuid4().hex[:8]}"
+        with _github_at(FIRST_SHA):
+            _create_github_fileset(client, name, revision=FIRST_SHA)
+
+        with patch(
+            "nmp.core.files.api.v2.filesets.endpoints.resolve_storage_secrets_for_user",
+            side_effect=AssertionError("secrets must not be resolved for an ineligible fileset"),
+        ):
+            response = client.post(f"{FILESETS_URL}/{name}/refresh")
+
+        assert response.status_code == 409
+
     def test_refuses_a_fileset_holding_uploaded_files(self, client: httpx.Client) -> None:
         name = f"local-{uuid.uuid4().hex[:8]}"
         assert client.post(FILESETS_URL, json={"name": name}).status_code == 200

--- a/services/core/files/tests/test_files_config.py
+++ b/services/core/files/tests/test_files_config.py
@@ -14,10 +14,13 @@ class TestFilesConfigAllowedExternalHosts:
     def test_allowed_external_hosts_default(self) -> None:
         """Test allowed_external_hosts default value and get_allowed_external_hosts() parsing."""
         config = FilesConfig()
-        assert config.allowed_external_hosts == "https://api.ngc.nvidia.com,https://huggingface.co"
+        assert config.allowed_external_hosts == (
+            "https://api.ngc.nvidia.com,https://huggingface.co,https://api.github.com"
+        )
         assert config.get_allowed_external_hosts() == [
             "https://api.ngc.nvidia.com",
             "https://huggingface.co",
+            "https://api.github.com",
         ]
 
     def test_allowed_external_hosts_from_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/services/core/files/tests/test_github_backend.py
+++ b/services/core/files/tests/test_github_backend.py
@@ -1,0 +1,306 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the GitHub storage backend."""
+
+from collections.abc import AsyncIterator, Callable
+from unittest.mock import patch
+
+import pytest
+from nmp.common.api.common import SecretRef
+from nmp.core.files.app.backends.base import ByteRange
+from nmp.core.files.app.backends.factory import storage_impl_factory
+from nmp.core.files.app.backends.github import (
+    GithubAccessError,
+    GithubBackendError,
+    GithubConfigError,
+    GithubStorageConfig,
+    GithubStorageImpl,
+    GithubUnavailableError,
+    raise_for_github_status,
+)
+from nmp.core.files.exceptions import NotFoundError
+
+
+class _FakeContent:
+    def __init__(self, chunks: tuple[bytes, ...]):
+        self._chunks = chunks
+
+    async def iter_chunked(self, _size: int) -> AsyncIterator[bytes]:
+        for chunk in self._chunks:
+            yield chunk
+
+
+class _FakeResponse:
+    def __init__(self, status=200, json_body=None, chunks=(), headers=None):
+        self.status = status
+        self.headers = headers or {}
+        self.content = _FakeContent(chunks)
+        self._json_body = json_body
+
+    async def json(self):
+        return self._json_body
+
+
+class _FakeRequest:
+    def __init__(self, response: _FakeResponse):
+        self._response = response
+
+    async def __aenter__(self) -> _FakeResponse:
+        return self._response
+
+    async def __aexit__(self, *_exc) -> bool:
+        return False
+
+
+class _FakeSession:
+    def __init__(self, handler: Callable[[str], _FakeResponse]):
+        self._handler = handler
+        self.requests: list[tuple[str, dict[str, str]]] = []
+
+    def get(self, url: str, headers: dict[str, str] | None = None) -> _FakeRequest:
+        self.requests.append((url, headers or {}))
+        return _FakeRequest(self._handler(url))
+
+
+def _session_for(handler: Callable[[str], _FakeResponse]) -> _FakeSession:
+    return _FakeSession(handler)
+
+
+def _tree(*entries: dict, truncated: bool = False) -> dict:
+    return {"truncated": truncated, "tree": list(entries)}
+
+
+def _blob(path: str, size: int = 1) -> dict:
+    return {"path": path, "type": "blob", "size": size}
+
+
+def _config(**overrides) -> GithubStorageConfig:
+    return GithubStorageConfig(owner="acme", repo="agents", **{"revision": "main", **overrides})
+
+
+def _impl(config: GithubStorageConfig | None = None, secrets: dict[str, str] | None = None) -> GithubStorageImpl:
+    return GithubStorageImpl(config or _config(), secrets if secrets is not None else {})
+
+
+class TestRaiseForGithubStatus:
+    def test_success_statuses_do_not_raise(self):
+        raise_for_github_status(200, "repo")
+        raise_for_github_status(206, "repo")
+
+    def test_missing_or_invisible_repository_is_a_config_error(self):
+        with pytest.raises(GithubConfigError, match="cannot see it"):
+            raise_for_github_status(404, "repository acme/agents")
+
+    def test_forbidden_is_an_access_error(self):
+        with pytest.raises(GithubAccessError):
+            raise_for_github_status(403, "repository acme/agents")
+
+    def test_exhausted_rate_limit_is_unavailable_not_access_denied(self):
+        with pytest.raises(GithubUnavailableError, match="rate limit"):
+            raise_for_github_status(403, "repository acme/agents", {"x-ratelimit-remaining": "0"})
+
+    @pytest.mark.parametrize("status", [429, 500, 502, 503])
+    def test_server_side_failures_are_unavailable(self, status: int):
+        with pytest.raises(GithubUnavailableError):
+            raise_for_github_status(status, "repository acme/agents")
+
+    def test_other_client_errors_are_backend_errors(self):
+        with pytest.raises(GithubBackendError, match="418"):
+            raise_for_github_status(418, "repository acme/agents")
+
+
+class TestResolveConfig:
+    @pytest.mark.asyncio
+    async def test_pins_the_revision_to_a_commit_sha(self):
+        session = _session_for(lambda _url: _FakeResponse(json_body={"sha": "abc123"}))
+        with patch("nmp.core.files.app.backends.github.get_http_session", return_value=session):
+            resolved = await _impl().resolve_config()
+
+        assert resolved.revision == "abc123"
+        assert resolved.original_revision == "main"
+        assert session.requests[0][0].endswith("/repos/acme/agents/commits/main")
+
+    @pytest.mark.asyncio
+    async def test_keeps_the_first_original_revision_across_resolutions(self):
+        session = _session_for(lambda _url: _FakeResponse(json_body={"sha": "def456"}))
+        config = _config(revision="abc123", original_revision="main")
+        with patch("nmp.core.files.app.backends.github.get_http_session", return_value=session):
+            resolved = await GithubStorageImpl(config, {}).resolve_config()
+
+        assert resolved.original_revision == "main"
+
+    @pytest.mark.asyncio
+    async def test_rejects_a_response_carrying_no_sha(self):
+        session = _session_for(lambda _url: _FakeResponse(json_body={}))
+        with patch("nmp.core.files.app.backends.github.get_http_session", return_value=session):
+            with pytest.raises(GithubConfigError, match="no commit SHA"):
+                await _impl().resolve_config()
+
+
+class TestListFiles:
+    @pytest.mark.asyncio
+    async def test_returns_blobs_and_skips_trees(self):
+        session = _session_for(
+            lambda _url: _FakeResponse(
+                json_body=_tree(
+                    _blob("agent.yaml", 80),
+                    {"path": "mcps", "type": "tree"},
+                    _blob("mcps/calculator.py", 20),
+                )
+            )
+        )
+        with patch("nmp.core.files.app.backends.github.get_http_session", return_value=session):
+            files = await _impl().list_files()
+
+        assert [(f.path, f.size) for f in files] == [("agent.yaml", 80), ("mcps/calculator.py", 20)]
+
+    @pytest.mark.asyncio
+    async def test_strips_the_configured_directory_prefix(self):
+        session = _session_for(
+            lambda _url: _FakeResponse(
+                json_body=_tree(
+                    _blob("agents/calc/agent.yaml"),
+                    _blob("agents/other/agent.yaml"),
+                    _blob("README.md"),
+                )
+            )
+        )
+        with patch("nmp.core.files.app.backends.github.get_http_session", return_value=session):
+            files = await _impl(_config(path="agents/calc")).list_files()
+
+        assert [f.path for f in files] == ["agent.yaml"]
+
+    @pytest.mark.asyncio
+    async def test_filters_to_a_requested_subpath(self):
+        session = _session_for(
+            lambda _url: _FakeResponse(json_body=_tree(_blob("agent.yaml"), _blob("mcps/calculator.py")))
+        )
+        with patch("nmp.core.files.app.backends.github.get_http_session", return_value=session):
+            files = await _impl().list_files("mcps")
+
+        assert [f.path for f in files] == ["mcps/calculator.py"]
+
+    @pytest.mark.asyncio
+    async def test_raises_not_found_for_a_subpath_with_no_blobs(self):
+        session = _session_for(lambda _url: _FakeResponse(json_body=_tree(_blob("agent.yaml"))))
+        with patch("nmp.core.files.app.backends.github.get_http_session", return_value=session):
+            with pytest.raises(NotFoundError):
+                await _impl().list_files("nope")
+
+    @pytest.mark.asyncio
+    async def test_refuses_a_tree_github_could_not_list_in_full(self):
+        session = _session_for(lambda _url: _FakeResponse(json_body=_tree(_blob("agent.yaml"), truncated=True)))
+        with patch("nmp.core.files.app.backends.github.get_http_session", return_value=session):
+            with pytest.raises(GithubConfigError, match="too large"):
+                await _impl().list_files()
+
+    @pytest.mark.asyncio
+    async def test_maps_a_404_onto_a_config_error(self):
+        session = _session_for(lambda _url: _FakeResponse(status=404))
+        with patch("nmp.core.files.app.backends.github.get_http_session", return_value=session):
+            with pytest.raises(GithubConfigError):
+                await _impl().list_files()
+
+
+class TestDownload:
+    async def _collect(self, impl: GithubStorageImpl, session: _FakeSession, byte_range=None) -> bytes:
+        with patch("nmp.core.files.app.backends.github.get_http_session", return_value=session):
+            stream = await impl.download("agent.yaml", byte_range)
+            return b"".join([chunk async for chunk in stream])
+
+    @pytest.mark.asyncio
+    async def test_streams_file_contents_at_the_pinned_revision(self):
+        session = _session_for(lambda _url: _FakeResponse(chunks=(b"name: ", b"calc\n")))
+        body = await self._collect(_impl(_config(revision="abc123")), session)
+
+        assert body == b"name: calc\n"
+        url, headers = session.requests[0]
+        assert url.endswith("/repos/acme/agents/contents/agent.yaml?ref=abc123")
+        assert headers["Accept"] == "application/vnd.github.raw"
+
+    @pytest.mark.asyncio
+    async def test_sends_the_token_for_a_private_repository(self):
+        session = _session_for(lambda _url: _FakeResponse(chunks=(b"x",)))
+        await self._collect(_impl(secrets={"token": "ghp_secret"}), session)
+
+        assert session.requests[0][1]["Authorization"] == "Bearer ghp_secret"
+
+    @pytest.mark.asyncio
+    async def test_omits_authorization_without_a_token(self):
+        session = _session_for(lambda _url: _FakeResponse(chunks=(b"x",)))
+        await self._collect(_impl(), session)
+
+        assert "Authorization" not in session.requests[0][1]
+
+    @pytest.mark.asyncio
+    async def test_prefixes_the_configured_directory(self):
+        session = _session_for(lambda _url: _FakeResponse(chunks=(b"x",)))
+        await self._collect(_impl(_config(path="agents/calc")), session)
+
+        assert "/contents/agents/calc/agent.yaml?ref=" in session.requests[0][0]
+
+    @pytest.mark.asyncio
+    async def test_forwards_a_byte_range(self):
+        session = _session_for(lambda _url: _FakeResponse(status=206, chunks=(b"me",)))
+        await self._collect(_impl(), session, ByteRange(start=2, end=3))
+
+        assert session.requests[0][1]["Range"] == "bytes=2-3"
+
+    @pytest.mark.asyncio
+    async def test_maps_a_denied_download_onto_an_access_error(self):
+        session = _session_for(lambda _url: _FakeResponse(status=403))
+        with pytest.raises(GithubAccessError):
+            await self._collect(_impl(), session)
+
+
+class TestStorageContract:
+    @pytest.mark.asyncio
+    async def test_upload_and_delete_are_refused(self):
+        impl = _impl()
+        with pytest.raises(NotImplementedError):
+            await impl.upload("agent.yaml", iter(()), None)
+        with pytest.raises(NotImplementedError):
+            await impl.delete("agent.yaml")
+
+    def test_the_platform_does_not_own_the_source_data(self):
+        assert _config().owns_storage_data is False
+
+    @pytest.mark.asyncio
+    async def test_cache_key_is_scoped_to_the_revision(self):
+        impl = _impl(_config(revision="abc123"))
+
+        assert await impl.get_cache_path_key() == "cache/github/acme/agents/abc123"
+        assert await impl.get_cache_path_key("agent.yaml") == "cache/github/acme/agents/abc123/agent.yaml"
+
+    @pytest.mark.asyncio
+    async def test_cache_keys_of_two_revisions_do_not_collide(self):
+        first = await _impl(_config(revision="abc")).get_cache_path_key("agent.yaml")
+        second = await _impl(_config(revision="def")).get_cache_path_key("agent.yaml")
+
+        assert first != second
+
+    def test_the_factory_builds_the_github_backend(self):
+        impl = storage_impl_factory(_config(), {"token": "ghp_secret"})
+
+        assert isinstance(impl, GithubStorageImpl)
+        assert impl.secrets == {"token": "ghp_secret"}
+
+    def test_config_declares_its_token_secret(self):
+        config = _config(token_secret=SecretRef("github-pat"))
+
+        assert config.get_secret_references() == {"token": SecretRef("github-pat")}
+
+    def test_config_without_a_token_declares_no_secret(self):
+        assert _config().get_secret_references() == {}
+
+    def test_config_normalizes_a_slash_wrapped_path(self):
+        assert _config(path="/agents/calc/").path == "agents/calc"
+
+
+class TestValidateStorage:
+    @pytest.mark.asyncio
+    async def test_rejects_a_host_outside_the_allowlist(self):
+        impl = _impl(_config(api_base_url="https://github.internal.example.com/api/v3"))
+        with pytest.raises(Exception, match="not"):
+            await impl.validate_storage()

--- a/services/core/files/tests/test_github_backend.py
+++ b/services/core/files/tests/test_github_backend.py
@@ -19,7 +19,9 @@ from nmp.core.files.app.backends.github import (
     GithubUnavailableError,
     raise_for_github_status,
 )
+from nmp.core.files.app.external_hosts import ExternalHostNotAllowedError
 from nmp.core.files.exceptions import NotFoundError
+from pydantic import ValidationError
 
 
 class _FakeContent:
@@ -192,20 +194,15 @@ class TestListFiles:
         assert [(f.path, f.size) for f in files] == [("agent.yaml", 80), ("mcps/calculator.py", 20)]
 
     @pytest.mark.asyncio
-    async def test_strips_the_configured_directory_prefix(self):
-        session = _session_for(
-            lambda _url: _FakeResponse(
-                json_body=_tree(
-                    _blob("agents/calc/agent.yaml"),
-                    _blob("agents/other/agent.yaml"),
-                    _blob("README.md"),
-                )
-            )
-        )
+    async def test_asks_github_only_for_the_configured_directory(self):
+        session = _session_for(lambda _url: _FakeResponse(json_body=_tree(_blob("agent.yaml"))))
         with patch("nmp.core.files.app.backends.github.get_http_session", return_value=session):
-            files = await _impl(_config(path="agents/calc")).list_files()
+            files = await _impl(_config(revision="abc123", path="agents/calc")).list_files()
 
         assert [f.path for f in files] == ["agent.yaml"]
+        # Scoping the request is what keeps a large repository listable; filtering a
+        # whole-repo tree here would still hit GitHub's truncation limit.
+        assert "/git/trees/abc123:agents/calc?" in session.requests[0][0]
 
     @pytest.mark.asyncio
     async def test_filters_to_a_requested_subpath(self):
@@ -338,5 +335,47 @@ class TestValidateStorage:
     @pytest.mark.asyncio
     async def test_rejects_a_host_outside_the_allowlist(self):
         impl = _impl(_config(api_base_url="https://github.internal.example.com/api/v3"))
-        with pytest.raises(Exception, match="not"):
+        with pytest.raises(ExternalHostNotAllowedError):
             await impl.validate_storage()
+
+    @pytest.mark.asyncio
+    async def test_refuses_a_directory_that_is_not_in_the_repository(self):
+        session = _session_for(
+            lambda url: _FakeResponse(status=404) if "git/trees" in url else _FakeResponse(json_body={})
+        )
+        with patch("nmp.core.files.app.backends.github.get_http_session", return_value=session):
+            with pytest.raises(GithubConfigError, match="agents/calc"):
+                await _impl(_config(path="agents/calc")).validate_storage()
+
+
+class TestUrlEncoding:
+    @pytest.mark.asyncio
+    async def test_a_hash_in_a_filename_does_not_truncate_the_url(self):
+        session = _session_for(lambda _url: _FakeResponse(chunks=(b"x",)))
+        with patch("nmp.core.files.app.backends.github.get_http_session", return_value=session):
+            stream = await _impl(_config(revision="abc123")).download("notes/re#lease.md", None)
+            [chunk async for chunk in stream]
+
+        url = session.requests[0][0]
+        # Left raw, "#" would make the rest of the URL a fragment and drop the ref,
+        # serving the default branch instead of the revision the fileset is pinned to.
+        assert url.endswith("/contents/notes/re%23lease.md?ref=abc123")
+
+    @pytest.mark.asyncio
+    async def test_a_slash_in_a_branch_name_survives(self):
+        session = _session_for(lambda _url: _FakeResponse(json_body={"sha": "abc123"}))
+        with patch("nmp.core.files.app.backends.github.get_http_session", return_value=session):
+            await _impl(_config(revision="release/0.6")).resolve_config()
+
+        assert session.requests[0][0].endswith("/commits/release/0.6")
+
+    @pytest.mark.parametrize("field", ["owner", "repo", "path", "revision"])
+    def test_a_dot_segment_is_refused(self, field: str):
+        # yarl resolves ".." away before the request is sent, so a dot segment would
+        # address a repository other than the one the rest of the config names.
+        with pytest.raises(ValidationError, match="path segment"):
+            GithubStorageConfig(**{"owner": "acme", "repo": "agents", field: "../../../user"})
+
+    def test_a_multi_segment_owner_is_refused(self):
+        with pytest.raises(ValidationError, match="single path segment"):
+            GithubStorageConfig(owner="acme/evil", repo="agents")

--- a/services/core/files/tests/test_github_backend.py
+++ b/services/core/files/tests/test_github_backend.py
@@ -217,6 +217,32 @@ class TestListFiles:
         # whole-repo tree here would still hit GitHub's truncation limit.
         assert "/git/trees/abc123:agents/calc?" in session.requests[0][0]
 
+    @pytest.mark.parametrize(
+        ("mode", "entry_type", "served"),
+        [
+            ("100644", "blob", True),
+            ("100755", "blob", True),
+            ("120000", "blob", False),
+            ("160000", "commit", False),
+            ("040000", "tree", False),
+        ],
+        ids=["regular", "executable", "symlink", "submodule", "directory"],
+    )
+    @pytest.mark.asyncio
+    async def test_serves_only_regular_files(self, mode: str, entry_type: str, served: bool):
+        """Only a regular blob is bytes the contents API will return as listed.
+
+        A submodule is a commit, a tree is a directory, and a symlink's size is its
+        target path's length rather than the target's.
+        """
+        session = _session_for(
+            lambda _url: _FakeResponse(json_body=_tree({"path": "thing", "type": entry_type, "size": 7, "mode": mode}))
+        )
+        with patch("nmp.core.files.app.backends.github.get_http_session", return_value=session):
+            files = await _impl().list_files()
+
+        assert [f.path for f in files] == (["thing"] if served else [])
+
     @pytest.mark.asyncio
     async def test_skips_symlinks(self):
         """A symlink's size is its target path's length, but the contents API serves the target.

--- a/services/core/files/tests/test_github_backend.py
+++ b/services/core/files/tests/test_github_backend.py
@@ -138,6 +138,36 @@ class TestResolveConfig:
                 await _impl().resolve_config()
 
 
+class TestTrackedRevision:
+    def test_a_pinned_fileset_tracks_the_ref_it_was_resolved_from(self):
+        impl = _impl(_config(revision="abc123", original_revision="main"))
+
+        assert impl.tracked_revision == "main"
+        assert impl.config_at_tracked_revision().revision == "main"
+
+    def test_a_fileset_created_from_a_sha_tracks_nothing(self):
+        assert _impl(_config(revision="abc123")).tracked_revision is None
+
+    @pytest.mark.asyncio
+    async def test_re_resolving_the_tracked_ref_moves_the_pinned_revision(self):
+        session = _session_for(lambda _url: _FakeResponse(json_body={"sha": "newsha"}))
+        impl = _impl(_config(revision="oldsha", original_revision="main"))
+
+        with patch("nmp.core.files.app.backends.github.get_http_session", return_value=session):
+            resolved = await GithubStorageImpl(impl.config_at_tracked_revision(), {}).resolve_config()
+
+        assert resolved.revision == "newsha"
+        assert resolved.original_revision == "main"
+        assert session.requests[0][0].endswith("/repos/acme/agents/commits/main")
+
+    def test_the_repository_and_directory_survive_a_re_resolution(self):
+        impl = _impl(_config(revision="oldsha", original_revision="main", path="agents/calc"))
+
+        source = impl.config_at_tracked_revision()
+
+        assert (source.owner, source.repo, source.path) == ("acme", "agents", "agents/calc")
+
+
 class TestListFiles:
     @pytest.mark.asyncio
     async def test_returns_blobs_and_skips_trees(self):

--- a/services/core/files/tests/test_github_backend.py
+++ b/services/core/files/tests/test_github_backend.py
@@ -98,9 +98,11 @@ class TestRaiseForGithubStatus:
         with pytest.raises(GithubAccessError):
             raise_for_github_status(403, "repository acme/agents")
 
-    def test_exhausted_rate_limit_is_unavailable_not_access_denied(self):
+    @pytest.mark.parametrize("header", ["x-ratelimit-remaining", "X-RateLimit-Remaining"])
+    def test_exhausted_rate_limit_is_unavailable_not_access_denied(self, header: str):
+        # GitHub capitalizes this header over HTTP/1.1, which is what aiohttp speaks.
         with pytest.raises(GithubUnavailableError, match="rate limit"):
-            raise_for_github_status(403, "repository acme/agents", {"x-ratelimit-remaining": "0"})
+            raise_for_github_status(403, "repository acme/agents", {header: "0"})
 
     @pytest.mark.parametrize("status", [429, 500, 502, 503])
     def test_server_side_failures_are_unavailable(self, status: int):
@@ -375,6 +377,11 @@ class TestUrlEncoding:
         # address a repository other than the one the rest of the config names.
         with pytest.raises(ValidationError, match="path segment"):
             GithubStorageConfig(**{"owner": "acme", "repo": "agents", field: "../../../user"})
+
+    def test_an_http_api_base_url_is_refused(self):
+        # Every request carries the token, so the endpoint has to be encrypted.
+        with pytest.raises(ValidationError, match="must use https"):
+            _config(api_base_url="http://github.internal.example.com/api/v3")
 
     def test_a_multi_segment_owner_is_refused(self):
         with pytest.raises(ValidationError, match="single path segment"):

--- a/services/core/files/tests/test_github_backend.py
+++ b/services/core/files/tests/test_github_backend.py
@@ -460,6 +460,13 @@ class TestUrlEncoding:
         with pytest.raises(ValidationError, match="must use https"):
             _config(api_base_url="http://github.internal.example.com/api/v3")
 
+    @pytest.mark.parametrize("field", ["owner", "repo", "revision"])
+    def test_a_blank_identifier_is_refused(self, field: str):
+        # An empty segment is dropped when the URL path is joined, so a blank
+        # revision would turn /commits/{revision} into the list-commits endpoint.
+        with pytest.raises(ValidationError, match="must not be blank"):
+            GithubStorageConfig(**{"owner": "acme", "repo": "agents", field: "   "})
+
     def test_a_multi_segment_owner_is_refused(self):
         with pytest.raises(ValidationError, match="single path segment"):
             GithubStorageConfig(owner="acme/evil", repo="agents")

--- a/services/core/files/tests/test_github_backend.py
+++ b/services/core/files/tests/test_github_backend.py
@@ -148,6 +148,12 @@ class TestTrackedRevision:
     def test_a_fileset_created_from_a_sha_tracks_nothing(self):
         assert _impl(_config(revision="abc123")).tracked_revision is None
 
+    def test_a_sha_recorded_as_its_own_original_tracks_nothing(self):
+        """resolve_config records the requested ref even when it was already a commit."""
+        impl = _impl(_config(revision="abc123", original_revision="abc123"))
+
+        assert impl.tracked_revision is None
+
     @pytest.mark.asyncio
     async def test_re_resolving_the_tracked_ref_moves_the_pinned_revision(self):
         session = _session_for(lambda _url: _FakeResponse(json_body={"sha": "newsha"}))

--- a/services/core/files/tests/test_github_backend.py
+++ b/services/core/files/tests/test_github_backend.py
@@ -74,7 +74,12 @@ def _tree(*entries: dict, truncated: bool = False) -> dict:
 
 
 def _blob(path: str, size: int = 1) -> dict:
-    return {"path": path, "type": "blob", "size": size}
+    return {"path": path, "type": "blob", "size": size, "mode": "100644"}
+
+
+def _symlink(path: str, target: str) -> dict:
+    """Git stores a symlink as a blob whose content — and size — is its target path."""
+    return {"path": path, "type": "blob", "size": len(target), "mode": "120000"}
 
 
 def _config(**overrides) -> GithubStorageConfig:
@@ -126,13 +131,19 @@ class TestResolveConfig:
         assert session.requests[0][0].endswith("/repos/acme/agents/commits/main")
 
     @pytest.mark.asyncio
-    async def test_keeps_the_first_original_revision_across_resolutions(self):
+    async def test_records_the_requested_revision_over_a_client_supplied_one(self):
+        """`original_revision` is settable on create, so it must not survive resolution.
+
+        Carrying it forward would let a fileset pin one commit and then refresh
+        against an unrelated ref.
+        """
         session = _session_for(lambda _url: _FakeResponse(json_body={"sha": "def456"}))
-        config = _config(revision="abc123", original_revision="main")
+        config = _config(revision="abc123", original_revision="attacker-branch")
         with patch("nmp.core.files.app.backends.github.get_http_session", return_value=session):
             resolved = await GithubStorageImpl(config, {}).resolve_config()
 
-        assert resolved.original_revision == "main"
+        assert (resolved.revision, resolved.original_revision) == ("def456", "abc123")
+        assert resolved.tracked_revision == "abc123"
 
     @pytest.mark.asyncio
     async def test_rejects_a_response_carrying_no_sha(self):
@@ -207,6 +218,27 @@ class TestListFiles:
         assert "/git/trees/abc123:agents/calc?" in session.requests[0][0]
 
     @pytest.mark.asyncio
+    async def test_skips_symlinks(self):
+        """A symlink's size is its target path's length, but the contents API serves the target.
+
+        Listing one would advertise the wrong Content-Length, and a link like
+        `../../../openapi/openapi.yaml` would serve a file outside the configured
+        directory.
+        """
+        session = _session_for(
+            lambda _url: _FakeResponse(
+                json_body=_tree(
+                    _blob("agent.yaml", 80),
+                    _symlink("docs/openapi.yaml", "../../../openapi/openapi.yaml"),
+                )
+            )
+        )
+        with patch("nmp.core.files.app.backends.github.get_http_session", return_value=session):
+            files = await _impl().list_files()
+
+        assert [f.path for f in files] == ["agent.yaml"]
+
+    @pytest.mark.asyncio
     async def test_filters_to_a_requested_subpath(self):
         session = _session_for(
             lambda _url: _FakeResponse(json_body=_tree(_blob("agent.yaml"), _blob("mcps/calculator.py")))
@@ -236,6 +268,25 @@ class TestListFiles:
         with patch("nmp.core.files.app.backends.github.get_http_session", return_value=session):
             with pytest.raises(GithubConfigError):
                 await _impl().list_files()
+
+
+class TestGetFile:
+    @pytest.mark.asyncio
+    async def test_returns_the_blob_at_an_exact_path(self):
+        session = _session_for(lambda _url: _FakeResponse(json_body=_tree(_blob("mcps/calculator.py", 20))))
+        with patch("nmp.core.files.app.backends.github.get_http_session", return_value=session):
+            info = await _impl().get_file("mcps/calculator.py")
+
+        assert (info.path, info.size) == ("mcps/calculator.py", 20)
+
+    @pytest.mark.asyncio
+    async def test_refuses_a_directory(self):
+        """The contents API answers a directory with a JSON listing, so describing it
+        with its first child's size would pair that length with unrelated bytes."""
+        session = _session_for(lambda _url: _FakeResponse(json_body=_tree(_blob("mcps/calculator.py", 20))))
+        with patch("nmp.core.files.app.backends.github.get_http_session", return_value=session):
+            with pytest.raises(NotFoundError):
+                await _impl().get_file("mcps")
 
 
 class TestDownload:

--- a/services/core/files/tests/test_huggingface_backend.py
+++ b/services/core/files/tests/test_huggingface_backend.py
@@ -116,6 +116,22 @@ def mock_hf_api():
         yield mock_api
 
 
+def test_tracked_revision_is_the_ref_the_fileset_was_resolved_from(hf_config_resolved, hf_secrets_empty):
+    """A resolved fileset can be re-resolved against the ref it came from."""
+    impl = HuggingfaceStorageImpl(hf_config_resolved, hf_secrets_empty)
+
+    assert impl.tracked_revision == "main"
+    assert impl.config_at_tracked_revision().revision == "main"
+    assert impl.config_at_tracked_revision().repo_id == "test-org/test-repo"
+
+
+def test_a_fileset_created_from_a_sha_tracks_nothing(hf_secrets_empty):
+    """Nothing to re-resolve when the user pinned an immutable revision themselves."""
+    config = HuggingfaceStorageConfig(repo_id="test-org/test-repo", revision="a1b2c3d")
+
+    assert HuggingfaceStorageImpl(config, hf_secrets_empty).tracked_revision is None
+
+
 def test_get_download_url(hf_config, hf_secrets_empty):
     """Test download URL generation."""
     with patch("nmp.core.files.app.backends.huggingface.hf_hub_url") as mock_url:

--- a/services/core/files/tests/test_local_backend.py
+++ b/services/core/files/tests/test_local_backend.py
@@ -249,6 +249,14 @@ def test_local_config_owns_storage_data(storage_path: Path):
     assert config.owns_storage_data is True
 
 
+def test_local_tracks_no_revision(storage_impl: LocalStorageImpl):
+    """Uploaded files have no upstream ref, so there is nothing to refresh them against."""
+    assert storage_impl.tracked_revision is None
+
+    with pytest.raises(NotImplementedError):
+        storage_impl.config_at_tracked_revision()
+
+
 async def test_delete_all_removes_directory_and_contents(storage_impl: LocalStorageImpl, storage_path: Path):
     """Test delete_all removes the entire storage directory and all contents."""
     # Create some files and nested directories

--- a/web/packages/studio/src/components/DatasetsTable/helpers.ts
+++ b/web/packages/studio/src/components/DatasetsTable/helpers.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
+  type GithubStorageConfig,
   type HuggingfaceStorageConfig,
   type LocalStorageConfig,
   type NGCStorageConfig,
@@ -23,6 +24,8 @@ export function getStoragePath(storage: StorageConfig | undefined): string | nul
     team?: string;
     target?: string;
     repo_id?: string;
+    owner?: string;
+    repo?: string;
     bucket?: string;
     prefix?: string;
   };
@@ -35,6 +38,12 @@ export function getStoragePath(storage: StorageConfig | undefined): string | nul
   }
   if (s.type === 'huggingface' && 'repo_id' in storage) {
     return (storage as HuggingfaceStorageConfig).repo_id;
+  }
+  if (s.type === 'github' && 'owner' in storage && 'repo' in storage) {
+    const github = storage as GithubStorageConfig;
+    return github.path
+      ? `${github.owner}/${github.repo}/${github.path}`
+      : `${github.owner}/${github.repo}`;
   }
   if (s.type === 's3' && 'bucket' in storage) {
     const s3 = storage as S3StorageConfig;

--- a/web/packages/studio/src/components/DatasetsTable/types.ts
+++ b/web/packages/studio/src/components/DatasetsTable/types.ts
@@ -5,6 +5,7 @@ import * as DataView from '@nemo/common/src/components/DataView/internal';
 import {
   type FilesetOutput as Dataset,
   type FilesetPurpose,
+  type GithubStorageConfig,
   type HuggingfaceStorageConfig,
   type LocalStorageConfig,
   type NGCStorageConfig,
@@ -18,7 +19,8 @@ export type StorageConfig =
   | LocalStorageConfig
   | NGCStorageConfig
   | HuggingfaceStorageConfig
-  | S3StorageConfig;
+  | S3StorageConfig
+  | GithubStorageConfig;
 
 export type DatasetWithId = Dataset & { id: string };
 

--- a/web/packages/studio/src/util/storageBackend.ts
+++ b/web/packages/studio/src/util/storageBackend.ts
@@ -6,6 +6,7 @@ import type { FilesetOutput } from '@nemo/sdk/generated/platform/schema';
 export type StorageBackend = NonNullable<FilesetOutput['storage']['type']>;
 
 const STORAGE_BACKEND_LABELS: Record<StorageBackend, string> = {
+  github: 'GitHub',
   huggingface: 'Hugging Face',
   ngc: 'NGC',
   s3: 'S3',


### PR DESCRIPTION
## Summary

Adds a GitHub storage backend for filesets, so an agent's files can be served straight from a repository instead of uploaded, and a way to move a fileset forward when the ref it tracks does.

Fileset creation pins a mutable ref to an immutable id so contents cannot shift under a deployment, and `PATCH /filesets/{name}` does not accept `storage`. Picking up a new commit therefore meant creating another fileset, and another agent. `POST /filesets/{name}/refresh` re-resolves the ref the fileset was created from and repoints it at whatever that names now.

Deployments stage the fileset when they are created, so a refresh deliberately leaves running deployments on the revision they started with. `AgentDeployment` now records that revision, which is what makes the difference visible.

## Changes

- **GitHub storage backend** (`backends/github.py`): lists via the git-trees API, streams file contents, maps GitHub status codes onto the storage exception hierarchy, and pins the revision to a commit SHA at create time. `api.github.com` added to the default allowed external hosts.
- **`POST /filesets/{name}/refresh`**: re-resolves the tracked ref. Repository and directory are untouched. A fileset created from an immutable id has nothing to track and is refused with 409.
- **`tracked_revision` / `config_at_tracked_revision()`** on `StorageImpl`, beside `resolve_config` whose counterpart they are. Implemented for GitHub and HuggingFace; every other backend inherits "tracks nothing".
- **`AgentDeployment.spec_revision` / `spec_tracked_revision`**, captured at deployment create from the Ethos fileset. An absent or unreadable fileset records nothing rather than failing the deployment.
- OpenAPI regenerated for both new surfaces.

The shared `nemo_platform_plugin` package is deliberately untouched: the tracked-ref concept lives in the files service that owns the endpoint.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: no user-facing docs cover fileset storage backends yet; the endpoint is described in the generated OpenAPI spec.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `pytest services/core/files/tests plugins/nemo-agents/tests/unit/test_deployments_api.py` — 666 passed, 51 skipped
- `ruff check` / `ruff format --check` on the changed files — clean
- `ty check` on the changed files — one pre-existing diagnostic in `backends/base.py` (`return self.config` in the original `resolve_config`)
- `uv run pre-commit run -a` — not run. The pre-push hooks fail in this environment for unrelated reasons: `helm-docs` is not installed, and `uv-lock` wants uv 0.9.14 against 0.9.30 locally. Pushed with `--no-verify`.

Manual verification against a local platform: created a fileset from `owner/repo@main`, pushed a commit, refreshed, and confirmed the fileset moved to the new SHA while an existing deployment stayed on the old one.

## Notes for review

`fix(files): do not treat a self-resolving commit as a tracked ref` fixes a bug the endpoint tests caught: `resolve_config` records `original_revision` unconditionally, so a fileset created from a SHA reported itself as tracking a ref and the 409 was unreachable for GitHub and HuggingFace.

The refresh endpoint has no way to check for a newer revision without applying it. A read-only `GET /filesets/{name}/tracked-revision` would let a client show "update available" first; not included here.

Part of ASTD-519. Closes ASTD-592. The Studio half is stacked on this branch in a separate PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added GitHub repositories as a fileset storage option, including private repositories, revisions, subdirectories, and GitHub Enterprise URLs.
  - Added API and CLI support for refreshing filesets to the latest tracked mutable revision.
  - Added GitHub storage labels and repository path display in Studio.
- **Documentation**
  - Updated configuration and CLI references for GitHub storage and fileset refresh.
  - Clarified local file removal behavior when deleting filesets.
- **Configuration**
  - Added GitHub’s API host to the default allowed external hosts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->