### PR TITLE
refactor(evaluator): migrate plugin off stainless

### DIFF
--- a/packages/nemo_platform/pyproject.toml
+++ b/packages/nemo_platform/pyproject.toml
@@ -337,7 +337,6 @@ nemo-deployments-plugin = [
 nemo-evaluator-plugin = [
   "cloudpickle>=3.1.1",
   "nemo-evaluator-sdk",
-  "nemo-platform-sdk",
   "nemo-platform-plugin",
   "pydantic>=2.12.0",
   "typer>=0.20.0",

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/evaluator/client.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/evaluator/client.py
@@ -15,10 +15,14 @@ from dataclasses import replace
 
 from nemo_platform_plugin.client.client import AsyncNemoClient, NemoClient
 from nemo_platform_plugin.client.method import method
-from nemo_platform_plugin.client.response import NemoResponse
+from nemo_platform_plugin.client.response import AsyncNemoBinaryResponse, NemoBinaryResponse, NemoResponse
 from nemo_platform_plugin.client.types import PreparedRequest
 from nemo_platform_plugin.evaluator import endpoints
 from nemo_platform_plugin.evaluator.types import CreateMetricRequest, FlatQueryParams, Metric, ProjectQueryParams
+
+_AGGREGATE_SCORES_RESULT_NAME = "aggregate-scores"
+_ROW_SCORES_RESULT_NAME = "row-scores"
+_ARTIFACTS_RESULT_NAME = "artifacts"
 
 
 def _create_metric_request(
@@ -41,19 +45,40 @@ def _create_metric_request(
 
 class _EvaluatorMethods:
     get_health = method(endpoints.get_health)
+    hello = method(endpoints.hello)
 
     list_evaluate_jobs = method(endpoints.list_evaluate_jobs)
     submit_evaluate_job = method(endpoints.submit_evaluate_job)
     get_evaluate_job = method(endpoints.get_evaluate_job)
     get_evaluate_job_status = method(endpoints.get_evaluate_job_status)
-    download_evaluate_job_aggregate_scores = method(endpoints.download_evaluate_job_aggregate_scores)
-    download_evaluate_job_row_scores = method(endpoints.download_evaluate_job_row_scores)
-    download_evaluate_job_artifacts = method(endpoints.download_evaluate_job_artifacts)
+    delete_evaluate_job = method(endpoints.delete_evaluate_job)
+    cancel_evaluate_job = method(endpoints.cancel_evaluate_job)
+    list_evaluate_job_logs = method(endpoints.list_evaluate_job_logs)
+    list_evaluate_job_results = method(endpoints.list_evaluate_job_results)
+    get_evaluate_job_result = method(endpoints.get_evaluate_job_result)
+    download_evaluate_job_result = method(endpoints.download_evaluate_job_result)
 
     list_agent_eval_jobs = method(endpoints.list_agent_eval_jobs)
     submit_agent_eval_job = method(endpoints.submit_agent_eval_job)
     get_agent_eval_job = method(endpoints.get_agent_eval_job)
     get_agent_eval_job_status = method(endpoints.get_agent_eval_job_status)
+    delete_agent_eval_job = method(endpoints.delete_agent_eval_job)
+    cancel_agent_eval_job = method(endpoints.cancel_agent_eval_job)
+    list_agent_eval_job_logs = method(endpoints.list_agent_eval_job_logs)
+    list_agent_eval_job_results = method(endpoints.list_agent_eval_job_results)
+    get_agent_eval_job_result = method(endpoints.get_agent_eval_job_result)
+    download_agent_eval_job_result = method(endpoints.download_agent_eval_job_result)
+
+    list_retrieve_eval_jobs = method(endpoints.list_retrieve_eval_jobs)
+    submit_retrieve_eval_job = method(endpoints.submit_retrieve_eval_job)
+    get_retrieve_eval_job = method(endpoints.get_retrieve_eval_job)
+    get_retrieve_eval_job_status = method(endpoints.get_retrieve_eval_job_status)
+    delete_retrieve_eval_job = method(endpoints.delete_retrieve_eval_job)
+    cancel_retrieve_eval_job = method(endpoints.cancel_retrieve_eval_job)
+    list_retrieve_eval_job_logs = method(endpoints.list_retrieve_eval_job_logs)
+    list_retrieve_eval_job_results = method(endpoints.list_retrieve_eval_job_results)
+    get_retrieve_eval_job_result = method(endpoints.get_retrieve_eval_job_result)
+    download_retrieve_eval_job_result = method(endpoints.download_retrieve_eval_job_result)
 
     get_metric = method(endpoints.get_metric)
     list_metrics = method(endpoints.list_metrics)
@@ -88,6 +113,30 @@ class _EvaluatorMethods:
 class EvaluatorClient(_EvaluatorMethods, NemoClient):
     """Sync client for the Evaluator service API."""
 
+    def download_evaluate_job_aggregate_scores(self, *, workspace: str | None = None, name: str) -> NemoBinaryResponse:
+        """Download the aggregate-scores artifact for an evaluate job."""
+        return self.download_evaluate_job_result(
+            workspace=workspace,
+            job=name,
+            name=_AGGREGATE_SCORES_RESULT_NAME,
+        )
+
+    def download_evaluate_job_row_scores(self, *, workspace: str | None = None, name: str) -> NemoBinaryResponse:
+        """Download the row-scores artifact for an evaluate job."""
+        return self.download_evaluate_job_result(
+            workspace=workspace,
+            job=name,
+            name=_ROW_SCORES_RESULT_NAME,
+        )
+
+    def download_evaluate_job_artifacts(self, *, workspace: str | None = None, name: str) -> NemoBinaryResponse:
+        """Download the artifacts bundle for an evaluate job."""
+        return self.download_evaluate_job_result(
+            workspace=workspace,
+            job=name,
+            name=_ARTIFACTS_RESULT_NAME,
+        )
+
     def create_metric(
         self,
         *,
@@ -110,6 +159,36 @@ class EvaluatorClient(_EvaluatorMethods, NemoClient):
 
 class AsyncEvaluatorClient(_EvaluatorMethods, AsyncNemoClient):
     """Async client for the Evaluator service API."""
+
+    async def download_evaluate_job_aggregate_scores(
+        self, *, workspace: str | None = None, name: str
+    ) -> AsyncNemoBinaryResponse:
+        """Download the aggregate-scores artifact for an evaluate job."""
+        return await self.download_evaluate_job_result(
+            workspace=workspace,
+            job=name,
+            name=_AGGREGATE_SCORES_RESULT_NAME,
+        )
+
+    async def download_evaluate_job_row_scores(
+        self, *, workspace: str | None = None, name: str
+    ) -> AsyncNemoBinaryResponse:
+        """Download the row-scores artifact for an evaluate job."""
+        return await self.download_evaluate_job_result(
+            workspace=workspace,
+            job=name,
+            name=_ROW_SCORES_RESULT_NAME,
+        )
+
+    async def download_evaluate_job_artifacts(
+        self, *, workspace: str | None = None, name: str
+    ) -> AsyncNemoBinaryResponse:
+        """Download the artifacts bundle for an evaluate job."""
+        return await self.download_evaluate_job_result(
+            workspace=workspace,
+            job=name,
+            name=_ARTIFACTS_RESULT_NAME,
+        )
 
     async def create_metric(
         self,

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/evaluator/endpoints.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/evaluator/endpoints.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from abc import abstractmethod
 
 from nemo_platform_plugin.client.endpoint import delete, get, post, put
-from nemo_platform_plugin.client.types import BinaryContent, Paginated
+from nemo_platform_plugin.client.types import BinaryContent, CursorPagination, Paginated
 from nemo_platform_plugin.evaluator.types import (
     AgentEvalJob,
     AgentEvalResult,
@@ -27,7 +27,9 @@ from nemo_platform_plugin.evaluator.types import (
     EvalResult,
     EvaluateJob,
     EvaluatorHealth,
+    EvaluatorJobLogsQueryParams,
     FlatQueryParams,
+    HelloResponse,
     ListAgentEvalResultsQueryParams,
     ListEvalResultsQueryParams,
     ListMetricsQueryParams,
@@ -38,19 +40,25 @@ from nemo_platform_plugin.evaluator.types import (
     ProjectQueryParams,
     ReplaceTaskRequest,
     ReplaceTasksetRequest,
+    RetrieveEvalJob,
     Revision,
     RevisionQueryParams,
     SubmitAgentEvalJobRequest,
     SubmitEvaluateJobRequest,
+    SubmitRetrieveEvalJobRequest,
     Task,
     Taskset,
 )
-from nemo_platform_plugin.jobs.schemas import PlatformJobStatusResponse
-from nemo_platform_plugin.jobs.types import ListJobsQueryParams
+from nemo_platform_plugin.jobs.schemas import PlatformJobLog, PlatformJobResultResponse, PlatformJobStatusResponse
+from nemo_platform_plugin.jobs.types import (
+    ListJobsQueryParams,
+    PlatformJobListResultResponse,
+)
 
 _EVAL_BASE = "/apis/evaluator/v2/workspaces/{workspace}"
 _EVAL_JOBS = f"{_EVAL_BASE}/evaluate/jobs"
 _AGENT_EVAL_JOBS = f"{_EVAL_BASE}/agent-evaluate/jobs"
+_RETRIEVE_EVAL_JOBS = f"{_EVAL_BASE}/retrieve-eval/jobs"
 _EVAL_RESULTS = f"{_EVAL_BASE}/eval-results"
 _AGENT_EVAL_RESULTS = f"{_EVAL_BASE}/agent-eval-results"
 _METRICS = f"{_EVAL_BASE}/metrics"
@@ -66,6 +74,11 @@ _TASKSETS = f"{_EVAL_BASE}/tasksets"
 @get("/apis/evaluator/v1/healthz")
 @abstractmethod
 def get_health() -> EvaluatorHealth: ...
+
+
+@get("/apis/evaluator/v1/hello/{name}")
+@abstractmethod
+def hello(*, name: str) -> HelloResponse: ...
 
 
 # ---------------------------------------------------------------------------
@@ -95,19 +108,36 @@ def get_evaluate_job(*, workspace: str | None = None, name: str) -> EvaluateJob:
 def get_evaluate_job_status(*, workspace: str | None = None, name: str) -> PlatformJobStatusResponse: ...
 
 
-@get(f"{_EVAL_JOBS}/{{name}}/results/aggregate-scores/download")
+@delete(f"{_EVAL_JOBS}/{{name}}")
 @abstractmethod
-def download_evaluate_job_aggregate_scores(*, workspace: str | None = None, name: str) -> BinaryContent: ...
+def delete_evaluate_job(*, workspace: str | None = None, name: str) -> None: ...
 
 
-@get(f"{_EVAL_JOBS}/{{name}}/results/row-scores/download")
+@post(f"{_EVAL_JOBS}/{{name}}/cancel")
 @abstractmethod
-def download_evaluate_job_row_scores(*, workspace: str | None = None, name: str) -> BinaryContent: ...
+def cancel_evaluate_job(*, workspace: str | None = None, name: str) -> EvaluateJob: ...
 
 
-@get(f"{_EVAL_JOBS}/{{name}}/results/artifacts/download")
+@get(f"{_EVAL_JOBS}/{{name}}/logs")
 @abstractmethod
-def download_evaluate_job_artifacts(*, workspace: str | None = None, name: str) -> BinaryContent: ...
+def list_evaluate_job_logs(
+    *, workspace: str | None = None, name: str, query_params: EvaluatorJobLogsQueryParams | None = None
+) -> Paginated[PlatformJobLog, CursorPagination]: ...
+
+
+@get(f"{_EVAL_JOBS}/{{name}}/results")
+@abstractmethod
+def list_evaluate_job_results(*, workspace: str | None = None, name: str) -> PlatformJobListResultResponse: ...
+
+
+@get(f"{_EVAL_JOBS}/{{job}}/results/{{name}}")
+@abstractmethod
+def get_evaluate_job_result(*, workspace: str | None = None, job: str, name: str) -> PlatformJobResultResponse: ...
+
+
+@get(f"{_EVAL_JOBS}/{{job}}/results/{{name}}/download")
+@abstractmethod
+def download_evaluate_job_result(*, workspace: str | None = None, job: str, name: str) -> BinaryContent: ...
 
 
 # ---------------------------------------------------------------------------
@@ -135,6 +165,99 @@ def get_agent_eval_job(*, workspace: str | None = None, name: str) -> AgentEvalJ
 @get(f"{_AGENT_EVAL_JOBS}/{{name}}/status")
 @abstractmethod
 def get_agent_eval_job_status(*, workspace: str | None = None, name: str) -> PlatformJobStatusResponse: ...
+
+
+@delete(f"{_AGENT_EVAL_JOBS}/{{name}}")
+@abstractmethod
+def delete_agent_eval_job(*, workspace: str | None = None, name: str) -> None: ...
+
+
+@post(f"{_AGENT_EVAL_JOBS}/{{name}}/cancel")
+@abstractmethod
+def cancel_agent_eval_job(*, workspace: str | None = None, name: str) -> AgentEvalJob: ...
+
+
+@get(f"{_AGENT_EVAL_JOBS}/{{name}}/logs")
+@abstractmethod
+def list_agent_eval_job_logs(
+    *, workspace: str | None = None, name: str, query_params: EvaluatorJobLogsQueryParams | None = None
+) -> Paginated[PlatformJobLog, CursorPagination]: ...
+
+
+@get(f"{_AGENT_EVAL_JOBS}/{{name}}/results")
+@abstractmethod
+def list_agent_eval_job_results(*, workspace: str | None = None, name: str) -> PlatformJobListResultResponse: ...
+
+
+@get(f"{_AGENT_EVAL_JOBS}/{{job}}/results/{{name}}")
+@abstractmethod
+def get_agent_eval_job_result(*, workspace: str | None = None, job: str, name: str) -> PlatformJobResultResponse: ...
+
+
+@get(f"{_AGENT_EVAL_JOBS}/{{job}}/results/{{name}}/download")
+@abstractmethod
+def download_agent_eval_job_result(*, workspace: str | None = None, job: str, name: str) -> BinaryContent: ...
+
+
+# ---------------------------------------------------------------------------
+# Retrieve-eval jobs
+# ---------------------------------------------------------------------------
+
+
+@post(_RETRIEVE_EVAL_JOBS)
+@abstractmethod
+def submit_retrieve_eval_job(
+    *, workspace: str | None = None, body: SubmitRetrieveEvalJobRequest
+) -> RetrieveEvalJob: ...
+
+
+@get(_RETRIEVE_EVAL_JOBS)
+@abstractmethod
+def list_retrieve_eval_jobs(
+    *, workspace: str | None = None, query_params: ListJobsQueryParams | FlatQueryParams | None = None
+) -> Paginated[RetrieveEvalJob]: ...
+
+
+@get(f"{_RETRIEVE_EVAL_JOBS}/{{name}}")
+@abstractmethod
+def get_retrieve_eval_job(*, workspace: str | None = None, name: str) -> RetrieveEvalJob: ...
+
+
+@get(f"{_RETRIEVE_EVAL_JOBS}/{{name}}/status")
+@abstractmethod
+def get_retrieve_eval_job_status(*, workspace: str | None = None, name: str) -> PlatformJobStatusResponse: ...
+
+
+@delete(f"{_RETRIEVE_EVAL_JOBS}/{{name}}")
+@abstractmethod
+def delete_retrieve_eval_job(*, workspace: str | None = None, name: str) -> None: ...
+
+
+@post(f"{_RETRIEVE_EVAL_JOBS}/{{name}}/cancel")
+@abstractmethod
+def cancel_retrieve_eval_job(*, workspace: str | None = None, name: str) -> RetrieveEvalJob: ...
+
+
+@get(f"{_RETRIEVE_EVAL_JOBS}/{{name}}/logs")
+@abstractmethod
+def list_retrieve_eval_job_logs(
+    *, workspace: str | None = None, name: str, query_params: EvaluatorJobLogsQueryParams | None = None
+) -> Paginated[PlatformJobLog, CursorPagination]: ...
+
+
+@get(f"{_RETRIEVE_EVAL_JOBS}/{{name}}/results")
+@abstractmethod
+def list_retrieve_eval_job_results(*, workspace: str | None = None, name: str) -> PlatformJobListResultResponse: ...
+
+
+@get(f"{_RETRIEVE_EVAL_JOBS}/{{job}}/results/{{name}}")
+@abstractmethod
+def get_retrieve_eval_job_result(*, workspace: str | None = None, job: str, name: str) -> PlatformJobResultResponse: ...
+
+
+@get(f"{_RETRIEVE_EVAL_JOBS}/{{job}}/results/{{name}}/download")
+@abstractmethod
+def download_retrieve_eval_job_result(*, workspace: str | None = None, job: str, name: str) -> BinaryContent: ...
 
 
 # ---------------------------------------------------------------------------

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/evaluator/types.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/evaluator/types.py
@@ -11,12 +11,29 @@ direct ``NeMoPlatform._client`` usage.
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Annotated, Any, Literal, NotRequired, TypeAlias, TypedDict
+from typing import Annotated, Any, Literal, NotRequired, Self, TypeAlias, TypedDict
 
+from nemo_platform_plugin.jobs.schemas import PlatformJobStatus
+from nemo_platform_plugin.jobs.types import validate_output_location
 from nemo_platform_plugin.schema import Page
-from pydantic import BaseModel, ConfigDict, Field, JsonValue, RootModel, field_validator
+from pydantic import BaseModel, ConfigDict, Field, JsonValue, RootModel, field_validator, model_validator
 
 FlatQueryParams: TypeAlias = dict[str, str | int | bool | None]
+
+_ENTITY_NAME_SEGMENT = r"[a-z](?:[a-z0-9@.+_]|-[a-z0-9@.+_]){1,62}"
+_QUALIFIED_MODEL_REF_PATTERN = rf"^{_ENTITY_NAME_SEGMENT}/{_ENTITY_NAME_SEGMENT}$"
+_SECRET_REF_PATTERN = r"^[A-Za-z0-9_-]+(/[A-Za-z0-9_-]+)?$"
+
+Truncation: TypeAlias = Literal["end", "start"]
+RetrieveEvalModelFormat: TypeAlias = Literal["nim", "openai", "llama_stack"]
+_RetrieveEvalModelRefRoot: TypeAlias = Annotated[
+    str,
+    Field(
+        pattern=_QUALIFIED_MODEL_REF_PATTERN,
+        description="Reference to a model (format: workspace/name).",
+        examples=["workspace/model_name"],
+    ),
+]
 
 # ---------------------------------------------------------------------------
 # Response types
@@ -32,6 +49,12 @@ class EvaluatorHealth(BaseModel):
     status: str | None = None
     service: str | None = None
     jobs: list[str] = Field(default_factory=list)
+
+
+class HelloResponse(BaseModel):
+    """Evaluator plugin hello response."""
+
+    message: str
 
 
 class EvaluateJob(BaseModel):
@@ -61,6 +84,166 @@ class AgentEvalJob(BaseModel):
 
 
 EvaluatorJobResponse: TypeAlias = EvaluateJob
+
+
+class RetrieveEvalFilesetRef(RootModel[str]):
+    """Reference to a persisted platform fileset, optionally with a file fragment."""
+
+    root: str = Field(description="Reference to a Fileset (format: workspace/fileset-name).")
+
+
+class RetrieveEvalModelRef(RootModel[_RetrieveEvalModelRefRoot]):
+    """Reference to a model resolved by the evaluator backend."""
+
+
+class RetrieveEvalSecretRef(RootModel[str]):
+    """Reference to a platform secret or local environment variable."""
+
+    root: str = Field(
+        description="Reference to a platform secret or local environment variable. "
+        "Format: 'secret_name' (uses request workspace) or 'workspace/secret_name' (explicit workspace).",
+        pattern=_SECRET_REF_PATTERN,
+        examples=[
+            "my-secret",
+            "my-workspace/my-secret",
+            "NVIDIA_API_KEY",
+        ],
+    )
+
+
+class RetrieveEvalModel(BaseModel):
+    """Inline model definition accepted by retrieve-eval specs."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    url: str = Field(description="URL of the model.")
+    name: str = Field(description="Name of the model.")
+    host_url: str | None = Field(
+        default=None,
+        description="Direct NIM endpoint URL populated when a model reference is resolved.",
+    )
+    api_key_secret: RetrieveEvalSecretRef | None = Field(
+        default=None,
+        description="API key secret reference for the model.",
+    )
+    format: RetrieveEvalModelFormat = Field(
+        default="openai",
+        description="Inference API format used by the model.",
+    )
+
+
+class RetrieveEvalRetrievalInputSpec(BaseModel):
+    """Submitter-facing retrieval target before platform model refs are resolved."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    embeddings: RetrieveEvalModel | RetrieveEvalModelRef
+    reranker: RetrieveEvalModel | RetrieveEvalModelRef | None = None
+    first_stage_k: int = Field(default=100, ge=1, description="Dense-search cutoff before reranking.")
+    truncate_long_documents: Truncation | None = Field(
+        default="end",
+        description="How to cap passages at 65535 characters: keep the start ('end'), the tail ('start'), or error (null).",
+        json_schema_extra={"nullable": True},
+    )
+    batch_size: int = Field(default=32, ge=1, description="Embedding HTTP batch size.")
+    embedding_dimensions: int | None = Field(
+        default=None,
+        gt=0,
+        description="Expected embedding width. Omit to accept the model's native width.",
+    )
+
+
+RetrieveEvalSubmitTarget: TypeAlias = RetrieveEvalRetrievalInputSpec | RetrieveEvalModel | RetrieveEvalModelRef
+
+
+class RetrieveEvalInputSpec(BaseModel):
+    """Submitter-facing BEIR retrieval evaluation spec."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    dataset: RetrieveEvalFilesetRef = Field(description="Fileset containing a BEIR test split.")
+    target: RetrieveEvalSubmitTarget = Field(
+        description="Retrieval pipeline, embedding NIM, or platform model reference."
+    )
+    baseline: RetrieveEvalSubmitTarget | None = Field(
+        default=None,
+        description="Optional baseline retrieval pipeline used for relative nDCG and recall at 10.",
+    )
+    k: list[int] = Field(default_factory=lambda: [1, 5, 10, 100], min_length=1)
+
+    @model_validator(mode="after")
+    def validate_k(self) -> Self:
+        """Require unique positive cutoffs."""
+        if any(cutoff < 1 for cutoff in self.k):
+            raise ValueError("retrieval cutoffs must be positive")
+        if len(set(self.k)) != len(self.k):
+            raise ValueError("retrieval cutoffs must be unique")
+        self.k.sort()
+        return self
+
+
+class RetrieveEvalRetrievalSpec(BaseModel):
+    """Canonical retrieval target returned after model refs are resolved."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    embeddings: RetrieveEvalModel = Field(description="Embedding NIM used to encode queries and passages.")
+    reranker: RetrieveEvalModel | None = Field(
+        default=None, description="Optional ranking NIM applied after dense search."
+    )
+    first_stage_k: int = Field(default=100, ge=1, description="Dense-search cutoff before reranking.")
+    truncate_long_documents: Truncation | None = Field(
+        default="end",
+        description="How to cap passages at 65535 characters: keep the start ('end'), the tail ('start'), or error (null).",
+        json_schema_extra={"nullable": True},
+    )
+    batch_size: int = Field(default=32, ge=1, description="Embedding HTTP batch size.")
+    embedding_dimensions: int | None = Field(
+        default=None,
+        gt=0,
+        description="Expected embedding width. Omit to accept the model's native width.",
+    )
+
+
+class RetrieveEvalSpec(BaseModel):
+    """Canonical BEIR retrieval evaluation spec."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    dataset: RetrieveEvalFilesetRef
+    target: RetrieveEvalRetrievalSpec
+    baseline: RetrieveEvalRetrievalSpec | None = None
+    k: list[int] = Field(default_factory=lambda: [1, 5, 10, 100], min_length=1)
+
+    @model_validator(mode="after")
+    def validate_k(self) -> Self:
+        """Require unique positive cutoffs in canonical task payloads."""
+        if any(cutoff < 1 for cutoff in self.k):
+            raise ValueError("retrieval cutoffs must be positive")
+        if len(set(self.k)) != len(self.k):
+            raise ValueError("retrieval cutoffs must be unique")
+        self.k.sort()
+        return self
+
+
+class RetrieveEvalJob(BaseModel):
+    """Response from a retrieve-eval job route."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: str | None = None
+    name: str
+    description: str | None = None
+    project: str | None = None
+    workspace: str | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+    spec: RetrieveEvalSpec
+    status: PlatformJobStatus | None = None
+    status_details: dict[str, JsonValue] | None = None
+    error_details: dict[str, JsonValue] | None = None
+    ownership: dict[str, JsonValue] | None = None
+    custom_fields: dict[str, JsonValue] | None = None
 
 
 class _WorkspaceResource(BaseModel):
@@ -146,6 +329,24 @@ class SubmitAgentEvalJobRequest(BaseModel):
     spec: dict[str, Any]
 
 
+class SubmitRetrieveEvalJobRequest(BaseModel):
+    """Request body for POST /retrieve-eval/jobs."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str | None = None
+    description: str | None = None
+    project: str | None = None
+    spec: RetrieveEvalInputSpec
+    profile: str | None = None
+    options: dict[str, JsonValue] | None = None
+    ownership: dict[str, JsonValue] | None = None
+    custom_fields: dict[str, JsonValue] | None = None
+    output_location: str | None = None
+
+    _validate_output_location = field_validator("output_location")(validate_output_location)
+
+
 class MetricMetadata(BaseModel):
     """User-facing metadata captured with a bundled metric."""
 
@@ -169,7 +370,7 @@ class MetricSecretRef(RootModel[str]):
     root: str = Field(
         description="Reference to a platform secret or local environment variable. "
         "Format: 'secret_name' (uses request workspace) or 'workspace/secret_name' (explicit workspace).",
-        pattern=r"^[A-Za-z0-9_-]+(/[A-Za-z0-9_-]+)?$",
+        pattern=_SECRET_REF_PATTERN,
         examples=[
             "my-secret",
             "my-workspace/my-secret",
@@ -291,6 +492,12 @@ class ListTasksetsQueryParams(TypedDict, total=False):
     page_size: NotRequired[int]
     sort: NotRequired[str]
     filter: NotRequired[str]
+
+
+class EvaluatorJobLogsQueryParams(TypedDict, total=False):
+    limit: NotRequired[int]
+    page_cursor: NotRequired[str]
+    tail: NotRequired[int]
 
 
 class ListRevisionsQueryParams(TypedDict, total=False):

--- a/packages/nemo_platform_plugin/tests/evaluator/test_endpoints.py
+++ b/packages/nemo_platform_plugin/tests/evaluator/test_endpoints.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 from typing import get_args, get_origin
 
+import pytest
 from nemo_platform_plugin.client.types import BinaryContent, Paginated, PreparedRequest
 from nemo_platform_plugin.evaluator import endpoints
 from nemo_platform_plugin.evaluator.types import (
@@ -18,18 +19,32 @@ from nemo_platform_plugin.evaluator.types import (
     EvalResult,
     EvaluateJob,
     EvaluatorHealth,
+    HelloResponse,
     InlineMetricPayload,
     Metric,
     ReplaceTaskRequest,
     ReplaceTasksetRequest,
+    RetrieveEvalFilesetRef,
+    RetrieveEvalInputSpec,
+    RetrieveEvalJob,
+    RetrieveEvalModel,
+    RetrieveEvalModelRef,
+    RetrieveEvalRetrievalInputSpec,
     Revision,
     SubmitAgentEvalJobRequest,
     SubmitEvaluateJobRequest,
+    SubmitRetrieveEvalJobRequest,
     Task,
     Taskset,
 )
-from nemo_platform_plugin.jobs.schemas import PlatformJobStatusResponse
-from pydantic import JsonValue
+from nemo_platform_plugin.jobs.schemas import (
+    PlatformJobLog,
+    PlatformJobResultResponse,
+    PlatformJobStatus,
+    PlatformJobStatusResponse,
+)
+from nemo_platform_plugin.jobs.types import PlatformJobListResultResponse
+from pydantic import JsonValue, ValidationError
 
 
 def _assert_paginated_model(response_type: object, model_type: type[object]) -> None:
@@ -86,6 +101,15 @@ def test_health_endpoint_shape() -> None:
     assert prepared.response_type is EvaluatorHealth
 
 
+def test_hello_endpoint_shape() -> None:
+    prepared = endpoints.hello(name="ada")
+
+    assert prepared.method == "GET"
+    assert prepared.path_template == "/apis/evaluator/v1/hello/{name}"
+    assert prepared.path_params == {"name": "ada"}
+    assert prepared.response_type is HelloResponse
+
+
 def test_evaluate_job_and_download_endpoint_shapes() -> None:
     job = endpoints.get_evaluate_job(workspace="team-a", name="job-1")
     jobs = endpoints.list_evaluate_jobs(
@@ -93,9 +117,12 @@ def test_evaluate_job_and_download_endpoint_shapes() -> None:
         query_params={"page": 2, "page_size": 25, "sort": "-created_at", "filter": '{"status":"completed"}'},
     )
     status = endpoints.get_evaluate_job_status(workspace="team-a", name="job-1")
-    aggregate = endpoints.download_evaluate_job_aggregate_scores(workspace="team-a", name="job-1")
-    row_scores = endpoints.download_evaluate_job_row_scores(workspace="team-a", name="job-1")
-    artifacts = endpoints.download_evaluate_job_artifacts(workspace="team-a", name="job-1")
+    deleted = endpoints.delete_evaluate_job(workspace="team-a", name="job-1")
+    cancelled = endpoints.cancel_evaluate_job(workspace="team-a", name="job-1")
+    logs = endpoints.list_evaluate_job_logs(workspace="team-a", name="job-1", query_params={"tail": 10})
+    results = endpoints.list_evaluate_job_results(workspace="team-a", name="job-1")
+    result = endpoints.get_evaluate_job_result(workspace="team-a", job="job-1", name="aggregate-scores")
+    download = endpoints.download_evaluate_job_result(workspace="team-a", job="job-1", name="aggregate-scores")
 
     assert job.method == "GET"
     assert job.path_template == "/apis/evaluator/v2/workspaces/{workspace}/evaluate/jobs/{name}"
@@ -105,9 +132,18 @@ def test_evaluate_job_and_download_endpoint_shapes() -> None:
     _assert_paginated_model(jobs.response_type, EvaluateJob)
     assert status.path_template.endswith("/evaluate/jobs/{name}/status")
     assert status.response_type is PlatformJobStatusResponse
-    assert aggregate.response_type is BinaryContent
-    assert row_scores.response_type is BinaryContent
-    assert artifacts.response_type is BinaryContent
+    assert deleted.response_type is None
+    assert cancelled.path_template.endswith("/evaluate/jobs/{name}/cancel")
+    assert cancelled.response_type is EvaluateJob
+    _assert_paginated_model(logs.response_type, PlatformJobLog)
+    assert logs.query_params == {"tail": 10}
+    assert results.path_template.endswith("/evaluate/jobs/{name}/results")
+    assert results.response_type is PlatformJobListResultResponse
+    assert result.path_template.endswith("/evaluate/jobs/{job}/results/{name}")
+    assert result.path_params == {"workspace": "team-a", "job": "job-1", "name": "aggregate-scores"}
+    assert result.response_type is PlatformJobResultResponse
+    assert download.path_template.endswith("/evaluate/jobs/{job}/results/{name}/download")
+    assert download.response_type is BinaryContent
 
 
 def test_agent_eval_job_endpoint_shapes() -> None:
@@ -117,6 +153,12 @@ def test_agent_eval_job_endpoint_shapes() -> None:
         query_params={"page": 2, "page_size": 25, "sort": "-created_at", "filter": '{"status":"completed"}'},
     )
     status = endpoints.get_agent_eval_job_status(workspace="team-a", name="job-1")
+    deleted = endpoints.delete_agent_eval_job(workspace="team-a", name="job-1")
+    cancelled = endpoints.cancel_agent_eval_job(workspace="team-a", name="job-1")
+    logs = endpoints.list_agent_eval_job_logs(workspace="team-a", name="job-1", query_params={"limit": 10})
+    results = endpoints.list_agent_eval_job_results(workspace="team-a", name="job-1")
+    result = endpoints.get_agent_eval_job_result(workspace="team-a", job="job-1", name="summary")
+    download = endpoints.download_agent_eval_job_result(workspace="team-a", job="job-1", name="summary")
 
     assert job.method == "GET"
     assert job.path_template == "/apis/evaluator/v2/workspaces/{workspace}/agent-evaluate/jobs/{name}"
@@ -126,6 +168,152 @@ def test_agent_eval_job_endpoint_shapes() -> None:
     _assert_paginated_model(jobs.response_type, AgentEvalJob)
     assert status.path_template.endswith("/agent-evaluate/jobs/{name}/status")
     assert status.response_type is PlatformJobStatusResponse
+    assert deleted.response_type is None
+    assert cancelled.response_type is AgentEvalJob
+    _assert_paginated_model(logs.response_type, PlatformJobLog)
+    assert logs.query_params == {"limit": 10}
+    assert results.response_type is PlatformJobListResultResponse
+    assert result.path_template.endswith("/agent-evaluate/jobs/{job}/results/{name}")
+    assert result.response_type is PlatformJobResultResponse
+    assert download.path_template.endswith("/agent-evaluate/jobs/{job}/results/{name}/download")
+    assert download.response_type is BinaryContent
+
+
+def test_retrieve_eval_job_endpoint_shapes() -> None:
+    submitted = endpoints.submit_retrieve_eval_job(
+        workspace="team-a",
+        body=SubmitRetrieveEvalJobRequest(
+            name="retrieval-smoke",
+            description="BEIR smoke",
+            project="search",
+            spec=RetrieveEvalInputSpec(
+                dataset=RetrieveEvalFilesetRef("team-a/beir"),
+                target=RetrieveEvalModelRef("team-a/embedder"),
+                k=[1, 10],
+            ),
+            profile="cpu-small",
+            options={"priority": "low"},
+            ownership={"principal_id": "principal-1"},
+            custom_fields={"suite": "nightly"},
+            output_location="retrieval-results",
+        ),
+    )
+    job = endpoints.get_retrieve_eval_job(workspace="team-a", name="job-1")
+    jobs = endpoints.list_retrieve_eval_jobs(workspace="team-a", query_params={"page": 2})
+    status = endpoints.get_retrieve_eval_job_status(workspace="team-a", name="job-1")
+    deleted = endpoints.delete_retrieve_eval_job(workspace="team-a", name="job-1")
+    cancelled = endpoints.cancel_retrieve_eval_job(workspace="team-a", name="job-1")
+    logs = endpoints.list_retrieve_eval_job_logs(workspace="team-a", name="job-1", query_params={"tail": 10})
+    results = endpoints.list_retrieve_eval_job_results(workspace="team-a", name="job-1")
+    result = endpoints.get_retrieve_eval_job_result(workspace="team-a", job="job-1", name="eval-results")
+    download = endpoints.download_retrieve_eval_job_result(workspace="team-a", job="job-1", name="eval-results")
+
+    assert submitted.method == "POST"
+    assert submitted.path_template == "/apis/evaluator/v2/workspaces/{workspace}/retrieve-eval/jobs"
+    assert isinstance(submitted.content, bytes)
+    assert json.loads(submitted.content) == {
+        "name": "retrieval-smoke",
+        "description": "BEIR smoke",
+        "project": "search",
+        "spec": {"dataset": "team-a/beir", "target": "team-a/embedder", "k": [1, 10]},
+        "profile": "cpu-small",
+        "options": {"priority": "low"},
+        "ownership": {"principal_id": "principal-1"},
+        "custom_fields": {"suite": "nightly"},
+        "output_location": "retrieval-results",
+    }
+    assert submitted.response_type is RetrieveEvalJob
+    assert job.path_template.endswith("/retrieve-eval/jobs/{name}")
+    assert job.response_type is RetrieveEvalJob
+    _assert_paginated_model(jobs.response_type, RetrieveEvalJob)
+    assert status.response_type is PlatformJobStatusResponse
+    assert deleted.response_type is None
+    assert cancelled.response_type is RetrieveEvalJob
+    _assert_paginated_model(logs.response_type, PlatformJobLog)
+    assert results.response_type is PlatformJobListResultResponse
+    assert result.response_type is PlatformJobResultResponse
+    assert download.path_template.endswith("/retrieve-eval/jobs/{job}/results/{name}/download")
+    assert download.response_type is BinaryContent
+
+
+def test_retrieve_eval_job_models_match_job_route_contract() -> None:
+    job = RetrieveEvalJob.model_validate(
+        {
+            "id": "job-id",
+            "name": "retrieval-smoke",
+            "description": "BEIR smoke",
+            "project": "search",
+            "workspace": "team-a",
+            "spec": {
+                "dataset": "team-a/beir",
+                "target": {
+                    "embeddings": {
+                        "url": "https://igw.example.test/v1/embeddings",
+                        "name": "embedder",
+                    },
+                    "first_stage_k": 50,
+                },
+                "k": [10, 1],
+            },
+            "status": "completed",
+            "status_details": {"progress": 1.0},
+            "error_details": None,
+            "ownership": {"principal_id": "principal-1"},
+            "custom_fields": {"suite": "nightly"},
+        }
+    )
+
+    assert job.name == "retrieval-smoke"
+    assert job.spec.dataset.root == "team-a/beir"
+    assert job.spec.target.embeddings.name == "embedder"
+    assert job.spec.target.first_stage_k == 50
+    assert job.spec.k == [1, 10]
+    assert job.status is PlatformJobStatus.COMPLETED
+    assert job.status_details == {"progress": 1.0}
+    assert job.ownership == {"principal_id": "principal-1"}
+    assert job.custom_fields == {"suite": "nightly"}
+
+    with pytest.raises(ValidationError):
+        RetrieveEvalJob.model_validate({"status": "completed", "spec": {}})
+
+    with pytest.raises(ValidationError):
+        SubmitRetrieveEvalJobRequest.model_validate({"spec": {}})
+
+    with pytest.raises(ValidationError):
+        SubmitRetrieveEvalJobRequest(
+            spec=RetrieveEvalInputSpec(
+                dataset=RetrieveEvalFilesetRef("team-a/beir"), target=RetrieveEvalModelRef("bad")
+            ),
+        )
+
+    with pytest.raises(ValidationError):
+        SubmitRetrieveEvalJobRequest(
+            spec=RetrieveEvalInputSpec(
+                dataset=RetrieveEvalFilesetRef("team-a/beir"),
+                target=RetrieveEvalRetrievalInputSpec(
+                    embeddings=RetrieveEvalModel(url="https://igw.example.test/v1/embeddings", name="embedder"),
+                    first_stage_k=0,
+                ),
+            ),
+        )
+
+    with pytest.raises(ValidationError):
+        SubmitRetrieveEvalJobRequest(
+            spec=RetrieveEvalInputSpec(
+                dataset=RetrieveEvalFilesetRef("team-a/beir"),
+                target=RetrieveEvalModelRef("team-a/embedder"),
+                k=[1, 1],
+            )
+        )
+
+    with pytest.raises(ValidationError):
+        SubmitRetrieveEvalJobRequest(
+            spec=RetrieveEvalInputSpec(
+                dataset=RetrieveEvalFilesetRef("team-a/beir"),
+                target=RetrieveEvalModelRef("team-a/embedder"),
+            ),
+            output_location="workspace/fileset",
+        )
 
 
 def test_metric_endpoint_shapes() -> None:

--- a/plugins/nemo-evaluator/pyproject.toml
+++ b/plugins/nemo-evaluator/pyproject.toml
@@ -9,7 +9,6 @@ requires-python = ">=3.11,<3.15"
 dependencies = [
     "cloudpickle>=3.1.1",
     "nemo-evaluator-sdk",
-    "nemo-platform-sdk",
     "nemo-platform-plugin",
     "pydantic>=2.12.0",
     "typer>=0.20.0",
@@ -43,7 +42,6 @@ packages = ["src/nemo_evaluator"]
 
 [tool.uv.sources]
 nemo-evaluator-sdk = { workspace = true }
-nemo-platform-sdk = { workspace = true }
 nemo-platform-plugin = { workspace = true }
 nmp-testing = { workspace = true }
 

--- a/plugins/nemo-evaluator/src/nemo_evaluator/api/dependencies.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/api/dependencies.py
@@ -10,19 +10,18 @@ from nemo_evaluator.api.service.metric_service import MetricService
 from nemo_evaluator.api.service.result_service import ResultService
 from nemo_evaluator.api.service.task_service import TaskService
 from nemo_evaluator.api.service.taskset_service import TasksetService
-from nemo_platform import AsyncNeMoPlatform
-from nemo_platform_plugin.client.adapter import client_from_platform
-from nemo_platform_plugin.dependencies import get_sdk_client
+from nemo_platform_plugin.client.client import AsyncNemoClient
+from nemo_platform_plugin.dependencies import get_nemo_client
 from nemo_platform_plugin.entity_client import NemoEntitiesClient, get_entity_client
 from nemo_platform_plugin.files.client import AsyncFilesClient
 
 
 def get_metric_service(
     entity_client: NemoEntitiesClient = Depends(get_entity_client),
-    sdk: AsyncNeMoPlatform = Depends(get_sdk_client),
+    async_client: AsyncNemoClient = Depends(get_nemo_client),
 ) -> MetricService:
     """Provide a MetricService wired to the Entity Store and Files service."""
-    return MetricService(entity_client, client_from_platform(sdk, AsyncFilesClient))
+    return MetricService(entity_client, AsyncFilesClient.from_client(async_client))
 
 
 def get_result_service(

--- a/plugins/nemo-evaluator/src/nemo_evaluator/intake/mapping.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/intake/mapping.py
@@ -47,13 +47,15 @@ from nemo_evaluator_sdk.values.otlp import (
     set_span_attributes,
 )
 from nemo_evaluator_sdk.values.protocol import OUTPUT_DETAIL
-from nemo_platform.types.intake.evaluation_context_param import EvaluationContextParam
-from nemo_platform.types.intake.evaluator_result_create_params import EvaluatorResultCreateParams
-from nemo_platform.types.intake.evaluator_result_data_type import EvaluatorResultDataType
-from nemo_platform.types.intake.ingest.atif_agent_param import AtifAgentParam
-from nemo_platform.types.intake.ingest.atif_create_params import AtifCreateParams
-from nemo_platform.types.intake.ingest.atif_final_metrics_param import AtifFinalMetricsParam
-from nemo_platform.types.intake.ingest.atif_step_param import AtifStepParam
+from nemo_platform_plugin.intake.types import (
+    AtifAgentParam,
+    AtifCreateParams,
+    AtifFinalMetricsParam,
+    AtifStepParam,
+    EvaluationContextParam,
+    EvaluatorResultCreateParams,
+    EvaluatorResultDataType,
+)
 from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
 from pydantic import RootModel
 

--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/agent_evaluate.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/agent_evaluate.py
@@ -66,7 +66,6 @@ from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalRunConfig, AgentEvalTas
 from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTarget
 from nemo_evaluator_sdk.metrics.protocol import Metric
 from nemo_evaluator_sdk.values import RunConfigOnline, RunConfigOnlineModel
-from nemo_platform import AsyncNeMoPlatform
 from nemo_platform_plugin.client.adapter import client_from_platform
 from nemo_platform_plugin.client.client import AsyncNemoClient, NemoClient
 from nemo_platform_plugin.client.errors import (
@@ -91,6 +90,7 @@ from nemo_platform_plugin.jobs.execution_profiles import (
     VolcanoJobExecutionProfile,
 )
 from nemo_platform_plugin.jobs.spec import BaseExecutionProfile
+from nemo_platform_plugin.sdk import AsyncNeMoPlatform
 from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)

--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/evaluate.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/evaluate.py
@@ -43,13 +43,13 @@ from nemo_evaluator_sdk.values import (
 )
 from nemo_evaluator_sdk.values.multi_metric_results import BenchmarkEvaluationResult
 from nemo_evaluator_sdk.values.results import EvaluationResult
-from nemo_platform import AsyncNeMoPlatform
 from nemo_platform_plugin.client.client import AsyncNemoClient, NemoClient
 from nemo_platform_plugin.entities import EntityClient
 from nemo_platform_plugin.intake.client import AsyncIntakeClient
 from nemo_platform_plugin.job import NemoJob
 from nemo_platform_plugin.job_context import JobContext
 from nemo_platform_plugin.jobs.api_factory import PlatformJobSpec
+from nemo_platform_plugin.sdk import AsyncNeMoPlatform
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 logger = logging.getLogger(__name__)

--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/metric_resolution.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/metric_resolution.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import asyncio
 from dataclasses import dataclass
 
-from models import AsyncModelsResource, parse_workspace_name_ref
+from models import parse_workspace_name_ref
 from nemo_evaluator.api.schemas import MetricInline
 from nemo_evaluator.metric_refs import MetricRef, MetricRefOrInline, resolve_metric_specs
 from nemo_evaluator.shared.metric_bundles.bundles import (
@@ -27,11 +27,12 @@ from nemo_evaluator.shared.metric_bundles.bundles import (
 from nemo_evaluator_sdk.metrics.protocol import Metric, MetricWithModels
 from nemo_evaluator_sdk.resolver_protocols import ModelResolver
 from nemo_evaluator_sdk.values import Model, ModelRef
-from nemo_platform import AsyncNeMoPlatform
-from nemo_platform import NotFoundError as SDKNotFoundError
 from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.client.errors import NotFoundError
 from nemo_platform_plugin.entities import EntityClient
 from nemo_platform_plugin.files.client import AsyncFilesClient
+from nemo_platform_plugin.models.client import AsyncModelsClient
+from nemo_platform_plugin.sdk import AsyncNeMoPlatform
 
 
 def unresolved_model_refs(metrics: list[Metric]) -> list[str]:
@@ -71,17 +72,17 @@ def _model_not_found_error(model_ref: ModelRef, workspace: str, name: str) -> Va
 
 @dataclass(frozen=True)
 class PlatformMetricModelResolver(ModelResolver):
-    """Resolve evaluator metric ``ModelRef`` values through the platform Models resource."""
+    """Resolve evaluator metric ``ModelRef`` values through the typed Models client."""
 
-    models: AsyncModelsResource
+    models_client: AsyncModelsClient
 
     async def resolve_model(self, model_ref: ModelRef) -> Model:
         workspace, name = parse_workspace_name_ref(
             model_ref.root, label="ModelRef", expected_format="workspace/model_name"
         )
         try:
-            resolved = await self.models.resolve_model_reference(model_ref.root)
-        except SDKNotFoundError as exc:
+            resolved = await self.models_client.resolve_model_reference(model_ref.root)
+        except NotFoundError as exc:
             raise _model_not_found_error(model_ref, workspace, name) from exc
         return Model(url=resolved.url, name=resolved.name, host_url=resolved.host_url)
 
@@ -100,7 +101,7 @@ async def resolve_metrics_to_inline(
     reference is present without a usable ``async_sdk`` connection.
 
     Stored-ref loading awaits real file I/O, so it uses the typed Files client
-    derived from the public SDK. Model-ref resolution uses the public SDK.
+    derived from the public SDK. Model-ref resolution uses the typed Models client.
     """
     has_metric_ref = any(isinstance(metric, MetricRef) for metric in metrics)
     files_client = (
@@ -121,7 +122,8 @@ async def resolve_metrics_to_inline(
                 "ModelRef metrics require a platform connection (models + inference) to resolve: "
                 + ", ".join(unresolved)
             )
-        resolver: ModelResolver = PlatformMetricModelResolver(async_sdk.models)
+        models_client = client_from_platform(async_sdk, AsyncModelsClient)
+        resolver: ModelResolver = PlatformMetricModelResolver(models_client)
         await asyncio.gather(
             *(metric.resolve_models(resolver) for metric in runtime_metrics if isinstance(metric, MetricWithModels))
         )

--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/retrieve_eval.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/retrieve_eval.py
@@ -38,7 +38,7 @@ from nemo_evaluator_sdk.metrics.retrieval import (
 from nemo_evaluator_sdk.values.models import Model, ModelRef
 from nemo_evaluator_sdk.values.multi_metric_results import BenchmarkEvaluationResult
 from nemo_evaluator_sdk.values.retrieval import Retrieval, Truncation
-from nemo_platform import AsyncNeMoPlatform
+from nemo_platform_plugin.client.adapter import client_from_platform
 from nemo_platform_plugin.client.client import AsyncNemoClient, NemoClient
 from nemo_platform_plugin.job import NemoJob
 from nemo_platform_plugin.job_context import JobContext
@@ -49,6 +49,8 @@ from nemo_platform_plugin.jobs.api_factory import (
     PlatformJobStep,
 )
 from nemo_platform_plugin.jobs.image import get_qualified_image
+from nemo_platform_plugin.models.client import AsyncModelsClient
+from nemo_platform_plugin.sdk import AsyncNeMoPlatform
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 EVAL_RESULTS_FILE_NAME = "eval_results.json"
@@ -283,7 +285,8 @@ async def _resolve_retrieval(
     if isinstance(value, ModelRef):
         if async_sdk is None:
             raise ValueError("a platform SDK client is required to resolve the retrieval target")
-        return Retrieval(embeddings=await PlatformMetricModelResolver(async_sdk.models).resolve_model(value))
+        models_client = client_from_platform(async_sdk, AsyncModelsClient)
+        return Retrieval(embeddings=await PlatformMetricModelResolver(models_client).resolve_model(value))
     if isinstance(value, Model):
         return Retrieval(embeddings=value)
     embeddings = value.embeddings
@@ -291,11 +294,13 @@ async def _resolve_retrieval(
     if isinstance(embeddings, ModelRef):
         if async_sdk is None:
             raise ValueError("a platform SDK client is required to resolve the retrieval target")
-        embeddings = await PlatformMetricModelResolver(async_sdk.models).resolve_model(embeddings)
+        models_client = client_from_platform(async_sdk, AsyncModelsClient)
+        embeddings = await PlatformMetricModelResolver(models_client).resolve_model(embeddings)
     if isinstance(reranker, ModelRef):
         if async_sdk is None:
             raise ValueError("a platform SDK client is required to resolve the retrieval reranker")
-        reranker = await PlatformMetricModelResolver(async_sdk.models).resolve_model(reranker)
+        models_client = client_from_platform(async_sdk, AsyncModelsClient)
+        reranker = await PlatformMetricModelResolver(models_client).resolve_model(reranker)
     return Retrieval(
         embeddings=embeddings,
         reranker=reranker,

--- a/plugins/nemo-evaluator/src/nemo_evaluator/sdk/resources.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/sdk/resources.py
@@ -53,10 +53,9 @@ from nemo_evaluator_sdk.values import (
     Model,
     ModelRef,
 )
-from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
 from nemo_platform_plugin.client.adapter import client_from_platform
 from nemo_platform_plugin.evaluator.client import AsyncEvaluatorClient, EvaluatorClient
-from nemo_platform_plugin.sdk import NemoPluginSDKResources
+from nemo_platform_plugin.sdk import AsyncNeMoPlatform, NeMoPlatform, NemoPluginSDKResources
 
 
 class Evaluator:

--- a/plugins/nemo-evaluator/tests/integration/test_agent_evaluate_job.py
+++ b/plugins/nemo-evaluator/tests/integration/test_agent_evaluate_job.py
@@ -61,9 +61,9 @@ from nemo_evaluator_sdk.enums import AgentFormat, ModelFormat
 from nemo_evaluator_sdk.metrics.exact_match import ExactMatchMetric
 from nemo_evaluator_sdk.metrics.protocol import MetricInput, MetricOutput, MetricOutputSpec, MetricResult
 from nemo_evaluator_sdk.values import GenericAgent, Model, RunConfigOnline, RunConfigOnlineModel
-from nemo_platform import NeMoPlatform
 from nemo_platform_plugin.client.adapter import client_from_platform
 from nemo_platform_plugin.scheduler import NemoJobScheduler
+from nemo_platform_plugin.sdk import NeMoPlatform
 from nemo_platform_plugin.workspaces.client import WorkspacesClient
 from nemo_platform_plugin.workspaces.types import CreateWorkspaceRequest
 from nmp.testing import add_mock_provider

--- a/plugins/nemo-evaluator/tests/integration/test_docs_manage_tasks_tasksets.py
+++ b/plugins/nemo-evaluator/tests/integration/test_docs_manage_tasks_tasksets.py
@@ -34,8 +34,8 @@ from nemo_evaluator.api.schemas import (
     TasksetRef,
 )
 from nemo_evaluator_sdk import ExactMatchMetric
-from nemo_platform import NeMoPlatform
 from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.sdk import NeMoPlatform
 from nemo_platform_plugin.workspaces.client import WorkspacesClient
 from nemo_platform_plugin.workspaces.types import CreateWorkspaceRequest
 

--- a/plugins/nemo-evaluator/tests/integration/test_evaluate_job_integration.py
+++ b/plugins/nemo-evaluator/tests/integration/test_evaluate_job_integration.py
@@ -19,9 +19,9 @@ from nemo_evaluator.jobs.evaluate import EvaluateInputSpec, EvaluateJob
 from nemo_evaluator.shared.metric_bundles.bundles import bundle_metric
 from nemo_evaluator.shared.metric_bundles.cloudpickle import CloudpickleMetricBundlePackager
 from nemo_evaluator_sdk.metrics.exact_match import ExactMatchMetric
-from nemo_platform import NeMoPlatform
 from nemo_platform_plugin.client.adapter import client_from_platform
 from nemo_platform_plugin.scheduler import NemoJobScheduler
+from nemo_platform_plugin.sdk import NeMoPlatform
 from nemo_platform_plugin.workspaces.client import WorkspacesClient
 from nemo_platform_plugin.workspaces.types import CreateWorkspaceRequest
 from nmp.testing.e2e import wait_for_platform_job

--- a/plugins/nemo-evaluator/tests/integration/test_metric_filtering.py
+++ b/plugins/nemo-evaluator/tests/integration/test_metric_filtering.py
@@ -17,8 +17,8 @@ import uuid
 import pytest
 from nemo_evaluator_sdk.metrics.exact_match import ExactMatchMetric
 from nemo_evaluator_sdk.metrics.string_check import StringCheckMetric
-from nemo_platform import NeMoPlatform
 from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.sdk import NeMoPlatform
 from nemo_platform_plugin.workspaces.client import WorkspacesClient
 from nemo_platform_plugin.workspaces.types import CreateWorkspaceRequest
 

--- a/plugins/nemo-evaluator/tests/integration/test_publish_to_intake.py
+++ b/plugins/nemo-evaluator/tests/integration/test_publish_to_intake.py
@@ -42,10 +42,10 @@ from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial, AgentEvalTrialS
 from nemo_evaluator_sdk.metrics.protocol import MetricOutput
 from nemo_evaluator_sdk.values.evidence import CandidateEvidence, EvidenceDescriptor
 from nemo_evaluator_sdk.values.results import AggregatedMetricResult, EvaluationResult, RowScore
-from nemo_platform import AsyncNeMoPlatform
 from nemo_platform.types.intake.trace_filter_param import TraceFilterParam
 from nemo_platform_plugin.client.adapter import client_from_platform
 from nemo_platform_plugin.intake.client import AsyncIntakeClient
+from nemo_platform_plugin.sdk import AsyncNeMoPlatform
 
 pytestmark = pytest.mark.integration
 

--- a/plugins/nemo-evaluator/tests/integration/test_submit_gym_agent_eval.py
+++ b/plugins/nemo-evaluator/tests/integration/test_submit_gym_agent_eval.py
@@ -42,7 +42,7 @@ from nemo_evaluator.shared.metric_bundles.bundles import bundle_metric
 from nemo_evaluator.shared.metric_bundles.cloudpickle import CloudpickleMetricBundlePackager
 from nemo_evaluator_sdk.agent_eval.runtimes.gym import GymAgentTaskRunner, GymRuntimeConfig
 from nemo_evaluator_sdk.metrics.protocol import MetricInput, MetricOutput, MetricOutputSpec, MetricResult
-from nemo_platform import NeMoPlatform
+from nemo_platform_plugin.sdk import NeMoPlatform
 
 WORKSPACE = "default"
 

--- a/plugins/nemo-evaluator/tests/integration/test_task_derived_metrics.py
+++ b/plugins/nemo-evaluator/tests/integration/test_task_derived_metrics.py
@@ -22,12 +22,12 @@ import os
 import uuid
 
 import pytest
-from nemo_evaluator.api.schemas import EvaluatorTaskDefinition, MetricInline, TaskInput
+from nemo_evaluator.api.schemas import EvaluatorTaskDefinition, MetricInline, TaskInput, TaskInputs
 from nemo_evaluator.shared.metric_bundles.bundles import bundle_metric
 from nemo_evaluator.shared.metric_bundles.cloudpickle import CloudpickleMetricBundlePackager
 from nemo_evaluator_sdk.metrics.exact_match import ExactMatchMetric
-from nemo_platform import NeMoPlatform
 from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.sdk import NeMoPlatform
 from nemo_platform_plugin.workspaces.client import WorkspacesClient
 from nemo_platform_plugin.workspaces.types import CreateWorkspaceRequest
 
@@ -60,7 +60,10 @@ def _inline_metric(marker: str) -> MetricInline:
 def _task_input(metric: MetricInline) -> TaskInput:
     return TaskInput(
         spec=EvaluatorTaskDefinition(
-            kind="evaluator", intent="Answer the question.", inputs={"instruction": "What is 2+2?"}, metrics=[metric]
+            kind="evaluator",
+            intent="Answer the question.",
+            inputs=TaskInputs(instruction="What is 2+2?"),
+            metrics=[metric],
         )
     )
 

--- a/plugins/nemo-evaluator/tests/integration/test_task_revisions.py
+++ b/plugins/nemo-evaluator/tests/integration/test_task_revisions.py
@@ -31,10 +31,12 @@ from nemo_evaluator.api.schemas import (
     EvaluatorTaskDefinition,
     HarborTaskDefinition,
     TaskInput,
+    TaskInputs,
+    TaskRef,
     TasksetInput,
 )
-from nemo_platform import NeMoPlatform
 from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.sdk import NeMoPlatform
 from nemo_platform_plugin.workspaces.client import WorkspacesClient
 from nemo_platform_plugin.workspaces.types import CreateWorkspaceRequest
 
@@ -55,7 +57,11 @@ def _unique(prefix: str) -> str:
 
 def _task_input(intent: str = "Answer the question.", *, tags: list[str] | None = None) -> TaskInput:
     return TaskInput(
-        spec=EvaluatorTaskDefinition(kind="evaluator", intent=intent, inputs={"instruction": "What is 2+2?"}),
+        spec=EvaluatorTaskDefinition(
+            kind="evaluator",
+            intent=intent,
+            inputs=TaskInputs(instruction="What is 2+2?"),
+        ),
         tags=tags or [],
     )
 
@@ -218,7 +224,7 @@ def test_taskset_membership_is_pinned_and_stays_pinned(subprocess_platform: str)
         client.evaluator.tasks.create(task_name, task=_task_input("Original."), workspace=WORKSPACE)
 
         created = client.evaluator.tasksets.create(
-            set_name, taskset=TasksetInput(tasks=[task_name]), workspace=WORKSPACE
+            set_name, taskset=TasksetInput(tasks=[TaskRef(task_name)]), workspace=WORKSPACE
         )
         member = created.tasks[0].root
         assert "#" in member, "membership must be stored digest-pinned"
@@ -250,13 +256,13 @@ def test_republishing_a_taskset_after_a_member_moves_cuts_a_revision(subprocess_
     try:
         client.evaluator.tasks.create(task_name, task=_task_input("v1."), workspace=WORKSPACE)
         created = client.evaluator.tasksets.create(
-            set_name, taskset=TasksetInput(tasks=[task_name]), workspace=WORKSPACE
+            set_name, taskset=TasksetInput(tasks=[TaskRef(task_name)]), workspace=WORKSPACE
         )
         assert created.revision == 1
 
         client.evaluator.tasks.replace(task_name, task=_task_input("v2."), workspace=WORKSPACE)
         republished = client.evaluator.tasksets.replace(
-            set_name, taskset=TasksetInput(tasks=[task_name]), workspace=WORKSPACE
+            set_name, taskset=TasksetInput(tasks=[TaskRef(task_name)]), workspace=WORKSPACE
         )
 
         assert republished.revision == 2, "the grouping names different content, so it is a new revision"

--- a/plugins/nemo-evaluator/tests/test_agent_evaluate.py
+++ b/plugins/nemo-evaluator/tests/test_agent_evaluate.py
@@ -64,7 +64,6 @@ from nemo_evaluator_sdk.agent_eval.trials import (
 from nemo_evaluator_sdk.enums import AgentFormat
 from nemo_evaluator_sdk.metrics.exact_match import ExactMatchMetric
 from nemo_evaluator_sdk.values import Agent, GenericAgent, Model, RunConfigOnline, RunConfigOnlineModel, SecretRef
-from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
 from nemo_platform_plugin.client.client import AsyncNemoClient, NemoClient
 from nemo_platform_plugin.client.errors import InternalServerError, NemoResponseValidationError, NemoTransportError
 from nemo_platform_plugin.commands import add_job_commands
@@ -86,6 +85,7 @@ from nemo_platform_plugin.jobs.execution_profiles import (
 from nemo_platform_plugin.jobs.providers import SubprocessExecutionProvider
 from nemo_platform_plugin.jobs.spec import BaseExecutionProfile, PlatformJobSpec
 from nemo_platform_plugin.scheduler import NemoJobScheduler
+from nemo_platform_plugin.sdk import AsyncNeMoPlatform, NeMoPlatform
 from pydantic import ValidationError
 from pytest_mock import MockerFixture
 from typer.testing import CliRunner

--- a/plugins/nemo-evaluator/tests/test_evaluate_job.py
+++ b/plugins/nemo-evaluator/tests/test_evaluate_job.py
@@ -13,7 +13,7 @@ from unittest.mock import AsyncMock, MagicMock
 import httpx
 import nemo_evaluator.cli as evaluator_cli
 import pytest
-from models import AsyncModelsResource, ResolvedModelReference
+from models import ResolvedModelReference
 from nemo_evaluator.cli import EvaluatorPluginCLI
 from nemo_evaluator.filesets import FilesetRef
 from nemo_evaluator.jobs.evaluate import (
@@ -56,14 +56,15 @@ from nemo_evaluator_sdk.values import (
 )
 from nemo_evaluator_sdk.values.models import ModelRef
 from nemo_evaluator_sdk.values.scores import JSONScoreParser, RangeScore
-from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
 from nemo_platform_plugin.client.client import AsyncNemoClient, NemoClient
 from nemo_platform_plugin.commands import add_job_commands
 from nemo_platform_plugin.job_context import JobContext, StoragePaths
 from nemo_platform_plugin.job_results import LocalJobResults
 from nemo_platform_plugin.jobs.constants import PERSISTENT_JOB_STORAGE_PATH_ENVVAR
 from nemo_platform_plugin.jobs.spec import PlatformJobSpec
+from nemo_platform_plugin.models.client import AsyncModelsClient
 from nemo_platform_plugin.scheduler import NemoJobScheduler
+from nemo_platform_plugin.sdk import AsyncNeMoPlatform, NeMoPlatform
 from pydantic import BaseModel, ConfigDict
 from pytest_mock import MockerFixture
 from typer.testing import CliRunner
@@ -232,7 +233,7 @@ def _generated_async_sdk() -> AsyncNeMoPlatform:
 
 
 def _patch_async_model_reference_resolution(mocker: MockerFixture) -> None:
-    async def resolve_model_reference(self: AsyncModelsResource, ref: str) -> ResolvedModelReference:
+    async def resolve_model_reference(self: AsyncModelsClient, ref: str) -> ResolvedModelReference:
         del self
         assert ref == "default/judge"
         return ResolvedModelReference(
@@ -242,7 +243,7 @@ def _patch_async_model_reference_resolution(mocker: MockerFixture) -> None:
         )
 
     mocker.patch(
-        "nemo_evaluator.jobs.metric_resolution.AsyncModelsResource.resolve_model_reference",
+        "nemo_evaluator.jobs.metric_resolution.AsyncModelsClient.resolve_model_reference",
         resolve_model_reference,
     )
 

--- a/plugins/nemo-evaluator/tests/test_platform_clients.py
+++ b/plugins/nemo-evaluator/tests/test_platform_clients.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import httpx
 import pytest
 from nemo_evaluator.sdk.resources import AsyncEvaluator, Evaluator, evaluator_sdk_resources
-from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
+from nemo_platform_plugin.sdk import AsyncNeMoPlatform, NeMoPlatform
 
 BASE = "http://test"
 

--- a/uv.lock
+++ b/uv.lock
@@ -23,6 +23,7 @@ members = [
     "garak-api",
     "models",
     "nemo-agent-config-example-calculator",
+    "nemo-agent-hardener-plugin",
     "nemo-agents-example-calculator",
     "nemo-agents-example-email-phishing",
     "nemo-agents-example-email-security",
@@ -39,7 +40,6 @@ members = [
     "nemo-experimentalist-plugin",
     "nemo-guardrails-plugin",
     "nemo-insights-plugin",
-    "nemo-agent-hardener-plugin",
     "nemo-nb",
     "nemo-optimization-plugin",
     "nemo-platform",
@@ -4069,6 +4069,45 @@ dependencies = [
 requires-dist = [{ name = "mcp", specifier = ">=1.28.1,<2" }]
 
 [[package]]
+name = "nemo-agent-hardener-plugin"
+version = "0.1.0"
+source = { editable = "plugins/nemo-agent-hardener" }
+dependencies = [
+    { name = "httpx", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nemo-agents-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nemo-platform", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nemo-platform-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pydantic", extra = ["email"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pyyaml", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "typer", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pytest-asyncio", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "ruff", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "nemo-agents-plugin", editable = "plugins/nemo-agents" },
+    { name = "nemo-platform", editable = "packages/nemo_platform" },
+    { name = "nemo-platform-plugin", editable = "packages/nemo_platform_plugin" },
+    { name = "pydantic", specifier = ">=2.10.6" },
+    { name = "pyyaml", specifier = ">=6.0.2" },
+    { name = "typer", specifier = ">=0.20.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.3.4" },
+    { name = "pytest-asyncio", specifier = ">=0.25.3" },
+    { name = "ruff", specifier = ">=0.11.8" },
+]
+
+[[package]]
 name = "nemo-agents-example-calculator"
 version = "0.0.0"
 source = { editable = "plugins/nemo-agents/examples/calculator-agent" }
@@ -4513,7 +4552,6 @@ dependencies = [
     { name = "cloudpickle", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-evaluator-sdk", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-platform-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nemo-platform-sdk", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "pydantic", extra = ["email"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "typer", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
@@ -4531,7 +4569,6 @@ requires-dist = [
     { name = "cloudpickle", specifier = ">=3.1.1" },
     { name = "nemo-evaluator-sdk", editable = "packages/nemo_evaluator_sdk" },
     { name = "nemo-platform-plugin", editable = "packages/nemo_platform_plugin" },
-    { name = "nemo-platform-sdk", editable = "sdk/python/nemo-platform" },
     { name = "pydantic", specifier = ">=2.12.0" },
     { name = "typer", specifier = ">=0.20.0" },
 ]
@@ -4866,45 +4903,6 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "typer", specifier = ">=0.20.0" },
     { name = "tzdata", specifier = "==2026.2" },
-]
-
-[[package]]
-name = "nemo-agent-hardener-plugin"
-version = "0.1.0"
-source = { editable = "plugins/nemo-agent-hardener" }
-dependencies = [
-    { name = "httpx", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nemo-agents-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nemo-platform", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nemo-platform-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pydantic", extra = ["email"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pyyaml", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "typer", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "pytest", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pytest-asyncio", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "ruff", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "httpx", specifier = ">=0.27" },
-    { name = "nemo-agents-plugin", editable = "plugins/nemo-agents" },
-    { name = "nemo-platform", editable = "packages/nemo_platform" },
-    { name = "nemo-platform-plugin", editable = "packages/nemo_platform_plugin" },
-    { name = "pydantic", specifier = ">=2.10.6" },
-    { name = "pyyaml", specifier = ">=6.0.2" },
-    { name = "typer", specifier = ">=0.20.0" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pytest", specifier = ">=8.3.4" },
-    { name = "pytest-asyncio", specifier = ">=0.25.3" },
-    { name = "ruff", specifier = ">=0.11.8" },
 ]
 
 [[package]]
@@ -5356,7 +5354,6 @@ nemo-evaluator-plugin = [
     { name = "cloudpickle", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-evaluator-sdk", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-platform-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nemo-platform-sdk", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "pydantic", extra = ["email"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "typer", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
@@ -6103,7 +6100,6 @@ requires-dist = [
     { name = "nemo-platform-sdk", marker = "extra == 'core-service'", editable = "sdk/python/nemo-platform" },
     { name = "nemo-platform-sdk", marker = "extra == 'entities-service'", editable = "sdk/python/nemo-platform" },
     { name = "nemo-platform-sdk", marker = "extra == 'nemo-deployments-plugin'", editable = "sdk/python/nemo-platform" },
-    { name = "nemo-platform-sdk", marker = "extra == 'nemo-evaluator-plugin'", editable = "sdk/python/nemo-platform" },
     { name = "nemo-platform-sdk", marker = "extra == 'nemo-platform-plugin'", editable = "sdk/python/nemo-platform" },
     { name = "nemo-platform-sdk", marker = "extra == 'nmp-common'", editable = "sdk/python/nemo-platform" },
     { name = "nemo-platform-sdk", marker = "extra == 'nmp-customization-common'", editable = "sdk/python/nemo-platform" },
@@ -7299,9 +7295,9 @@ dev = [
     { name = "mlflow-skinny", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "mypy", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "myst-parser", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nemo-agent-hardener-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-anonymizer-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-data-designer-plugin", extra = ["retrieval-sdg"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nemo-agent-hardener-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-nb", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-platform", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-platform-ext", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -7529,9 +7525,9 @@ dev = [
     { name = "mlflow-skinny", specifier = ">=3.15.0,<3.16.0" },
     { name = "mypy" },
     { name = "myst-parser", specifier = ">=4.0.0" },
+    { name = "nemo-agent-hardener-plugin", editable = "plugins/nemo-agent-hardener" },
     { name = "nemo-anonymizer-plugin", editable = "plugins/nemo-anonymizer" },
     { name = "nemo-data-designer-plugin", extras = ["retrieval-sdg"], editable = "plugins/nemo-data-designer" },
-    { name = "nemo-agent-hardener-plugin", editable = "plugins/nemo-agent-hardener" },
     { name = "nemo-nb", editable = "packages/nemo_nb" },
     { name = "nemo-platform", editable = "packages/nemo_platform" },
     { name = "nemo-platform-ext", editable = "packages/nemo_platform_ext" },


### PR DESCRIPTION
## TL;DR

Migrate the evaluator plugin off its direct Stainless SDK dependency by routing evaluator, models, intake, and files interactions through `nemo_platform_plugin` typed clients and compatibility SDK exports. The plugin keeps its existing SDK/CLI behavior while removing `nemo-platform-sdk` from its direct dependency set.

## What Changed

- Expanded the source-owned evaluator typed client to cover health/hello, evaluate and agent-evaluate lifecycle actions, generic job logs/results/download endpoints, and the retrieve-eval job surface.
- Added typed retrieve-eval request/response models with validation for model refs, secret refs, retrieval cutoffs, and output locations so those API calls no longer rely on generated SDK DTOs.
- Updated evaluator plugin services, jobs, and tests to import platform compatibility SDK types and typed clients from `nemo_platform_plugin`, including files, intake, and models client usage.
- Swapped model reference resolution from generated `AsyncModelsResource` calls to `AsyncModelsClient` adaptation at the platform boundary.
- Removed `nemo-platform-sdk` from the evaluator plugin package and wrapper extra metadata, then refreshed `uv.lock`.
- Added and updated endpoint/plugin coverage plus the approved migration plan under `plans/`.

## Reviewer Notes

- The compatibility `NeMoPlatform` and `AsyncNeMoPlatform` names still appear where the plugin exposes or accepts the SDK-shaped boundary; their source is now `nemo_platform_plugin.sdk`.
- Existing evaluator artifact helper methods are preserved by mapping aggregate scores, row scores, and artifacts onto the generic typed job result download endpoint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added retrieve-evaluation job support, including submission, status tracking, cancellation, deletion, logs, and result retrieval.
  - Expanded evaluation job management with lifecycle controls, logs, and unified result downloads.
  - Added typed configuration and validation for retrieval models, secrets, inputs, and outputs.
  - Added synchronous and asynchronous downloads for aggregate scores, row scores, and artifact bundles.

- **Tests**
  - Expanded coverage for evaluation workflows, result handling, lifecycle operations, and retrieve-evaluation validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->