### PR TITLE
refactor(insights): migrate plugin off stainless clients

### DIFF
--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/agents/client.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/agents/client.py
@@ -7,7 +7,10 @@ Wraps the endpoint functions from ``agents.endpoints`` as direct methods
 using the ``method()`` descriptor, following the files/models pattern.
 """
 
+from functools import cached_property
+
 from nemo_platform_plugin.agents import endpoints
+from nemo_platform_plugin.agents.types import CreateExecuteJobRequest, JsonObject
 from nemo_platform_plugin.client.client import AsyncNemoClient, NemoClient
 from nemo_platform_plugin.client.method import method
 
@@ -23,11 +26,89 @@ class _AgentsMethods:
     delete_deployment = method(endpoints.delete_deployment)
     invoke_agent = method(endpoints.invoke_agent)
     invoke_deployment = method(endpoints.invoke_deployment)
+    create_execute_job = method(endpoints.create_execute_job)
+    get_execute_job = method(endpoints.get_execute_job)
+    list_execute_job_results = method(endpoints.list_execute_job_results)
+
+
+class _ExecuteJobsCompat:
+    def __init__(self, client: "AgentsClient") -> None:
+        self._client = client
+
+    def create(
+        self,
+        *,
+        spec: JsonObject,
+        name: str | None = None,
+        description: str | None = None,
+        workspace: str | None = None,
+    ) -> JsonObject:
+        return self._client.create_execute_job(
+            workspace=workspace,
+            body=CreateExecuteJobRequest(spec=spec, name=name, description=description),
+        ).data()
+
+    def get(self, name: str, *, workspace: str | None = None) -> JsonObject:
+        return self._client.get_execute_job(name=name, workspace=workspace).data()
+
+    def list_results(self, name: str, *, workspace: str | None = None) -> JsonObject:
+        return self._client.list_execute_job_results(name=name, workspace=workspace).data()
+
+
+class _AsyncExecuteJobsCompat:
+    def __init__(self, client: "AsyncAgentsClient") -> None:
+        self._client = client
+
+    async def create(
+        self,
+        *,
+        spec: JsonObject,
+        name: str | None = None,
+        description: str | None = None,
+        workspace: str | None = None,
+    ) -> JsonObject:
+        response = await self._client.create_execute_job(
+            workspace=workspace,
+            body=CreateExecuteJobRequest(spec=spec, name=name, description=description),
+        )
+        return response.data()
+
+    async def get(self, name: str, *, workspace: str | None = None) -> JsonObject:
+        return (await self._client.get_execute_job(name=name, workspace=workspace)).data()
+
+    async def list_results(self, name: str, *, workspace: str | None = None) -> JsonObject:
+        return (await self._client.list_execute_job_results(name=name, workspace=workspace)).data()
+
+
+class _JobsCompat:
+    def __init__(self, client: "AgentsClient") -> None:
+        self._client = client
+
+    @cached_property
+    def execute(self) -> _ExecuteJobsCompat:
+        return _ExecuteJobsCompat(self._client)
+
+
+class _AsyncJobsCompat:
+    def __init__(self, client: "AsyncAgentsClient") -> None:
+        self._client = client
+
+    @cached_property
+    def execute(self) -> _AsyncExecuteJobsCompat:
+        return _AsyncExecuteJobsCompat(self._client)
 
 
 class AgentsClient(_AgentsMethods, NemoClient):
     """Sync client for the Agents service API."""
 
+    @cached_property
+    def jobs(self) -> _JobsCompat:
+        return _JobsCompat(self)
+
 
 class AsyncAgentsClient(_AgentsMethods, AsyncNemoClient):
     """Async client for the Agents service API."""
+
+    @cached_property
+    def jobs(self) -> _AsyncJobsCompat:
+        return _AsyncJobsCompat(self)

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/agents/endpoints.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/agents/endpoints.py
@@ -17,7 +17,9 @@ from nemo_platform_plugin.agents.types import (
     AgentDeployment,
     CreateAgentDeploymentRequest,
     CreateAgentRequest,
+    CreateExecuteJobRequest,
     InvokeAgentRequest,
+    JsonObject,
     ListAgentsQueryParams,
     ListDeploymentsQueryParams,
 )
@@ -26,6 +28,7 @@ from nemo_platform_plugin.client.types import Paginated, PreparedRequest
 
 _AGENTS = "/apis/agents/v2/workspaces/{workspace}/agents"
 _DEPLOYMENTS = "/apis/agents/v2/workspaces/{workspace}/deployments"
+_EXECUTE_JOBS = "/apis/agents/v2/workspaces/{workspace}/jobs/execute"
 
 
 # ---------------------------------------------------------------------------
@@ -100,3 +103,23 @@ def invoke_agent(*, workspace: str | None = None, name: str, body: InvokeAgentRe
 @post(f"{_DEPLOYMENTS}/{{name}}/-/v1/chat/completions")
 @abstractmethod
 def invoke_deployment(*, workspace: str | None = None, name: str, body: InvokeAgentRequest) -> dict[str, Any]: ...
+
+
+# ---------------------------------------------------------------------------
+# agents.execute jobs
+# ---------------------------------------------------------------------------
+
+
+@post(_EXECUTE_JOBS)
+@abstractmethod
+def create_execute_job(*, workspace: str | None = None, body: CreateExecuteJobRequest) -> JsonObject: ...
+
+
+@get(f"{_EXECUTE_JOBS}/{{name}}")
+@abstractmethod
+def get_execute_job(*, workspace: str | None = None, name: str) -> JsonObject: ...
+
+
+@get(f"{_EXECUTE_JOBS}/{{name}}/results")
+@abstractmethod
+def list_execute_job_results(*, workspace: str | None = None, name: str) -> JsonObject: ...

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/agents/types.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/agents/types.py
@@ -13,7 +13,7 @@ from datetime import datetime
 from typing import Any, NotRequired, TypedDict
 
 from nemo_platform_plugin.schema import Page
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, JsonValue
 
 # ---------------------------------------------------------------------------
 # Response types
@@ -86,6 +86,17 @@ class InvokeAgentRequest(BaseModel):
 
     messages: list[dict[str, Any]] = Field(default_factory=list)
     stream: bool = False
+
+
+JsonObject = dict[str, JsonValue]
+
+
+class CreateExecuteJobRequest(BaseModel):
+    """Request body for the agents.execute job collection."""
+
+    spec: JsonObject = Field(description="ExecuteAgentJobConfig payload owned by the Agents plugin.")
+    name: str | None = None
+    description: str | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/intake/client.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/intake/client.py
@@ -1,11 +1,31 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Typed HTTP clients for the Intake APIs used by evaluator."""
+"""Typed HTTP clients for the Intake APIs used by evaluator and Insights."""
+
+from __future__ import annotations
+
+from functools import cached_property
 
 from nemo_platform_plugin.client.client import AsyncNemoClient, NemoClient
 from nemo_platform_plugin.client.method import method
+from nemo_platform_plugin.client.response import AsyncNemoPaginatedResponse, NemoPaginatedResponse
+from nemo_platform_plugin.client.types import OffsetPagination
 from nemo_platform_plugin.intake import endpoints
+from nemo_platform_plugin.intake.types import (
+    Annotation,
+    EvaluatorResult,
+    ListAnnotationsQueryParams,
+    ListSpanGroupsQueryParams,
+    ListSpansQueryParams,
+    Span,
+    SpanGroupsPage,
+    SpanMode,
+)
+from pydantic import JsonValue
+
+FilterQueryParam = dict[str, JsonValue]
+EvaluatorResults = list[EvaluatorResult]
 
 
 class _IntakeMethods:
@@ -17,11 +37,257 @@ class _IntakeMethods:
     patch_evaluation = method(endpoints.patch_evaluation)
     list_evaluator_results = method(endpoints.list_evaluator_results)
     list_evaluator_results_for_span = method(endpoints.list_evaluator_results_for_span)
+    list_spans = method(endpoints.list_spans)
+    list_span_groups = method(endpoints.list_span_groups)
+    get_span = method(endpoints.get_span)
+    list_annotations = method(endpoints.list_annotations)
+    get_annotation = method(endpoints.get_annotation)
+
+
+def _list_spans_params(
+    *,
+    page: int | None = None,
+    page_size: int | None = None,
+    sort: str | None = None,
+    filter: FilterQueryParam | None = None,
+    mode: SpanMode | None = None,
+) -> ListSpansQueryParams | None:
+    params: ListSpansQueryParams = {}
+    if page is not None:
+        params["page"] = page
+    if page_size is not None:
+        params["page_size"] = page_size
+    if sort is not None:
+        params["sort"] = sort
+    if filter is not None:
+        params["filter"] = filter
+    if mode is not None:
+        params["mode"] = mode
+    return params or None
+
+
+def _list_span_groups_params(
+    *,
+    by: str,
+    page: int | None = None,
+    page_size: int | None = None,
+    sort: str | None = None,
+    filter: FilterQueryParam | None = None,
+) -> ListSpanGroupsQueryParams:
+    params: ListSpanGroupsQueryParams = {"by": by}
+    if page is not None:
+        params["page"] = page
+    if page_size is not None:
+        params["page_size"] = page_size
+    if sort is not None:
+        params["sort"] = sort
+    if filter is not None:
+        params["filter"] = filter
+    return params
+
+
+def _list_annotations_params(
+    *,
+    page: int | None = None,
+    page_size: int | None = None,
+    sort: str | None = None,
+    filter: FilterQueryParam | None = None,
+) -> ListAnnotationsQueryParams | None:
+    params: ListAnnotationsQueryParams = {}
+    if page is not None:
+        params["page"] = page
+    if page_size is not None:
+        params["page_size"] = page_size
+    if sort is not None:
+        params["sort"] = sort
+    if filter is not None:
+        params["filter"] = filter
+    return params or None
+
+
+class _SpansCompat:
+    def __init__(self, client: "IntakeClient") -> None:
+        self._client = client
+
+    @cached_property
+    def groups(self) -> "_SpanGroupsCompat":
+        return _SpanGroupsCompat(self._client)
+
+    @cached_property
+    def evaluator_results(self) -> "_SpanEvaluatorResultsCompat":
+        return _SpanEvaluatorResultsCompat(self._client)
+
+    def list(
+        self,
+        *,
+        workspace: str | None = None,
+        page: int | None = None,
+        page_size: int | None = None,
+        sort: str | None = None,
+        filter: FilterQueryParam | None = None,
+        mode: SpanMode | None = None,
+    ) -> NemoPaginatedResponse[Span, OffsetPagination]:
+        return self._client.list_spans(
+            workspace=workspace,
+            query_params=_list_spans_params(page=page, page_size=page_size, sort=sort, filter=filter, mode=mode),
+        )
+
+    def retrieve(self, span_id: str, *, workspace: str | None = None) -> Span:
+        return self._client.get_span(span_id=span_id, workspace=workspace).data()
+
+
+class _AsyncSpansCompat:
+    def __init__(self, client: "AsyncIntakeClient") -> None:
+        self._client = client
+
+    @cached_property
+    def groups(self) -> "_AsyncSpanGroupsCompat":
+        return _AsyncSpanGroupsCompat(self._client)
+
+    @cached_property
+    def evaluator_results(self) -> "_AsyncSpanEvaluatorResultsCompat":
+        return _AsyncSpanEvaluatorResultsCompat(self._client)
+
+    async def list(
+        self,
+        *,
+        workspace: str | None = None,
+        page: int | None = None,
+        page_size: int | None = None,
+        sort: str | None = None,
+        filter: FilterQueryParam | None = None,
+        mode: SpanMode | None = None,
+    ) -> AsyncNemoPaginatedResponse[Span, OffsetPagination]:
+        return await self._client.list_spans(
+            workspace=workspace,
+            query_params=_list_spans_params(page=page, page_size=page_size, sort=sort, filter=filter, mode=mode),
+        )
+
+    async def retrieve(self, span_id: str, *, workspace: str | None = None) -> Span:
+        return (await self._client.get_span(span_id=span_id, workspace=workspace)).data()
+
+
+class _SpanGroupsCompat:
+    def __init__(self, client: "IntakeClient") -> None:
+        self._client = client
+
+    def list(
+        self,
+        *,
+        workspace: str | None = None,
+        by: str,
+        page: int | None = None,
+        page_size: int | None = None,
+        sort: str | None = None,
+        filter: FilterQueryParam | None = None,
+    ) -> SpanGroupsPage:
+        return self._client.list_span_groups(
+            workspace=workspace,
+            query_params=_list_span_groups_params(by=by, page=page, page_size=page_size, sort=sort, filter=filter),
+        ).data()
+
+
+class _AsyncSpanGroupsCompat:
+    def __init__(self, client: "AsyncIntakeClient") -> None:
+        self._client = client
+
+    async def list(
+        self,
+        *,
+        workspace: str | None = None,
+        by: str,
+        page: int | None = None,
+        page_size: int | None = None,
+        sort: str | None = None,
+        filter: FilterQueryParam | None = None,
+    ) -> SpanGroupsPage:
+        return (
+            await self._client.list_span_groups(
+                workspace=workspace,
+                query_params=_list_span_groups_params(by=by, page=page, page_size=page_size, sort=sort, filter=filter),
+            )
+        ).data()
+
+
+class _SpanEvaluatorResultsCompat:
+    def __init__(self, client: "IntakeClient") -> None:
+        self._client = client
+
+    def list(self, span_id: str, *, workspace: str | None = None) -> EvaluatorResults:
+        return self._client.list_evaluator_results_for_span(span_id=span_id, workspace=workspace).data()
+
+
+class _AsyncSpanEvaluatorResultsCompat:
+    def __init__(self, client: "AsyncIntakeClient") -> None:
+        self._client = client
+
+    async def list(self, span_id: str, *, workspace: str | None = None) -> EvaluatorResults:
+        return (await self._client.list_evaluator_results_for_span(span_id=span_id, workspace=workspace)).data()
+
+
+class _AnnotationsCompat:
+    def __init__(self, client: "IntakeClient") -> None:
+        self._client = client
+
+    def list(
+        self,
+        *,
+        workspace: str | None = None,
+        page: int | None = None,
+        page_size: int | None = None,
+        sort: str | None = None,
+        filter: FilterQueryParam | None = None,
+    ) -> NemoPaginatedResponse[Annotation, OffsetPagination]:
+        return self._client.list_annotations(
+            workspace=workspace,
+            query_params=_list_annotations_params(page=page, page_size=page_size, sort=sort, filter=filter),
+        )
+
+    def retrieve(self, annotation_id: str, *, workspace: str | None = None) -> Annotation:
+        return self._client.get_annotation(annotation_id=annotation_id, workspace=workspace).data()
+
+
+class _AsyncAnnotationsCompat:
+    def __init__(self, client: "AsyncIntakeClient") -> None:
+        self._client = client
+
+    async def list(
+        self,
+        *,
+        workspace: str | None = None,
+        page: int | None = None,
+        page_size: int | None = None,
+        sort: str | None = None,
+        filter: FilterQueryParam | None = None,
+    ) -> AsyncNemoPaginatedResponse[Annotation, OffsetPagination]:
+        return await self._client.list_annotations(
+            workspace=workspace,
+            query_params=_list_annotations_params(page=page, page_size=page_size, sort=sort, filter=filter),
+        )
+
+    async def retrieve(self, annotation_id: str, *, workspace: str | None = None) -> Annotation:
+        return (await self._client.get_annotation(annotation_id=annotation_id, workspace=workspace)).data()
 
 
 class IntakeClient(_IntakeMethods, NemoClient):
     """Sync client for the Intake API subset evaluator uses."""
 
+    @cached_property
+    def spans(self) -> _SpansCompat:
+        return _SpansCompat(self)
+
+    @cached_property
+    def annotations(self) -> _AnnotationsCompat:
+        return _AnnotationsCompat(self)
+
 
 class AsyncIntakeClient(_IntakeMethods, AsyncNemoClient):
     """Async client for the Intake API subset evaluator uses."""
+
+    @cached_property
+    def spans(self) -> _AsyncSpansCompat:
+        return _AsyncSpansCompat(self)
+
+    @cached_property
+    def annotations(self) -> _AsyncAnnotationsCompat:
+        return _AsyncAnnotationsCompat(self)

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/intake/endpoints.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/intake/endpoints.py
@@ -112,7 +112,7 @@ def list_spans(
 def list_span_groups(
     *,
     workspace: str | None = None,
-    query_params: ListSpanGroupsQueryParams | None = None,
+    query_params: ListSpanGroupsQueryParams,
 ) -> SpanGroupsPage: ...
 
 

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/intake/endpoints.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/intake/endpoints.py
@@ -11,14 +11,20 @@ from collections.abc import AsyncIterable, Iterable
 from nemo_platform_plugin.client.endpoint import get, patch, post
 from nemo_platform_plugin.client.types import Paginated, PreparedRequest
 from nemo_platform_plugin.intake.types import (
+    Annotation,
     AtifCreateRequest,
     EvaluationPatchRequest,
     EvaluationResponse,
     EvaluatorResult,
     EvaluatorResultCreateRequest,
     IngestResponse,
+    ListAnnotationsQueryParams,
     ListEvaluatorResultsQueryParams,
+    ListSpanGroupsQueryParams,
+    ListSpansQueryParams,
     ListTracesQueryParams,
+    Span,
+    SpanGroupsPage,
     Trace,
 )
 
@@ -90,3 +96,40 @@ def list_evaluator_results(
 @get(f"{_INTAKE_BASE}/spans/{{span_id}}/evaluator-results")
 @abstractmethod
 def list_evaluator_results_for_span(*, workspace: str | None = None, span_id: str) -> list[EvaluatorResult]: ...
+
+
+@get(f"{_INTAKE_BASE}/spans")
+@abstractmethod
+def list_spans(
+    *,
+    workspace: str | None = None,
+    query_params: ListSpansQueryParams | None = None,
+) -> Paginated[Span]: ...
+
+
+@get(f"{_INTAKE_BASE}/spans/groups")
+@abstractmethod
+def list_span_groups(
+    *,
+    workspace: str | None = None,
+    query_params: ListSpanGroupsQueryParams | None = None,
+) -> SpanGroupsPage: ...
+
+
+@get(f"{_INTAKE_BASE}/spans/{{span_id}}")
+@abstractmethod
+def get_span(*, workspace: str | None = None, span_id: str) -> Span: ...
+
+
+@get(f"{_INTAKE_BASE}/annotations")
+@abstractmethod
+def list_annotations(
+    *,
+    workspace: str | None = None,
+    query_params: ListAnnotationsQueryParams | None = None,
+) -> Paginated[Annotation]: ...
+
+
+@get(f"{_INTAKE_BASE}/annotations/{{annotation_id}}")
+@abstractmethod
+def get_annotation(*, workspace: str | None = None, annotation_id: str) -> Annotation: ...

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/intake/types.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/intake/types.py
@@ -9,11 +9,12 @@ from datetime import datetime
 from typing import Any, Literal, NotRequired, Required, TypedDict
 
 from nemo_platform_plugin.schema import Page
-from pydantic import BaseModel, ConfigDict, Field, RootModel, model_validator
+from pydantic import BaseModel, ConfigDict, Field, JsonValue, RootModel, model_validator
 
 EvaluatorResultDataType = Literal["NUMERIC", "BOOLEAN", "CATEGORICAL", "TEXT"]
 TraceMode = Literal["summary", "preview", "detailed"]
 TraceStatus = Literal["OK", "ERROR", "UNSET"] | str
+SpanMode = Literal["summary", "preview", "detailed"]
 
 
 class EvaluationContextParam(TypedDict, total=False):
@@ -221,6 +222,82 @@ class Trace(BaseModel):
     error_count: int | None = Field(default=None, ge=0)
 
 
+class SpanEvaluationContext(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    evaluation_name: str | None = None
+    test_case_name: str | None = None
+
+
+class Span(BaseModel):
+    """Span row returned by the Intake spans API."""
+
+    span_id: str
+    session_id: str
+    workspace: str
+    project: str | None = None
+    evaluation_context: SpanEvaluationContext | None = None
+    parent_span_id: str | None = None
+    kind: str
+    name: str | None = None
+    source: str
+    trace_id: str | None = None
+    started_at: datetime
+    ended_at: datetime | None = None
+    status: str
+    error_type: str | None = None
+    error_message: str | None = None
+    provider: str | None = None
+    model: str | None = None
+    prompt_id: str | None = None
+    agent_id: str | None = None
+    agent_name: str | None = None
+    tool_name: str | None = None
+    input_tokens: int | None = Field(default=None, ge=0)
+    output_tokens: int | None = Field(default=None, ge=0)
+    cached_tokens: int | None = Field(default=None, ge=0)
+    total_tokens: int | None = Field(default=None, ge=0)
+    usage_details: dict[str, int] = Field(default_factory=dict)
+    cost_total_usd: float | None = None
+    cost_input_usd: float | None = None
+    cost_output_usd: float | None = None
+    cost_details: dict[str, float] = Field(default_factory=dict)
+    input: str | None = None
+    output: str | None = None
+    raw_attributes: str | None = None
+    ingested_at: datetime
+
+
+class SpanGroup(BaseModel):
+    group: dict[str, str]
+    span_count: int = Field(ge=0)
+    started_at: datetime
+
+
+class SpanGroupsPage(Page[SpanGroup]):
+    grouped_by: list[str] = Field(default_factory=list)
+
+
+class Annotation(BaseModel):
+    """Flattened read shape for Intake post-hoc annotations."""
+
+    model_config = ConfigDict(extra="allow")
+
+    annotation_id: str
+    workspace: str
+    span_id: str | None = None
+    session_id: str
+    kind: str
+    name: str | None = None
+    value: str | float | None = None
+    value_type: str | None = None
+    text: str | None = None
+    metadata: dict[str, JsonValue] | None = None
+    created_by: str | None = None
+    created_at: datetime
+    ingested_at: datetime
+
+
 class TraceFilterParam(TypedDict, total=False):
     id: str
     session_id: str
@@ -241,6 +318,60 @@ class ListTracesQueryParams(TypedDict, total=False):
     filter: TraceFilterParam
 
 
+class SpanFilterParam(TypedDict, total=False):
+    session_id: str
+    trace_id: str
+    parent_span_id: str
+    project: str
+    evaluation_name: str
+    test_case_name: str
+    evaluation_id: str
+    test_case_id: str
+    source: str
+    kind: str
+    status: str
+    model: str
+    tool_name: str
+    provider: str
+    agent_id: str
+    agent_name: str
+    started_at: dict[str, str]
+
+
+class ListSpansQueryParams(TypedDict, total=False):
+    page: int
+    page_size: int
+    sort: str
+    mode: SpanMode
+    filter: SpanFilterParam | dict[str, JsonValue]
+
+
+class ListSpanGroupsQueryParams(TypedDict, total=False):
+    by: str
+    page: int
+    page_size: int
+    sort: str
+    filter: SpanFilterParam | dict[str, JsonValue]
+
+
+class AnnotationFilterParam(TypedDict, total=False):
+    span_id: str
+    session_id: str
+    kind: str
+    name: str
+    value_text: str
+    value_numeric: dict[str, float]
+    created_by: str
+    created_at: dict[str, str]
+
+
+class ListAnnotationsQueryParams(TypedDict, total=False):
+    page: int
+    page_size: int
+    sort: str
+    filter: AnnotationFilterParam | dict[str, JsonValue]
+
+
 class ListEvaluatorResultsQueryParams(TypedDict, total=False):
     page: int
     page_size: int
@@ -250,3 +381,5 @@ class ListEvaluatorResultsQueryParams(TypedDict, total=False):
 
 TracePage = Page[Trace]
 EvaluatorResultPage = Page[EvaluatorResult]
+SpanPage = Page[Span]
+AnnotationPage = Page[Annotation]

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/intake/types.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/intake/types.py
@@ -347,7 +347,7 @@ class ListSpansQueryParams(TypedDict, total=False):
 
 
 class ListSpanGroupsQueryParams(TypedDict, total=False):
-    by: str
+    by: Required[str]
     page: int
     page_size: int
     sort: str

--- a/plugins/nemo-insights/evaluation/adapters.py
+++ b/plugins/nemo-insights/evaluation/adapters.py
@@ -25,7 +25,7 @@ from evaluation.registry import Subject
 from evaluation.tau2run import load_tasks, policy_version, read_policy, resolve_paths, run_tau2
 from nemo_insights_plugin.analyst.observability import AnalystEvaluationContext
 from nemo_insights_plugin.analyst.run import run_analyst
-from nemo_insights_plugin.client import make_client
+from nemo_insights_plugin.platform_client import make_client
 from nemo_platform import AsyncNeMoPlatform
 
 REPO_ROOT = Path(__file__).resolve().parent.parent

--- a/plugins/nemo-insights/examples/execute-agent-job/submit_analysis_run.py
+++ b/plugins/nemo-insights/examples/execute-agent-job/submit_analysis_run.py
@@ -28,7 +28,7 @@ import json
 from typing import Any
 
 import httpx
-from nemo_insights_plugin.client import make_client
+from nemo_insights_plugin.platform_client import make_client
 from nemo_platform import AsyncNeMoPlatform
 
 REPORT_RESULT_NAME = "analysis-report"

--- a/plugins/nemo-insights/examples/research-agent/tests/test_analyst_e2e.py
+++ b/plugins/nemo-insights/examples/research-agent/tests/test_analyst_e2e.py
@@ -327,7 +327,7 @@ def platform_server(clickhouse: None) -> Iterator[str]:  # noqa: ARG001 - orderi
 # --------------------------------------------------------------------------- #
 def _count_traces() -> int:
     from nemo_insights_plugin.analyst.analyst_backend import make_analyst_backend
-    from nemo_insights_plugin.client import make_client
+    from nemo_insights_plugin.platform_client import make_client
 
     async def _run() -> int:
         client = make_client(BASE_URL)
@@ -341,7 +341,7 @@ def _count_traces() -> int:
 
 
 def _list_insight_ids() -> list[str]:
-    from nemo_insights_plugin.client import make_client
+    from nemo_insights_plugin.platform_client import make_client
 
     async def _run() -> list[str]:
         client = make_client(BASE_URL)
@@ -355,7 +355,7 @@ def _list_insight_ids() -> list[str]:
 
 
 def _delete_insights(insight_ids: list[str]) -> None:
-    from nemo_insights_plugin.client import make_client
+    from nemo_insights_plugin.platform_client import make_client
 
     async def _run() -> None:
         client = make_client(BASE_URL)

--- a/plugins/nemo-insights/src/nemo_insights_plugin/analysis_runs.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/analysis_runs.py
@@ -22,7 +22,8 @@ from __future__ import annotations
 
 import logging
 import uuid
-from typing import Any
+from collections.abc import Awaitable, Mapping
+from typing import Protocol
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from nemo_insights_plugin._perms import AnalysisRunPerms
@@ -30,11 +31,19 @@ from nemo_insights_plugin.analyst.agent_config import AGENT_CONFIG_FORMAT, build
 from nemo_insights_plugin.authz import scope
 from nemo_insights_plugin.entities import AnalysisRun
 from nemo_insights_plugin.schema import AnalysisRunPage, AnalysisRunResponse, CreateAnalysisRunRequest
-from nemo_platform import APIConnectionError, APIStatusError, AsyncNeMoPlatform
+from nemo_platform import AsyncNeMoPlatform
+from nemo_platform_plugin.agents.client import AsyncAgentsClient
+from nemo_platform_plugin.agents.types import CreateExecuteJobRequest, JsonObject
 from nemo_platform_plugin.authz import CallerKind, path_rule
+from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.client.errors import NemoHTTPError, NemoTransportError, NotFoundError
+from nemo_platform_plugin.client.response import NemoResponse
 from nemo_platform_plugin.dependencies import get_sdk_client
 from nemo_platform_plugin.entity_client import NemoEntitiesClient, NemoEntityNotFoundError, get_entity_client
+from nemo_platform_plugin.models.client import AsyncModelsClient
+from nemo_platform_plugin.models.types import ModelEntity
 from nemo_platform_plugin.schema import PaginationData
+from pydantic import TypeAdapter
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +51,23 @@ INSIGHTS_ANALYSIS_EXTENSION_KIND = "insights.analysis"
 ANALYSIS_RUN_NAME_PREFIX = "insights-run-"
 
 router = APIRouter(tags=["Insights Analysis Runs"])
+_JSON_OBJECT_ADAPTER = TypeAdapter(JsonObject)
+
+
+class ModelLookupClient(Protocol):
+    def get_model(self, *, name: str, workspace: str | None = None) -> Awaitable[NemoResponse[ModelEntity]]: ...
+
+
+class ExecuteJobClient(Protocol):
+    def create_execute_job(
+        self, *, body: CreateExecuteJobRequest, workspace: str | None = None
+    ) -> Awaitable[NemoResponse[JsonObject]]: ...
+
+    def get_execute_job(self, *, name: str, workspace: str | None = None) -> Awaitable[NemoResponse[JsonObject]]: ...
+
+
+def _json_object(value: object) -> JsonObject:
+    return _JSON_OBJECT_ADAPTER.validate_python(value)
 
 
 def mint_analysis_run_name() -> str:
@@ -65,10 +91,12 @@ async def create_analysis_run(
     entity_client: NemoEntitiesClient = Depends(get_entity_client),
 ) -> AnalysisRunResponse:
     """Create an Insights analysis run backed by the generic ``agents.execute`` job."""
+    agents_client = client_from_platform(sdk, AsyncAgentsClient)
+    models_client = client_from_platform(sdk, AsyncModelsClient)
     # Resolve before recording anything: a bogus ref would otherwise persist a
     # run and submit a job that cannot start, and the request carries the only
     # copy of the operator's intent.
-    request = await _resolve_model_refs(sdk, request, workspace=workspace)
+    request = await _resolve_model_refs(models_client, request, workspace=workspace)
     run = AnalysisRun(
         name=mint_analysis_run_name(),
         workspace=workspace,
@@ -87,8 +115,13 @@ async def create_analysis_run(
 
     spec = build_execute_agent_job_config(request, workspace=workspace, run_name=saved.name)
     try:
-        job = await sdk.agents.jobs.execute.create(spec=spec, name=saved.name, workspace=workspace)
-    except APIStatusError as exc:
+        job = (
+            await agents_client.create_execute_job(
+                workspace=workspace,
+                body=CreateExecuteJobRequest(spec=spec, name=saved.name),
+            )
+        ).data()
+    except NemoHTTPError as exc:
         # The run record is deliberately left in place. Deleting it here could
         # remove the only pointer to a job that was in fact created (a create
         # that timed out client-side still lands), which is the untracked-job
@@ -103,9 +136,9 @@ async def create_analysis_run(
             # while ``run`` names the record this call stranded.
             detail={"error": _error_detail(exc), "run": saved.name},
         ) from exc
-    except APIConnectionError as exc:
-        # Same stranded run, but a sibling of APIStatusError rather than a
-        # subclass, so it needs its own arm — and it is the case most likely to
+    except NemoTransportError as exc:
+        # Same stranded run, but a transport error rather than an HTTP status
+        # error, so it needs its own arm — and it is the case most likely to
         # be worth retrying, since the request may never have reached Jobs.
         # Log the run name: without it the orphan cannot be found afterwards.
         logger.warning("Analysis run %r recorded but the Jobs service was unreachable: %s", saved.name, exc)
@@ -119,7 +152,7 @@ async def create_analysis_run(
                 "run": saved.name,
             },
         ) from exc
-    return AnalysisRunResponse(run=saved, job=job)
+    return AnalysisRunResponse(run=saved, job=dict(job))
 
 
 @router.get("/analysis-runs", response_model=AnalysisRunPage)
@@ -164,27 +197,28 @@ async def get_analysis_run(
     entity_client: NemoEntitiesClient = Depends(get_entity_client),
 ) -> AnalysisRunResponse:
     """Get one analysis run, joined with the live state of its backing job."""
+    agents_client = client_from_platform(sdk, AsyncAgentsClient)
     try:
         run = await entity_client.get(AnalysisRun, name=name, workspace=workspace)
     except NemoEntityNotFoundError as exc:
         raise HTTPException(
             status_code=404, detail=f"Analysis run '{name}' not found in workspace '{workspace}'."
         ) from exc
-    return AnalysisRunResponse(run=run, job=await _backing_job(sdk, workspace=workspace, name=name))
+    return AnalysisRunResponse(run=run, job=await _backing_job(agents_client, workspace=workspace, name=name))
 
 
-async def _backing_job(sdk: AsyncNeMoPlatform, *, workspace: str, name: str) -> dict[str, Any] | None:
+async def _backing_job(client: ExecuteJobClient, *, workspace: str, name: str) -> JsonObject | None:
     """Read the job sharing this run's name, or None when submission never landed."""
     try:
-        return await sdk.agents.jobs.execute.get(name, workspace=workspace)
-    except APIStatusError as exc:
-        if exc.status_code == 404:
-            return None
+        return (await client.get_execute_job(name=name, workspace=workspace)).data()
+    except NotFoundError:
+        return None
+    except NemoHTTPError:
         raise
 
 
 async def _resolve_model_refs(
-    sdk: AsyncNeMoPlatform,
+    client: ModelLookupClient,
     request: CreateAnalysisRunRequest,
     *,
     workspace: str,
@@ -198,14 +232,22 @@ async def _resolve_model_refs(
     is what gets stored and put in the job spec, because the Analyst only accepts
     qualified refs.
     """
-    resolved = {
-        field: await _resolve_model_ref(sdk, getattr(request, field), field=field, workspace=workspace)
-        for field in ("default_model", "fast_model")
-    }
-    return request.model_copy(update=resolved)
+    default_model = await _resolve_model_ref(
+        client,
+        request.default_model,
+        field="default_model",
+        workspace=workspace,
+    )
+    fast_model = await _resolve_model_ref(
+        client,
+        request.fast_model,
+        field="fast_model",
+        workspace=workspace,
+    )
+    return request.model_copy(update={"default_model": default_model, "fast_model": fast_model})
 
 
-async def _resolve_model_ref(sdk: AsyncNeMoPlatform, ref: str, *, field: str, workspace: str) -> str:
+async def _resolve_model_ref(client: ModelLookupClient, ref: str, *, field: str, workspace: str) -> str:
     """Return ``<workspace>/<name>`` for an existing Model Entity, or raise 422."""
     match ref.split("/"):
         case [name]:
@@ -219,15 +261,15 @@ async def _resolve_model_ref(sdk: AsyncNeMoPlatform, ref: str, *, field: str, wo
             )
 
     try:
-        await sdk.models.retrieve(name, workspace=model_workspace)
-    except APIStatusError as exc:
-        if exc.status_code == 404:
-            raise HTTPException(
-                status_code=422,
-                detail=f"{field} '{model_workspace}/{name}' is not a known Model Entity.",
-            ) from exc
+        await client.get_model(name=name, workspace=model_workspace)
+    except NotFoundError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail=f"{field} '{model_workspace}/{name}' is not a known Model Entity.",
+        ) from exc
+    except NemoHTTPError as exc:
         raise HTTPException(status_code=exc.status_code, detail=_error_detail(exc)) from exc
-    except APIConnectionError as exc:
+    except NemoTransportError as exc:
         # Same reasoning as the submit path: an unreachable dependency is not
         # the caller's bad request, and nothing has been recorded yet.
         logger.warning("Could not reach the Models service to validate %s %r: %s", field, ref, exc)
@@ -237,29 +279,29 @@ async def _resolve_model_ref(sdk: AsyncNeMoPlatform, ref: str, *, field: str, wo
     return f"{model_workspace}/{name}"
 
 
-def build_execute_agent_job_config(
-    request: CreateAnalysisRunRequest, *, workspace: str, run_name: str
-) -> dict[str, Any]:
+def build_execute_agent_job_config(request: CreateAnalysisRunRequest, *, workspace: str, run_name: str) -> JsonObject:
     """Translate a high-level Insights request into a generic execute-agent job config."""
-    extension_config: dict[str, Any] = {
+    extension_config: JsonObject = {
         "agent": request.agent,
         "workspace": workspace,
     }
-    payload: dict[str, Any] = {
-        "agent": _inline_analyst(request, workspace=workspace),
-        "input": _analysis_prompt(request.agent),
-        "extension": {
-            "kind": INSIGHTS_ANALYSIS_EXTENSION_KIND,
-            "config": extension_config,
-        },
-    }
+    payload = _json_object(
+        {
+            "agent": _inline_analyst(request, workspace=workspace),
+            "input": _analysis_prompt(request.agent),
+            "extension": {
+                "kind": INSIGHTS_ANALYSIS_EXTENSION_KIND,
+                "config": extension_config,
+            },
+        }
+    )
     if request.timeout_seconds is not None:
         payload["timeout_seconds"] = request.timeout_seconds
 
     return payload
 
 
-def _inline_analyst(request: CreateAnalysisRunRequest, *, workspace: str) -> dict[str, Any]:
+def _inline_analyst(request: CreateAnalysisRunRequest, *, workspace: str) -> JsonObject:
     """Build the ``agent`` arm of the execute job as an inline definition.
 
     The Analyst has no Agent entity: its config is composed here from the
@@ -267,35 +309,39 @@ def _inline_analyst(request: CreateAnalysisRunRequest, *, workspace: str) -> dic
     accepts an entity ref, so pointing a run at a stored Analyst is a small
     change if a use case appears.
     """
-    return {
-        # AgentInline defaults to the legacy NAT format, matching the Agent
-        # entity; the Analyst is a Fabric spec agent, so say so explicitly.
-        "config_format": AGENT_CONFIG_FORMAT,
-        "config": build_analyst_agent_config(
-            agent=request.agent,
-            workspace=workspace,
-            default_model=request.default_model,
-            fast_model=request.fast_model,
-            ethos=request.ethos,
-            since=request.since,
-            evaluation_id=request.evaluation_id,
-            # The Analyst's self-observability builds its own OTLP exporter from
-            # the operator's local CLI config, which does not exist in a task
-            # pod, so on a cluster it exports unauthenticated at best. Telemetry
-            # for these runs belongs in the agent config's relay endpoints,
-            # where the agents layer already carries auth; until that is wired,
-            # a run must not depend on it.
-            enable_observability=False,
-        ),
-    }
+    return _json_object(
+        {
+            # AgentInline defaults to the legacy NAT format, matching the Agent
+            # entity; the Analyst is a Fabric spec agent, so say so explicitly.
+            "config_format": AGENT_CONFIG_FORMAT,
+            "config": build_analyst_agent_config(
+                agent=request.agent,
+                workspace=workspace,
+                default_model=request.default_model,
+                fast_model=request.fast_model,
+                ethos=request.ethos,
+                since=request.since,
+                evaluation_id=request.evaluation_id,
+                # The Analyst's self-observability builds its own OTLP exporter from
+                # the operator's local CLI config, which does not exist in a task
+                # pod, so on a cluster it exports unauthenticated at best. Telemetry
+                # for these runs belongs in the agent config's relay endpoints,
+                # where the agents layer already carries auth; until that is wired,
+                # a run must not depend on it.
+                enable_observability=False,
+            ),
+        }
+    )
 
 
-def _error_detail(error: APIStatusError) -> Any:
+def _error_detail(error: NemoHTTPError) -> object:
     """Unwrap the Agents service's ``detail`` from a failed job-create call."""
-    body: Any = error.body
-    if isinstance(body, dict) and "detail" in body:
-        return body["detail"]
-    return body if body is not None else error.message
+    body = error.body
+    if isinstance(body, Mapping):
+        detail = body.get("detail")
+        if detail is not None:
+            return detail
+    return body if body is not None else error.detail
 
 
 def _analysis_prompt(agent: str) -> str:

--- a/plugins/nemo-insights/src/nemo_insights_plugin/analyst/agent.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/analyst/agent.py
@@ -31,6 +31,7 @@ from typing import Annotated, Any
 from nemo_insights_plugin.analyst.deps import AnalystDeps
 from nemo_insights_plugin.analyst.functions import annotations, insights, spans
 from nemo_insights_plugin.analyst.result import AnalystResult
+from nemo_platform_plugin.intake.types import SpanMode
 from nemo_platform_plugin.nooa_model_client import get_default_model, get_fast_model
 from nooa import Agent, CodeActStrategy, hidden, strategy
 from nooa.agents import TokenBudgetSummarizer
@@ -192,7 +193,7 @@ class Analyst(Agent):
         filter: dict[str, object] | None = None,
         group_by: str | None = None,
         sort: str | None = None,
-        mode: str = "detailed",
+        mode: SpanMode = "detailed",
         limit: int | None = None,
     ) -> dict[str, object]:
         """List the AUT's spans from Intake, or roll them up into groups.

--- a/plugins/nemo-insights/src/nemo_insights_plugin/analyst/analyst_backend.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/analyst/analyst_backend.py
@@ -38,24 +38,31 @@ caller (the CLI), so the backend never closes it.
 
 import uuid
 from abc import ABC, abstractmethod
+from collections.abc import AsyncIterable
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, cast
 
 import httpx
 import yaml
 from nemo_insights_plugin.analyst.result import AnalystResult
 from nemo_insights_plugin.entities import Insight, InsightStatus
 from nemo_insights_plugin.schema import InsightListItem, InsightPage
-from nemo_platform import AsyncNeMoPlatform, omit
+from nemo_platform import AsyncNeMoPlatform
+from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.client.errors import NotFoundError
+from nemo_platform_plugin.intake.client import AsyncIntakeClient
+from nemo_platform_plugin.intake.types import SpanMode
 from nemo_platform_plugin.schema import PaginationData
+from pydantic import BaseModel, JsonValue
+
+FilterParam = dict[str, JsonValue]
 
 
 class InsightNotFoundError(Exception):
     """No insight with the given id exists in the workspace."""
 
 
-def _dump(item) -> dict:
+def _dump(item: BaseModel) -> dict[str, object]:
     """Serialize one SDK model to a plain JSON-able dict (drop null fields)."""
     return item.model_dump(mode="json", exclude_none=True)
 
@@ -71,7 +78,7 @@ def _union_refs(existing: list[str] | None, new: list[str] | None) -> list[str]:
     return merged
 
 
-async def _drain(paginator, *, limit: int) -> tuple[list, bool]:
+async def _drain(paginator: AsyncIterable[BaseModel], *, limit: int) -> tuple[list[BaseModel], bool]:
     """Pull up to *limit* items across pages; return ``(items, truncated)``.
 
     ``truncated`` is True when the stream still had more items than *limit*,
@@ -93,21 +100,23 @@ def _page_size_for(limit: int) -> int:
     return max(1, min(limit, 100))
 
 
-def _merge_since_filter(filter_obj: dict | None, *, since: datetime | None) -> dict | None:
+def _merge_since_filter(filter_obj: FilterParam | None, *, since: datetime | None) -> FilterParam | None:
     """Return *filter_obj* with an enforced ``started_at >= since`` lower bound."""
     return _merge_datetime_lower_bound(filter_obj, key="started_at", since=since)
 
 
-def _merge_created_since_filter(filter_obj: dict | None, *, since: datetime | None) -> dict | None:
+def _merge_created_since_filter(filter_obj: FilterParam | None, *, since: datetime | None) -> FilterParam | None:
     """Return *filter_obj* with an enforced ``created_at >= since`` lower bound."""
     return _merge_datetime_lower_bound(filter_obj, key="created_at", since=since)
 
 
-def _merge_datetime_lower_bound(filter_obj: dict | None, *, key: str, since: datetime | None) -> dict | None:
+def _merge_datetime_lower_bound(
+    filter_obj: FilterParam | None, *, key: str, since: datetime | None
+) -> FilterParam | None:
     if since is None:
         return filter_obj
 
-    merged: dict = dict(filter_obj or {})
+    merged: FilterParam = dict(filter_obj or {})
     existing = merged.get(key)
     lower_bound = since.isoformat()
     if isinstance(existing, dict):
@@ -139,7 +148,7 @@ def _parse_datetime(value: object) -> datetime | None:
     return parsed.astimezone(timezone.utc)
 
 
-def _merge_eval_filter(filter_obj: dict | None, *, evaluation_id: str | None) -> dict | None:
+def _merge_eval_filter(filter_obj: FilterParam | None, *, evaluation_id: str | None) -> FilterParam | None:
     """AND-pin the run scope onto a span filter.
 
     Mirrors ``_merge_since_filter``: a set ``evaluation_id`` is forced onto every
@@ -148,7 +157,7 @@ def _merge_eval_filter(filter_obj: dict | None, *, evaluation_id: str | None) ->
     """
     if evaluation_id is None:
         return filter_obj
-    merged: dict = dict(filter_obj or {})
+    merged: FilterParam = dict(filter_obj or {})
     merged["evaluation_id"] = evaluation_id
     return merged
 
@@ -166,6 +175,7 @@ class AnalystBackend(ABC):
 
     def __init__(self, client: AsyncNeMoPlatform) -> None:
         self.client = client
+        self.intake = client_from_platform(client, AsyncIntakeClient)
 
     # -- reads: always against the live platform -------------------------- #
 
@@ -198,22 +208,22 @@ class AnalystBackend(ABC):
         self,
         *,
         workspace: str,
-        filter: dict | None,
+        filter: FilterParam | None,
         sort: str,
-        mode: str,
+        mode: SpanMode,
         limit: int,
         since: datetime | None = None,
         evaluation_id: str | None = None,
     ) -> dict:
         effective_filter = _merge_eval_filter(_merge_since_filter(filter, since=since), evaluation_id=evaluation_id)
-        paginator = self.client.intake.spans.list(
+        paginator = await self.intake.spans.list(
             workspace=workspace,
             page_size=_page_size_for(limit),
-            sort=cast(Any, sort),
-            filter=cast(Any, effective_filter) or omit,
-            mode=cast(Any, mode),
+            sort=sort,
+            filter=effective_filter,
+            mode=mode,
         )
-        items, truncated = await _drain(paginator, limit=limit)
+        items, truncated = await _drain(paginator.items(), limit=limit)
         return {
             "spans": [_dump(s) for s in items],
             "count": len(items),
@@ -224,7 +234,7 @@ class AnalystBackend(ABC):
         self,
         *,
         workspace: str,
-        filter: dict | None,
+        filter: FilterParam | None,
         group_by: str = "session_id",
         sort: str = "-span_count",
         limit: int,
@@ -242,13 +252,13 @@ class AnalystBackend(ABC):
         """
         effective_filter = _merge_eval_filter(_merge_since_filter(filter, since=since), evaluation_id=evaluation_id)
         page_size = max(1, min(limit, 1000))
-        page = await self.client.intake.spans.groups.list(
+        page = await self.intake.spans.groups.list(
             workspace=workspace,
             by=group_by,
             page=1,
             page_size=page_size,
-            filter=cast(Any, effective_filter or omit),
-            sort=cast(Any, sort),
+            filter=effective_filter,
+            sort=sort,
         )
         groups = [_dump(g) for g in page.data]
         total = page.pagination.total_results if page.pagination is not None else len(groups)
@@ -264,19 +274,19 @@ class AnalystBackend(ABC):
         self,
         *,
         workspace: str,
-        filter: dict | None,
+        filter: FilterParam | None,
         sort: str,
         limit: int,
         since: datetime | None = None,
     ) -> dict:
         effective_filter = _merge_created_since_filter(filter, since=since)
-        paginator = self.client.intake.annotations.list(
+        paginator = await self.intake.annotations.list(
             workspace=workspace,
             page_size=_page_size_for(limit),
-            sort=cast(Any, sort),
-            filter=cast(Any, effective_filter) or omit,
+            sort=sort,
+            filter=effective_filter,
         )
-        items, truncated = await _drain(paginator, limit=limit)
+        items, truncated = await _drain(paginator.items(), limit=limit)
         return {
             "annotations": [_dump(a) for a in items],
             "count": len(items),
@@ -284,15 +294,15 @@ class AnalystBackend(ABC):
         }
 
     async def get_span(self, *, workspace: str, span_id: str) -> dict:
-        span = await self.client.intake.spans.retrieve(span_id, workspace=workspace)
+        span = await self.intake.spans.retrieve(span_id, workspace=workspace)
         return _dump(span)
 
     async def get_annotation(self, *, workspace: str, annotation_id: str) -> dict:
-        annotation = await self.client.intake.annotations.retrieve(annotation_id, workspace=workspace)
+        annotation = await self.intake.annotations.retrieve(annotation_id, workspace=workspace)
         return _dump(annotation)
 
     async def list_scores(self, *, workspace: str, span_id: str) -> dict:
-        results = await self.client.intake.spans.evaluator_results.list(span_id, workspace=workspace)
+        results = await self.intake.spans.evaluator_results.list(span_id, workspace=workspace)
         return {
             "evaluator_results": [_dump(r) for r in results],
             "count": len(results),
@@ -544,18 +554,24 @@ class RemoteAnalystBackend(AnalystBackend):
                 insight_id=insight_id,
                 trace_refs=_union_refs(current.trace_refs, trace_refs),
             )
-        except httpx.HTTPStatusError as exc:
-            if exc.response.status_code == 404:
+        except (httpx.HTTPStatusError, NotFoundError) as exc:
+            if _is_not_found(exc):
                 raise InsightNotFoundError(insight_id) from exc
             raise
 
     async def _get(self, *, workspace: str, insight_id: str) -> Insight:
         try:
             return await self._insights.get(workspace=workspace, insight_id=insight_id)
-        except httpx.HTTPStatusError as exc:
-            if exc.response.status_code == 404:
+        except (httpx.HTTPStatusError, NotFoundError) as exc:
+            if _is_not_found(exc):
                 raise InsightNotFoundError(insight_id) from exc
             raise
+
+
+def _is_not_found(error: httpx.HTTPStatusError | NotFoundError) -> bool:
+    if isinstance(error, NotFoundError):
+        return True
+    return error.response.status_code == 404
 
 
 class LocalAnalystBackend(AnalystBackend):

--- a/plugins/nemo-insights/src/nemo_insights_plugin/analyst/analyst_backend.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/analyst/analyst_backend.py
@@ -85,7 +85,7 @@ async def _drain(paginator: AsyncIterable[BaseModel], *, limit: int) -> tuple[li
     so the model knows it is looking at a capped view and can narrow its
     filter or raise the limit.
     """
-    items: list = []
+    items: list[BaseModel] = []
     truncated = False
     async for item in paginator:
         if len(items) >= limit:

--- a/plugins/nemo-insights/src/nemo_insights_plugin/analyst/functions/spans.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/analyst/functions/spans.py
@@ -11,6 +11,7 @@ supplies the raw Intake filter and composes the results in Nooa CodeAct.
 from typing import Any
 
 from nemo_insights_plugin.analyst.deps import AnalystDeps
+from nemo_platform_plugin.intake.types import SpanMode
 
 # Sentinel the analyst can pass as ``filter["agent_name"]`` to query spans across
 # all agents instead of the run's default agent under test.
@@ -39,7 +40,7 @@ async def fetch_spans(
     filter: dict[str, Any] | None = None,
     group_by: str | None = None,
     sort: str | None = None,
-    mode: str = "detailed",
+    mode: SpanMode = "detailed",
     limit: int | None = None,
 ) -> dict[str, Any]:
     """List the AUT's spans from Intake, or roll them up into groups.

--- a/plugins/nemo-insights/src/nemo_insights_plugin/analyst/observability.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/analyst/observability.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from urllib.parse import urlparse
 from uuid import uuid4
 
-from nemo_insights_plugin.client import LOOPBACK_HOSTS
+from nemo_insights_plugin.platform_client import LOOPBACK_HOSTS
 from nemo_platform_ext.config.config import Config
 from nooa.tracing import enable_tracing, exporters, flush_traces, set_session
 

--- a/plugins/nemo-insights/src/nemo_insights_plugin/cli.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/cli.py
@@ -23,7 +23,6 @@ from typing import Any, ClassVar, TypeVar
 import httpx
 import typer
 from nemo_insights_plugin.analyst.run import ClientConstructionError, run_analyst
-from nemo_insights_plugin.client import make_client
 from nemo_insights_plugin.contracts.checks import CheckResult, advisories, format_report, required_failures
 from nemo_insights_plugin.contracts.insights import InsightsFileError, validate_insights_file
 from nemo_insights_plugin.contracts.profile import (
@@ -34,6 +33,7 @@ from nemo_insights_plugin.contracts.profile import (
     load_env_file,
     resolve_base_url,
 )
+from nemo_insights_plugin.platform_client import make_client
 from nemo_insights_plugin.preflight import (
     AnalysisProbes,
     check_environment,

--- a/plugins/nemo-insights/src/nemo_insights_plugin/client.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/client.py
@@ -1,55 +1,44 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Shared NeMo Platform SDK client construction for analyst read methods.
+"""Typed HTTP clients for the Insights plugin API."""
 
-Auth lives in the active ``nemo auth login`` context in
-``~/.config/nmp/config.yaml``. The SDK only wires up that context (and the
-transparent OIDC token refresh that comes with it) when it runs its config
-bootstrap. Passing ``base_url`` *alone* puts the SDK in "direct mode", which
-skips the bootstrap and injects **no** auth headers — fine for an
-unauthenticated local ``nemo services run``, but it 401s against a remote
-deployment. To authenticate against a remote URL we must trigger the bootstrap
-(by also passing ``config_path``) so the explicit ``base_url`` is combined with
-the context's credentials.
+from __future__ import annotations
 
-The analyst run takes ``base_url`` from its CLI/job context, so this helper is
-the one place that branch lives.
-"""
-
-from urllib.parse import urlparse
-
-from nemo_platform import AsyncNeMoPlatform
-from nemo_platform_ext.auth.helpers import discover_nmp_config
-from nemo_platform_ext.config.config import Config
-
-# Loopback hosts are served by an unauthenticated local platform; attaching
-# (and refreshing) OAuth tokens there is both unnecessary and a failure mode
-# when the cached token is stale and OIDC discovery against localhost fails.
-LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1", "0.0.0.0"})
+from nemo_insights_plugin import endpoints
+from nemo_platform_plugin.client.client import AsyncNemoClient, NemoClient
+from nemo_platform_plugin.client.method import method
 
 
-def make_client(base_url: str | None) -> AsyncNeMoPlatform:
-    """Construct an :class:`AsyncNeMoPlatform` honoring an optional ``base_url``.
+class _InsightsMethods:
+    create_insight = method(endpoints.create_insight)
+    list_insights = method(endpoints.list_insights)
+    get_insight = method(endpoints.get_insight)
+    update_insight = method(endpoints.update_insight)
+    delete_insight = method(endpoints.delete_insight)
 
-    - No ``base_url``: use the active nmp context for both URL and auth.
-    - Loopback ``base_url``: direct mode (local platform is unauthenticated).
-    - Authenticated remote ``base_url`` with an nmp config present: combine the
-      URL with the context's auth so the SDK injects and refreshes a Bearer token.
-    - Unauthenticated remote ``base_url``: direct mode, even when an unrelated
-      OAuth context exists locally.
-    - Remote ``base_url`` without an nmp config: direct mode (no credentials to
-      use; the request will surface a clear auth error).
-    """
-    if not base_url:
-        return AsyncNeMoPlatform()
+    enable_analysis_config = method(endpoints.enable_analysis_config)
+    disable_analysis_config = method(endpoints.disable_analysis_config)
+    list_analysis_configs = method(endpoints.list_analysis_configs)
+    get_analysis_config = method(endpoints.get_analysis_config)
+    update_analysis_config = method(endpoints.update_analysis_config)
 
-    host = (urlparse(base_url).hostname or "").lower()
-    config_path = Config.get_default_config_path()
-    if host in LOOPBACK_HOSTS or not config_path.exists():
-        return AsyncNeMoPlatform(base_url=base_url)
+    list_analysis_run_statuses = method(endpoints.list_analysis_run_statuses)
+    get_analysis_run_status = method(endpoints.get_analysis_run_status)
+    update_analysis_run_status = method(endpoints.update_analysis_run_status)
 
-    if not discover_nmp_config(base_url).auth_enabled:
-        return AsyncNeMoPlatform(base_url=base_url)
+    create_analysis_run = method(endpoints.create_analysis_run)
+    list_analysis_runs = method(endpoints.list_analysis_runs)
+    get_analysis_run = method(endpoints.get_analysis_run)
 
-    return AsyncNeMoPlatform(base_url=base_url, config_path=config_path)
+    create_analysis_job = method(endpoints.create_analysis_job)
+    list_analysis_jobs = method(endpoints.list_analysis_jobs)
+    get_analysis_job = method(endpoints.get_analysis_job)
+
+
+class InsightsClient(_InsightsMethods, NemoClient):
+    """Sync client for the Insights plugin API."""
+
+
+class AsyncInsightsClient(_InsightsMethods, AsyncNemoClient):
+    """Async client for the Insights plugin API."""

--- a/plugins/nemo-insights/src/nemo_insights_plugin/controller.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/controller.py
@@ -15,7 +15,6 @@ from zoneinfo import ZoneInfo
 from nemo_insights_plugin.analyst.analyst_backend import make_analyst_backend
 from nemo_insights_plugin.config import InsightsConfig
 from nemo_insights_plugin.entities import AnalysisConfig, AnalysisRunStatus
-from nemo_insights_plugin.jobs.analyze import AnalyzeSpec
 from nemo_insights_plugin.schedule import is_due
 from nemo_insights_plugin.sdk_resources.analysis_jobs import (
     AnalysisJob,
@@ -23,6 +22,7 @@ from nemo_insights_plugin.sdk_resources.analysis_jobs import (
     CreateAnalysisJobRequest,
     ListAnalysisJobsQueryParams,
 )
+from nemo_insights_plugin.types import AnalyzeSpec
 from nemo_platform import AsyncNeMoPlatform
 from nemo_platform_plugin.client.adapter import client_from_platform
 from nemo_platform_plugin.config import get_nemo_config

--- a/plugins/nemo-insights/src/nemo_insights_plugin/endpoints.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/endpoints.py
@@ -1,0 +1,146 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Typed endpoint definitions for the Insights plugin API."""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+
+from nemo_insights_plugin.entities import AnalysisConfig, AnalysisRun, AnalysisRunStatus, Insight
+from nemo_insights_plugin.jobs.analyze import AnalyzeJob
+from nemo_insights_plugin.schema import (
+    AnalysisRunResponse,
+    CreateAnalysisRunRequest,
+    CreateInsightRequest,
+    EnableAnalysisConfigRequest,
+    InsightListItem,
+    UpdateAnalysisConfigRequest,
+    UpdateAnalysisRunStatusRequest,
+    UpdateInsightRequest,
+)
+from nemo_insights_plugin.types import (
+    AnalysisJob,
+    CreateAnalysisJobRequest,
+    ListAnalysisConfigsQueryParams,
+    ListAnalysisJobsQueryParams,
+    ListAnalysisRunsQueryParams,
+    ListAnalysisRunStatusesQueryParams,
+    ListInsightsQueryParams,
+)
+from nemo_platform_plugin.client.endpoint import delete, get, patch, post
+from nemo_platform_plugin.client.types import Paginated
+
+_INSIGHTS_BASE = "/apis/insights/v2/workspaces/{workspace}"
+_ANALYSIS_JOBS = f"{_INSIGHTS_BASE}/jobs/{AnalyzeJob.name}"
+
+
+@post(f"{_INSIGHTS_BASE}/insights")
+@abstractmethod
+def create_insight(*, workspace: str | None = None, body: CreateInsightRequest) -> Insight: ...
+
+
+@get(f"{_INSIGHTS_BASE}/insights")
+@abstractmethod
+def list_insights(
+    *, workspace: str | None = None, query_params: ListInsightsQueryParams | None = None
+) -> Paginated[InsightListItem]: ...
+
+
+@get(f"{_INSIGHTS_BASE}/insights/{{insight_id}}")
+@abstractmethod
+def get_insight(*, workspace: str | None = None, insight_id: str) -> Insight: ...
+
+
+@patch(f"{_INSIGHTS_BASE}/insights/{{insight_id}}")
+@abstractmethod
+def update_insight(*, workspace: str | None = None, insight_id: str, body: UpdateInsightRequest) -> Insight: ...
+
+
+@delete(f"{_INSIGHTS_BASE}/insights/{{insight_id}}")
+@abstractmethod
+def delete_insight(*, workspace: str | None = None, insight_id: str) -> None: ...
+
+
+@post(f"{_INSIGHTS_BASE}/analysis-configs/{{agent}}/enable")
+@abstractmethod
+def enable_analysis_config(
+    *, workspace: str | None = None, agent: str, body: EnableAnalysisConfigRequest
+) -> AnalysisConfig: ...
+
+
+@post(f"{_INSIGHTS_BASE}/analysis-configs/{{agent}}/disable")
+@abstractmethod
+def disable_analysis_config(*, workspace: str | None = None, agent: str) -> AnalysisConfig: ...
+
+
+@get(f"{_INSIGHTS_BASE}/analysis-configs")
+@abstractmethod
+def list_analysis_configs(
+    *, workspace: str | None = None, query_params: ListAnalysisConfigsQueryParams | None = None
+) -> Paginated[AnalysisConfig]: ...
+
+
+@get(f"{_INSIGHTS_BASE}/analysis-configs/{{agent}}")
+@abstractmethod
+def get_analysis_config(*, workspace: str | None = None, agent: str) -> AnalysisConfig: ...
+
+
+@patch(f"{_INSIGHTS_BASE}/analysis-configs/{{agent}}")
+@abstractmethod
+def update_analysis_config(
+    *, workspace: str | None = None, agent: str, body: UpdateAnalysisConfigRequest
+) -> AnalysisConfig: ...
+
+
+@get(f"{_INSIGHTS_BASE}/analysis-run-statuses")
+@abstractmethod
+def list_analysis_run_statuses(
+    *, workspace: str | None = None, query_params: ListAnalysisRunStatusesQueryParams | None = None
+) -> Paginated[AnalysisRunStatus]: ...
+
+
+@get(f"{_INSIGHTS_BASE}/analysis-run-statuses/{{agent}}")
+@abstractmethod
+def get_analysis_run_status(*, workspace: str | None = None, agent: str) -> AnalysisRunStatus: ...
+
+
+@patch(f"{_INSIGHTS_BASE}/analysis-run-statuses/{{agent}}")
+@abstractmethod
+def update_analysis_run_status(
+    *, workspace: str | None = None, agent: str, body: UpdateAnalysisRunStatusRequest
+) -> AnalysisRunStatus: ...
+
+
+@post(f"{_INSIGHTS_BASE}/analysis-runs")
+@abstractmethod
+def create_analysis_run(*, workspace: str | None = None, body: CreateAnalysisRunRequest) -> AnalysisRunResponse: ...
+
+
+@get(f"{_INSIGHTS_BASE}/analysis-runs")
+@abstractmethod
+def list_analysis_runs(
+    *, workspace: str | None = None, query_params: ListAnalysisRunsQueryParams | None = None
+) -> Paginated[AnalysisRun]: ...
+
+
+@get(f"{_INSIGHTS_BASE}/analysis-runs/{{name}}")
+@abstractmethod
+def get_analysis_run(*, workspace: str | None = None, name: str) -> AnalysisRunResponse: ...
+
+
+@post(_ANALYSIS_JOBS)
+@abstractmethod
+def create_analysis_job(*, workspace: str | None = None, body: CreateAnalysisJobRequest) -> AnalysisJob: ...
+
+
+@get(_ANALYSIS_JOBS)
+@abstractmethod
+def list_analysis_jobs(
+    *, workspace: str | None = None, query_params: ListAnalysisJobsQueryParams | None = None
+) -> Paginated[AnalysisJob]: ...
+
+
+@get(f"{_ANALYSIS_JOBS}/{{name}}")
+@abstractmethod
+def get_analysis_job(*, workspace: str | None = None, name: str) -> AnalysisJob: ...

--- a/plugins/nemo-insights/src/nemo_insights_plugin/endpoints.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/endpoints.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from abc import abstractmethod
 
 from nemo_insights_plugin.entities import AnalysisConfig, AnalysisRun, AnalysisRunStatus, Insight
-from nemo_insights_plugin.jobs.analyze import AnalyzeJob
 from nemo_insights_plugin.schema import (
     AnalysisRunResponse,
     CreateAnalysisRunRequest,
@@ -20,6 +19,7 @@ from nemo_insights_plugin.schema import (
     UpdateInsightRequest,
 )
 from nemo_insights_plugin.types import (
+    ANALYSIS_JOB_NAME,
     AnalysisJob,
     CreateAnalysisJobRequest,
     ListAnalysisConfigsQueryParams,
@@ -32,7 +32,7 @@ from nemo_platform_plugin.client.endpoint import delete, get, patch, post
 from nemo_platform_plugin.client.types import Paginated
 
 _INSIGHTS_BASE = "/apis/insights/v2/workspaces/{workspace}"
-_ANALYSIS_JOBS = f"{_INSIGHTS_BASE}/jobs/{AnalyzeJob.name}"
+_ANALYSIS_JOBS = f"{_INSIGHTS_BASE}/jobs/{ANALYSIS_JOB_NAME}"
 
 
 @post(f"{_INSIGHTS_BASE}/insights")

--- a/plugins/nemo-insights/src/nemo_insights_plugin/jobs/analyze.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/jobs/analyze.py
@@ -12,6 +12,7 @@ from typing import ClassVar
 
 from nemo_insights_plugin.analyst.run import run_analyst
 from nemo_insights_plugin.entities import AnalysisConfigStatus
+from nemo_insights_plugin.types import ANALYSIS_JOB_NAME, AnalyzeSpec
 from nemo_platform import NeMoPlatform
 from nemo_platform_plugin.job import NemoJob
 from nemo_platform_plugin.job_context import JobContext
@@ -29,7 +30,7 @@ from nemo_platform_plugin.jobs.constants import (
 from nemo_platform_plugin.jobs.image import get_qualified_image
 from nemo_platform_plugin.nooa_model_client import ConfiguredModelRefs
 from nemo_platform_plugin.sdk_provider import get_async_task_sdk
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
 
@@ -37,43 +38,10 @@ REPORT_RESULT_NAME = "analysis-report"
 REPORT_FILE_NAME = "analysis-report.txt"
 
 
-class AnalyzeSpec(BaseModel):
-    """Canonical input for one insights analyst run."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    agent: str = Field(description="Agent under test.")
-    ethos: str | None = Field(
-        default=None,
-        description="Optional Ethos Markdown for the agent under test.",
-    )
-    base_url: str | None = Field(
-        default=None,
-        description="Optional platform base URL. Unset uses the active platform context.",
-    )
-    insights_output: str | None = Field(
-        default=None,
-        description=(
-            "Optional local YAML path mirroring the Insights the platform stored. "
-            "Container-local unless it points at mounted storage."
-        ),
-    )
-    since: datetime | None = Field(
-        default=None,
-        description="Optional lower bound for incremental trace/span analysis.",
-    )
-    update_analysis_config: bool = Field(
-        default=True,
-        description="Update the matching AnalysisRunStatus with run metadata.",
-    )
-    default_model: str = Field(description="Workspace-qualified default Model Entity ID selected during setup.")
-    fast_model: str = Field(description="Workspace-qualified fast Model Entity ID selected during setup.")
-
-
 class AnalyzeJob(NemoJob):
     """Run the insights analyst once for a single agent."""
 
-    name: ClassVar[str] = "analyze-job"
+    name: ClassVar[str] = ANALYSIS_JOB_NAME
     description: ClassVar[str] = "Run the insights analyst once for a single agent."
     container: ClassVar[str] = "cpu-tasks"
     spec_schema: ClassVar[type[BaseModel] | None] = AnalyzeSpec

--- a/plugins/nemo-insights/src/nemo_insights_plugin/platform_client.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/platform_client.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared NeMo Platform SDK client construction for analyst read methods.
+
+Auth lives in the active ``nemo auth login`` context in
+``~/.config/nmp/config.yaml``. The SDK only wires up that context (and the
+transparent OIDC token refresh that comes with it) when it runs its config
+bootstrap. Passing ``base_url`` *alone* puts the SDK in "direct mode", which
+skips the bootstrap and injects **no** auth headers — fine for an
+unauthenticated local ``nemo services run``, but it 401s against a remote
+deployment. To authenticate against a remote URL we must trigger the bootstrap
+(by also passing ``config_path``) so the explicit ``base_url`` is combined with
+the context's credentials.
+
+The analyst run takes ``base_url`` from its CLI/job context, so this helper is
+the one place that branch lives.
+"""
+
+from urllib.parse import urlparse
+
+from nemo_platform import AsyncNeMoPlatform
+from nemo_platform_ext.auth.helpers import discover_nmp_config
+from nemo_platform_ext.config.config import Config
+
+# Loopback hosts are served by an unauthenticated local platform; attaching
+# (and refreshing) OAuth tokens there is both unnecessary and a failure mode
+# when the cached token is stale and OIDC discovery against localhost fails.
+LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1", "0.0.0.0"})
+
+
+def make_client(base_url: str | None) -> AsyncNeMoPlatform:
+    """Construct an :class:`AsyncNeMoPlatform` honoring an optional ``base_url``.
+
+    - No ``base_url``: use the active nmp context for both URL and auth.
+    - Loopback ``base_url``: direct mode (local platform is unauthenticated).
+    - Authenticated remote ``base_url`` with an nmp config present: combine the
+      URL with the context's auth so the SDK injects and refreshes a Bearer token.
+    - Unauthenticated remote ``base_url``: direct mode, even when an unrelated
+      OAuth context exists locally.
+    - Remote ``base_url`` without an nmp config: direct mode (no credentials to
+      use; the request will surface a clear auth error).
+    """
+    if not base_url:
+        return AsyncNeMoPlatform()
+
+    host = (urlparse(base_url).hostname or "").lower()
+    config_path = Config.get_default_config_path()
+    if host in LOOPBACK_HOSTS or not config_path.exists():
+        return AsyncNeMoPlatform(base_url=base_url)
+
+    if not discover_nmp_config(base_url).auth_enabled:
+        return AsyncNeMoPlatform(base_url=base_url)
+
+    return AsyncNeMoPlatform(base_url=base_url, config_path=config_path)

--- a/plugins/nemo-insights/src/nemo_insights_plugin/platform_client.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/platform_client.py
@@ -19,6 +19,7 @@ the one place that branch lives.
 
 from urllib.parse import urlparse
 
+import httpx
 from nemo_platform import AsyncNeMoPlatform
 from nemo_platform_ext.auth.helpers import discover_nmp_config
 from nemo_platform_ext.config.config import Config
@@ -44,12 +45,21 @@ def make_client(base_url: str | None) -> AsyncNeMoPlatform:
     if not base_url:
         return AsyncNeMoPlatform()
 
-    host = (urlparse(base_url).hostname or "").lower()
+    parsed = urlparse(base_url)
+    host = (parsed.hostname or "").lower()
     config_path = Config.get_default_config_path()
     if host in LOOPBACK_HOSTS or not config_path.exists():
         return AsyncNeMoPlatform(base_url=base_url)
 
-    if not discover_nmp_config(base_url).auth_enabled:
+    try:
+        nmp_config = discover_nmp_config(base_url)
+    except (httpx.HTTPError, ValueError) as exc:
+        raise RuntimeError(f"could not discover NeMo Platform auth configuration at {base_url}: {exc}") from exc
+
+    if not nmp_config.auth_enabled:
         return AsyncNeMoPlatform(base_url=base_url)
+
+    if parsed.scheme.lower() != "https":
+        raise ValueError(f"refusing to send credentials to a non-HTTPS remote URL: {base_url}")
 
     return AsyncNeMoPlatform(base_url=base_url, config_path=config_path)

--- a/plugins/nemo-insights/src/nemo_insights_plugin/preflight.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/preflight.py
@@ -9,8 +9,8 @@ from pathlib import Path
 
 import httpx
 from nemo_insights_plugin.analyst.analyst_backend import make_analyst_backend
-from nemo_insights_plugin.client import make_client
 from nemo_insights_plugin.contracts.checks import CheckResult, make_check_result
+from nemo_insights_plugin.platform_client import make_client
 from nemo_insights_plugin.profile import AnalysisProfile
 from nemo_platform import AsyncNeMoPlatform, NeMoPlatformError
 from nemo_platform_plugin.nooa_model_client import configured_model_refs

--- a/plugins/nemo-insights/src/nemo_insights_plugin/sdk.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/sdk.py
@@ -23,6 +23,7 @@ Modeled on ``nemo_auditor.sdk`` — same shape, same hand-written CRUD-only
 resource pattern. No Stainless codegen.
 """
 
+from nemo_insights_plugin.client import AsyncInsightsClient, InsightsClient
 from nemo_insights_plugin.sdk_resources.analysis_configs import (
     _AnalysisConfigResource,
     _AnalysisRunStatusResource,
@@ -38,6 +39,7 @@ from nemo_insights_plugin.sdk_resources.insights import (
     _InsightResource,
 )
 from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
+from nemo_platform_plugin.client.adapter import client_from_platform
 from nemo_platform_plugin.sdk import NemoPluginSDKResources
 
 
@@ -46,7 +48,7 @@ class InsightsPluginResource:
 
     def __init__(self, platform: NeMoPlatform) -> None:
         self._platform = platform
-        self._http_client = platform._client
+        self._client = client_from_platform(platform, InsightsClient)
         self._insights: _InsightResource | None = None
         self._analysis_configs: _AnalysisConfigResource | None = None
         self._analysis_runs: _AnalysisRunResource | None = None
@@ -76,16 +78,13 @@ class InsightsPluginResource:
             self._analysis_run_statuses = _AnalysisRunStatusResource(self)
         return self._analysis_run_statuses
 
-    def _url(self, path: str) -> str:
-        return str(self._platform.base_url).rstrip("/") + "/apis/insights" + path
-
 
 class AsyncInsightsPluginResource:
     """Async SDK namespace mounted as ``client.insights``."""
 
     def __init__(self, platform: AsyncNeMoPlatform) -> None:
         self._platform = platform
-        self._http_client = platform._client
+        self._client = client_from_platform(platform, AsyncInsightsClient)
         self._insights: _AsyncInsightResource | None = None
         self._analysis_configs: _AsyncAnalysisConfigResource | None = None
         self._analysis_runs: _AsyncAnalysisRunResource | None = None
@@ -114,9 +113,6 @@ class AsyncInsightsPluginResource:
         if self._analysis_run_statuses is None:
             self._analysis_run_statuses = _AsyncAnalysisRunStatusResource(self)
         return self._analysis_run_statuses
-
-    def _url(self, path: str) -> str:
-        return str(self._platform.base_url).rstrip("/") + "/apis/insights" + path
 
 
 insights_sdk_resources = NemoPluginSDKResources(

--- a/plugins/nemo-insights/src/nemo_insights_plugin/sdk_resources/_entity.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/sdk_resources/_entity.py
@@ -11,6 +11,17 @@ from nemo_platform_plugin.entity import NemoEntity
 _EntityT = TypeVar("_EntityT", bound=NemoEntity)
 
 
+def object_dict(value: object) -> dict[str, object] | None:
+    """Return a string-keyed object dict from raw JSON-like data."""
+    if not isinstance(value, dict):
+        return None
+    result: dict[str, object] = {}
+    for key, item in value.items():
+        if isinstance(key, str):
+            result[key] = item
+    return result
+
+
 def entity_from_response(entity_type: type[_EntityT], data: dict[str, object]) -> _EntityT:
     """Parse an entity response and restore its store-managed metadata."""
     entity = entity_type.model_validate(data)
@@ -31,9 +42,10 @@ def hydrate_page(items: list[_EntityT], raw_items: object) -> None:
     if not isinstance(raw_items, list):
         return
     for item, raw in zip(items, raw_items, strict=True):
-        if not isinstance(raw, dict):
+        raw_data = object_dict(raw)
+        if raw_data is None:
             continue
-        hydrated = entity_from_response(type(item), raw)
+        hydrated = entity_from_response(type(item), raw_data)
         item.__pydantic_private__ = hydrated.__pydantic_private__
 
 

--- a/plugins/nemo-insights/src/nemo_insights_plugin/sdk_resources/_errors.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/sdk_resources/_errors.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Error compatibility helpers for SDK resources mounted on NeMoPlatform."""
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+import httpx
+from nemo_platform_plugin.client.errors import NemoHTTPError
+
+
+@contextmanager
+def httpx_status_errors() -> Iterator[None]:
+    """Preserve the historical raw-httpx error shape of plugin SDK resources."""
+    try:
+        yield
+    except NemoHTTPError as exc:
+        try:
+            exc.http_response.raise_for_status()
+        except httpx.HTTPStatusError as httpx_exc:
+            raise httpx_exc from exc
+        raise

--- a/plugins/nemo-insights/src/nemo_insights_plugin/sdk_resources/analysis_configs.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/sdk_resources/analysis_configs.py
@@ -4,8 +4,9 @@
 """SDK sub-resources for periodic analysis opt-in configs and run status."""
 
 from datetime import datetime
-from typing import Any, Protocol
+from typing import Protocol, TypedDict
 
+from nemo_insights_plugin.client import AsyncInsightsClient, InsightsClient
 from nemo_insights_plugin.entities import (
     AnalysisConfig,
     AnalysisConfigStatus,
@@ -19,14 +20,26 @@ from nemo_insights_plugin.schema import (
     UpdateAnalysisRunStatusRequest,
 )
 from nemo_insights_plugin.sdk_resources._entity import entity_from_response, hydrate_page
+from nemo_insights_plugin.types import ListAnalysisConfigsQueryParams, ListAnalysisRunStatusesQueryParams
+
+
+class _AnalysisRunStatusPatch(TypedDict, total=False):
+    status: AnalysisConfigStatus
+    last_successful_run_at: datetime
+    last_attempted_at: datetime
+    last_completed_at: datetime
+    last_submitted_job: str
+    last_error: str
 
 
 class _ResourceParent(Protocol):
     """The slice of the insights SDK namespace this sub-resource needs."""
 
-    _http_client: Any
+    _client: InsightsClient
 
-    def _url(self, path: str) -> str: ...
+
+class _AsyncResourceParent(Protocol):
+    _client: AsyncInsightsClient
 
 
 def _list_params(
@@ -35,8 +48,8 @@ def _list_params(
     page_size: int,
     sort: str,
     enabled: bool | None,
-) -> dict[str, Any]:
-    params: dict[str, Any] = {"page": page, "page_size": page_size, "sort": sort}
+) -> ListAnalysisConfigsQueryParams:
+    params: ListAnalysisConfigsQueryParams = {"page": page, "page_size": page_size, "sort": sort}
     if enabled is not None:
         params["enabled"] = enabled
     return params
@@ -45,14 +58,14 @@ def _list_params(
 def _build_update_body(
     *,
     enabled: bool | None,
-) -> dict[str, Any]:
-    body = UpdateAnalysisConfigRequest(enabled=enabled)
-    return body.model_dump(mode="json", exclude_none=True, exclude_unset=True)
+) -> UpdateAnalysisConfigRequest:
+    if enabled is None:
+        return UpdateAnalysisConfigRequest()
+    return UpdateAnalysisConfigRequest(enabled=enabled)
 
 
-def _build_enable_body(*, default_model: str, fast_model: str) -> dict[str, Any]:
-    body = EnableAnalysisConfigRequest(default_model=default_model, fast_model=fast_model)
-    return body.model_dump(mode="json")
+def _build_enable_body(*, default_model: str, fast_model: str) -> EnableAnalysisConfigRequest:
+    return EnableAnalysisConfigRequest(default_model=default_model, fast_model=fast_model)
 
 
 def _build_status_update_body(
@@ -63,25 +76,30 @@ def _build_status_update_body(
     last_completed_at: datetime | None,
     last_submitted_job: str | None,
     last_error: str | None,
-) -> dict[str, Any]:
-    body = UpdateAnalysisRunStatusRequest(
-        status=AnalysisConfigStatus(status) if isinstance(status, str) else status,
-        last_successful_run_at=last_successful_run_at,
-        last_attempted_at=last_attempted_at,
-        last_completed_at=last_completed_at,
-        last_submitted_job=last_submitted_job,
-        last_error=last_error,
-    )
-    return body.model_dump(mode="json", exclude_none=True, exclude_unset=True)
+) -> UpdateAnalysisRunStatusRequest:
+    update: _AnalysisRunStatusPatch = {}
+    if status is not None:
+        update["status"] = AnalysisConfigStatus(status) if isinstance(status, str) else status
+    if last_successful_run_at is not None:
+        update["last_successful_run_at"] = last_successful_run_at
+    if last_attempted_at is not None:
+        update["last_attempted_at"] = last_attempted_at
+    if last_completed_at is not None:
+        update["last_completed_at"] = last_completed_at
+    if last_submitted_job is not None:
+        update["last_submitted_job"] = last_submitted_job
+    if last_error is not None:
+        update["last_error"] = last_error
+    return UpdateAnalysisRunStatusRequest(**update)
 
 
-def _analysis_config_page_from_response(data: dict[str, Any]) -> AnalysisConfigPage:
+def _analysis_config_page_from_response(data: dict[str, object]) -> AnalysisConfigPage:
     page = AnalysisConfigPage.model_validate(data)
     hydrate_page(page.data, data.get("data"))
     return page
 
 
-def _analysis_run_status_page_from_response(data: dict[str, Any]) -> AnalysisRunStatusPage:
+def _analysis_run_status_page_from_response(data: dict[str, object]) -> AnalysisRunStatusPage:
     page = AnalysisRunStatusPage.model_validate(data)
     hydrate_page(page.data, data.get("data"))
     return page
@@ -93,20 +111,21 @@ class _AnalysisConfigResource:
     def __init__(self, parent: _ResourceParent) -> None:
         self._parent = parent
 
+    @property
+    def _client(self) -> InsightsClient:
+        return self._parent._client
+
     def enable(self, *, workspace: str, agent: str, default_model: str, fast_model: str) -> AnalysisConfig:
-        response = self._parent._http_client.post(
-            self._parent._url(f"/v2/workspaces/{workspace}/analysis-configs/{agent}/enable"),
-            json=_build_enable_body(default_model=default_model, fast_model=fast_model),
+        response = self._client.enable_analysis_config(
+            workspace=workspace,
+            agent=agent,
+            body=_build_enable_body(default_model=default_model, fast_model=fast_model),
         )
-        response.raise_for_status()
-        return entity_from_response(AnalysisConfig, response.json())
+        return entity_from_response(AnalysisConfig, response.http_response.json())
 
     def disable(self, *, workspace: str, agent: str) -> AnalysisConfig:
-        response = self._parent._http_client.post(
-            self._parent._url(f"/v2/workspaces/{workspace}/analysis-configs/{agent}/disable")
-        )
-        response.raise_for_status()
-        return entity_from_response(AnalysisConfig, response.json())
+        response = self._client.disable_analysis_config(workspace=workspace, agent=agent)
+        return entity_from_response(AnalysisConfig, response.http_response.json())
 
     def list_configs(
         self,
@@ -117,19 +136,16 @@ class _AnalysisConfigResource:
         sort: str = "-created_at",
         enabled: bool | None = None,
     ) -> AnalysisConfigPage:
-        response = self._parent._http_client.get(
-            self._parent._url(f"/v2/workspaces/{workspace}/analysis-configs"),
-            params=_list_params(page=page, page_size=page_size, sort=sort, enabled=enabled),
+        response = self._client.list_analysis_configs(
+            workspace=workspace,
+            query_params=_list_params(page=page, page_size=page_size, sort=sort, enabled=enabled),
         )
-        response.raise_for_status()
-        return _analysis_config_page_from_response(response.json())
+        response.page()
+        return _analysis_config_page_from_response(response.http_response.json())
 
     def get(self, *, workspace: str, agent: str) -> AnalysisConfig:
-        response = self._parent._http_client.get(
-            self._parent._url(f"/v2/workspaces/{workspace}/analysis-configs/{agent}")
-        )
-        response.raise_for_status()
-        return entity_from_response(AnalysisConfig, response.json())
+        response = self._client.get_analysis_config(workspace=workspace, agent=agent)
+        return entity_from_response(AnalysisConfig, response.http_response.json())
 
     def update(
         self,
@@ -138,34 +154,35 @@ class _AnalysisConfigResource:
         agent: str,
         enabled: bool | None = None,
     ) -> AnalysisConfig:
-        response = self._parent._http_client.patch(
-            self._parent._url(f"/v2/workspaces/{workspace}/analysis-configs/{agent}"),
-            json=_build_update_body(enabled=enabled),
+        response = self._client.update_analysis_config(
+            workspace=workspace,
+            agent=agent,
+            body=_build_update_body(enabled=enabled),
         )
-        response.raise_for_status()
-        return entity_from_response(AnalysisConfig, response.json())
+        return entity_from_response(AnalysisConfig, response.http_response.json())
 
 
 class _AsyncAnalysisConfigResource:
     """Async ``analysis_configs`` sub-resource."""
 
-    def __init__(self, parent: _ResourceParent) -> None:
+    def __init__(self, parent: _AsyncResourceParent) -> None:
         self._parent = parent
 
+    @property
+    def _client(self) -> AsyncInsightsClient:
+        return self._parent._client
+
     async def enable(self, *, workspace: str, agent: str, default_model: str, fast_model: str) -> AnalysisConfig:
-        response = await self._parent._http_client.post(
-            self._parent._url(f"/v2/workspaces/{workspace}/analysis-configs/{agent}/enable"),
-            json=_build_enable_body(default_model=default_model, fast_model=fast_model),
+        response = await self._client.enable_analysis_config(
+            workspace=workspace,
+            agent=agent,
+            body=_build_enable_body(default_model=default_model, fast_model=fast_model),
         )
-        response.raise_for_status()
-        return entity_from_response(AnalysisConfig, response.json())
+        return entity_from_response(AnalysisConfig, response.http_response.json())
 
     async def disable(self, *, workspace: str, agent: str) -> AnalysisConfig:
-        response = await self._parent._http_client.post(
-            self._parent._url(f"/v2/workspaces/{workspace}/analysis-configs/{agent}/disable")
-        )
-        response.raise_for_status()
-        return entity_from_response(AnalysisConfig, response.json())
+        response = await self._client.disable_analysis_config(workspace=workspace, agent=agent)
+        return entity_from_response(AnalysisConfig, response.http_response.json())
 
     async def list_configs(
         self,
@@ -176,19 +193,16 @@ class _AsyncAnalysisConfigResource:
         sort: str = "-created_at",
         enabled: bool | None = None,
     ) -> AnalysisConfigPage:
-        response = await self._parent._http_client.get(
-            self._parent._url(f"/v2/workspaces/{workspace}/analysis-configs"),
-            params=_list_params(page=page, page_size=page_size, sort=sort, enabled=enabled),
+        response = await self._client.list_analysis_configs(
+            workspace=workspace,
+            query_params=_list_params(page=page, page_size=page_size, sort=sort, enabled=enabled),
         )
-        response.raise_for_status()
-        return _analysis_config_page_from_response(response.json())
+        response.page()
+        return _analysis_config_page_from_response(response.http_response.json())
 
     async def get(self, *, workspace: str, agent: str) -> AnalysisConfig:
-        response = await self._parent._http_client.get(
-            self._parent._url(f"/v2/workspaces/{workspace}/analysis-configs/{agent}")
-        )
-        response.raise_for_status()
-        return entity_from_response(AnalysisConfig, response.json())
+        response = await self._client.get_analysis_config(workspace=workspace, agent=agent)
+        return entity_from_response(AnalysisConfig, response.http_response.json())
 
     async def update(
         self,
@@ -197,12 +211,12 @@ class _AsyncAnalysisConfigResource:
         agent: str,
         enabled: bool | None = None,
     ) -> AnalysisConfig:
-        response = await self._parent._http_client.patch(
-            self._parent._url(f"/v2/workspaces/{workspace}/analysis-configs/{agent}"),
-            json=_build_update_body(enabled=enabled),
+        response = await self._client.update_analysis_config(
+            workspace=workspace,
+            agent=agent,
+            body=_build_update_body(enabled=enabled),
         )
-        response.raise_for_status()
-        return entity_from_response(AnalysisConfig, response.json())
+        return entity_from_response(AnalysisConfig, response.http_response.json())
 
 
 class _AnalysisRunStatusResource:
@@ -210,6 +224,10 @@ class _AnalysisRunStatusResource:
 
     def __init__(self, parent: _ResourceParent) -> None:
         self._parent = parent
+
+    @property
+    def _client(self) -> InsightsClient:
+        return self._parent._client
 
     def list_statuses(
         self,
@@ -219,19 +237,17 @@ class _AnalysisRunStatusResource:
         page_size: int = 20,
         sort: str = "-updated_at",
     ) -> AnalysisRunStatusPage:
-        response = self._parent._http_client.get(
-            self._parent._url(f"/v2/workspaces/{workspace}/analysis-run-statuses"),
-            params={"page": page, "page_size": page_size, "sort": sort},
+        query_params: ListAnalysisRunStatusesQueryParams = {"page": page, "page_size": page_size, "sort": sort}
+        response = self._client.list_analysis_run_statuses(
+            workspace=workspace,
+            query_params=query_params,
         )
-        response.raise_for_status()
-        return _analysis_run_status_page_from_response(response.json())
+        response.page()
+        return _analysis_run_status_page_from_response(response.http_response.json())
 
     def get(self, *, workspace: str, agent: str) -> AnalysisRunStatus:
-        response = self._parent._http_client.get(
-            self._parent._url(f"/v2/workspaces/{workspace}/analysis-run-statuses/{agent}")
-        )
-        response.raise_for_status()
-        return entity_from_response(AnalysisRunStatus, response.json())
+        response = self._client.get_analysis_run_status(workspace=workspace, agent=agent)
+        return entity_from_response(AnalysisRunStatus, response.http_response.json())
 
     def update(
         self,
@@ -245,9 +261,10 @@ class _AnalysisRunStatusResource:
         last_submitted_job: str | None = None,
         last_error: str | None = None,
     ) -> AnalysisRunStatus:
-        response = self._parent._http_client.patch(
-            self._parent._url(f"/v2/workspaces/{workspace}/analysis-run-statuses/{agent}"),
-            json=_build_status_update_body(
+        response = self._client.update_analysis_run_status(
+            workspace=workspace,
+            agent=agent,
+            body=_build_status_update_body(
                 status=status,
                 last_successful_run_at=last_successful_run_at,
                 last_attempted_at=last_attempted_at,
@@ -256,15 +273,18 @@ class _AnalysisRunStatusResource:
                 last_error=last_error,
             ),
         )
-        response.raise_for_status()
-        return entity_from_response(AnalysisRunStatus, response.json())
+        return entity_from_response(AnalysisRunStatus, response.http_response.json())
 
 
 class _AsyncAnalysisRunStatusResource:
     """Async ``analysis_run_statuses`` sub-resource."""
 
-    def __init__(self, parent: _ResourceParent) -> None:
+    def __init__(self, parent: _AsyncResourceParent) -> None:
         self._parent = parent
+
+    @property
+    def _client(self) -> AsyncInsightsClient:
+        return self._parent._client
 
     async def list_statuses(
         self,
@@ -274,19 +294,17 @@ class _AsyncAnalysisRunStatusResource:
         page_size: int = 20,
         sort: str = "-updated_at",
     ) -> AnalysisRunStatusPage:
-        response = await self._parent._http_client.get(
-            self._parent._url(f"/v2/workspaces/{workspace}/analysis-run-statuses"),
-            params={"page": page, "page_size": page_size, "sort": sort},
+        query_params: ListAnalysisRunStatusesQueryParams = {"page": page, "page_size": page_size, "sort": sort}
+        response = await self._client.list_analysis_run_statuses(
+            workspace=workspace,
+            query_params=query_params,
         )
-        response.raise_for_status()
-        return _analysis_run_status_page_from_response(response.json())
+        response.page()
+        return _analysis_run_status_page_from_response(response.http_response.json())
 
     async def get(self, *, workspace: str, agent: str) -> AnalysisRunStatus:
-        response = await self._parent._http_client.get(
-            self._parent._url(f"/v2/workspaces/{workspace}/analysis-run-statuses/{agent}")
-        )
-        response.raise_for_status()
-        return entity_from_response(AnalysisRunStatus, response.json())
+        response = await self._client.get_analysis_run_status(workspace=workspace, agent=agent)
+        return entity_from_response(AnalysisRunStatus, response.http_response.json())
 
     async def update(
         self,
@@ -300,9 +318,10 @@ class _AsyncAnalysisRunStatusResource:
         last_submitted_job: str | None = None,
         last_error: str | None = None,
     ) -> AnalysisRunStatus:
-        response = await self._parent._http_client.patch(
-            self._parent._url(f"/v2/workspaces/{workspace}/analysis-run-statuses/{agent}"),
-            json=_build_status_update_body(
+        response = await self._client.update_analysis_run_status(
+            workspace=workspace,
+            agent=agent,
+            body=_build_status_update_body(
                 status=status,
                 last_successful_run_at=last_successful_run_at,
                 last_attempted_at=last_attempted_at,
@@ -311,8 +330,7 @@ class _AsyncAnalysisRunStatusResource:
                 last_error=last_error,
             ),
         )
-        response.raise_for_status()
-        return entity_from_response(AnalysisRunStatus, response.json())
+        return entity_from_response(AnalysisRunStatus, response.http_response.json())
 
 
 __all__ = [

--- a/plugins/nemo-insights/src/nemo_insights_plugin/sdk_resources/analysis_configs.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/sdk_resources/analysis_configs.py
@@ -4,7 +4,8 @@
 """SDK sub-resources for periodic analysis opt-in configs and run status."""
 
 from datetime import datetime
-from typing import Protocol, TypedDict
+from enum import Enum
+from typing import Protocol, TypeAlias, TypedDict
 
 from nemo_insights_plugin.client import AsyncInsightsClient, InsightsClient
 from nemo_insights_plugin.entities import (
@@ -26,11 +27,19 @@ from nemo_insights_plugin.types import ListAnalysisConfigsQueryParams, ListAnaly
 
 class _AnalysisRunStatusPatch(TypedDict, total=False):
     status: AnalysisConfigStatus
-    last_successful_run_at: datetime
-    last_attempted_at: datetime
-    last_completed_at: datetime
+    last_successful_run_at: datetime | None
+    last_attempted_at: datetime | None
+    last_completed_at: datetime | None
     last_submitted_job: str
     last_error: str
+
+
+class _Unset(Enum):
+    VALUE = "unset"
+
+
+_UNSET = _Unset.VALUE
+_NullableDatetimeUpdate: TypeAlias = datetime | None | _Unset
 
 
 class _ResourceParent(Protocol):
@@ -71,21 +80,21 @@ def _build_enable_body(*, default_model: str, fast_model: str) -> EnableAnalysis
 
 def _build_status_update_body(
     *,
-    status: AnalysisConfigStatus | str | None,
-    last_successful_run_at: datetime | None,
-    last_attempted_at: datetime | None,
-    last_completed_at: datetime | None,
-    last_submitted_job: str | None,
-    last_error: str | None,
+    status: AnalysisConfigStatus | str | None = None,
+    last_successful_run_at: _NullableDatetimeUpdate = _UNSET,
+    last_attempted_at: _NullableDatetimeUpdate = _UNSET,
+    last_completed_at: _NullableDatetimeUpdate = _UNSET,
+    last_submitted_job: str | None = None,
+    last_error: str | None = None,
 ) -> UpdateAnalysisRunStatusRequest:
     update: _AnalysisRunStatusPatch = {}
     if status is not None:
         update["status"] = AnalysisConfigStatus(status) if isinstance(status, str) else status
-    if last_successful_run_at is not None:
+    if not isinstance(last_successful_run_at, _Unset):
         update["last_successful_run_at"] = last_successful_run_at
-    if last_attempted_at is not None:
+    if not isinstance(last_attempted_at, _Unset):
         update["last_attempted_at"] = last_attempted_at
-    if last_completed_at is not None:
+    if not isinstance(last_completed_at, _Unset):
         update["last_completed_at"] = last_completed_at
     if last_submitted_job is not None:
         update["last_submitted_job"] = last_submitted_job
@@ -268,9 +277,9 @@ class _AnalysisRunStatusResource:
         workspace: str,
         agent: str,
         status: AnalysisConfigStatus | str | None = None,
-        last_successful_run_at: datetime | None = None,
-        last_attempted_at: datetime | None = None,
-        last_completed_at: datetime | None = None,
+        last_successful_run_at: _NullableDatetimeUpdate = _UNSET,
+        last_attempted_at: _NullableDatetimeUpdate = _UNSET,
+        last_completed_at: _NullableDatetimeUpdate = _UNSET,
         last_submitted_job: str | None = None,
         last_error: str | None = None,
     ) -> AnalysisRunStatus:
@@ -328,9 +337,9 @@ class _AsyncAnalysisRunStatusResource:
         workspace: str,
         agent: str,
         status: AnalysisConfigStatus | str | None = None,
-        last_successful_run_at: datetime | None = None,
-        last_attempted_at: datetime | None = None,
-        last_completed_at: datetime | None = None,
+        last_successful_run_at: _NullableDatetimeUpdate = _UNSET,
+        last_attempted_at: _NullableDatetimeUpdate = _UNSET,
+        last_completed_at: _NullableDatetimeUpdate = _UNSET,
         last_submitted_job: str | None = None,
         last_error: str | None = None,
     ) -> AnalysisRunStatus:

--- a/plugins/nemo-insights/src/nemo_insights_plugin/sdk_resources/analysis_configs.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/sdk_resources/analysis_configs.py
@@ -20,6 +20,7 @@ from nemo_insights_plugin.schema import (
     UpdateAnalysisRunStatusRequest,
 )
 from nemo_insights_plugin.sdk_resources._entity import entity_from_response, hydrate_page
+from nemo_insights_plugin.sdk_resources._errors import httpx_status_errors
 from nemo_insights_plugin.types import ListAnalysisConfigsQueryParams, ListAnalysisRunStatusesQueryParams
 
 
@@ -116,16 +117,18 @@ class _AnalysisConfigResource:
         return self._parent._client
 
     def enable(self, *, workspace: str, agent: str, default_model: str, fast_model: str) -> AnalysisConfig:
-        response = self._client.enable_analysis_config(
-            workspace=workspace,
-            agent=agent,
-            body=_build_enable_body(default_model=default_model, fast_model=fast_model),
-        )
-        return entity_from_response(AnalysisConfig, response.http_response.json())
+        with httpx_status_errors():
+            response = self._client.enable_analysis_config(
+                workspace=workspace,
+                agent=agent,
+                body=_build_enable_body(default_model=default_model, fast_model=fast_model),
+            )
+            return entity_from_response(AnalysisConfig, response.http_response.json())
 
     def disable(self, *, workspace: str, agent: str) -> AnalysisConfig:
-        response = self._client.disable_analysis_config(workspace=workspace, agent=agent)
-        return entity_from_response(AnalysisConfig, response.http_response.json())
+        with httpx_status_errors():
+            response = self._client.disable_analysis_config(workspace=workspace, agent=agent)
+            return entity_from_response(AnalysisConfig, response.http_response.json())
 
     def list_configs(
         self,
@@ -136,16 +139,18 @@ class _AnalysisConfigResource:
         sort: str = "-created_at",
         enabled: bool | None = None,
     ) -> AnalysisConfigPage:
-        response = self._client.list_analysis_configs(
-            workspace=workspace,
-            query_params=_list_params(page=page, page_size=page_size, sort=sort, enabled=enabled),
-        )
-        response.page()
-        return _analysis_config_page_from_response(response.http_response.json())
+        with httpx_status_errors():
+            response = self._client.list_analysis_configs(
+                workspace=workspace,
+                query_params=_list_params(page=page, page_size=page_size, sort=sort, enabled=enabled),
+            )
+            response.page()
+            return _analysis_config_page_from_response(response.http_response.json())
 
     def get(self, *, workspace: str, agent: str) -> AnalysisConfig:
-        response = self._client.get_analysis_config(workspace=workspace, agent=agent)
-        return entity_from_response(AnalysisConfig, response.http_response.json())
+        with httpx_status_errors():
+            response = self._client.get_analysis_config(workspace=workspace, agent=agent)
+            return entity_from_response(AnalysisConfig, response.http_response.json())
 
     def update(
         self,
@@ -154,12 +159,13 @@ class _AnalysisConfigResource:
         agent: str,
         enabled: bool | None = None,
     ) -> AnalysisConfig:
-        response = self._client.update_analysis_config(
-            workspace=workspace,
-            agent=agent,
-            body=_build_update_body(enabled=enabled),
-        )
-        return entity_from_response(AnalysisConfig, response.http_response.json())
+        with httpx_status_errors():
+            response = self._client.update_analysis_config(
+                workspace=workspace,
+                agent=agent,
+                body=_build_update_body(enabled=enabled),
+            )
+            return entity_from_response(AnalysisConfig, response.http_response.json())
 
 
 class _AsyncAnalysisConfigResource:
@@ -173,16 +179,18 @@ class _AsyncAnalysisConfigResource:
         return self._parent._client
 
     async def enable(self, *, workspace: str, agent: str, default_model: str, fast_model: str) -> AnalysisConfig:
-        response = await self._client.enable_analysis_config(
-            workspace=workspace,
-            agent=agent,
-            body=_build_enable_body(default_model=default_model, fast_model=fast_model),
-        )
-        return entity_from_response(AnalysisConfig, response.http_response.json())
+        with httpx_status_errors():
+            response = await self._client.enable_analysis_config(
+                workspace=workspace,
+                agent=agent,
+                body=_build_enable_body(default_model=default_model, fast_model=fast_model),
+            )
+            return entity_from_response(AnalysisConfig, response.http_response.json())
 
     async def disable(self, *, workspace: str, agent: str) -> AnalysisConfig:
-        response = await self._client.disable_analysis_config(workspace=workspace, agent=agent)
-        return entity_from_response(AnalysisConfig, response.http_response.json())
+        with httpx_status_errors():
+            response = await self._client.disable_analysis_config(workspace=workspace, agent=agent)
+            return entity_from_response(AnalysisConfig, response.http_response.json())
 
     async def list_configs(
         self,
@@ -193,16 +201,18 @@ class _AsyncAnalysisConfigResource:
         sort: str = "-created_at",
         enabled: bool | None = None,
     ) -> AnalysisConfigPage:
-        response = await self._client.list_analysis_configs(
-            workspace=workspace,
-            query_params=_list_params(page=page, page_size=page_size, sort=sort, enabled=enabled),
-        )
-        response.page()
-        return _analysis_config_page_from_response(response.http_response.json())
+        with httpx_status_errors():
+            response = await self._client.list_analysis_configs(
+                workspace=workspace,
+                query_params=_list_params(page=page, page_size=page_size, sort=sort, enabled=enabled),
+            )
+            response.page()
+            return _analysis_config_page_from_response(response.http_response.json())
 
     async def get(self, *, workspace: str, agent: str) -> AnalysisConfig:
-        response = await self._client.get_analysis_config(workspace=workspace, agent=agent)
-        return entity_from_response(AnalysisConfig, response.http_response.json())
+        with httpx_status_errors():
+            response = await self._client.get_analysis_config(workspace=workspace, agent=agent)
+            return entity_from_response(AnalysisConfig, response.http_response.json())
 
     async def update(
         self,
@@ -211,12 +221,13 @@ class _AsyncAnalysisConfigResource:
         agent: str,
         enabled: bool | None = None,
     ) -> AnalysisConfig:
-        response = await self._client.update_analysis_config(
-            workspace=workspace,
-            agent=agent,
-            body=_build_update_body(enabled=enabled),
-        )
-        return entity_from_response(AnalysisConfig, response.http_response.json())
+        with httpx_status_errors():
+            response = await self._client.update_analysis_config(
+                workspace=workspace,
+                agent=agent,
+                body=_build_update_body(enabled=enabled),
+            )
+            return entity_from_response(AnalysisConfig, response.http_response.json())
 
 
 class _AnalysisRunStatusResource:
@@ -238,16 +249,18 @@ class _AnalysisRunStatusResource:
         sort: str = "-updated_at",
     ) -> AnalysisRunStatusPage:
         query_params: ListAnalysisRunStatusesQueryParams = {"page": page, "page_size": page_size, "sort": sort}
-        response = self._client.list_analysis_run_statuses(
-            workspace=workspace,
-            query_params=query_params,
-        )
-        response.page()
-        return _analysis_run_status_page_from_response(response.http_response.json())
+        with httpx_status_errors():
+            response = self._client.list_analysis_run_statuses(
+                workspace=workspace,
+                query_params=query_params,
+            )
+            response.page()
+            return _analysis_run_status_page_from_response(response.http_response.json())
 
     def get(self, *, workspace: str, agent: str) -> AnalysisRunStatus:
-        response = self._client.get_analysis_run_status(workspace=workspace, agent=agent)
-        return entity_from_response(AnalysisRunStatus, response.http_response.json())
+        with httpx_status_errors():
+            response = self._client.get_analysis_run_status(workspace=workspace, agent=agent)
+            return entity_from_response(AnalysisRunStatus, response.http_response.json())
 
     def update(
         self,
@@ -261,19 +274,20 @@ class _AnalysisRunStatusResource:
         last_submitted_job: str | None = None,
         last_error: str | None = None,
     ) -> AnalysisRunStatus:
-        response = self._client.update_analysis_run_status(
-            workspace=workspace,
-            agent=agent,
-            body=_build_status_update_body(
-                status=status,
-                last_successful_run_at=last_successful_run_at,
-                last_attempted_at=last_attempted_at,
-                last_completed_at=last_completed_at,
-                last_submitted_job=last_submitted_job,
-                last_error=last_error,
-            ),
-        )
-        return entity_from_response(AnalysisRunStatus, response.http_response.json())
+        with httpx_status_errors():
+            response = self._client.update_analysis_run_status(
+                workspace=workspace,
+                agent=agent,
+                body=_build_status_update_body(
+                    status=status,
+                    last_successful_run_at=last_successful_run_at,
+                    last_attempted_at=last_attempted_at,
+                    last_completed_at=last_completed_at,
+                    last_submitted_job=last_submitted_job,
+                    last_error=last_error,
+                ),
+            )
+            return entity_from_response(AnalysisRunStatus, response.http_response.json())
 
 
 class _AsyncAnalysisRunStatusResource:
@@ -295,16 +309,18 @@ class _AsyncAnalysisRunStatusResource:
         sort: str = "-updated_at",
     ) -> AnalysisRunStatusPage:
         query_params: ListAnalysisRunStatusesQueryParams = {"page": page, "page_size": page_size, "sort": sort}
-        response = await self._client.list_analysis_run_statuses(
-            workspace=workspace,
-            query_params=query_params,
-        )
-        response.page()
-        return _analysis_run_status_page_from_response(response.http_response.json())
+        with httpx_status_errors():
+            response = await self._client.list_analysis_run_statuses(
+                workspace=workspace,
+                query_params=query_params,
+            )
+            response.page()
+            return _analysis_run_status_page_from_response(response.http_response.json())
 
     async def get(self, *, workspace: str, agent: str) -> AnalysisRunStatus:
-        response = await self._client.get_analysis_run_status(workspace=workspace, agent=agent)
-        return entity_from_response(AnalysisRunStatus, response.http_response.json())
+        with httpx_status_errors():
+            response = await self._client.get_analysis_run_status(workspace=workspace, agent=agent)
+            return entity_from_response(AnalysisRunStatus, response.http_response.json())
 
     async def update(
         self,
@@ -318,19 +334,20 @@ class _AsyncAnalysisRunStatusResource:
         last_submitted_job: str | None = None,
         last_error: str | None = None,
     ) -> AnalysisRunStatus:
-        response = await self._client.update_analysis_run_status(
-            workspace=workspace,
-            agent=agent,
-            body=_build_status_update_body(
-                status=status,
-                last_successful_run_at=last_successful_run_at,
-                last_attempted_at=last_attempted_at,
-                last_completed_at=last_completed_at,
-                last_submitted_job=last_submitted_job,
-                last_error=last_error,
-            ),
-        )
-        return entity_from_response(AnalysisRunStatus, response.http_response.json())
+        with httpx_status_errors():
+            response = await self._client.update_analysis_run_status(
+                workspace=workspace,
+                agent=agent,
+                body=_build_status_update_body(
+                    status=status,
+                    last_successful_run_at=last_successful_run_at,
+                    last_attempted_at=last_attempted_at,
+                    last_completed_at=last_completed_at,
+                    last_submitted_job=last_submitted_job,
+                    last_error=last_error,
+                ),
+            )
+            return entity_from_response(AnalysisRunStatus, response.http_response.json())
 
 
 __all__ = [

--- a/plugins/nemo-insights/src/nemo_insights_plugin/sdk_resources/analysis_jobs.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/sdk_resources/analysis_jobs.py
@@ -1,93 +1,13 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Typed client for Insights analysis jobs."""
+"""Compatibility imports for the Insights analysis-jobs typed client."""
 
-from __future__ import annotations
+from nemo_insights_plugin.client import AsyncInsightsClient, InsightsClient
+from nemo_insights_plugin.types import AnalysisJob, CreateAnalysisJobRequest, ListAnalysisJobsQueryParams
 
-from abc import abstractmethod
-from datetime import datetime
-
-from nemo_insights_plugin.jobs.analyze import AnalyzeJob, AnalyzeSpec
-from nemo_platform_plugin.client.client import AsyncNemoClient, NemoClient
-from nemo_platform_plugin.client.endpoint import get, post
-from nemo_platform_plugin.client.method import method
-from nemo_platform_plugin.client.types import Paginated
-from nemo_platform_plugin.jobs.schemas import PlatformJobStatus
-from pydantic import BaseModel
-from typing_extensions import NotRequired, TypedDict
-
-
-class CreateAnalysisJobRequest(BaseModel):
-    """Body accepted by the Insights analysis job route."""
-
-    name: str | None = None
-    description: str | None = None
-    project: str | None = None
-    spec: AnalyzeSpec
-    ownership: dict[str, object] | None = None
-    custom_fields: dict[str, object] | None = None
-    output_location: str | None = None
-
-
-class AnalysisJob(BaseModel):
-    """Insights analysis job response from the plugin-owned job route."""
-
-    id: str | None = None
-    name: str
-    description: str | None = None
-    project: str | None = None
-    workspace: str | None = None
-    created_at: datetime | None = None
-    updated_at: datetime | None = None
-    spec: AnalyzeSpec
-    status: PlatformJobStatus | None = None
-    status_details: dict[str, object] | None = None
-    error_details: dict[str, object] | None = None
-    ownership: dict[str, object] | None = None
-    custom_fields: dict[str, object] | None = None
-
-
-_COLLECTION = f"/jobs/{AnalyzeJob.name}"
-
-
-class ListAnalysisJobsQueryParams(TypedDict, total=False):
-    page: NotRequired[int]
-    page_size: NotRequired[int]
-    sort: NotRequired[str]
-    filter: NotRequired[str]
-
-
-@post(f"/apis/insights/v2/workspaces/{{workspace}}{_COLLECTION}")
-@abstractmethod
-def create_analysis_job(*, workspace: str | None = None, body: CreateAnalysisJobRequest) -> AnalysisJob: ...
-
-
-@get(f"/apis/insights/v2/workspaces/{{workspace}}{_COLLECTION}")
-@abstractmethod
-def list_analysis_jobs(
-    *, workspace: str | None = None, query_params: ListAnalysisJobsQueryParams | None = None
-) -> Paginated[AnalysisJob]: ...
-
-
-@get(f"/apis/insights/v2/workspaces/{{workspace}}{_COLLECTION}/{{name}}")
-@abstractmethod
-def get_analysis_job(*, workspace: str | None = None, name: str) -> AnalysisJob: ...
-
-
-class _AnalysisJobsMethods:
-    create_analysis_job = method(create_analysis_job)
-    list_analysis_jobs = method(list_analysis_jobs)
-    get_analysis_job = method(get_analysis_job)
-
-
-class AnalysisJobsClient(_AnalysisJobsMethods, NemoClient):
-    """Sync client for the Insights analysis job API."""
-
-
-class AsyncAnalysisJobsClient(_AnalysisJobsMethods, AsyncNemoClient):
-    """Async client for the Insights analysis job API."""
-
+AnalysisJobsClient = InsightsClient
+AsyncAnalysisJobsClient = AsyncInsightsClient
 
 __all__ = [
     "AnalysisJob",

--- a/plugins/nemo-insights/src/nemo_insights_plugin/sdk_resources/analysis_runs.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/sdk_resources/analysis_runs.py
@@ -13,9 +13,9 @@ a caller polling on its own would have to know that rule.
 
 import asyncio
 import time
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from datetime import datetime
-from typing import Any, Protocol
+from typing import NotRequired, Protocol, TypedDict
 
 from nemo_insights_plugin.entities import AnalysisRun
 from nemo_insights_plugin.schema import (
@@ -23,7 +23,8 @@ from nemo_insights_plugin.schema import (
     AnalysisRunResponse,
     CreateAnalysisRunRequest,
 )
-from nemo_insights_plugin.sdk_resources._entity import entity_from_response, hydrate_page
+from nemo_insights_plugin.sdk_resources._entity import entity_from_response, hydrate_page, object_dict
+from nemo_insights_plugin.types import ListAnalysisRunsQueryParams
 
 DEFAULT_WAIT_TIMEOUT = 900.0
 DEFAULT_POLL_INTERVAL = 5.0
@@ -42,12 +43,58 @@ class AnalysisRunTimeoutError(TimeoutError):
     """The backing job did not reach a terminal state within the wait budget."""
 
 
+class _HTTPResponse(Protocol):
+    def json(self) -> dict[str, object]: ...
+
+
+class _TypedResponse(Protocol):
+    http_response: _HTTPResponse
+
+
+class _PaginatedTypedResponse(_TypedResponse, Protocol):
+    def page(self) -> object: ...
+
+
+class _CreateAnalysisRunFields(TypedDict):
+    agent: str
+    default_model: str
+    fast_model: str
+    ethos: NotRequired[str]
+    since: NotRequired[datetime]
+    evaluation_id: NotRequired[str]
+    timeout_seconds: NotRequired[float]
+
+
+class _AnalysisRunsClient(Protocol):
+    def create_analysis_run(self, *, workspace: str, body: CreateAnalysisRunRequest) -> _TypedResponse: ...
+
+    def list_analysis_runs(
+        self, *, workspace: str, query_params: ListAnalysisRunsQueryParams
+    ) -> _PaginatedTypedResponse: ...
+
+    def get_analysis_run(self, *, workspace: str, name: str) -> _TypedResponse: ...
+
+
+class _AsyncAnalysisRunsClient(Protocol):
+    def create_analysis_run(self, *, workspace: str, body: CreateAnalysisRunRequest) -> Awaitable[_TypedResponse]: ...
+
+    def list_analysis_runs(
+        self, *, workspace: str, query_params: ListAnalysisRunsQueryParams
+    ) -> Awaitable[_PaginatedTypedResponse]: ...
+
+    def get_analysis_run(self, *, workspace: str, name: str) -> Awaitable[_TypedResponse]: ...
+
+
 class _ResourceParent(Protocol):
     """The slice of the insights SDK namespace this sub-resource needs."""
 
-    _http_client: Any
+    @property
+    def _client(self) -> _AnalysisRunsClient: ...
 
-    def _url(self, path: str) -> str: ...
+
+class _AsyncResourceParent(Protocol):
+    @property
+    def _client(self) -> _AsyncAnalysisRunsClient: ...
 
 
 def _build_create_body(
@@ -59,17 +106,21 @@ def _build_create_body(
     since: datetime | None,
     evaluation_id: str | None,
     timeout_seconds: float | None,
-) -> dict[str, Any]:
-    body = CreateAnalysisRunRequest(
-        agent=agent,
-        default_model=default_model,
-        fast_model=fast_model,
-        ethos=ethos,
-        since=since,
-        evaluation_id=evaluation_id,
-        timeout_seconds=timeout_seconds,
-    )
-    return body.model_dump(mode="json", exclude_none=True)
+) -> CreateAnalysisRunRequest:
+    body: _CreateAnalysisRunFields = {
+        "agent": agent,
+        "default_model": default_model,
+        "fast_model": fast_model,
+    }
+    if ethos is not None:
+        body["ethos"] = ethos
+    if since is not None:
+        body["since"] = since
+    if evaluation_id is not None:
+        body["evaluation_id"] = evaluation_id
+    if timeout_seconds is not None:
+        body["timeout_seconds"] = timeout_seconds
+    return CreateAnalysisRunRequest(**body)
 
 
 def _list_params(
@@ -78,23 +129,23 @@ def _list_params(
     page_size: int,
     sort: str,
     agent: str | None,
-) -> dict[str, Any]:
-    params: dict[str, Any] = {"page": page, "page_size": page_size, "sort": sort}
+) -> ListAnalysisRunsQueryParams:
+    params: ListAnalysisRunsQueryParams = {"page": page, "page_size": page_size, "sort": sort}
     if agent is not None:
         params["agent"] = agent
     return params
 
 
-def _run_response_from_response(data: dict[str, Any]) -> AnalysisRunResponse:
+def _run_response_from_response(data: dict[str, object]) -> AnalysisRunResponse:
     """Parse a run-plus-job body, preserving the run's store-assigned metadata."""
     response = AnalysisRunResponse.model_validate(data)
-    raw_run = data.get("run")
-    if isinstance(raw_run, dict):
+    raw_run = object_dict(data.get("run"))
+    if raw_run is not None:
         response.run = entity_from_response(AnalysisRun, raw_run)
     return response
 
 
-def _page_from_response(data: dict[str, Any]) -> AnalysisRunPage:
+def _page_from_response(data: dict[str, object]) -> AnalysisRunPage:
     page = AnalysisRunPage.model_validate(data)
     hydrate_page(page.data, data.get("data"))
     return page
@@ -129,6 +180,10 @@ class _AnalysisRunResource:
     def __init__(self, parent: _ResourceParent) -> None:
         self._parent = parent
 
+    @property
+    def _client(self) -> _AnalysisRunsClient:
+        return self._parent._client
+
     def create(
         self,
         *,
@@ -142,9 +197,9 @@ class _AnalysisRunResource:
         timeout_seconds: float | None = None,
     ) -> AnalysisRunResponse:
         """Submit an analysis run. The model pair is required — see the route."""
-        response = self._parent._http_client.post(
-            self._parent._url(f"/v2/workspaces/{workspace}/analysis-runs"),
-            json=_build_create_body(
+        response = self._client.create_analysis_run(
+            workspace=workspace,
+            body=_build_create_body(
                 agent=agent,
                 default_model=default_model,
                 fast_model=fast_model,
@@ -154,8 +209,7 @@ class _AnalysisRunResource:
                 timeout_seconds=timeout_seconds,
             ),
         )
-        response.raise_for_status()
-        return _run_response_from_response(response.json())
+        return _run_response_from_response(response.http_response.json())
 
     def list_runs(
         self,
@@ -167,20 +221,17 @@ class _AnalysisRunResource:
         agent: str | None = None,
     ) -> AnalysisRunPage:
         """List analysis runs. Job state is not joined — read one run to get it."""
-        response = self._parent._http_client.get(
-            self._parent._url(f"/v2/workspaces/{workspace}/analysis-runs"),
-            params=_list_params(page=page, page_size=page_size, sort=sort, agent=agent),
+        response = self._client.list_analysis_runs(
+            workspace=workspace,
+            query_params=_list_params(page=page, page_size=page_size, sort=sort, agent=agent),
         )
-        response.raise_for_status()
-        return _page_from_response(response.json())
+        response.page()
+        return _page_from_response(response.http_response.json())
 
     def get(self, *, workspace: str, name: str) -> AnalysisRunResponse:
         """Get one analysis run joined with the live state of its backing job."""
-        response = self._parent._http_client.get(
-            self._parent._url(f"/v2/workspaces/{workspace}/analysis-runs/{name}"),
-        )
-        response.raise_for_status()
-        return _run_response_from_response(response.json())
+        response = self._client.get_analysis_run(workspace=workspace, name=name)
+        return _run_response_from_response(response.http_response.json())
 
     def wait(
         self,
@@ -214,8 +265,12 @@ class _AnalysisRunResource:
 class _AsyncAnalysisRunResource:
     """Async ``analysis_runs`` sub-resource — mirrors :class:`_AnalysisRunResource`."""
 
-    def __init__(self, parent: _ResourceParent) -> None:
+    def __init__(self, parent: _AsyncResourceParent) -> None:
         self._parent = parent
+
+    @property
+    def _client(self) -> _AsyncAnalysisRunsClient:
+        return self._parent._client
 
     async def create(
         self,
@@ -230,9 +285,9 @@ class _AsyncAnalysisRunResource:
         timeout_seconds: float | None = None,
     ) -> AnalysisRunResponse:
         """Submit an analysis run. The model pair is required — see the route."""
-        response = await self._parent._http_client.post(
-            self._parent._url(f"/v2/workspaces/{workspace}/analysis-runs"),
-            json=_build_create_body(
+        response = await self._client.create_analysis_run(
+            workspace=workspace,
+            body=_build_create_body(
                 agent=agent,
                 default_model=default_model,
                 fast_model=fast_model,
@@ -242,8 +297,7 @@ class _AsyncAnalysisRunResource:
                 timeout_seconds=timeout_seconds,
             ),
         )
-        response.raise_for_status()
-        return _run_response_from_response(response.json())
+        return _run_response_from_response(response.http_response.json())
 
     async def list_runs(
         self,
@@ -255,20 +309,17 @@ class _AsyncAnalysisRunResource:
         agent: str | None = None,
     ) -> AnalysisRunPage:
         """List analysis runs. Job state is not joined — read one run to get it."""
-        response = await self._parent._http_client.get(
-            self._parent._url(f"/v2/workspaces/{workspace}/analysis-runs"),
-            params=_list_params(page=page, page_size=page_size, sort=sort, agent=agent),
+        response = await self._client.list_analysis_runs(
+            workspace=workspace,
+            query_params=_list_params(page=page, page_size=page_size, sort=sort, agent=agent),
         )
-        response.raise_for_status()
-        return _page_from_response(response.json())
+        response.page()
+        return _page_from_response(response.http_response.json())
 
     async def get(self, *, workspace: str, name: str) -> AnalysisRunResponse:
         """Get one analysis run joined with the live state of its backing job."""
-        response = await self._parent._http_client.get(
-            self._parent._url(f"/v2/workspaces/{workspace}/analysis-runs/{name}"),
-        )
-        response.raise_for_status()
-        return _run_response_from_response(response.json())
+        response = await self._client.get_analysis_run(workspace=workspace, name=name)
+        return _run_response_from_response(response.http_response.json())
 
     async def wait(
         self,

--- a/plugins/nemo-insights/src/nemo_insights_plugin/sdk_resources/analysis_runs.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/sdk_resources/analysis_runs.py
@@ -24,6 +24,7 @@ from nemo_insights_plugin.schema import (
     CreateAnalysisRunRequest,
 )
 from nemo_insights_plugin.sdk_resources._entity import entity_from_response, hydrate_page, object_dict
+from nemo_insights_plugin.sdk_resources._errors import httpx_status_errors
 from nemo_insights_plugin.types import ListAnalysisRunsQueryParams
 
 DEFAULT_WAIT_TIMEOUT = 900.0
@@ -197,19 +198,20 @@ class _AnalysisRunResource:
         timeout_seconds: float | None = None,
     ) -> AnalysisRunResponse:
         """Submit an analysis run. The model pair is required — see the route."""
-        response = self._client.create_analysis_run(
-            workspace=workspace,
-            body=_build_create_body(
-                agent=agent,
-                default_model=default_model,
-                fast_model=fast_model,
-                ethos=ethos,
-                since=since,
-                evaluation_id=evaluation_id,
-                timeout_seconds=timeout_seconds,
-            ),
-        )
-        return _run_response_from_response(response.http_response.json())
+        with httpx_status_errors():
+            response = self._client.create_analysis_run(
+                workspace=workspace,
+                body=_build_create_body(
+                    agent=agent,
+                    default_model=default_model,
+                    fast_model=fast_model,
+                    ethos=ethos,
+                    since=since,
+                    evaluation_id=evaluation_id,
+                    timeout_seconds=timeout_seconds,
+                ),
+            )
+            return _run_response_from_response(response.http_response.json())
 
     def list_runs(
         self,
@@ -221,17 +223,19 @@ class _AnalysisRunResource:
         agent: str | None = None,
     ) -> AnalysisRunPage:
         """List analysis runs. Job state is not joined — read one run to get it."""
-        response = self._client.list_analysis_runs(
-            workspace=workspace,
-            query_params=_list_params(page=page, page_size=page_size, sort=sort, agent=agent),
-        )
-        response.page()
-        return _page_from_response(response.http_response.json())
+        with httpx_status_errors():
+            response = self._client.list_analysis_runs(
+                workspace=workspace,
+                query_params=_list_params(page=page, page_size=page_size, sort=sort, agent=agent),
+            )
+            response.page()
+            return _page_from_response(response.http_response.json())
 
     def get(self, *, workspace: str, name: str) -> AnalysisRunResponse:
         """Get one analysis run joined with the live state of its backing job."""
-        response = self._client.get_analysis_run(workspace=workspace, name=name)
-        return _run_response_from_response(response.http_response.json())
+        with httpx_status_errors():
+            response = self._client.get_analysis_run(workspace=workspace, name=name)
+            return _run_response_from_response(response.http_response.json())
 
     def wait(
         self,
@@ -285,19 +289,20 @@ class _AsyncAnalysisRunResource:
         timeout_seconds: float | None = None,
     ) -> AnalysisRunResponse:
         """Submit an analysis run. The model pair is required — see the route."""
-        response = await self._client.create_analysis_run(
-            workspace=workspace,
-            body=_build_create_body(
-                agent=agent,
-                default_model=default_model,
-                fast_model=fast_model,
-                ethos=ethos,
-                since=since,
-                evaluation_id=evaluation_id,
-                timeout_seconds=timeout_seconds,
-            ),
-        )
-        return _run_response_from_response(response.http_response.json())
+        with httpx_status_errors():
+            response = await self._client.create_analysis_run(
+                workspace=workspace,
+                body=_build_create_body(
+                    agent=agent,
+                    default_model=default_model,
+                    fast_model=fast_model,
+                    ethos=ethos,
+                    since=since,
+                    evaluation_id=evaluation_id,
+                    timeout_seconds=timeout_seconds,
+                ),
+            )
+            return _run_response_from_response(response.http_response.json())
 
     async def list_runs(
         self,
@@ -309,17 +314,19 @@ class _AsyncAnalysisRunResource:
         agent: str | None = None,
     ) -> AnalysisRunPage:
         """List analysis runs. Job state is not joined — read one run to get it."""
-        response = await self._client.list_analysis_runs(
-            workspace=workspace,
-            query_params=_list_params(page=page, page_size=page_size, sort=sort, agent=agent),
-        )
-        response.page()
-        return _page_from_response(response.http_response.json())
+        with httpx_status_errors():
+            response = await self._client.list_analysis_runs(
+                workspace=workspace,
+                query_params=_list_params(page=page, page_size=page_size, sort=sort, agent=agent),
+            )
+            response.page()
+            return _page_from_response(response.http_response.json())
 
     async def get(self, *, workspace: str, name: str) -> AnalysisRunResponse:
         """Get one analysis run joined with the live state of its backing job."""
-        response = await self._client.get_analysis_run(workspace=workspace, name=name)
-        return _run_response_from_response(response.http_response.json())
+        with httpx_status_errors():
+            response = await self._client.get_analysis_run(workspace=workspace, name=name)
+            return _run_response_from_response(response.http_response.json())
 
     async def wait(
         self,

--- a/plugins/nemo-insights/src/nemo_insights_plugin/sdk_resources/insights.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/sdk_resources/insights.py
@@ -18,6 +18,7 @@ from nemo_insights_plugin.schema import (
     UpdateInsightRequest,
 )
 from nemo_insights_plugin.sdk_resources._entity import entity_from_response, hydrate_page
+from nemo_insights_plugin.sdk_resources._errors import httpx_status_errors
 from nemo_insights_plugin.types import ListInsightsQueryParams
 
 
@@ -136,8 +137,9 @@ class _InsightResource:
             status=status,
             trace_refs=trace_refs,
         )
-        response = self._client.create_insight(workspace=workspace, body=body)
-        return _insight_from_response(response.http_response.json())
+        with httpx_status_errors():
+            response = self._client.create_insight(workspace=workspace, body=body)
+            return _insight_from_response(response.http_response.json())
 
     def list_insights(
         self,
@@ -149,22 +151,24 @@ class _InsightResource:
         agent: str | None = None,
         status: InsightStatus | str | None = None,
     ) -> InsightPage:
-        response = self._client.list_insights(
-            workspace=workspace,
-            query_params=_list_params(
-                page=page,
-                page_size=page_size,
-                sort=sort,
-                agent=agent,
-                status=status,
-            ),
-        )
-        response.page()
-        return _page_from_response(response.http_response.json())
+        with httpx_status_errors():
+            response = self._client.list_insights(
+                workspace=workspace,
+                query_params=_list_params(
+                    page=page,
+                    page_size=page_size,
+                    sort=sort,
+                    agent=agent,
+                    status=status,
+                ),
+            )
+            response.page()
+            return _page_from_response(response.http_response.json())
 
     def get(self, *, workspace: str, insight_id: str) -> Insight:
-        response = self._client.get_insight(workspace=workspace, insight_id=insight_id)
-        return _insight_from_response(response.http_response.json())
+        with httpx_status_errors():
+            response = self._client.get_insight(workspace=workspace, insight_id=insight_id)
+            return _insight_from_response(response.http_response.json())
 
     def update(
         self,
@@ -182,11 +186,13 @@ class _InsightResource:
             status=status,
             trace_refs=trace_refs,
         )
-        response = self._client.update_insight(workspace=workspace, insight_id=insight_id, body=body)
-        return _insight_from_response(response.http_response.json())
+        with httpx_status_errors():
+            response = self._client.update_insight(workspace=workspace, insight_id=insight_id, body=body)
+            return _insight_from_response(response.http_response.json())
 
     def delete(self, *, workspace: str, insight_id: str) -> None:
-        self._client.delete_insight(workspace=workspace, insight_id=insight_id).data()
+        with httpx_status_errors():
+            self._client.delete_insight(workspace=workspace, insight_id=insight_id).data()
 
     @property
     def _client(self) -> InsightsClient:
@@ -216,8 +222,9 @@ class _AsyncInsightResource:
             status=status,
             trace_refs=trace_refs,
         )
-        response = await self._client.create_insight(workspace=workspace, body=body)
-        return _insight_from_response(response.http_response.json())
+        with httpx_status_errors():
+            response = await self._client.create_insight(workspace=workspace, body=body)
+            return _insight_from_response(response.http_response.json())
 
     async def list_insights(
         self,
@@ -229,22 +236,24 @@ class _AsyncInsightResource:
         agent: str | None = None,
         status: InsightStatus | str | None = None,
     ) -> InsightPage:
-        response = await self._client.list_insights(
-            workspace=workspace,
-            query_params=_list_params(
-                page=page,
-                page_size=page_size,
-                sort=sort,
-                agent=agent,
-                status=status,
-            ),
-        )
-        response.page()
-        return _page_from_response(response.http_response.json())
+        with httpx_status_errors():
+            response = await self._client.list_insights(
+                workspace=workspace,
+                query_params=_list_params(
+                    page=page,
+                    page_size=page_size,
+                    sort=sort,
+                    agent=agent,
+                    status=status,
+                ),
+            )
+            response.page()
+            return _page_from_response(response.http_response.json())
 
     async def get(self, *, workspace: str, insight_id: str) -> Insight:
-        response = await self._client.get_insight(workspace=workspace, insight_id=insight_id)
-        return _insight_from_response(response.http_response.json())
+        with httpx_status_errors():
+            response = await self._client.get_insight(workspace=workspace, insight_id=insight_id)
+            return _insight_from_response(response.http_response.json())
 
     async def update(
         self,
@@ -262,11 +271,13 @@ class _AsyncInsightResource:
             status=status,
             trace_refs=trace_refs,
         )
-        response = await self._client.update_insight(workspace=workspace, insight_id=insight_id, body=body)
-        return _insight_from_response(response.http_response.json())
+        with httpx_status_errors():
+            response = await self._client.update_insight(workspace=workspace, insight_id=insight_id, body=body)
+            return _insight_from_response(response.http_response.json())
 
     async def delete(self, *, workspace: str, insight_id: str) -> None:
-        (await self._client.delete_insight(workspace=workspace, insight_id=insight_id)).data()
+        with httpx_status_errors():
+            (await self._client.delete_insight(workspace=workspace, insight_id=insight_id)).data()
 
     @property
     def _client(self) -> AsyncInsightsClient:

--- a/plugins/nemo-insights/src/nemo_insights_plugin/sdk_resources/insights.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/sdk_resources/insights.py
@@ -8,8 +8,9 @@ Each method maps 1:1 onto the FastAPI routes in
 :mod:`nemo_insights_plugin.service`.
 """
 
-from typing import Any, Protocol
+from typing import Protocol, TypedDict
 
+from nemo_insights_plugin.client import AsyncInsightsClient, InsightsClient
 from nemo_insights_plugin.entities import Insight, InsightStatus
 from nemo_insights_plugin.schema import (
     CreateInsightRequest,
@@ -17,14 +18,22 @@ from nemo_insights_plugin.schema import (
     UpdateInsightRequest,
 )
 from nemo_insights_plugin.sdk_resources._entity import entity_from_response, hydrate_page
+from nemo_insights_plugin.types import ListInsightsQueryParams
 
 
-def _insight_from_response(data: dict[str, Any]) -> Insight:
+class _InsightUpdatePatch(TypedDict, total=False):
+    agent: str
+    description: str
+    status: InsightStatus
+    trace_refs: list[str]
+
+
+def _insight_from_response(data: dict[str, object]) -> Insight:
     """Parse one insight response body, preserving its store-assigned id."""
     return entity_from_response(Insight, data)
 
 
-def _page_from_response(data: dict[str, Any]) -> InsightPage:
+def _page_from_response(data: dict[str, object]) -> InsightPage:
     """Parse a list response, preserving each item's store-assigned id.
 
     Validated items lose their ids (computed field), so we re-attach them
@@ -44,9 +53,11 @@ class _ResourceParent(Protocol):
     imports the resource classes defined here.
     """
 
-    _http_client: Any
+    _client: InsightsClient
 
-    def _url(self, path: str) -> str: ...
+
+class _AsyncResourceParent(Protocol):
+    _client: AsyncInsightsClient
 
 
 def _build_create_body(
@@ -56,7 +67,7 @@ def _build_create_body(
     description: str,
     status: InsightStatus | str,
     trace_refs: list[str] | None,
-) -> dict[str, Any]:
+) -> CreateInsightRequest:
     body = CreateInsightRequest(
         title=title,
         agent=agent,
@@ -64,7 +75,7 @@ def _build_create_body(
         status=InsightStatus(status) if isinstance(status, str) else status,
         trace_refs=list(trace_refs or []),
     )
-    return body.model_dump(mode="json")
+    return body
 
 
 def _build_update_body(
@@ -73,14 +84,17 @@ def _build_update_body(
     description: str | None,
     status: InsightStatus | str | None,
     trace_refs: list[str] | None,
-) -> dict[str, Any]:
-    body = UpdateInsightRequest(
-        agent=agent,
-        description=description,
-        status=InsightStatus(status) if isinstance(status, str) else status,
-        trace_refs=trace_refs,
-    )
-    return body.model_dump(mode="json", exclude_none=True)
+) -> UpdateInsightRequest:
+    update: _InsightUpdatePatch = {}
+    if agent is not None:
+        update["agent"] = agent
+    if description is not None:
+        update["description"] = description
+    if status is not None:
+        update["status"] = InsightStatus(status) if isinstance(status, str) else status
+    if trace_refs is not None:
+        update["trace_refs"] = trace_refs
+    return UpdateInsightRequest(**update)
 
 
 def _list_params(
@@ -90,8 +104,8 @@ def _list_params(
     sort: str,
     agent: str | None,
     status: InsightStatus | str | None,
-) -> dict[str, Any]:
-    params: dict[str, Any] = {"page": page, "page_size": page_size, "sort": sort}
+) -> ListInsightsQueryParams:
+    params: ListInsightsQueryParams = {"page": page, "page_size": page_size, "sort": sort}
     if agent is not None:
         params["agent"] = agent
     if status is not None:
@@ -122,12 +136,8 @@ class _InsightResource:
             status=status,
             trace_refs=trace_refs,
         )
-        response = self._parent._http_client.post(
-            self._parent._url(f"/v2/workspaces/{workspace}/insights"),
-            json=body,
-        )
-        response.raise_for_status()
-        return _insight_from_response(response.json())
+        response = self._client.create_insight(workspace=workspace, body=body)
+        return _insight_from_response(response.http_response.json())
 
     def list_insights(
         self,
@@ -139,9 +149,9 @@ class _InsightResource:
         agent: str | None = None,
         status: InsightStatus | str | None = None,
     ) -> InsightPage:
-        response = self._parent._http_client.get(
-            self._parent._url(f"/v2/workspaces/{workspace}/insights"),
-            params=_list_params(
+        response = self._client.list_insights(
+            workspace=workspace,
+            query_params=_list_params(
                 page=page,
                 page_size=page_size,
                 sort=sort,
@@ -149,15 +159,12 @@ class _InsightResource:
                 status=status,
             ),
         )
-        response.raise_for_status()
-        return _page_from_response(response.json())
+        response.page()
+        return _page_from_response(response.http_response.json())
 
     def get(self, *, workspace: str, insight_id: str) -> Insight:
-        response = self._parent._http_client.get(
-            self._parent._url(f"/v2/workspaces/{workspace}/insights/{insight_id}"),
-        )
-        response.raise_for_status()
-        return _insight_from_response(response.json())
+        response = self._client.get_insight(workspace=workspace, insight_id=insight_id)
+        return _insight_from_response(response.http_response.json())
 
     def update(
         self,
@@ -175,24 +182,21 @@ class _InsightResource:
             status=status,
             trace_refs=trace_refs,
         )
-        response = self._parent._http_client.patch(
-            self._parent._url(f"/v2/workspaces/{workspace}/insights/{insight_id}"),
-            json=body,
-        )
-        response.raise_for_status()
-        return _insight_from_response(response.json())
+        response = self._client.update_insight(workspace=workspace, insight_id=insight_id, body=body)
+        return _insight_from_response(response.http_response.json())
 
     def delete(self, *, workspace: str, insight_id: str) -> None:
-        response = self._parent._http_client.delete(
-            self._parent._url(f"/v2/workspaces/{workspace}/insights/{insight_id}"),
-        )
-        response.raise_for_status()
+        self._client.delete_insight(workspace=workspace, insight_id=insight_id).data()
+
+    @property
+    def _client(self) -> InsightsClient:
+        return self._parent._client
 
 
 class _AsyncInsightResource:
     """Async ``insights`` sub-resource — mirrors :class:`_InsightResource`."""
 
-    def __init__(self, parent: _ResourceParent) -> None:
+    def __init__(self, parent: _AsyncResourceParent) -> None:
         self._parent = parent
 
     async def create(
@@ -212,12 +216,8 @@ class _AsyncInsightResource:
             status=status,
             trace_refs=trace_refs,
         )
-        response = await self._parent._http_client.post(
-            self._parent._url(f"/v2/workspaces/{workspace}/insights"),
-            json=body,
-        )
-        response.raise_for_status()
-        return _insight_from_response(response.json())
+        response = await self._client.create_insight(workspace=workspace, body=body)
+        return _insight_from_response(response.http_response.json())
 
     async def list_insights(
         self,
@@ -229,9 +229,9 @@ class _AsyncInsightResource:
         agent: str | None = None,
         status: InsightStatus | str | None = None,
     ) -> InsightPage:
-        response = await self._parent._http_client.get(
-            self._parent._url(f"/v2/workspaces/{workspace}/insights"),
-            params=_list_params(
+        response = await self._client.list_insights(
+            workspace=workspace,
+            query_params=_list_params(
                 page=page,
                 page_size=page_size,
                 sort=sort,
@@ -239,15 +239,12 @@ class _AsyncInsightResource:
                 status=status,
             ),
         )
-        response.raise_for_status()
-        return _page_from_response(response.json())
+        response.page()
+        return _page_from_response(response.http_response.json())
 
     async def get(self, *, workspace: str, insight_id: str) -> Insight:
-        response = await self._parent._http_client.get(
-            self._parent._url(f"/v2/workspaces/{workspace}/insights/{insight_id}"),
-        )
-        response.raise_for_status()
-        return _insight_from_response(response.json())
+        response = await self._client.get_insight(workspace=workspace, insight_id=insight_id)
+        return _insight_from_response(response.http_response.json())
 
     async def update(
         self,
@@ -265,18 +262,15 @@ class _AsyncInsightResource:
             status=status,
             trace_refs=trace_refs,
         )
-        response = await self._parent._http_client.patch(
-            self._parent._url(f"/v2/workspaces/{workspace}/insights/{insight_id}"),
-            json=body,
-        )
-        response.raise_for_status()
-        return _insight_from_response(response.json())
+        response = await self._client.update_insight(workspace=workspace, insight_id=insight_id, body=body)
+        return _insight_from_response(response.http_response.json())
 
     async def delete(self, *, workspace: str, insight_id: str) -> None:
-        response = await self._parent._http_client.delete(
-            self._parent._url(f"/v2/workspaces/{workspace}/insights/{insight_id}"),
-        )
-        response.raise_for_status()
+        (await self._client.delete_insight(workspace=workspace, insight_id=insight_id)).data()
+
+    @property
+    def _client(self) -> AsyncInsightsClient:
+        return self._parent._client
 
 
 __all__ = ["_AsyncInsightResource", "_InsightResource"]

--- a/plugins/nemo-insights/src/nemo_insights_plugin/types.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/types.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Typed request/response DTOs for the Insights plugin HTTP client."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import NotRequired, TypedDict
+
+from nemo_insights_plugin.jobs.analyze import AnalyzeSpec
+from nemo_platform_plugin.jobs.schemas import PlatformJobStatus
+from pydantic import BaseModel, JsonValue
+
+
+class ListInsightsQueryParams(TypedDict, total=False):
+    page: NotRequired[int]
+    page_size: NotRequired[int]
+    sort: NotRequired[str]
+    agent: NotRequired[str]
+    status: NotRequired[str]
+
+
+class ListAnalysisConfigsQueryParams(TypedDict, total=False):
+    page: NotRequired[int]
+    page_size: NotRequired[int]
+    sort: NotRequired[str]
+    enabled: NotRequired[bool]
+
+
+class ListAnalysisRunsQueryParams(TypedDict, total=False):
+    page: NotRequired[int]
+    page_size: NotRequired[int]
+    sort: NotRequired[str]
+    agent: NotRequired[str]
+
+
+class ListAnalysisRunStatusesQueryParams(TypedDict, total=False):
+    page: NotRequired[int]
+    page_size: NotRequired[int]
+    sort: NotRequired[str]
+
+
+class CreateAnalysisJobRequest(BaseModel):
+    """Body accepted by the Insights analysis job route."""
+
+    name: str | None = None
+    description: str | None = None
+    project: str | None = None
+    spec: AnalyzeSpec
+    ownership: dict[str, JsonValue] | None = None
+    custom_fields: dict[str, JsonValue] | None = None
+    output_location: str | None = None
+
+
+class AnalysisJob(BaseModel):
+    """Insights analysis job response from the plugin-owned job route."""
+
+    id: str | None = None
+    name: str
+    description: str | None = None
+    project: str | None = None
+    workspace: str | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+    spec: AnalyzeSpec
+    status: PlatformJobStatus | None = None
+    status_details: dict[str, JsonValue] | None = None
+    error_details: dict[str, JsonValue] | None = None
+    ownership: dict[str, JsonValue] | None = None
+    custom_fields: dict[str, JsonValue] | None = None
+
+
+class ListAnalysisJobsQueryParams(TypedDict, total=False):
+    page: NotRequired[int]
+    page_size: NotRequired[int]
+    sort: NotRequired[str]
+    filter: NotRequired[str | dict[str, JsonValue]]

--- a/plugins/nemo-insights/src/nemo_insights_plugin/types.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/types.py
@@ -8,9 +8,43 @@ from __future__ import annotations
 from datetime import datetime
 from typing import NotRequired, TypedDict
 
-from nemo_insights_plugin.jobs.analyze import AnalyzeSpec
 from nemo_platform_plugin.jobs.schemas import PlatformJobStatus
-from pydantic import BaseModel, JsonValue
+from pydantic import BaseModel, ConfigDict, Field, JsonValue
+
+ANALYSIS_JOB_NAME = "analyze-job"
+
+
+class AnalyzeSpec(BaseModel):
+    """Canonical input for one insights analyst run."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    agent: str = Field(description="Agent under test.")
+    ethos: str | None = Field(
+        default=None,
+        description="Optional Ethos Markdown for the agent under test.",
+    )
+    base_url: str | None = Field(
+        default=None,
+        description="Optional platform base URL. Unset uses the active platform context.",
+    )
+    insights_output: str | None = Field(
+        default=None,
+        description=(
+            "Optional local YAML path mirroring the Insights the platform stored. "
+            "Container-local unless it points at mounted storage."
+        ),
+    )
+    since: datetime | None = Field(
+        default=None,
+        description="Optional lower bound for incremental trace/span analysis.",
+    )
+    update_analysis_config: bool = Field(
+        default=True,
+        description="Update the matching AnalysisRunStatus with run metadata.",
+    )
+    default_model: str = Field(description="Workspace-qualified default Model Entity ID selected during setup.")
+    fast_model: str = Field(description="Workspace-qualified fast Model Entity ID selected during setup.")
 
 
 class ListInsightsQueryParams(TypedDict, total=False):

--- a/plugins/nemo-insights/tests/test_analysis_config_contract.py
+++ b/plugins/nemo-insights/tests/test_analysis_config_contract.py
@@ -92,22 +92,17 @@ def test_update_config_sdk_body_omits_none_enabled() -> None:
     assert _build_update_body(enabled=False).model_dump(mode="json", exclude_unset=True) == {"enabled": False}
 
 
-def test_update_run_status_sdk_body_omits_none_fields() -> None:
-    empty = _build_status_update_body(
-        status=None,
-        last_successful_run_at=None,
-        last_attempted_at=None,
-        last_completed_at=None,
-        last_submitted_job=None,
-        last_error=None,
-    )
+def test_update_run_status_sdk_body_omits_unset_fields_and_keeps_explicit_null_timestamps() -> None:
+    empty = _build_status_update_body()
     partial = _build_status_update_body(
         status=AnalysisConfigStatus.RUNNING,
+        last_submitted_job="job-123",
+        last_error="",
+    )
+    clear_timestamps = _build_status_update_body(
         last_successful_run_at=None,
         last_attempted_at=None,
         last_completed_at=None,
-        last_submitted_job="job-123",
-        last_error="",
     )
 
     assert empty.model_dump(mode="json", exclude_unset=True) == {}
@@ -115,6 +110,11 @@ def test_update_run_status_sdk_body_omits_none_fields() -> None:
         "status": "running",
         "last_submitted_job": "job-123",
         "last_error": "",
+    }
+    assert clear_timestamps.model_dump(mode="json", exclude_unset=True) == {
+        "last_successful_run_at": None,
+        "last_attempted_at": None,
+        "last_completed_at": None,
     }
 
 

--- a/plugins/nemo-insights/tests/test_analysis_config_contract.py
+++ b/plugins/nemo-insights/tests/test_analysis_config_contract.py
@@ -10,8 +10,12 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from nemo_insights_plugin import cli
-from nemo_insights_plugin.entities import AnalysisConfig
-from nemo_insights_plugin.sdk_resources.analysis_configs import _build_enable_body
+from nemo_insights_plugin.entities import AnalysisConfig, AnalysisConfigStatus
+from nemo_insights_plugin.sdk_resources.analysis_configs import (
+    _build_enable_body,
+    _build_status_update_body,
+    _build_update_body,
+)
 from nemo_insights_plugin.service import InsightsService
 from nemo_platform_plugin.entity_client import NemoEntityNotFoundError, get_entity_client
 
@@ -77,9 +81,40 @@ def test_enable_sdk_body_contains_both_model_refs() -> None:
     assert _build_enable_body(
         default_model="default/gpt-5",
         fast_model="default/gpt-5-mini",
-    ) == {
+    ).model_dump(mode="json") == {
         "default_model": "default/gpt-5",
         "fast_model": "default/gpt-5-mini",
+    }
+
+
+def test_update_config_sdk_body_omits_none_enabled() -> None:
+    assert _build_update_body(enabled=None).model_dump(mode="json", exclude_unset=True) == {}
+    assert _build_update_body(enabled=False).model_dump(mode="json", exclude_unset=True) == {"enabled": False}
+
+
+def test_update_run_status_sdk_body_omits_none_fields() -> None:
+    empty = _build_status_update_body(
+        status=None,
+        last_successful_run_at=None,
+        last_attempted_at=None,
+        last_completed_at=None,
+        last_submitted_job=None,
+        last_error=None,
+    )
+    partial = _build_status_update_body(
+        status=AnalysisConfigStatus.RUNNING,
+        last_successful_run_at=None,
+        last_attempted_at=None,
+        last_completed_at=None,
+        last_submitted_job="job-123",
+        last_error="",
+    )
+
+    assert empty.model_dump(mode="json", exclude_unset=True) == {}
+    assert partial.model_dump(mode="json", exclude_unset=True) == {
+        "status": "running",
+        "last_submitted_job": "job-123",
+        "last_error": "",
     }
 
 

--- a/plugins/nemo-insights/tests/test_analysis_runs.py
+++ b/plugins/nemo-insights/tests/test_analysis_runs.py
@@ -25,10 +25,14 @@ from nemo_insights_plugin.analysis_runs import (
 )
 from nemo_insights_plugin.entities import AnalysisRun
 from nemo_insights_plugin.schema import AnalysisRunPage
-from nemo_platform import APIConnectionError, APIStatusError, AsyncNeMoPlatform
+from nemo_platform import AsyncNeMoPlatform
+from nemo_platform_plugin.agents.client import AsyncAgentsClient
+from nemo_platform_plugin.agents.types import CreateExecuteJobRequest
+from nemo_platform_plugin.client.errors import NemoHTTPError, NemoTransportError, raise_for_status
 from nemo_platform_plugin.entities.base import ListResponse, PaginationInfo
 from nemo_platform_plugin.entity_client import NemoEntitiesClient, NemoEntityNotFoundError
 from nemo_platform_plugin.entity_naming import NAME_MAX_LENGTH, NAME_PATTERN
+from nemo_platform_plugin.models.client import AsyncModelsClient
 from pydantic import ValidationError
 
 DEFAULT_MODEL = "default/big"
@@ -87,12 +91,57 @@ class _StubModels:
         return object()
 
 
+class _TypedResponse:
+    def __init__(self, body: object) -> None:
+        self._body = body
+
+    def data(self) -> object:
+        return self._body
+
+
+class _TypedAgentsClient:
+    def __init__(self, jobs: _StubExecuteJobs) -> None:
+        self._jobs = jobs
+
+    async def create_execute_job(
+        self, *, body: CreateExecuteJobRequest, workspace: str | None = None
+    ) -> _TypedResponse:
+        assert workspace is not None
+        return _TypedResponse(await self._jobs.create(spec=body.spec, name=body.name, workspace=workspace))
+
+    async def get_execute_job(self, *, name: str, workspace: str | None = None) -> _TypedResponse:
+        assert workspace is not None
+        return _TypedResponse(await self._jobs.get(name, workspace=workspace))
+
+
+class _TypedModelsClient:
+    def __init__(self, models: _StubModels) -> None:
+        self._models = models
+
+    async def get_model(self, *, name: str, workspace: str | None = None) -> _TypedResponse:
+        assert workspace is not None
+        return _TypedResponse(await self._models.retrieve(name, workspace=workspace))
+
+
 class _StubSdk:
     """Minimal stand-in for the request-scoped ``AsyncNeMoPlatform``."""
 
     def __init__(self, jobs: _StubExecuteJobs, models: _StubModels | None = None) -> None:
+        self.jobs = jobs
         self.agents = type("_Agents", (), {"jobs": type("_Jobs", (), {"execute": jobs})()})()
         self.models = models or _StubModels()
+
+
+@pytest.fixture(autouse=True)
+def _patch_clients(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_client_from_platform(platform: _StubSdk, client_cls: type[object]) -> object:
+        if client_cls is AsyncAgentsClient:
+            return _TypedAgentsClient(platform.jobs)
+        if client_cls is AsyncModelsClient:
+            return _TypedModelsClient(platform.models)
+        raise AssertionError(f"unexpected client type: {client_cls!r}")
+
+    monkeypatch.setattr("nemo_insights_plugin.analysis_runs.client_from_platform", fake_client_from_platform)
 
 
 class _StubEntities:
@@ -147,10 +196,18 @@ def _raise(error: Exception) -> Any:
     return _fail
 
 
-def _api_status_error(status_code: int, body: Any) -> APIStatusError:
+def _nemo_http_error(status_code: int, body: Any) -> NemoHTTPError:
     request = httpx.Request("POST", "http://platform/apis/agents/v2/workspaces/default/jobs/execute")
     response = httpx.Response(status_code, json=body, request=request)
-    return APIStatusError("boom", response=response, body=body)
+    try:
+        raise_for_status(response)
+    except NemoHTTPError as exc:
+        return exc
+    raise AssertionError("expected raise_for_status to fail")
+
+
+def _transport_error(method: str, url: str) -> NemoTransportError:
+    return NemoTransportError(httpx.ConnectError("boom", request=httpx.Request(method, url)))
 
 
 def _run(**overrides: Any) -> AnalysisRun:
@@ -354,7 +411,7 @@ async def test_a_bare_model_name_is_looked_up_in_the_run_workspace() -> None:
 
 async def test_a_denied_model_lookup_keeps_the_status_the_store_returned() -> None:
     """A cross-workspace ref the caller cannot read is a 403, not a malformed request."""
-    denied = _api_status_error(403, {"detail": "no access to workspace-b"})
+    denied = _nemo_http_error(403, {"detail": "no access to workspace-b"})
     entities = _StubEntities()
 
     with pytest.raises(HTTPException) as excinfo:
@@ -372,7 +429,7 @@ async def test_a_denied_model_lookup_keeps_the_status_the_store_returned() -> No
 
 async def test_an_unreachable_models_service_is_not_reported_as_a_bad_request() -> None:
     """Nothing is recorded yet, so this is a 503 rather than a 422 blaming the caller."""
-    unreachable = APIConnectionError(request=httpx.Request("GET", "http://platform/models"))
+    unreachable = _transport_error("GET", "http://platform/models")
     entities = _StubEntities()
 
     with pytest.raises(HTTPException) as excinfo:
@@ -397,7 +454,7 @@ async def test_nothing_is_submitted_when_the_run_cannot_be_recorded() -> None:
 
 async def test_a_failed_submission_leaves_the_run_record_in_place() -> None:
     """Deleting it could orphan a job that a timed-out create actually landed."""
-    jobs = _StubExecuteJobs(error=_api_status_error(422, {"detail": "bad model ref"}))
+    jobs = _StubExecuteJobs(error=_nemo_http_error(422, {"detail": "bad model ref"}))
     entities = _StubEntities()
 
     with pytest.raises(HTTPException) as excinfo:
@@ -409,12 +466,12 @@ async def test_a_failed_submission_leaves_the_run_record_in_place() -> None:
 
 
 async def test_an_unreachable_jobs_service_leaves_a_findable_run_record() -> None:
-    """APIConnectionError is a sibling of APIStatusError, so it needs its own arm.
+    """Transport errors are siblings of HTTP status errors, so they need their own arm.
 
     This is the case a retry could plausibly fix, so the orphan has to be
     findable afterwards rather than vanishing into an unhandled 500.
     """
-    unreachable = APIConnectionError(request=httpx.Request("POST", "http://platform/jobs/execute"))
+    unreachable = _transport_error("POST", "http://platform/jobs/execute")
     jobs = _StubExecuteJobs(error=unreachable)
     entities = _StubEntities()
 
@@ -424,12 +481,13 @@ async def test_an_unreachable_jobs_service_leaves_a_findable_run_record() -> Non
     assert excinfo.value.status_code == 503
     assert len(entities.created) == 1
     # The caller cannot recover a run it was never told the name of.
+    assert isinstance(excinfo.value.detail, dict)
     assert excinfo.value.detail["run"] == entities.created[0].name
 
 
 async def test_a_failed_submission_falls_back_to_the_raw_error_body() -> None:
     """A body with no ``detail`` key is surfaced whole rather than dropped."""
-    jobs = _StubExecuteJobs(error=_api_status_error(500, {"message": "upstream exploded"}))
+    jobs = _StubExecuteJobs(error=_nemo_http_error(500, {"message": "upstream exploded"}))
     entities = _StubEntities()
 
     with pytest.raises(HTTPException) as excinfo:
@@ -457,7 +515,7 @@ async def test_get_joins_the_run_with_its_backing_job() -> None:
 
 async def test_a_run_whose_job_is_missing_reads_as_never_submitted() -> None:
     """This is the disambiguation: no job under the run's name means it never landed."""
-    jobs = _StubExecuteJobs(get_error=_api_status_error(404, {"detail": "not found"}))
+    jobs = _StubExecuteJobs(get_error=_nemo_http_error(404, {"detail": "not found"}))
     entities = _StubEntities(existing=_run())
 
     response = await get_analysis_run("default", RUN_NAME, _sdk(jobs), _entities(entities))
@@ -467,10 +525,10 @@ async def test_a_run_whose_job_is_missing_reads_as_never_submitted() -> None:
 
 
 async def test_a_non_404_job_lookup_failure_is_not_swallowed() -> None:
-    jobs = _StubExecuteJobs(get_error=_api_status_error(503, {"detail": "jobs down"}))
+    jobs = _StubExecuteJobs(get_error=_nemo_http_error(503, {"detail": "jobs down"}))
     entities = _StubEntities(existing=_run())
 
-    with pytest.raises(APIStatusError):
+    with pytest.raises(NemoHTTPError):
         await get_analysis_run("default", RUN_NAME, _sdk(jobs), _entities(entities))
 
 

--- a/plugins/nemo-insights/tests/test_client.py
+++ b/plugins/nemo-insights/tests/test_client.py
@@ -6,9 +6,9 @@ from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
-from nemo_insights_plugin.jobs.analyze import AnalyzeSpec
 from nemo_insights_plugin.platform_client import make_client
 from nemo_insights_plugin.sdk_resources.analysis_jobs import AsyncAnalysisJobsClient, CreateAnalysisJobRequest
+from nemo_insights_plugin.types import AnalyzeSpec
 from nemo_platform_ext.auth.helpers import NMPOIDCConfig
 
 REMOTE_URL = "https://nemo-platform.example.com"
@@ -51,6 +51,66 @@ def test_remote_auth_uses_local_oauth_context() -> None:
         client = make_client(REMOTE_URL)
 
     client_cls.assert_called_once_with(base_url=REMOTE_URL, config_path=config_path)
+    assert client is client_cls.return_value
+
+
+def test_remote_auth_rejects_http_before_credential_bootstrap() -> None:
+    config_path = MagicMock()
+    config_path.exists.return_value = True
+    base_url = "http://nemo-platform.example.com"
+
+    with (
+        patch("nemo_insights_plugin.platform_client.Config.get_default_config_path", return_value=config_path),
+        patch(
+            "nemo_insights_plugin.platform_client.discover_nmp_config",
+            return_value=NMPOIDCConfig(
+                auth_enabled=True,
+                client_id="nemo-cli",
+                token_endpoint="https://auth.example.com/token",
+            ),
+        ),
+        patch("nemo_insights_plugin.platform_client.AsyncNeMoPlatform") as client_cls,
+        pytest.raises(ValueError, match="non-HTTPS remote URL"),
+    ):
+        make_client(base_url)
+
+    client_cls.assert_not_called()
+
+
+def test_remote_discovery_failure_raises_controlled_error() -> None:
+    config_path = MagicMock()
+    config_path.exists.return_value = True
+
+    with (
+        patch("nemo_insights_plugin.platform_client.Config.get_default_config_path", return_value=config_path),
+        patch(
+            "nemo_insights_plugin.platform_client.discover_nmp_config",
+            side_effect=httpx.ConnectError("connection refused"),
+        ),
+        patch("nemo_insights_plugin.platform_client.AsyncNeMoPlatform") as client_cls,
+        pytest.raises(RuntimeError, match="could not discover NeMo Platform auth configuration"),
+    ):
+        make_client(REMOTE_URL)
+
+    client_cls.assert_not_called()
+
+
+def test_remote_no_auth_allows_http_without_credentials() -> None:
+    config_path = MagicMock()
+    config_path.exists.return_value = True
+    base_url = "http://nemo-platform.example.com"
+
+    with (
+        patch("nemo_insights_plugin.platform_client.Config.get_default_config_path", return_value=config_path),
+        patch(
+            "nemo_insights_plugin.platform_client.discover_nmp_config",
+            return_value=NMPOIDCConfig(auth_enabled=False),
+        ),
+        patch("nemo_insights_plugin.platform_client.AsyncNeMoPlatform") as client_cls,
+    ):
+        client = make_client(base_url)
+
+    client_cls.assert_called_once_with(base_url=base_url)
     assert client is client_cls.return_value
 
 

--- a/plugins/nemo-insights/tests/test_client.py
+++ b/plugins/nemo-insights/tests/test_client.py
@@ -6,8 +6,8 @@ from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
-from nemo_insights_plugin.client import make_client
 from nemo_insights_plugin.jobs.analyze import AnalyzeSpec
+from nemo_insights_plugin.platform_client import make_client
 from nemo_insights_plugin.sdk_resources.analysis_jobs import AsyncAnalysisJobsClient, CreateAnalysisJobRequest
 from nemo_platform_ext.auth.helpers import NMPOIDCConfig
 
@@ -19,12 +19,12 @@ def test_remote_no_auth_ignores_unrelated_local_oauth_context() -> None:
     config_path.exists.return_value = True
 
     with (
-        patch("nemo_insights_plugin.client.Config.get_default_config_path", return_value=config_path),
+        patch("nemo_insights_plugin.platform_client.Config.get_default_config_path", return_value=config_path),
         patch(
-            "nemo_insights_plugin.client.discover_nmp_config",
+            "nemo_insights_plugin.platform_client.discover_nmp_config",
             return_value=NMPOIDCConfig(auth_enabled=False),
         ),
-        patch("nemo_insights_plugin.client.AsyncNeMoPlatform") as client_cls,
+        patch("nemo_insights_plugin.platform_client.AsyncNeMoPlatform") as client_cls,
     ):
         client = make_client(REMOTE_URL)
 
@@ -37,16 +37,16 @@ def test_remote_auth_uses_local_oauth_context() -> None:
     config_path.exists.return_value = True
 
     with (
-        patch("nemo_insights_plugin.client.Config.get_default_config_path", return_value=config_path),
+        patch("nemo_insights_plugin.platform_client.Config.get_default_config_path", return_value=config_path),
         patch(
-            "nemo_insights_plugin.client.discover_nmp_config",
+            "nemo_insights_plugin.platform_client.discover_nmp_config",
             return_value=NMPOIDCConfig(
                 auth_enabled=True,
                 client_id="nemo-cli",
                 token_endpoint="https://auth.example.com/token",
             ),
         ),
-        patch("nemo_insights_plugin.client.AsyncNeMoPlatform") as client_cls,
+        patch("nemo_insights_plugin.platform_client.AsyncNeMoPlatform") as client_cls,
     ):
         client = make_client(REMOTE_URL)
 

--- a/plugins/nemo-insights/tests/test_client_imports.py
+++ b/plugins/nemo-insights/tests/test_client_imports.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib
+import sys
+
+
+def test_typed_client_import_does_not_load_analysis_runtime() -> None:
+    for module_name in [
+        "nemo_insights_plugin.client",
+        "nemo_insights_plugin.endpoints",
+        "nemo_insights_plugin.types",
+        "nemo_insights_plugin.jobs.analyze",
+        "nemo_insights_plugin.analyst.run",
+    ]:
+        sys.modules.pop(module_name, None)
+
+    importlib.import_module("nemo_insights_plugin.client")
+
+    assert "nemo_insights_plugin.jobs.analyze" not in sys.modules
+    assert "nemo_insights_plugin.analyst.run" not in sys.modules

--- a/plugins/nemo-insights/tests/test_client_imports.py
+++ b/plugins/nemo-insights/tests/test_client_imports.py
@@ -4,8 +4,10 @@
 import importlib
 import sys
 
+import pytest
 
-def test_typed_client_import_does_not_load_analysis_runtime() -> None:
+
+def test_typed_client_import_does_not_load_analysis_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
     for module_name in [
         "nemo_insights_plugin.client",
         "nemo_insights_plugin.endpoints",
@@ -13,7 +15,7 @@ def test_typed_client_import_does_not_load_analysis_runtime() -> None:
         "nemo_insights_plugin.jobs.analyze",
         "nemo_insights_plugin.analyst.run",
     ]:
-        sys.modules.pop(module_name, None)
+        monkeypatch.delitem(sys.modules, module_name, raising=False)
 
     importlib.import_module("nemo_insights_plugin.client")
 

--- a/plugins/nemo-insights/tests/test_periodic_analysis.py
+++ b/plugins/nemo-insights/tests/test_periodic_analysis.py
@@ -46,14 +46,12 @@ from nemo_insights_plugin.sdk_resources.analysis_jobs import (
     CreateAnalysisJobRequest,
     ListAnalysisJobsQueryParams,
 )
-from nemo_platform import AsyncNeMoPlatform, NeMoPlatform, Omit
-from nemo_platform.pagination import AsyncDefaultPagination, DefaultPaginationPagination
-from nemo_platform.types.intake.span_filter_param import SpanFilterParam
-from nemo_platform.types.intake.spans.span_group import SpanGroup
-from nemo_platform.types.intake.spans.span_group_sort_field import SpanGroupSortField
+from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
 from nemo_platform_plugin.client.adapter import client_from_platform
 from nemo_platform_plugin.entities.client import AsyncEntitiesClient
 from nemo_platform_plugin.entity_client import NemoEntitiesClient, NemoEntityNotFoundError
+from nemo_platform_plugin.intake.client import AsyncIntakeClient
+from nemo_platform_plugin.intake.types import SpanFilterParam, SpanGroup, SpanGroupsPage
 from nemo_platform_plugin.job_context import JobContext, StoragePaths
 from nemo_platform_plugin.job_results import JobResults, ResultRef
 from nemo_platform_plugin.jobs.constants import (
@@ -62,7 +60,8 @@ from nemo_platform_plugin.jobs.constants import (
 )
 from nemo_platform_plugin.jobs.schemas import PlatformJobStatus
 from nemo_platform_plugin.nooa_model_client import ConfiguredModelRefs
-from pydantic import ValidationError
+from nemo_platform_plugin.schema import PaginationData
+from pydantic import JsonValue, ValidationError
 
 _BASE_URL = "https://example.com"
 _T = TypeVar("_T")
@@ -422,10 +421,10 @@ def test_merge_eval_filter_overwrites_model_supplied_scope() -> None:
 class _SpanGroupsCall:
     workspace: str | None
     by: str
-    filter: SpanFilterParam | Omit
-    page: int | Omit
-    page_size: int | Omit
-    sort: SpanGroupSortField | Omit
+    filter: SpanFilterParam | dict[str, JsonValue] | None
+    page: int | None
+    page_size: int | None
+    sort: str | None
 
 
 class _SpanGroups:
@@ -439,11 +438,11 @@ class _SpanGroups:
         *,
         workspace: str | None = None,
         by: str,
-        filter: SpanFilterParam | Omit,
-        page: int | Omit,
-        page_size: int | Omit,
-        sort: SpanGroupSortField | Omit,
-    ) -> AsyncDefaultPagination[SpanGroup]:
+        filter: SpanFilterParam | dict[str, JsonValue] | None,
+        page: int | None,
+        page_size: int | None,
+        sort: str | None,
+    ) -> SpanGroupsPage:
         self.calls.append(
             _SpanGroupsCall(
                 workspace=workspace,
@@ -454,11 +453,13 @@ class _SpanGroups:
                 sort=sort,
             )
         )
-        size = page_size if isinstance(page_size, int) else len(self.data)
-        return AsyncDefaultPagination[SpanGroup](
+        current_page = page or 1
+        size = page_size or len(self.data)
+        return SpanGroupsPage(
             data=self.data,
-            pagination=DefaultPaginationPagination(
-                page=1,
+            grouped_by=[by],
+            pagination=PaginationData(
+                page=current_page,
                 page_size=size,
                 current_page_size=len(self.data),
                 total_pages=1,
@@ -467,13 +468,33 @@ class _SpanGroups:
         )
 
 
+class _SpansWithGroups:
+    def __init__(self, groups: _SpanGroups) -> None:
+        self.groups = groups
+
+
+class _IntakeWithGroups:
+    def __init__(self, groups: _SpanGroups) -> None:
+        self.spans = _SpansWithGroups(groups)
+
+
+def _patch_intake_groups(monkeypatch: pytest.MonkeyPatch, groups: _SpanGroups) -> None:
+    def fake_client_from_platform(platform: AsyncNeMoPlatform, client_cls: type[object]) -> object:
+        del platform
+        if client_cls is AsyncIntakeClient:
+            return _IntakeWithGroups(groups)
+        raise AssertionError(f"unexpected client type: {client_cls!r}")
+
+    monkeypatch.setattr("nemo_insights_plugin.analyst.analyst_backend.client_from_platform", fake_client_from_platform)
+
+
 @pytest.mark.asyncio
 async def test_count_agent_sessions_uses_server_side_session_groups(monkeypatch: pytest.MonkeyPatch) -> None:
     since = datetime(2026, 6, 4, 12, tzinfo=timezone.utc)
     groups = _SpanGroups(data=[SpanGroup(group={"session_id": "session-1"}, span_count=3, started_at=_STAMP)], total=7)
 
     async with _async_platform() as client:
-        monkeypatch.setattr(client.intake.spans.groups, "list", groups.list)
+        _patch_intake_groups(monkeypatch, groups)
         backend = RemoteAnalystBackend(client)
         count = await backend.count_agent_sessions(
             agent="research-agent",
@@ -509,7 +530,7 @@ async def test_list_span_groups_fans_out_over_sessions(monkeypatch: pytest.Monke
     )
 
     async with _async_platform() as client:
-        monkeypatch.setattr(client.intake.spans.groups, "list", groups.list)
+        _patch_intake_groups(monkeypatch, groups)
         backend = RemoteAnalystBackend(client)
         result = await backend.list_span_groups(
             workspace="default",
@@ -550,7 +571,7 @@ async def test_count_agent_sessions_pins_evaluation_id(monkeypatch: pytest.Monke
     groups = _SpanGroups(data=[SpanGroup(group={"session_id": "session-1"}, span_count=3, started_at=_STAMP)], total=7)
 
     async with _async_platform() as client:
-        monkeypatch.setattr(client.intake.spans.groups, "list", groups.list)
+        _patch_intake_groups(monkeypatch, groups)
         backend = RemoteAnalystBackend(client)
         await backend.count_agent_sessions(
             agent="research-agent",
@@ -578,7 +599,7 @@ async def test_list_span_groups_pins_evaluation_id(monkeypatch: pytest.MonkeyPat
     )
 
     async with _async_platform() as client:
-        monkeypatch.setattr(client.intake.spans.groups, "list", groups.list)
+        _patch_intake_groups(monkeypatch, groups)
         backend = RemoteAnalystBackend(client)
         await backend.list_span_groups(
             workspace="default",

--- a/plugins/nemo-insights/tests/test_sdk_analysis_runs.py
+++ b/plugins/nemo-insights/tests/test_sdk_analysis_runs.py
@@ -6,16 +6,17 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Any, cast
+from typing import Any
 
 import pytest
+from nemo_insights_plugin.schema import CreateAnalysisRunRequest
 from nemo_insights_plugin.sdk_resources.analysis_runs import (
     AnalysisRunNotSubmittedError,
     AnalysisRunTimeoutError,
     _AnalysisRunResource,
     _AsyncAnalysisRunResource,
-    _ResourceParent,
 )
+from nemo_insights_plugin.types import ListAnalysisRunsQueryParams
 
 RUN_NAME = "insights-run-0123456789abcdef0123456789abcdef"
 DEFAULT_MODEL = "default/big"
@@ -41,72 +42,109 @@ def _response_body(status: str | None = "created", **run_overrides: Any) -> dict
     return {"run": _run_body(**run_overrides), "job": job}
 
 
-class _StubResponse:
+class _StubHTTPResponse:
     def __init__(self, payload: dict[str, Any]) -> None:
         self._payload = payload
-
-    def raise_for_status(self) -> None:
-        """Every stubbed response is a success; failures are exercised elsewhere."""
 
     def json(self) -> dict[str, Any]:
         return self._payload
 
 
-class _StubHttpClient:
-    """Records requests and replays a queued sequence of response bodies.
+class _StubTypedResponse:
+    def __init__(self, payload: dict[str, Any], *, page_error: Exception | None = None) -> None:
+        self.http_response = _StubHTTPResponse(payload)
+        self._page_error = page_error
+
+    def page(self) -> object:
+        if self._page_error is not None:
+            raise self._page_error
+        return None
+
+
+class _StubInsightsClient:
+    """Records typed client calls and replays a queued sequence of response bodies.
 
     The last body repeats, so a polling test only has to queue the states it
     cares about.
     """
 
-    def __init__(self, *bodies: dict[str, Any]) -> None:
+    def __init__(self, *bodies: dict[str, Any], page_error: Exception | None = None) -> None:
         self.calls: list[dict[str, Any]] = []
         self._bodies = list(bodies) or [_response_body()]
+        self._page_error = page_error
 
-    def _next(self) -> _StubResponse:
+    def _next(self) -> _StubTypedResponse:
         body = self._bodies[0] if len(self._bodies) == 1 else self._bodies.pop(0)
-        return _StubResponse(body)
+        return _StubTypedResponse(body, page_error=self._page_error)
 
-    def post(self, url: str, json: dict[str, Any] | None = None) -> _StubResponse:
-        self.calls.append({"method": "POST", "url": url, "json": json})
+    def create_analysis_run(self, *, workspace: str, body: CreateAnalysisRunRequest) -> _StubTypedResponse:
+        self.calls.append(
+            {
+                "method": "POST",
+                "url": f"http://platform/apis/insights/v2/workspaces/{workspace}/analysis-runs",
+                "json": body.model_dump(mode="json", exclude_unset=True),
+            }
+        )
         return self._next()
 
-    def get(self, url: str, params: dict[str, Any] | None = None) -> _StubResponse:
-        self.calls.append({"method": "GET", "url": url, "params": params})
+    def list_analysis_runs(self, *, workspace: str, query_params: ListAnalysisRunsQueryParams) -> _StubTypedResponse:
+        self.calls.append(
+            {
+                "method": "GET",
+                "url": f"http://platform/apis/insights/v2/workspaces/{workspace}/analysis-runs",
+                "params": query_params,
+            }
+        )
+        return self._next()
+
+    def get_analysis_run(self, *, workspace: str, name: str) -> _StubTypedResponse:
+        self.calls.append(
+            {
+                "method": "GET",
+                "url": f"http://platform/apis/insights/v2/workspaces/{workspace}/analysis-runs/{name}",
+            }
+        )
         return self._next()
 
 
-class _AsyncStubHttpClient:
-    """Async mirror of :class:`_StubHttpClient`, delegating to one for recording."""
+class _AsyncStubInsightsClient:
+    """Async mirror of :class:`_StubInsightsClient`, delegating to one for recording."""
 
     def __init__(self, *bodies: dict[str, Any]) -> None:
-        self._sync = _StubHttpClient(*bodies)
+        self._sync = _StubInsightsClient(*bodies)
 
     @property
     def calls(self) -> list[dict[str, Any]]:
         return self._sync.calls
 
-    async def post(self, url: str, json: dict[str, Any] | None = None) -> _StubResponse:
-        return self._sync.post(url, json)
+    async def create_analysis_run(self, *, workspace: str, body: CreateAnalysisRunRequest) -> _StubTypedResponse:
+        return self._sync.create_analysis_run(workspace=workspace, body=body)
 
-    async def get(self, url: str, params: dict[str, Any] | None = None) -> _StubResponse:
-        return self._sync.get(url, params)
+    async def list_analysis_runs(
+        self, *, workspace: str, query_params: ListAnalysisRunsQueryParams
+    ) -> _StubTypedResponse:
+        return self._sync.list_analysis_runs(workspace=workspace, query_params=query_params)
+
+    async def get_analysis_run(self, *, workspace: str, name: str) -> _StubTypedResponse:
+        return self._sync.get_analysis_run(workspace=workspace, name=name)
 
 
 class _StubParent:
-    def __init__(self, http_client: _StubHttpClient) -> None:
-        self._http_client = http_client
-
-    def _url(self, path: str) -> str:
-        return f"http://platform/apis/insights{path}"
+    def __init__(self, client: _StubInsightsClient) -> None:
+        self._client = client
 
 
-def _resource(http_client: _StubHttpClient) -> _AnalysisRunResource:
-    return _AnalysisRunResource(cast(_ResourceParent, _StubParent(http_client)))
+class _AsyncStubParent:
+    def __init__(self, client: _AsyncStubInsightsClient) -> None:
+        self._client = client
 
 
-def _async_resource(http_client: _AsyncStubHttpClient) -> _AsyncAnalysisRunResource:
-    return _AsyncAnalysisRunResource(cast(_ResourceParent, _StubParent(cast(_StubHttpClient, http_client))))
+def _resource(client: _StubInsightsClient) -> _AnalysisRunResource:
+    return _AnalysisRunResource(_StubParent(client))
+
+
+def _async_resource(client: _AsyncStubInsightsClient) -> _AsyncAnalysisRunResource:
+    return _AsyncAnalysisRunResource(_AsyncStubParent(client))
 
 
 # ---------------------------------------------------------------------------
@@ -115,7 +153,7 @@ def _async_resource(http_client: _AsyncStubHttpClient) -> _AsyncAnalysisRunResou
 
 
 def test_create_posts_the_request_to_the_analysis_runs_route() -> None:
-    http = _StubHttpClient()
+    http = _StubInsightsClient()
 
     _resource(http).create(
         workspace="team-a",
@@ -134,7 +172,7 @@ def test_create_posts_the_request_to_the_analysis_runs_route() -> None:
 
 def test_create_sends_optional_read_scope_when_given() -> None:
     """Unset optionals stay off the wire so the server's defaults apply."""
-    http = _StubHttpClient()
+    http = _StubInsightsClient()
 
     _resource(http).create(
         workspace="default",
@@ -158,7 +196,7 @@ def test_create_sends_optional_read_scope_when_given() -> None:
 
 def test_create_sends_the_ethos_inline() -> None:
     """The Fabric adapter has no Files access, so the Markdown travels in the body."""
-    http = _StubHttpClient()
+    http = _StubInsightsClient()
 
     _resource(http).create(
         workspace="default",
@@ -172,7 +210,7 @@ def test_create_sends_the_ethos_inline() -> None:
 
 
 def test_create_omits_the_ethos_when_unset() -> None:
-    http = _StubHttpClient()
+    http = _StubInsightsClient()
 
     _resource(http).create(workspace="default", agent="demo-agent", default_model=DEFAULT_MODEL, fast_model=FAST_MODEL)
 
@@ -180,7 +218,7 @@ def test_create_omits_the_ethos_when_unset() -> None:
 
 
 async def test_async_create_sends_the_ethos_inline() -> None:
-    http = _AsyncStubHttpClient()
+    http = _AsyncStubInsightsClient()
 
     await _async_resource(http).create(
         workspace="default",
@@ -194,7 +232,7 @@ async def test_async_create_sends_the_ethos_inline() -> None:
 
 
 def test_create_returns_the_run_with_its_store_assigned_id() -> None:
-    response = _resource(_StubHttpClient()).create(
+    response = _resource(_StubInsightsClient()).create(
         workspace="default",
         agent="demo-agent",
         default_model=DEFAULT_MODEL,
@@ -212,7 +250,7 @@ def test_create_returns_the_run_with_its_store_assigned_id() -> None:
 
 
 def test_list_runs_omits_the_agent_filter_when_not_given() -> None:
-    http = _StubHttpClient({"data": [], "pagination": None, "sort": "-created_at", "filter": None})
+    http = _StubInsightsClient({"data": [], "pagination": None, "sort": "-created_at", "filter": None})
 
     _resource(http).list_runs(workspace="default")
 
@@ -220,7 +258,7 @@ def test_list_runs_omits_the_agent_filter_when_not_given() -> None:
 
 
 def test_list_runs_filters_by_agent_and_hydrates_items() -> None:
-    http = _StubHttpClient(
+    http = _StubInsightsClient(
         {
             "data": [_run_body()],
             "pagination": {
@@ -241,8 +279,18 @@ def test_list_runs_filters_by_agent_and_hydrates_items() -> None:
     assert page.data[0].id == "entity-123"
 
 
+def test_list_runs_uses_paginated_response_status_handling() -> None:
+    http = _StubInsightsClient(
+        {"detail": "permission denied"},
+        page_error=RuntimeError("paginated status error"),
+    )
+
+    with pytest.raises(RuntimeError, match="paginated status error"):
+        _resource(http).list_runs(workspace="default")
+
+
 def test_get_reads_one_run_joined_with_its_job() -> None:
-    http = _StubHttpClient(_response_body(status="active"))
+    http = _StubInsightsClient(_response_body(status="active"))
 
     response = _resource(http).get(workspace="default", name=RUN_NAME)
 
@@ -253,7 +301,7 @@ def test_get_reads_one_run_joined_with_its_job() -> None:
 
 def test_a_run_with_no_job_has_no_status_and_is_not_terminal() -> None:
     """A missing job means submission never landed — not that the run finished."""
-    response = _resource(_StubHttpClient(_response_body(status=None))).get(workspace="default", name=RUN_NAME)
+    response = _resource(_StubInsightsClient(_response_body(status=None))).get(workspace="default", name=RUN_NAME)
 
     assert response.job is None
     assert response.job_status is None
@@ -265,7 +313,7 @@ def test_a_run_with_no_job_has_no_status_and_is_not_terminal() -> None:
     [("completed", True), ("error", True), ("cancelled", True), ("pending", False), ("active", False)],
 )
 def test_job_terminality_follows_the_platform_job_states(status: str, terminal: bool) -> None:
-    response = _resource(_StubHttpClient(_response_body(status=status))).get(workspace="default", name=RUN_NAME)
+    response = _resource(_StubInsightsClient(_response_body(status=status))).get(workspace="default", name=RUN_NAME)
 
     assert response.job_is_terminal is terminal
 
@@ -276,7 +324,7 @@ def test_job_terminality_follows_the_platform_job_states(status: str, terminal: 
 
 
 def test_wait_polls_until_the_job_is_terminal() -> None:
-    http = _StubHttpClient(
+    http = _StubInsightsClient(
         _response_body(status="created"),
         _response_body(status="active"),
         _response_body(status="completed"),
@@ -297,7 +345,7 @@ def test_wait_polls_until_the_job_is_terminal() -> None:
 
 def test_wait_returns_a_failed_job_rather_than_raising() -> None:
     """A job that ran and failed is an answer; the caller decides what it means."""
-    response = _resource(_StubHttpClient(_response_body(status="error"))).wait(
+    response = _resource(_StubInsightsClient(_response_body(status="error"))).wait(
         workspace="default", name=RUN_NAME, poll_interval=0
     )
 
@@ -307,7 +355,7 @@ def test_wait_returns_a_failed_job_rather_than_raising() -> None:
 
 def test_wait_refuses_to_poll_a_run_that_was_never_submitted() -> None:
     """Its job will never appear, so polling would only burn the timeout."""
-    http = _StubHttpClient(_response_body(status=None))
+    http = _StubInsightsClient(_response_body(status=None))
 
     with pytest.raises(AnalysisRunNotSubmittedError) as excinfo:
         _resource(http).wait(workspace="default", name=RUN_NAME, poll_interval=0)
@@ -317,7 +365,7 @@ def test_wait_refuses_to_poll_a_run_that_was_never_submitted() -> None:
 
 
 def test_wait_times_out_with_the_last_status_it_saw() -> None:
-    http = _StubHttpClient(_response_body(status="active"))
+    http = _StubInsightsClient(_response_body(status="active"))
 
     with pytest.raises(AnalysisRunTimeoutError) as excinfo:
         _resource(http).wait(workspace="default", name=RUN_NAME, timeout=0, poll_interval=0)
@@ -331,7 +379,7 @@ def test_wait_times_out_with_the_last_status_it_saw() -> None:
 
 
 async def test_async_create_matches_the_sync_request() -> None:
-    http = _AsyncStubHttpClient()
+    http = _AsyncStubInsightsClient()
 
     response = await _async_resource(http).create(
         workspace="team-a",
@@ -345,7 +393,7 @@ async def test_async_create_matches_the_sync_request() -> None:
 
 
 async def test_async_wait_polls_until_terminal() -> None:
-    http = _AsyncStubHttpClient(
+    http = _AsyncStubInsightsClient(
         _response_body(status="active"),
         _response_body(status="completed"),
     )
@@ -357,7 +405,7 @@ async def test_async_wait_polls_until_terminal() -> None:
 
 
 async def test_async_get_reads_one_run() -> None:
-    http = _AsyncStubHttpClient(_response_body(status="active"))
+    http = _AsyncStubInsightsClient(_response_body(status="active"))
 
     response = await _async_resource(http).get(workspace="default", name=RUN_NAME)
 

--- a/plugins/nemo-insights/tests/test_sdk_insights.py
+++ b/plugins/nemo-insights/tests/test_sdk_insights.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The ``client.insights.insights`` SDK sub-resource."""
+
+from nemo_insights_plugin.entities import InsightStatus
+from nemo_insights_plugin.sdk_resources.insights import _build_update_body
+
+
+def test_update_insight_sdk_body_omits_none_fields() -> None:
+    empty = _build_update_body(agent=None, description=None, status=None, trace_refs=None)
+    partial = _build_update_body(
+        agent=None,
+        description="Updated description",
+        status=InsightStatus.RESOLVED,
+        trace_refs=[],
+    )
+
+    assert empty.model_dump(mode="json", exclude_unset=True) == {}
+    assert partial.model_dump(mode="json", exclude_unset=True) == {
+        "description": "Updated description",
+        "status": "resolved",
+        "trace_refs": [],
+    }


### PR DESCRIPTION
## TL;DR

Migrate the `nemo-insights` plugin off Stainless-backed SDK calls and onto the repository-owned typed client infrastructure, while preserving the existing high-level Insights SDK resource shape and analysis workflows.

## What Changed

This PR adds an owned typed HTTP client surface for the Insights plugin: endpoint declarations, request/response DTOs, and sync/async client classes for insights, analysis configs, analysis run statuses, analysis runs, and analysis jobs. The existing `client.insights` SDK resources now use those typed clients internally instead of relying on Stainless-generated resource calls.

It also fills the platform typed-client gaps that Insights needs:

- Agents typed clients now cover `agents.execute` job creation, reads, and result listing.
- Intake typed clients now cover spans, span groups, annotations, and evaluator results used by the Analyst backend.
- Insights CLI, preflight, evaluation adapters, periodic analysis, and examples now construct platform SDK clients through `platform_client.py`, which keeps local loopback direct mode separate from authenticated remote platform contexts.
- Mounted Insights SDK resources preserve their historical `httpx.HTTPStatusError` behavior while direct typed-client callers continue to receive typed-client errors.

## Reviewer Notes

The intended behavior is an internal client migration, not a user-facing change. On-demand and periodic Insights analysis should continue to expose the same workflows, but the implementation now adapts from `NeMoPlatform` / `AsyncNeMoPlatform` to typed clients at service boundaries.

The most important review areas are:

- Authentication behavior in `nemo_insights_plugin.platform_client`, especially loopback versus remote auth-enabled URLs.
- Paginated SDK wrappers, which intentionally load the typed paginated response before parsing raw response JSON for entity hydration.
- SDK resource error compatibility, where mounted `NeMoPlatform.insights` resources retain the raw-httpx error contract expected by existing integrations.
- PATCH/update helpers, which omit unset fields so optional values are not accidentally serialized as `null`.
- Compatibility aliases for analysis jobs, which keep existing controller call sites working while routing through the unified Insights typed client.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for creating, retrieving, and listing results from agent execution jobs.
  * Added APIs for viewing and filtering spans, span groups, annotations, and evaluator results.
  * Added typed Insights API support for insights, analysis configurations, runs, statuses, and jobs.
  * Added shared analysis configuration and job models.

* **Bug Fixes**
  * Improved handling of HTTP, transport, and not-found errors.
  * Preserved explicit false, empty, and null values in updates.

* **Documentation**
  * Clarified client authentication and connection behavior for local and remote deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->