### PR TITLE
refactor(experimentalist): migrate to typed platform clients

### DIFF
--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -7331,13 +7331,13 @@ nemo agents experimentalist [OPTIONS] COMMAND [ARGS]...
 
 **Commands:**
 
-* `run`: Run offline optimization for a baseline agent (local dir...
+* `run`: Run local optimization for a baseline agent (local dir or...
 * `components`: List the components this install can resolve by name.
 * `doctor`: Diagnose Experimentalist setup: profile, artifacts,...
 
 ##### nemo agents experimentalist run
 
-Run offline optimization for a baseline agent (local dir or git source).
+Run local optimization for a baseline agent (local dir or git source).
 
 **Usage:**
 

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/client/client.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/client/client.py
@@ -730,6 +730,12 @@ class NemoClient(BaseNemoClient[httpx.Client]):
         if self._owns_http:
             self._http.close()
 
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        self.close()
+
     @overload
     def send(
         self,
@@ -991,6 +997,21 @@ class AsyncNemoClient(BaseNemoClient[httpx.AsyncClient]):
             url_resolver=client._url_resolver,
         )
 
+    async def close(self) -> None:
+        """Close the underlying async HTTP transport."""
+        if self._owns_http:
+            await self._http.aclose()
+
+    async def aclose(self) -> None:
+        """Alias for compatibility with httpx-style async resources."""
+        await self.close()
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        await self.close()
+
     def with_http_client(self, http_client: httpx.AsyncClient) -> Self:
         """Return a copy of this client using a different async transport."""
         transport_owner = AsyncNemoClient(
@@ -1005,11 +1026,6 @@ class AsyncNemoClient(BaseNemoClient[httpx.AsyncClient]):
             url_resolver=self._url_resolver,
         )
         return type(self).from_client(transport_owner)
-
-    async def aclose(self) -> None:
-        """Close the underlying async HTTP transport."""
-        if self._owns_http:
-            await self._http.aclose()
 
     @overload
     async def send(

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/client/config/config.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/client/config/config.py
@@ -332,6 +332,7 @@ class Config(BaseModel):
             effective_workspace = DEFAULT_WORKSPACE
 
         effective_default_model = os.environ.get("NEMO_DEFAULT_MODEL") or context.default_model
+        effective_fast_model = os.environ.get("NEMO_FAST_MODEL") or context.fast_model or effective_default_model
 
         return Context(
             context_name=context_name,
@@ -339,6 +340,7 @@ class Config(BaseModel):
             user=user,
             workspace=effective_workspace,
             default_model=effective_default_model,
+            fast_model=effective_fast_model,
             preferences=prefs,
         )
 
@@ -371,12 +373,16 @@ class Config(BaseModel):
         if self.color_output is not None:
             prefs.color_output = self.color_output
 
+        effective_default_model = os.environ.get("NEMO_DEFAULT_MODEL") or context_def.default_model
+        effective_fast_model = os.environ.get("NEMO_FAST_MODEL") or context_def.fast_model or effective_default_model
+
         return Context(
             context_name=context_name,
             cluster=cluster,
             user=user,
             workspace=context_def.workspace or DEFAULT_WORKSPACE,
-            default_model=os.environ.get("NEMO_DEFAULT_MODEL") or context_def.default_model,
+            default_model=effective_default_model,
+            fast_model=effective_fast_model,
             preferences=prefs,
         )
 

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/client/config/models.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/client/config/models.py
@@ -140,6 +140,7 @@ class ContextDefinition(BaseModel):
     user: str = Field(..., min_length=1, description="Reference to user name")
     workspace: str | None = Field(default=None, description="Default workspace")
     default_model: str | None = Field(default=None, description="Default model entity ID for inference")
+    fast_model: str | None = Field(default=None, description="Low-latency model entity ID for agent workloads")
     preferences: Preferences = Field(default_factory=Preferences, description="Context-specific preferences")
     metadata: dict[str, Any] = Field(default_factory=dict, description="Additional context metadata")
 
@@ -160,6 +161,7 @@ class ConfigParams(TypedDict, total=False):
     refresh_token: str | None
     workspace: str
     default_model: str
+    fast_model: str
     output_format: OutputFormat
     timestamp_format: TimestampFormat
     truncate: bool
@@ -204,7 +206,7 @@ class ConfigFile(BaseModel):
             cluster.base_url = HttpUrl(params["base_url"])
 
         # Find existing or create user
-        user: User = next((u for u in self.users if u.name == user_name), None)  # type: ignore[assignment]
+        user = next((u for u in self.users if u.name == user_name), None)
         access_token_provided = "access_token" in params
         refresh_token_provided = "refresh_token" in params
         access_token = params.get("access_token")
@@ -257,6 +259,8 @@ class ConfigFile(BaseModel):
             context.workspace = params["workspace"]
         if "default_model" in params:
             context.default_model = params["default_model"]
+        if "fast_model" in params:
+            context.fast_model = params["fast_model"]
         if "output_format" in params:
             context.preferences.output_format = params["output_format"]
         if "timestamp_format" in params:
@@ -314,4 +318,5 @@ class Context(BaseModel):
     user: User | None = Field(default=None, description="Resolved user with authentication credentials")
     workspace: str = Field(..., description="Active workspace")
     default_model: str | None = Field(default=None, description="Default model entity ID for inference")
+    fast_model: str | None = Field(default=None, description="Low-latency model entity ID for agent workloads")
     preferences: Preferences = Field(..., description="Effective preferences")

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/intake/client.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/intake/client.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Typed HTTP clients for the Intake APIs used by evaluator and Insights."""
+"""Typed HTTP clients for the Intake APIs used by evaluator, Experimentalist, and Insights."""
 
 from __future__ import annotations
 
@@ -19,9 +19,11 @@ from nemo_platform_plugin.intake.types import (
     ListSpanGroupsQueryParams,
     ListSpansQueryParams,
     Span,
+    SpanGroup,
     SpanGroupsPage,
     SpanMode,
 )
+from nemo_platform_plugin.schema import PaginationData
 from pydantic import JsonValue
 
 FilterQueryParam = dict[str, JsonValue]
@@ -32,13 +34,19 @@ class _IntakeMethods:
     create_atif = method(endpoints.create_atif)
     create_otlp_traces = method(endpoints.create_otlp_traces)
     list_traces = method(endpoints.list_traces)
+    get_trace = method(endpoints.get_trace)
+    list_spans = method(endpoints.list_spans)
+    list_span_groups = method(endpoints.list_span_groups)
+    create_experiment = method(endpoints.create_experiment)
+    get_experiment = method(endpoints.get_experiment)
+    update_experiment = method(endpoints.update_experiment)
+    create_evaluation = method(endpoints.create_evaluation)
     create_evaluator_result = method(endpoints.create_evaluator_result)
     get_evaluation = method(endpoints.get_evaluation)
+    update_evaluation = method(endpoints.update_evaluation)
     patch_evaluation = method(endpoints.patch_evaluation)
     list_evaluator_results = method(endpoints.list_evaluator_results)
     list_evaluator_results_for_span = method(endpoints.list_evaluator_results_for_span)
-    list_spans = method(endpoints.list_spans)
-    list_span_groups = method(endpoints.list_span_groups)
     get_span = method(endpoints.get_span)
     list_annotations = method(endpoints.list_annotations)
     get_annotation = method(endpoints.get_annotation)
@@ -103,6 +111,27 @@ def _list_annotations_params(
     if filter is not None:
         params["filter"] = filter
     return params or None
+
+
+def _grouped_by_fields(by: str) -> list[str]:
+    return [field.strip() for field in by.split(",") if field.strip()]
+
+
+def _span_groups_page(
+    *,
+    items: list[SpanGroup],
+    metadata: object,
+    by: str,
+    sort: str | None,
+    filter: FilterQueryParam | None,
+) -> SpanGroupsPage:
+    return SpanGroupsPage(
+        data=items,
+        grouped_by=_grouped_by_fields(by),
+        pagination=PaginationData.model_validate(metadata),
+        sort=sort,
+        filter=filter,
+    )
 
 
 class _SpansCompat:
@@ -181,10 +210,14 @@ class _SpanGroupsCompat:
         sort: str | None = None,
         filter: FilterQueryParam | None = None,
     ) -> SpanGroupsPage:
-        return self._client.list_span_groups(
+        response = self._client.list_span_groups(
             workspace=workspace,
             query_params=_list_span_groups_params(by=by, page=page, page_size=page_size, sort=sort, filter=filter),
-        ).data()
+        )
+        page_result = response.page()
+        return _span_groups_page(
+            items=page_result.items, metadata=page_result.metadata, by=by, sort=sort, filter=filter
+        )
 
 
 class _AsyncSpanGroupsCompat:
@@ -201,12 +234,14 @@ class _AsyncSpanGroupsCompat:
         sort: str | None = None,
         filter: FilterQueryParam | None = None,
     ) -> SpanGroupsPage:
-        return (
-            await self._client.list_span_groups(
-                workspace=workspace,
-                query_params=_list_span_groups_params(by=by, page=page, page_size=page_size, sort=sort, filter=filter),
-            )
-        ).data()
+        response = await self._client.list_span_groups(
+            workspace=workspace,
+            query_params=_list_span_groups_params(by=by, page=page, page_size=page_size, sort=sort, filter=filter),
+        )
+        page_result = response.page()
+        return _span_groups_page(
+            items=page_result.items, metadata=page_result.metadata, by=by, sort=sort, filter=filter
+        )
 
 
 class _SpanEvaluatorResultsCompat:
@@ -270,7 +305,7 @@ class _AsyncAnnotationsCompat:
 
 
 class IntakeClient(_IntakeMethods, NemoClient):
-    """Sync client for the Intake API subset evaluator uses."""
+    """Sync client for the Intake API subset evaluator, Experimentalist, and Insights use."""
 
     @cached_property
     def spans(self) -> _SpansCompat:
@@ -282,7 +317,7 @@ class IntakeClient(_IntakeMethods, NemoClient):
 
 
 class AsyncIntakeClient(_IntakeMethods, AsyncNemoClient):
-    """Async client for the Intake API subset evaluator uses."""
+    """Async client for the Intake API subset evaluator, Experimentalist, and Insights use."""
 
     @cached_property
     def spans(self) -> _AsyncSpansCompat:

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/intake/endpoints.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/intake/endpoints.py
@@ -1,30 +1,35 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Typed endpoint definitions for the Intake APIs used by evaluator."""
+"""Typed endpoint definitions for the Intake APIs used by evaluator and Experimentalist."""
 
 from __future__ import annotations
 
 from abc import abstractmethod
 from collections.abc import AsyncIterable, Iterable
 
-from nemo_platform_plugin.client.endpoint import get, patch, post
+from nemo_platform_plugin.client.endpoint import get, patch, post, put
 from nemo_platform_plugin.client.types import Paginated, PreparedRequest
 from nemo_platform_plugin.intake.types import (
     Annotation,
     AtifCreateRequest,
+    EvaluationCreateRequest,
     EvaluationPatchRequest,
     EvaluationResponse,
     EvaluatorResult,
     EvaluatorResultCreateRequest,
+    ExperimentCreateRequest,
+    ExperimentResponse,
+    ExperimentUpdateRequest,
     IngestResponse,
     ListAnnotationsQueryParams,
     ListEvaluatorResultsQueryParams,
     ListSpanGroupsQueryParams,
     ListSpansQueryParams,
     ListTracesQueryParams,
+    RetrieveTraceQueryParams,
     Span,
-    SpanGroupsPage,
+    SpanGroup,
     Trace,
 )
 
@@ -60,6 +65,67 @@ def list_traces(
 ) -> Paginated[Trace]: ...
 
 
+@get(f"{_INTAKE_BASE}/traces/{{id}}")
+@abstractmethod
+def get_trace(
+    *,
+    workspace: str | None = None,
+    id: str,
+    query_params: RetrieveTraceQueryParams | None = None,
+) -> Trace: ...
+
+
+@get(f"{_INTAKE_BASE}/spans")
+@abstractmethod
+def list_spans(
+    *,
+    workspace: str | None = None,
+    query_params: ListSpansQueryParams | None = None,
+) -> Paginated[Span]: ...
+
+
+@get(f"{_INTAKE_BASE}/spans/groups")
+@abstractmethod
+def list_span_groups(
+    *,
+    workspace: str | None = None,
+    query_params: ListSpanGroupsQueryParams | None = None,
+) -> Paginated[SpanGroup]: ...
+
+
+@post(f"{_INTAKE_BASE}/experiments")
+@abstractmethod
+def create_experiment(
+    *,
+    workspace: str | None = None,
+    body: ExperimentCreateRequest,
+) -> ExperimentResponse: ...
+
+
+@get(f"{_INTAKE_BASE}/experiments/{{name}}")
+@abstractmethod
+def get_experiment(*, workspace: str | None = None, name: str) -> ExperimentResponse: ...
+
+
+@put(f"{_INTAKE_BASE}/experiments/{{name}}")
+@abstractmethod
+def update_experiment(
+    *,
+    workspace: str | None = None,
+    name: str,
+    body: ExperimentUpdateRequest,
+) -> ExperimentResponse: ...
+
+
+@post(f"{_INTAKE_BASE}/evaluations")
+@abstractmethod
+def create_evaluation(
+    *,
+    workspace: str | None = None,
+    body: EvaluationCreateRequest,
+) -> EvaluationResponse: ...
+
+
 @post(f"{_INTAKE_BASE}/evaluator-results")
 @abstractmethod
 def create_evaluator_result(
@@ -72,6 +138,16 @@ def create_evaluator_result(
 @get(f"{_INTAKE_BASE}/evaluations/{{name}}")
 @abstractmethod
 def get_evaluation(*, workspace: str | None = None, name: str) -> EvaluationResponse: ...
+
+
+@put(f"{_INTAKE_BASE}/evaluations/{{name}}")
+@abstractmethod
+def update_evaluation(
+    *,
+    workspace: str | None = None,
+    name: str,
+    body: EvaluationCreateRequest,
+) -> EvaluationResponse: ...
 
 
 @patch(f"{_INTAKE_BASE}/evaluations/{{name}}")
@@ -96,24 +172,6 @@ def list_evaluator_results(
 @get(f"{_INTAKE_BASE}/spans/{{span_id}}/evaluator-results")
 @abstractmethod
 def list_evaluator_results_for_span(*, workspace: str | None = None, span_id: str) -> list[EvaluatorResult]: ...
-
-
-@get(f"{_INTAKE_BASE}/spans")
-@abstractmethod
-def list_spans(
-    *,
-    workspace: str | None = None,
-    query_params: ListSpansQueryParams | None = None,
-) -> Paginated[Span]: ...
-
-
-@get(f"{_INTAKE_BASE}/spans/groups")
-@abstractmethod
-def list_span_groups(
-    *,
-    workspace: str | None = None,
-    query_params: ListSpanGroupsQueryParams,
-) -> SpanGroupsPage: ...
 
 
 @get(f"{_INTAKE_BASE}/spans/{{span_id}}")

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/intake/types.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/intake/types.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Typed wire shapes for the Intake APIs used by evaluator."""
+"""Typed wire shapes for the Intake APIs used by evaluator and Experimentalist."""
 
 from __future__ import annotations
 
@@ -15,11 +15,15 @@ EvaluatorResultDataType = Literal["NUMERIC", "BOOLEAN", "CATEGORICAL", "TEXT"]
 TraceMode = Literal["summary", "preview", "detailed"]
 TraceStatus = Literal["OK", "ERROR", "UNSET"] | str
 SpanMode = Literal["summary", "preview", "detailed"]
+SpanKind = Literal["AGENT", "CHAIN", "EVALUATOR", "LLM", "TOOL"] | str
+SpanStatus = Literal["success", "error", "cancelled", "unknown", "OK", "ERROR", "UNSET"] | str
 
 
 class EvaluationContextParam(TypedDict, total=False):
     evaluation_name: str
     test_case_name: str
+    evaluation_id: str
+    test_case_id: str
 
 
 class AtifAgentParam(TypedDict, total=False):
@@ -138,6 +142,7 @@ class EvaluatorResult(BaseModel):
 class EvaluatorAggregate(BaseModel):
     """Aggregate stats hydrated onto evaluation responses."""
 
+    sum: float | None = None
     mean: float | None = None
     min: float | None = None
     max: float | None = None
@@ -146,6 +151,33 @@ class EvaluatorAggregate(BaseModel):
     p95: float | None = None
     p99: float | None = None
     count: int = 0
+
+
+class EvaluationCreateRequest(BaseModel):
+    """Create/full-update body for an Evaluation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    experiment_ids: list[str] = Field(default_factory=list)
+    experiment_group_id: str | None = None
+    dataset_name: str
+    dataset_version: str | None = None
+    source_link: str | None = None
+    metadata: dict[str, str] = Field(default_factory=dict)
+    description: str | None = None
+    parent_evaluation_id: str | None = None
+    status: str | None = None
+    root_cause: str | None = None
+
+    @model_validator(mode="after")
+    def _resolve_group_membership(self) -> EvaluationCreateRequest:
+        if not self.experiment_ids and self.experiment_group_id:
+            self.experiment_ids = [self.experiment_group_id]
+        if not self.experiment_ids:
+            raise ValueError("Evaluation requires at least one experiment id.")
+        self.experiment_ids = list(dict.fromkeys(self.experiment_ids))
+        return self
 
 
 class EvaluationPatchRequest(BaseModel):
@@ -192,6 +224,50 @@ class EvaluationResponse(BaseModel):
     tokens: EvaluatorAggregate | None = None
 
 
+class ExperimentCreateRequest(BaseModel):
+    """Create body for an Experiment."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    description: str | None = None
+    insight_id: str | None = None
+    summary: str | None = None
+    metadata: dict[str, str] | None = None
+    default_sort: str = "-created_at"
+    pareto: dict[str, Any] | None = None
+    column_layout: dict[str, Any] | None = None
+    is_favorite: bool = False
+    show_evaluations_over_time: bool = False
+
+
+class ExperimentUpdateRequest(ExperimentCreateRequest):
+    """Full-update body for an Experiment."""
+
+    baseline_evaluation_name: str | None = None
+
+
+class ExperimentResponse(BaseModel):
+    """Experiment as served by the Intake API."""
+
+    id: str
+    name: str
+    workspace: str
+    description: str | None = None
+    insight_id: str | None = None
+    summary: str | None = None
+    metadata: dict[str, str] | None = None
+    default_sort: str
+    pareto: dict[str, Any] | None = None
+    column_layout: dict[str, Any] | None = None
+    is_favorite: bool = False
+    show_evaluations_over_time: bool = False
+    baseline_evaluation_name: str | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+    evaluation_count: int = 0
+
+
 class Trace(BaseModel):
     """Trace summary returned by Intake trace listing."""
 
@@ -227,10 +303,14 @@ class SpanEvaluationContext(BaseModel):
 
     evaluation_name: str | None = None
     test_case_name: str | None = None
+    evaluation_id: str | None = None
+    test_case_id: str | None = None
 
 
 class Span(BaseModel):
     """Span row returned by the Intake spans API."""
+
+    model_config = ConfigDict(extra="allow")
 
     span_id: str
     session_id: str
@@ -238,13 +318,13 @@ class Span(BaseModel):
     project: str | None = None
     evaluation_context: SpanEvaluationContext | None = None
     parent_span_id: str | None = None
-    kind: str
+    kind: SpanKind
     name: str | None = None
     source: str
     trace_id: str | None = None
     started_at: datetime
     ended_at: datetime | None = None
-    status: str
+    status: SpanStatus
     error_type: str | None = None
     error_message: str | None = None
     provider: str | None = None
@@ -269,6 +349,8 @@ class Span(BaseModel):
 
 
 class SpanGroup(BaseModel):
+    """Grouped span row returned by Intake."""
+
     group: dict[str, str]
     span_count: int = Field(ge=0)
     started_at: datetime
@@ -299,7 +381,7 @@ class Annotation(BaseModel):
 
 
 class TraceFilterParam(TypedDict, total=False):
-    id: str
+    id: str | dict[str, list[str]]
     session_id: str
     status: str
     started_at: dict[str, str]
@@ -316,6 +398,10 @@ class ListTracesQueryParams(TypedDict, total=False):
     sort: str
     mode: TraceMode
     filter: TraceFilterParam
+
+
+class RetrieveTraceQueryParams(TypedDict, total=False):
+    mode: TraceMode
 
 
 class SpanFilterParam(TypedDict, total=False):
@@ -380,6 +466,7 @@ class ListEvaluatorResultsQueryParams(TypedDict, total=False):
 
 
 TracePage = Page[Trace]
-EvaluatorResultPage = Page[EvaluatorResult]
 SpanPage = Page[Span]
+SpanGroupPage = Page[SpanGroup]
+EvaluatorResultPage = Page[EvaluatorResult]
 AnnotationPage = Page[Annotation]

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/nooa_model_client.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/nooa_model_client.py
@@ -9,24 +9,27 @@ and client lifetime behavior without making Nooa a required dependency of the
 public plugin contract.
 """
 
-from collections.abc import Iterator
+import inspect
+from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
 
-from nemo_platform import AsyncNeMoPlatform
-from nemo_platform_ext.config import get_context
-from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.client.auth import AsyncTokenProvider, TokenProvider, resolve_token_async
+from nemo_platform_plugin.client.client import AsyncNemoClient
+from nemo_platform_plugin.client.config.config import get_context
 from nemo_platform_plugin.models.client import AsyncModelsClient
 from nemo_platform_plugin.models.refs import parse_workspace_name_ref
 from nemo_platform_plugin.models.types import ModelEntity, ModelProvider
-from nooa.unifiedllm import CompletionClient, UnifiedLLM
+from nooa.unifiedllm import CompletionClient, LLMResponse, Tool, UnifiedLLM
+from pydantic import BaseModel
 
 _PLACEHOLDER_API_KEY = "not-needed"
 _OPENAI_FORMAT = "OPENAI_CHAT"
 _ANTHROPIC_FORMAT = "ANTHROPIC_MESSAGES"
 _ACCEPT_ENCODING_HEADER = "accept-encoding"
 _IDENTITY_ENCODING = "identity"
+_AUTHORIZATION_HEADER = "Authorization"
 
 
 @dataclass(frozen=True)
@@ -101,6 +104,95 @@ def _validate_configured_ref(model_ref: str, env_var: str) -> None:
         ) from None
 
 
+def _normalize_extra_headers(headers: object, *, label: str) -> dict[str, str]:
+    if headers is None:
+        return {}
+    if not isinstance(headers, Mapping):
+        raise TypeError(f"{label} must be a mapping of string headers")
+    normalized: dict[str, str] = {}
+    for key, value in headers.items():
+        if not isinstance(key, str) or not isinstance(value, str):
+            raise TypeError(f"{label} must contain only string header names and values")
+        normalized[key] = value
+    return normalized
+
+
+class _AuthenticatedCompletionClient(CompletionClient):
+    """CompletionClient that resolves Platform auth at each Nooa call boundary."""
+
+    def __init__(
+        self,
+        model: str,
+        *,
+        platform_auth: TokenProvider | AsyncTokenProvider,
+        **config,
+    ) -> None:
+        self._platform_auth = platform_auth
+        super().__init__(model, **config)
+
+    def _extra_headers(self, token: str, call_headers: object) -> dict[str, str]:
+        headers = _normalize_extra_headers(self.config.get("extra_headers"), label="CompletionClient extra_headers")
+        headers.update(_normalize_extra_headers(call_headers, label="Per-call extra_headers"))
+        headers = {key: value for key, value in headers.items() if key.lower() != _AUTHORIZATION_HEADER.lower()}
+        headers[_AUTHORIZATION_HEADER] = f"Bearer {token}"
+        return headers
+
+    def _sync_access_token(self) -> str:
+        get_token = self._platform_auth.get_access_token
+        if inspect.iscoroutinefunction(get_token):
+            raise TypeError("Async token provider cannot be used from a synchronous Nooa completion call")
+        token = get_token()
+        if inspect.isawaitable(token):
+            raise TypeError("Async token provider cannot be used from a synchronous Nooa completion call")
+        return token
+
+    def call(
+        self,
+        messages: list[dict[str, object]],
+        tools: list[Tool] | None = None,
+        output_model: type[BaseModel] | None = None,
+        cache_control_injection_points: list[dict[str, object]] | None = None,
+        **kwargs,
+    ) -> LLMResponse:
+        kwargs["extra_headers"] = self._extra_headers(self._sync_access_token(), kwargs.get("extra_headers"))
+        return super().call(
+            messages,
+            tools=tools,
+            output_model=output_model,
+            cache_control_injection_points=cache_control_injection_points,
+            **kwargs,
+        )
+
+    async def acall(
+        self,
+        messages: list[dict[str, object]],
+        tools: list[Tool] | None = None,
+        output_model: type[BaseModel] | None = None,
+        cache_control_injection_points: list[dict[str, object]] | None = None,
+        **kwargs,
+    ) -> LLMResponse:
+        token = await resolve_token_async(self._platform_auth)
+        kwargs["extra_headers"] = self._extra_headers(token, kwargs.get("extra_headers"))
+        return await super().acall(
+            messages,
+            tools=tools,
+            output_model=output_model,
+            cache_control_injection_points=cache_control_injection_points,
+            **kwargs,
+        )
+
+
+def _platform_completion_client(
+    model: str,
+    *,
+    platform_auth: TokenProvider | AsyncTokenProvider | None,
+    **config,
+) -> CompletionClient:
+    if platform_auth is None:
+        return CompletionClient(model, **config)
+    return _AuthenticatedCompletionClient(model, platform_auth=platform_auth, **config)
+
+
 def _completion_client(
     models_client: AsyncModelsClient,
     model_entity: ModelEntity,
@@ -115,10 +207,12 @@ def _completion_client(
     extra_headers[_ACCEPT_ENCODING_HEADER] = _IDENTITY_ENCODING
     # Backend format is the Platform-facing wire contract, not the upstream
     # provider identity. The LiteLLM prefix selects the adapter for that shape.
+    platform_auth = models_client._auth
     if model_entity.backend_format == _OPENAI_FORMAT:
         litellm_model = f"openai/{served_model_name}"
-        return CompletionClient(
+        return _platform_completion_client(
             litellm_model,
+            platform_auth=platform_auth,
             api_base=api_base,
             api_key=_PLACEHOLDER_API_KEY,
             # Platform rewrites the response model to the Model Entity ID. Keep
@@ -141,8 +235,9 @@ def _completion_client(
         )
 
     litellm_model = f"anthropic/{served_model_name}"
-    return CompletionClient(
+    return _platform_completion_client(
         litellm_model,
+        platform_auth=platform_auth,
         api_base=api_base,
         api_key=_PLACEHOLDER_API_KEY,
         base_model=litellm_model,
@@ -174,11 +269,11 @@ async def _served_model_name(
 
 
 async def resolve_model_clients(
-    async_sdk: AsyncNeMoPlatform,
+    client: AsyncNemoClient | AsyncModelsClient,
     refs: ConfiguredModelRefs | None = None,
 ) -> ConfiguredModelClients:
     """Resolve configured Model Entities and construct each distinct client once."""
-    models_client = client_from_platform(async_sdk, AsyncModelsClient)
+    models_client = client if isinstance(client, AsyncModelsClient) else AsyncModelsClient.from_client(client)
     selected = refs or configured_model_refs()
     resolved: dict[str, UnifiedLLM] = {}
     provider_cache: dict[str, ModelProvider] = {}

--- a/packages/nemo_platform_plugin/tests/intake/test_client.py
+++ b/packages/nemo_platform_plugin/tests/intake/test_client.py
@@ -179,3 +179,56 @@ async def test_async_list_traces_returns_paginated_items_and_serializes_filter()
 
     assert len(traces) == 1
     assert traces[0].root_span_id == "span-1"
+
+
+@pytest.mark.asyncio
+async def test_async_list_spans_accepts_deprecated_evaluation_context_aliases() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "GET"
+        assert request.url.path == "/apis/intake/v2/workspaces/default/spans"
+        assert json.loads(request.url.params["filter"]) == {"evaluation_name": "eval-1"}
+        return httpx.Response(
+            200,
+            request=request,
+            json={
+                "data": [
+                    {
+                        "span_id": "span-1",
+                        "session_id": "session-1",
+                        "workspace": "default",
+                        "evaluation_context": {
+                            "evaluation_name": "eval-1",
+                            "test_case_name": "case-1",
+                            "evaluation_id": "eval-1",
+                            "test_case_id": "case-1",
+                        },
+                        "kind": "CHAIN",
+                        "source": "otel",
+                        "trace_id": "trace-1",
+                        "started_at": "2026-01-02T03:04:05Z",
+                        "status": "success",
+                        "ingested_at": "2026-01-02T03:04:06Z",
+                    }
+                ],
+                "pagination": {
+                    "page": 1,
+                    "page_size": 10,
+                    "current_page_size": 1,
+                    "total_pages": 1,
+                    "total_results": 1,
+                },
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http_client:
+        client = AsyncIntakeClient(base_url=BASE, workspace="default", http_client=http_client)
+
+        spans = [
+            span
+            async for span in (await client.list_spans(query_params={"filter": {"evaluation_name": "eval-1"}})).items()
+        ]
+
+    assert len(spans) == 1
+    assert spans[0].evaluation_context is not None
+    assert spans[0].evaluation_context.evaluation_name == "eval-1"
+    assert spans[0].evaluation_context.evaluation_id == "eval-1"

--- a/packages/nemo_platform_plugin/tests/test_config.py
+++ b/packages/nemo_platform_plugin/tests/test_config.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import ClassVar
 
 import pytest
@@ -294,3 +295,18 @@ def test_validate_docker_available_returns_false_on_connection_failures() -> Non
             assert validate_docker_available() is False
         client.close.assert_called()
     reset_capability_cache()
+
+
+def test_default_client_config_fast_model_falls_back_to_env_default_model(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from nemo_platform_plugin.client.config.config import Config
+    from nemo_platform_plugin.client.config.models import ConfigFile
+
+    monkeypatch.setenv("NEMO_DEFAULT_MODEL", "default/quality")
+    monkeypatch.delenv("NEMO_FAST_MODEL", raising=False)
+
+    context = Config.create(tmp_path / "config.yaml", ConfigFile()).resolve()
+
+    assert context.default_model == "default/quality"
+    assert context.fast_model == "default/quality"

--- a/packages/nemo_platform_plugin/tests/test_nooa_model_client.py
+++ b/packages/nemo_platform_plugin/tests/test_nooa_model_client.py
@@ -31,13 +31,14 @@ def _model_entity(**attrs):
 
 
 def _mock_models_client(models, providers=None):
-    """Build a mock ``AsyncModelsClient`` returned by ``client_from_platform``.
+    """Build a mock ``AsyncModelsClient`` for model resolution tests.
 
     ``models`` maps ``(workspace, name)`` to the Model Entity ``get_model`` should
     return. ``get_model`` is an AsyncMock; its awaited result must expose a
     ``.data()`` accessor mirroring ``NemoResponse``.
     """
     client = MagicMock()
+    client._auth = None
     client.default_headers = {}
     client.get_model_entity_route_openai_url.return_value = "http://platform/model/example/-/v1"
     providers = providers or {}
@@ -58,7 +59,7 @@ def _mock_models_client(models, providers=None):
 def _patch_models_client(models, providers=None):
     client = _mock_models_client(models, providers=providers)
     ctx = patch(
-        "nemo_platform_plugin.nooa_model_client.client_from_platform",
+        "nemo_platform_plugin.nooa_model_client.AsyncModelsClient.from_client",
         return_value=client,
     )
     return ctx, client
@@ -258,6 +259,64 @@ async def test_resolve_model_clients_uses_provider_served_name(monkeypatch):
         drop_params=True,
         _skip_responses_api_bridge=True,
     )
+
+
+async def test_resolve_model_clients_refreshes_auth_for_completion_calls(monkeypatch):
+    class _TokenProvider:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def get_access_token(self) -> str:
+            self.calls += 1
+            return f"token-{self.calls}"
+
+    model_entity = _model_entity(
+        workspace="default",
+        name="gpt-4-1",
+        backend_format="OPENAI_CHAT",
+    )
+    ctx, client = _patch_models_client({("default", "gpt-4-1"): model_entity})
+    client.default_headers = {"authorization": "Bearer stale", "x-test": "value"}
+    token_provider = _TokenProvider()
+    client._auth = token_provider
+    captured_headers: list[dict[str, str]] = []
+
+    async def _recording_acall(
+        self,
+        messages: list[dict[str, object]],
+        tools=None,
+        output_model=None,
+        cache_control_injection_points=None,
+        **kwargs,
+    ):
+        captured_headers.append(kwargs["extra_headers"])
+        return MagicMock()
+
+    monkeypatch.setattr(nooa_model_client.CompletionClient, "acall", _recording_acall)
+
+    with ctx:
+        result = await resolve_model_clients(
+            MagicMock(),
+            ConfiguredModelRefs(default="default/gpt-4-1", fast="default/gpt-4-1"),
+        )
+
+    await result.default.acall([{"role": "user", "content": "hello"}], extra_headers={"x-call": "one"})
+    await result.default.acall([{"role": "user", "content": "again"}])
+
+    assert captured_headers == [
+        {
+            "x-test": "value",
+            "accept-encoding": "identity",
+            "x-call": "one",
+            "Authorization": "Bearer token-1",
+        },
+        {
+            "x-test": "value",
+            "accept-encoding": "identity",
+            "Authorization": "Bearer token-2",
+        },
+    ]
+    assert token_provider.calls == 2
 
 
 def test_active_model_clients_are_scoped():

--- a/packages/nmp_testing/src/nmp/testing/client.py
+++ b/packages/nmp_testing/src/nmp/testing/client.py
@@ -18,6 +18,7 @@ import httpx
 from fastapi.testclient import TestClient
 from nemo_platform import AsyncNeMoPlatform, NeMoPlatform, NotGiven, not_given
 from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.client.client import AsyncNemoClient
 from nemo_platform_plugin.entities.client import AsyncEntitiesClient
 from nemo_platform_plugin.workspaces.client import WorkspacesClient
 from nemo_platform_plugin.workspaces.types import CreateWorkspaceRequest
@@ -51,6 +52,9 @@ class ClientContext:
     async_sdk: AsyncNeMoPlatform
     """Asynchronous NeMoPlatform SDK client."""
 
+    async_client: AsyncNemoClient
+    """Asynchronous typed platform client."""
+
     entity_client: EntityClient
     """EntityClient for direct entity operations."""
 
@@ -61,7 +65,7 @@ class ClientContext:
     """Captured requests when access_log=True was passed to create_test_client."""
 
 
-ClientT = TypeVar("ClientT", TestClient, AsyncNeMoPlatform, NeMoPlatform, EntityClient, ClientContext)
+ClientT = TypeVar("ClientT", TestClient, AsyncNemoClient, AsyncNeMoPlatform, NeMoPlatform, EntityClient, ClientContext)
 
 
 class SDKTestClientAdapter(httpx.Client):
@@ -249,8 +253,8 @@ def create_test_client(
 
     Args:
         *service_types: One or more Service classes to test
-        client_type: The client type to yield. One of TestClient, AsyncNeMoPlatform,
-                     NeMoPlatform, or EntityClient. Defaults to NeMoPlatform.
+        client_type: The client type to yield. One of TestClient, AsyncNemoClient,
+                     AsyncNeMoPlatform, NeMoPlatform, or EntityClient. Defaults to NeMoPlatform.
         dependency_overrides: Custom dependency overrides dict. If get_entity_client
                       is not in dependency_overrides, an EntityClient will be created.
         service_configs: Optional map of service class → config. Overrides defaults
@@ -477,6 +481,7 @@ def create_test_client(
             base_url="http://testserver",
             http_client=async_http_client,
         ).copy(workspace=workspace)
+        async_client = AsyncNemoClient(base_url="http://testserver", http_client=async_http_client, workspace=workspace)
 
         # Create the EntityClient (used for DI and optionally yielded)
         entity_client = EntityClient(client_from_platform(async_sdk, AsyncEntitiesClient))
@@ -658,6 +663,8 @@ def create_test_client(
 
             if selected_client_type is TestClient:
                 yield client  # ty: ignore[invalid-yield]
+            elif selected_client_type is AsyncNemoClient:
+                yield async_client  # ty: ignore[invalid-yield]
             elif selected_client_type is AsyncNeMoPlatform:
                 yield async_sdk  # ty: ignore[invalid-yield]
             elif selected_client_type is EntityClient:
@@ -666,6 +673,7 @@ def create_test_client(
                 yield ClientContext(
                     sdk=sdk,
                     async_sdk=async_sdk,
+                    async_client=async_client,
                     entity_client=entity_client,
                     test_client=client,
                     access_log=access_log_instance,

--- a/packages/nmp_testing/tests/unit/test_client.py
+++ b/packages/nmp_testing/tests/unit/test_client.py
@@ -5,6 +5,7 @@
 
 import pytest
 from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.client.client import AsyncNemoClient
 from nemo_platform_plugin.workspaces.client import WorkspacesClient
 from nmp.common.config import Configuration
 from nmp.core.entities.service import EntitiesService
@@ -109,6 +110,7 @@ def test_create_test_client_returns_client_context():
     with create_test_client(EntitiesService, client_type=ClientContext) as ctx:
         assert isinstance(ctx, ClientContext)
         assert ctx.sdk is not None
+        assert isinstance(ctx.async_client, AsyncNemoClient)
         assert ctx.test_client is not None
 
 

--- a/plugins/nemo-experimentalist/examples/smoke-agent/scripts/record_traces.py
+++ b/plugins/nemo-experimentalist/examples/smoke-agent/scripts/record_traces.py
@@ -26,8 +26,10 @@ from nemo_experimentalist_plugin.experimentalist.components.evaluator.harbor_nat
     HarborNativeOutcomeEvaluator,
 )
 from nemo_experimentalist_plugin.experimentalist.otlp import jsonl_to_protobuf, read_trace_id
-from nemo_platform import AsyncNeMoPlatform, ConflictError, NotFoundError
-from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.client.client import AsyncNemoClient
+from nemo_platform_plugin.client.errors import ConflictError, NotFoundError
+from nemo_platform_plugin.intake.client import AsyncIntakeClient
+from nemo_platform_plugin.intake.types import EvaluationCreateRequest, ExperimentCreateRequest
 from nemo_platform_plugin.workspaces.client import AsyncWorkspacesClient
 from nemo_platform_plugin.workspaces.types import CreateWorkspaceRequest
 
@@ -37,26 +39,29 @@ POLL_ATTEMPTS = 30
 POLL_DELAY_SECONDS = 2.0
 
 
-async def _ensure_evaluation(client: AsyncNeMoPlatform, *, workspace: str, name: str) -> None:
+async def _ensure_evaluation(client: AsyncNemoClient, *, workspace: str, name: str) -> None:
     """Register the Evaluation these spans name, or Intake drops them."""
+    intake = AsyncIntakeClient.from_client(client)
     try:
-        group = await client.experiments.create(workspace=workspace, name=name)
+        group = (await intake.create_experiment(workspace=workspace, body=ExperimentCreateRequest(name=name))).data()
     except ConflictError:
-        group = await client.experiments.retrieve(name, workspace=workspace)
+        group = (await intake.get_experiment(name=name, workspace=workspace)).data()
     try:
-        await client.evaluations.create(
+        await intake.create_evaluation(
             workspace=workspace,
-            name=name,
-            experiment_ids=[group.id],
-            dataset_name=name,
-            dataset_version="v1",
+            body=EvaluationCreateRequest(
+                name=name,
+                experiment_ids=[group.id],
+                dataset_name=name,
+                dataset_version="v1",
+            ),
         )
     except ConflictError:
         pass
 
 
 async def _upload_trials(
-    client: AsyncNeMoPlatform,
+    client: AsyncNemoClient,
     trials: list[TrialResult],
     *,
     workspace: str,
@@ -64,6 +69,7 @@ async def _upload_trials(
 ) -> dict[str, str]:
     """Upload each trial's trace; return {task_id: trace_id}."""
     trace_ids: dict[str, str] = {}
+    intake = AsyncIntakeClient.from_client(client)
 
     for trial in trials:
         if trial.trace is None:
@@ -84,7 +90,7 @@ async def _upload_trials(
         if not payloads:
             raise RuntimeError(f"Trial {trial.id} produced an empty trace")
         for payload in payloads:
-            await client.intake.ingest.otlp.v1.traces.create(body=payload, workspace=workspace)
+            await intake.create_otlp_traces(content=payload, workspace=workspace)
         # Every recording run uses one attempt per task.  Keep the task id here
         # so the caller can put precisely the failing task traces in an Insight.
         trace_ids[trial.task_id] = trace_id
@@ -92,13 +98,14 @@ async def _upload_trials(
     return trace_ids
 
 
-async def _wait_retrievable(client: AsyncNeMoPlatform, workspace: str, trace_ids: set[str]) -> None:
+async def _wait_retrievable(client: AsyncNemoClient, workspace: str, trace_ids: set[str]) -> None:
     """Block until every trace id resolves, or raise once the budget is spent."""
     pending = set(trace_ids)
+    intake = AsyncIntakeClient.from_client(client)
     for _ in range(POLL_ATTEMPTS):
         for trace_id in sorted(pending):
             try:
-                await client.intake.traces.retrieve(trace_id, workspace=workspace)
+                await intake.get_trace(id=trace_id, workspace=workspace)
             except NotFoundError:
                 continue
             pending.discard(trace_id)
@@ -124,7 +131,7 @@ async def run(args: argparse.Namespace) -> dict[str, str]:
     client = make_client(args.base_url)
     try:
         (
-            await client_from_platform(client, AsyncWorkspacesClient).create_workspace(
+            await AsyncWorkspacesClient.from_client(client).create_workspace(
                 exist_ok=True,
                 body=CreateWorkspaceRequest(name=args.workspace, description="smoke-agent traces for Insights"),
             )

--- a/plugins/nemo-experimentalist/examples/tau3-nooa-agent/pyproject.toml
+++ b/plugins/nemo-experimentalist/examples/tau3-nooa-agent/pyproject.toml
@@ -9,7 +9,11 @@ readme = "README.md"
 requires-python = ">=3.12,<3.14"
 dependencies = [
     "mcp==1.25.0",
+    "nemo-platform-plugin",
     "nooa[tracing]>=0.0.9",
     "opentelemetry-exporter-otlp-proto-http",
     "orjson==3.11.9",
 ]
+
+[tool.uv.sources]
+nemo-platform-plugin = { path = "../../../../packages/nemo_platform_plugin", editable = true }

--- a/plugins/nemo-experimentalist/examples/tau3-nooa-agent/record_tau_airline_traces.py
+++ b/plugins/nemo-experimentalist/examples/tau3-nooa-agent/record_tau_airline_traces.py
@@ -24,8 +24,10 @@ from nemo_experimentalist_plugin.experimentalist.components.evaluator.harbor_nat
     HarborNativeOutcomeEvaluator,
 )
 from nemo_experimentalist_plugin.experimentalist.otlp import jsonl_to_protobuf, read_trace_id
-from nemo_platform import AsyncNeMoPlatform, ConflictError, NotFoundError
-from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.client.client import AsyncNemoClient
+from nemo_platform_plugin.client.errors import ConflictError, NotFoundError
+from nemo_platform_plugin.intake.client import AsyncIntakeClient
+from nemo_platform_plugin.intake.types import EvaluationCreateRequest, ExperimentCreateRequest
 from nemo_platform_plugin.workspaces.client import AsyncWorkspacesClient
 from nemo_platform_plugin.workspaces.types import CreateWorkspaceRequest
 
@@ -131,26 +133,29 @@ def _write_upload_summary(
     return summary_path
 
 
-async def _ensure_evaluation(client: AsyncNeMoPlatform, *, workspace: str, name: str) -> None:
+async def _ensure_evaluation(client: AsyncNemoClient, *, workspace: str, name: str) -> None:
     """Register the Evaluation these spans name, or Intake drops them."""
+    intake = AsyncIntakeClient.from_client(client)
     try:
-        group = await client.experiments.create(workspace=workspace, name=name)
+        group = (await intake.create_experiment(workspace=workspace, body=ExperimentCreateRequest(name=name))).data()
     except ConflictError:
-        group = await client.experiments.retrieve(name, workspace=workspace)
+        group = (await intake.get_experiment(name=name, workspace=workspace)).data()
     try:
-        await client.evaluations.create(
+        await intake.create_evaluation(
             workspace=workspace,
-            name=name,
-            experiment_ids=[group.id],
-            dataset_name=name,
-            dataset_version="v1",
+            body=EvaluationCreateRequest(
+                name=name,
+                experiment_ids=[group.id],
+                dataset_name=name,
+                dataset_version="v1",
+            ),
         )
     except ConflictError:
         pass
 
 
 async def _upload_trials(
-    client: AsyncNeMoPlatform,
+    client: AsyncNemoClient,
     trials: list[TrialResult],
     *,
     workspace: str,
@@ -160,6 +165,7 @@ async def _upload_trials(
     model: str,
 ) -> dict[str, str]:
     trace_ids: dict[str, str] = {}
+    intake = AsyncIntakeClient.from_client(client)
 
     for trial in trials:
         if trial.trace is None:
@@ -181,25 +187,26 @@ async def _upload_trials(
         if not payloads:
             raise RuntimeError(f"Trial {trial.id} produced an empty agent execution trace")
         for payload in payloads:
-            await client.intake.ingest.otlp.v1.traces.create(body=payload, workspace=workspace)
+            await intake.create_otlp_traces(content=payload, workspace=workspace)
         trace_ids[trial.id] = trace_id
 
     return trace_ids
 
 
 async def _wait_for_traces(
-    client: AsyncNeMoPlatform,
+    client: AsyncNemoClient,
     trace_ids: set[str],
     *,
     workspace: str,
     retries: int = 6,
 ) -> None:
     pending = set(trace_ids)
+    intake = AsyncIntakeClient.from_client(client)
     delay = 1.0
     for attempt in range(retries):
         for trace_id in tuple(pending):
             try:
-                await client.intake.traces.retrieve(trace_id, workspace=workspace)
+                await intake.get_trace(id=trace_id, workspace=workspace)
             except NotFoundError:
                 continue
             pending.remove(trace_id)
@@ -237,7 +244,7 @@ async def run(args: argparse.Namespace) -> Path:
 
         evaluation_name = args.evaluation_name or run_dir.name
         client = make_client(args.base_url)
-        workspaces = client_from_platform(client, AsyncWorkspacesClient)
+        workspaces = AsyncWorkspacesClient.from_client(client)
         try:
             (
                 await workspaces.create_workspace(
@@ -282,7 +289,7 @@ async def run(args: argparse.Namespace) -> Path:
 
     _configure_models(model=args.model, user_model=args.user_model, api_base=args.api_base)
     client = make_client(args.base_url)
-    workspaces = client_from_platform(client, AsyncWorkspacesClient)
+    workspaces = AsyncWorkspacesClient.from_client(client)
     try:
         (
             await workspaces.create_workspace(

--- a/plugins/nemo-experimentalist/examples/tau3-nooa-agent/uv.lock
+++ b/plugins/nemo-experimentalist/examples/tau3-nooa-agent/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = ">=3.12, <3.14"
 
 [[package]]
+name = "aiofiles"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/c3/534eac40372d8ee36ef40df62ec129bee4fdb5ad9706e58a29be53b2c970/aiofiles-25.1.0.tar.gz", hash = "sha256:a8d728f0a29de45dc521f18f07297428d56992a742f0cd2701ba86e44d23d5b2", size = 46354, upload-time = "2025-10-09T20:51:04.358Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl", hash = "sha256:abe311e527c862958650f9438e859c1fa7568a141b22abcd015e120e86a85695", size = 14668, upload-time = "2025-10-09T20:51:03.174Z" },
+]
+
+[[package]]
 name = "aiohappyeyeballs"
 version = "2.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -84,12 +93,39 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/8e/38aa427ed5402449e226975b649c5dc73ccadfefeb95e6aecb8f8ea4b6b6/annotated_doc-0.0.5.tar.gz", hash = "sha256:c7e58ce09192557605d8bbd92836d7e1d520ac9580096042c0bfd197efacf1bb", size = 10758, upload-time = "2026-07-28T13:50:58.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/30/e900b21425a860e195f32e37657aa1f7c7f2b1bfb26f03ca209b90933c06/annotated_doc-0.0.5-py3-none-any.whl", hash = "sha256:117bac03a25ede5df5440e855b32d556049ca169ead221505badf432fed4b101", size = 5302, upload-time = "2026-07-28T13:50:57.239Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5f/56/a8120250d128bed162cd73c76d45f6ef9991f3e068f62a8ee060afa3104a/annotated_types-0.8.0.tar.gz", hash = "sha256:13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7", size = 15893, upload-time = "2026-07-23T20:16:13.995Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl", hash = "sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0", size = 13427, upload-time = "2026-07-23T20:16:12.938Z" },
+]
+
+[[package]]
+name = "anthropic"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "docstring-parser" },
+    { name = "httpx2" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6e/43/6f3f6006f5216d43a059a1a856d275ef6536cdfa94883b64cc04d7873cb7/anthropic-1.5.0.tar.gz", hash = "sha256:b25f87f5758861f25993383a5c9bf274eb6e0f1b010c84019ad91854cb4e1bc6", size = 1156657, upload-time = "2026-09-10T17:45:35.93Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/1c/c32fce35ca0be0205f2377d2238e3ed73dea5abc2be09d15fbd032091d60/anthropic-1.5.0-py3-none-any.whl", hash = "sha256:d9ce04b29ad1f7025dda3e3bc478cde8d2924d2de5417d2d4a4bb0378ecbc2a6", size = 1235236, upload-time = "2026-09-10T17:45:34.216Z" },
 ]
 
 [[package]]
@@ -112,6 +148,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "boto3"
+version = "1.43.92"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/bf/322eace5751ada6198727ee9210b34be12670151dd9c001e36738272a41a/boto3-1.43.92.tar.gz", hash = "sha256:30a1ff4bb729831c4890e0a0d121f9d43f066de724c5916e358c9f68f94749dd", size = 112652, upload-time = "2026-09-10T19:21:48.52Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/fa/51808a448896a4707321b6b325c21637f4e10f51beb3304525686693b8a7/boto3-1.43.92-py3-none-any.whl", hash = "sha256:aee16b1ad54caf6e7b8f48f2682d18b03a2feefaf7afaf56fed6204016fa687d", size = 140028, upload-time = "2026-09-10T19:21:46.45Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.92"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/cf/abc185dee932c8ebb3f35b608148226c1974e9c78af6b46a67901076dd36/botocore-1.43.92.tar.gz", hash = "sha256:a5efebb7d8fd9e7a47a1ac3138688dae4234fcb2f5355c51f7c7aced63ef6df8", size = 16096751, upload-time = "2026-09-10T19:21:43.374Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/ea/84e86e2797afd7ce7e25c0da0b47c77fc636103659da17e2cc261e70da3a/botocore-1.43.92-py3-none-any.whl", hash = "sha256:a6f003615a3b6059628146e4a1d13bc132f7bc8f415c469a63d1c616bccee18f", size = 15788294, upload-time = "2026-09-10T19:21:39.287Z" },
 ]
 
 [[package]]
@@ -260,6 +324,45 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "docker"
+version = "7.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/7f/731ff914b0255d3d065f45fd4e626d4b8c95dbcbaada049f337a6ac16410/docker-7.2.0.tar.gz", hash = "sha256:cebb93773d334f778e023a7ee352a8d6e13ab1bd3b863a4d4a59dec897df43ac", size = 118731, upload-time = "2026-07-09T14:53:46.39Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/23/529140fe1aab80fc6992f93a706deec709140a6397439139a054e1515c45/docker-7.2.0-py3-none-any.whl", hash = "sha256:a3f45fdeb9165e2d25d9a1d02ddf3bc70fb572cf5ebbf9b58558c22caf29b71f", size = 148775, upload-time = "2026-07-09T14:53:45.224Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.141.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/02/91e3416a8fdd715abb903a952a6bec7cdd8d14eed55d415fc8595524c319/fastapi-0.141.1.tar.gz", hash = "sha256:e8822fc40db1e1858054d7a949a888695bc9bdce70139178e33bd2871a453ca1", size = 425799, upload-time = "2026-07-29T17:18:05.568Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/03/10388a42375ee7e4ac9b94eb2c5c569c8b5795e377e701c9ac3ad63de890/fastapi-0.141.1-py3-none-any.whl", hash = "sha256:bfb91aa2d334c61cb35ba9a116fc123b3d3df31640b801cf57a7a78ec3f603b3", size = 131954, upload-time = "2026-07-29T17:18:04.364Z" },
 ]
 
 [[package]]
@@ -418,6 +521,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074, upload-time = "2026-08-18T13:22:05.854Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -439,6 +555,32 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "httpx2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040, upload-time = "2026-08-18T13:22:09.086Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427, upload-time = "2026-08-18T13:22:06.834Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
 ]
 
 [[package]]
@@ -480,6 +622,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e7/72/c600ae4f68c28fc19f9c31b9403053e5dbb8cace2e6842c7b7c3e4d42fe9/importlib_metadata-8.9.0.tar.gz", hash = "sha256:58850626cef4bd2df100378b0f2aea9724a7b92f10770d547725b047078f99ee", size = 56140, upload-time = "2026-03-20T16:56:26.362Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/f9/97f2ca8bb3ec6e4b1d64f983ebe98b9a192faddff67fac3d6303a537e670/importlib_metadata-8.9.0-py3-none-any.whl", hash = "sha256:e0f761b6ea91ced3b0844c14c9d955224d538105921f8e6754c00f6ca79fba7f", size = 27220, upload-time = "2026-03-20T16:56:25.07Z" },
+]
+
+[[package]]
+name = "isodate"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6", size = 29705, upload-time = "2024-10-08T23:04:11.5Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15", size = 22320, upload-time = "2024-10-08T23:04:09.501Z" },
 ]
 
 [[package]]
@@ -535,6 +686,15 @@ wheels = [
 ]
 
 [[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -562,6 +722,15 @@ wheels = [
 ]
 
 [[package]]
+name = "lark"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/34/28fff3ab31ccff1fd4f6c7c7b0ceb2b6968d8ea4950663eadcb5720591a0/lark-1.3.1.tar.gz", hash = "sha256:b426a7a6d6d53189d318f2b6236ab5d6429eaf09259f1ca33eb716eed10d2905", size = 382732, upload-time = "2025-10-27T18:25:56.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3d/14ce75ef66813643812f3093ab17e46d3a206942ce7376d31ec2d36229e7/lark-1.3.1-py3-none-any.whl", hash = "sha256:c629b661023a014c37da873b4ff58a817398d12635d3bbb2c5a03be7fe5d1e12", size = 113151, upload-time = "2025-10-27T18:25:54.882Z" },
+]
+
+[[package]]
 name = "litellm"
 version = "1.93.0"
 source = { registry = "https://pypi.org/simple" }
@@ -585,6 +754,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/db/6af798603c6e2cf21ad7f2edf7e95019bd859dda82284b94014d608fcd85/litellm-1.93.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:0784172435de48f66ef7ad89d421604db1ad0db1321ef7f39dbcfe6b20111417", size = 20156724, upload-time = "2026-07-19T03:01:09.037Z" },
     { url = "https://files.pythonhosted.org/packages/f5/e1/eabe3f13d9c8b853a01377b59e78a295f34c24c36b09e5fc1c60c0167f19/litellm-1.93.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:23b8eea4fb8b3b6ade05e7b6085ec9ca12daffcfb38d033d0bbce9c1d5894da5", size = 20164863, upload-time = "2026-07-19T03:01:12.035Z" },
     { url = "https://files.pythonhosted.org/packages/64/49/2db5757f7e284eb12618b547cb62dab49687ffaf1d749ca048210e3d0dbd/litellm-1.93.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:98c15e84d32e922a821c105308bf9ddae8700de9ed396530bee2cbb1cacf4cbb", size = 20157288, upload-time = "2026-07-19T03:01:15.395Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
 ]
 
 [[package]]
@@ -654,6 +835,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
 name = "multidict"
 version = "6.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -717,11 +907,163 @@ wheels = [
 ]
 
 [[package]]
+name = "nemo-platform-plugin"
+source = { editable = "../../../../packages/nemo_platform_plugin" }
+dependencies = [
+    { name = "anthropic" },
+    { name = "fastapi" },
+    { name = "jsonschema" },
+    { name = "lark" },
+    { name = "nemo-platform-sdk" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyyaml" },
+    { name = "typer" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "anthropic", specifier = ">=0.88.0" },
+    { name = "anyio", marker = "extra == 'nemo-platform-sdk'", specifier = ">=4.0.0,<5" },
+    { name = "distro", marker = "extra == 'nemo-platform-sdk'", specifier = ">=1.7.0,<2" },
+    { name = "docker", marker = "extra == 'nemo-platform-sdk'", specifier = ">=7.0.0" },
+    { name = "fastapi", specifier = ">=0.115.4" },
+    { name = "fsspec", marker = "extra == 'nemo-platform-sdk'", specifier = ">=2023.1.0" },
+    { name = "httpx", marker = "extra == 'nemo-evaluator-sdk'", specifier = ">=0.27.0,<1" },
+    { name = "httpx", marker = "extra == 'nemo-platform-sdk'", specifier = ">=0.23.0,<1" },
+    { name = "jinja2", marker = "extra == 'nemo-evaluator-sdk'", specifier = ">=3.1.6" },
+    { name = "jsonpath-ng", marker = "extra == 'nemo-evaluator-sdk'", specifier = ">=1.7.0" },
+    { name = "jsonschema", specifier = ">=4.0.0" },
+    { name = "jsonschema", marker = "extra == 'nemo-evaluator-sdk'", specifier = ">=4.23.0" },
+    { name = "langchain-nvidia-ai-endpoints", marker = "extra == 'nemo-evaluator-sdk'", specifier = ">=1.4.3,<2.0.0" },
+    { name = "langchain-openai", marker = "extra == 'nemo-evaluator-sdk'", specifier = ">=1.3.5" },
+    { name = "lark", specifier = ">=1.1.0" },
+    { name = "nemo-fabric", marker = "extra == 'nemo-evaluator-sdk'", specifier = "==0.3.0b1" },
+    { name = "nemo-platform-sdk", editable = "../../../../sdk/python/nemo-platform" },
+    { name = "nemo-relay", marker = "extra == 'nemo-evaluator-sdk'", specifier = ">=0.7.3,<0.8" },
+    { name = "ngcsdk", marker = "extra == 'nemo-platform-sdk'", specifier = ">=4.8.2" },
+    { name = "nvidia-ml-py", marker = "extra == 'nemo-platform-sdk'", specifier = ">=13.0.0" },
+    { name = "openai", specifier = ">=1.109.1" },
+    { name = "openai", marker = "extra == 'nemo-evaluator-sdk'", specifier = ">=1.61.0" },
+    { name = "openai", marker = "extra == 'nemo-platform-sdk'" },
+    { name = "opentelemetry-proto", marker = "extra == 'nemo-evaluator-sdk'", specifier = ">=1.27.0" },
+    { name = "pandas", marker = "extra == 'nemo-evaluator-sdk'", specifier = ">=1.5.3" },
+    { name = "prompt-toolkit", marker = "extra == 'nemo-platform-sdk'", specifier = ">=3.0.0" },
+    { name = "psutil", marker = "extra == 'nemo-platform-sdk'", specifier = ">=5.9.0" },
+    { name = "pyarrow", marker = "extra == 'nemo-evaluator-sdk'", specifier = ">=19.0.1" },
+    { name = "pydantic", specifier = ">=2.12.0" },
+    { name = "pydantic", marker = "extra == 'nemo-evaluator-sdk'", specifier = ">=2.10.6" },
+    { name = "pydantic", marker = "extra == 'nemo-platform-sdk'", specifier = ">=2.0.0,<3" },
+    { name = "pydantic-settings", specifier = ">=2.8.1" },
+    { name = "pytrec-eval-terrier", marker = "extra == 'nemo-evaluator-sdk'", specifier = "==0.5.10" },
+    { name = "pyyaml", specifier = ">=6.0.2" },
+    { name = "pyyaml", marker = "extra == 'nemo-platform-sdk'", specifier = ">=6.0.0" },
+    { name = "ragas", marker = "extra == 'nemo-evaluator-sdk'", specifier = "==0.4.3" },
+    { name = "requests", marker = "extra == 'nemo-platform-sdk'", specifier = ">=2.31.0" },
+    { name = "rich", marker = "extra == 'nemo-platform-sdk'", specifier = ">=13.7.1" },
+    { name = "rouge-score", marker = "extra == 'nemo-evaluator-sdk'", specifier = "==0.1.2" },
+    { name = "sacrebleu", marker = "extra == 'nemo-evaluator-sdk'", specifier = ">=2.5.1" },
+    { name = "sniffio", marker = "extra == 'nemo-platform-sdk'" },
+    { name = "typer", specifier = ">=0.20.0,<0.26" },
+    { name = "typer", marker = "extra == 'nemo-platform-sdk'", specifier = ">=0.20.0" },
+    { name = "typing-extensions", marker = "extra == 'nemo-platform-sdk'", specifier = ">=4.14,<5" },
+]
+provides-extras = ["nemo-evaluator-sdk", "nemo-platform-sdk"]
+
+[[package]]
+name = "nemo-platform-sdk"
+source = { editable = "../../../../sdk/python/nemo-platform" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docker" },
+    { name = "fsspec" },
+    { name = "httpx" },
+    { name = "nemo-platform-plugin" },
+    { name = "ngcsdk" },
+    { name = "nvidia-ml-py" },
+    { name = "openai" },
+    { name = "prompt-toolkit" },
+    { name = "psutil" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "sniffio" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aiohttp", marker = "extra == 'aiohttp'" },
+    { name = "anyio", specifier = ">=4.0.0,<5" },
+    { name = "distro", specifier = ">=1.7.0,<2" },
+    { name = "docker", specifier = ">=7.0.0" },
+    { name = "fsspec", specifier = ">=2023.1.0" },
+    { name = "httpx", specifier = ">=0.23.0,<1" },
+    { name = "httpx", marker = "extra == 'nemo-evaluator-sdk'", specifier = ">=0.27.0,<1" },
+    { name = "httpx-aiohttp", marker = "extra == 'aiohttp'", specifier = ">=0.1.9" },
+    { name = "jinja2", marker = "extra == 'nemo-evaluator-sdk'", specifier = ">=3.1.6" },
+    { name = "jsonpath-ng", marker = "extra == 'nemo-evaluator-sdk'", specifier = ">=1.7.0" },
+    { name = "jsonschema", marker = "extra == 'nemo-evaluator-sdk'", specifier = ">=4.23.0" },
+    { name = "langchain-nvidia-ai-endpoints", marker = "extra == 'nemo-evaluator-sdk'", specifier = ">=1.4.3,<2.0.0" },
+    { name = "langchain-openai", marker = "extra == 'nemo-evaluator-sdk'", specifier = ">=1.3.5" },
+    { name = "nemo-fabric", marker = "extra == 'nemo-evaluator-sdk'", specifier = "==0.3.0b1" },
+    { name = "nemo-platform-plugin", editable = "../../../../packages/nemo_platform_plugin" },
+    { name = "nemo-relay", marker = "extra == 'nemo-evaluator-sdk'", specifier = ">=0.7.3,<0.8" },
+    { name = "ngcsdk", specifier = ">=4.8.2" },
+    { name = "nvidia-ml-py", specifier = ">=13.0.0" },
+    { name = "openai" },
+    { name = "openai", marker = "extra == 'nemo-evaluator-sdk'", specifier = ">=1.61.0" },
+    { name = "opentelemetry-proto", marker = "extra == 'nemo-evaluator-sdk'", specifier = ">=1.27.0" },
+    { name = "pandas", marker = "extra == 'nemo-evaluator-sdk'", specifier = ">=1.5.3" },
+    { name = "prompt-toolkit", specifier = ">=3.0.0" },
+    { name = "psutil", specifier = ">=5.9.0" },
+    { name = "pyarrow", marker = "extra == 'nemo-evaluator-sdk'", specifier = ">=19.0.1" },
+    { name = "pydantic", specifier = ">=2.0.0,<3" },
+    { name = "pydantic", marker = "extra == 'nemo-evaluator-sdk'", specifier = ">=2.10.6" },
+    { name = "pytrec-eval-terrier", marker = "extra == 'nemo-evaluator-sdk'", specifier = "==0.5.10" },
+    { name = "pyyaml", specifier = ">=6.0.0" },
+    { name = "ragas", marker = "extra == 'nemo-evaluator-sdk'", specifier = "==0.4.3" },
+    { name = "requests", specifier = ">=2.31.0" },
+    { name = "rich", specifier = ">=13.7.1" },
+    { name = "rouge-score", marker = "extra == 'nemo-evaluator-sdk'", specifier = "==0.1.2" },
+    { name = "sacrebleu", marker = "extra == 'nemo-evaluator-sdk'", specifier = ">=2.5.1" },
+    { name = "sandboxed-gym", marker = "extra == 'nemo-evaluator-sdk'", editable = "../../../../packages/sandboxed_gym" },
+    { name = "sniffio" },
+    { name = "typer", specifier = ">=0.20.0" },
+    { name = "typing-extensions", specifier = ">=4.14,<5" },
+]
+provides-extras = ["aiohttp", "nemo-evaluator-sdk"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "dirty-equals", specifier = ">=0.6.0" },
+    { name = "importlib-metadata", specifier = ">=6.7.0" },
+    { name = "mypy", specifier = "==1.17" },
+    { name = "pyright", specifier = "==1.1.399" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-xdist", specifier = ">=3.6.1" },
+    { name = "respx" },
+    { name = "rich", specifier = ">=13.7.1" },
+    { name = "ruff" },
+    { name = "time-machine" },
+]
+pydantic-v2 = [
+    { name = "pydantic", marker = "python_full_version < '3.14'", specifier = "~=2.0" },
+    { name = "pydantic", marker = "python_full_version >= '3.14'", specifier = "~=2.12" },
+]
+
+[[package]]
 name = "nemo-tau3-oo-agent"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "mcp" },
+    { name = "nemo-platform-plugin" },
     { name = "nooa", extra = ["tracing"] },
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "orjson" },
@@ -730,9 +1072,39 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "mcp", specifier = "==1.25.0" },
+    { name = "nemo-platform-plugin", editable = "../../../../packages/nemo_platform_plugin" },
     { name = "nooa", extras = ["tracing"], specifier = ">=0.0.9" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "orjson", specifier = "==3.11.9" },
+]
+
+[[package]]
+name = "ngcsdk"
+version = "4.36.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiofiles" },
+    { name = "aiohttp" },
+    { name = "boto3" },
+    { name = "botocore" },
+    { name = "certifi" },
+    { name = "cryptography" },
+    { name = "docker" },
+    { name = "isodate" },
+    { name = "packaging" },
+    { name = "polling2" },
+    { name = "prettytable" },
+    { name = "psutil" },
+    { name = "python-dateutil" },
+    { name = "requests" },
+    { name = "requests-toolbelt" },
+    { name = "rich" },
+    { name = "shortuuid" },
+    { name = "urllib3" },
+    { name = "validators" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/cf/e4901fd5a50621d3f058d0ba4f732651a86d672fb76b7a404473b2b23ac1/ngcsdk-4.36.6-py3-none-any.whl", hash = "sha256:8cf4ce3bd071b3d2e24d40f2c66abc2c2b49022b53d400a2eb9fe6018fe3f343", size = 2443632, upload-time = "2026-09-04T22:09:43.312Z" },
 ]
 
 [[package]]
@@ -757,6 +1129,15 @@ tracing = [
     { name = "openinference-semantic-conventions" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-sdk" },
+]
+
+[[package]]
+name = "nvidia-ml-py"
+version = "13.610.43"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/b5/a8fbc356f768fa5c9cfd646668fd7d34bf55bdd1c6e20754642a64d930d4/nvidia_ml_py-13.610.43.tar.gz", hash = "sha256:65437eb73d68d0c62c931ca4d45038472faff03bd0b8729abba4b899f70d60f2", size = 52109, upload-time = "2026-06-01T18:54:08.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/45/caa600acfab94560807a20a64b5830d2cd3c3202b7f1328644d70b7d6bd8/nvidia_ml_py-13.610.43-py3-none-any.whl", hash = "sha256:f13c72698edef492f985cc225f14faafe68ae065a2e407f45bdf6f4b9b43fde8", size = 53163, upload-time = "2026-06-01T18:54:07.704Z" },
 ]
 
 [[package]]
@@ -964,6 +1345,39 @@ wheels = [
 ]
 
 [[package]]
+name = "polling2"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/9d/6a560ab95e1b92dfce97321d8ffc9f20d352fa4b12a91525d4c575df1c74/polling2-0.5.0.tar.gz", hash = "sha256:90b7da82cf7adbb48029724d3546af93f21ab6e592ec37c8c4619aedd010e342", size = 6549, upload-time = "2021-07-19T18:06:54.951Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/de/e5bf2556ebd6db12590788207575c7c75b1de62f5ddc8b4916b668e04e6b/polling2-0.5.0-py2.py3-none-any.whl", hash = "sha256:ad86d56fbd7502f0856cac2d0109d595c18fa6c7fb12c88cee5e5d16c17286c1", size = 6431, upload-time = "2021-07-19T18:06:53.681Z" },
+]
+
+[[package]]
+name = "prettytable"
+version = "3.18.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/74/ba08d81e668ccfe8658d7520a307e63c19862c08eb4ccb26f356c5239a7a/prettytable-3.18.0.tar.gz", hash = "sha256:439217116152244369caf3d9f1caf2f9fe29b03bd79e88d2928c8e718c95d680", size = 76373, upload-time = "2026-06-22T16:07:50.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/be/2e6798ace5cc036f5d05d36b7b2fd85346f1a708c87060890b070d0ec607/prettytable-3.18.0-py3-none-any.whl", hash = "sha256:b3346e0e6f79180833aebaac088ae926340586cf6d7d991b9eb125b65f72313a", size = 37357, upload-time = "2026-06-22T16:07:48.595Z" },
+]
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.53"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/ea/39b988c938f75cb75d7045b5c69f8bfed47ee2152c8837fb403de29d6fb8/prompt_toolkit-3.0.53.tar.gz", hash = "sha256:9ec8a0ad96d5c56148b3f914aa79c1564c3fde5d2e6b876e7bc327e353cf8fa6", size = 435492, upload-time = "2026-07-26T20:56:14.758Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/6f/84908cad2d6aa5144abcf7b42709fe4fdb459bc640ec7ac5786e7693dabc/prompt_toolkit-3.0.53-py3-none-any.whl", hash = "sha256:01c0891d7f9237d5e339f7d3e42cdae80b7534abb1c7c0e3352efba6231492f2", size = 392288, upload-time = "2026-07-26T20:56:12.512Z" },
+]
+
+[[package]]
 name = "propcache"
 version = "0.5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1036,6 +1450,28 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d8/bc/6d6c7ba8709c85f8f2c390b2b118d6fb08a783676a572271851bf45a7d22/protobuf-7.35.1-cp310-abi3-win32.whl", hash = "sha256:353652e4efd0bca5b5fc2656abf8307ef351f0cf938c9eba09f0e09c20a25c30", size = 428945, upload-time = "2026-06-11T21:55:37.034Z" },
     { url = "https://files.pythonhosted.org/packages/0a/19/8d0cb6f20a1ef7b18f1c8986ad5783f22f84cce39c6ce9a6e645ea55192e/protobuf-7.35.1-cp310-abi3-win_amd64.whl", hash = "sha256:230a75ddfc2de4806e56696ce9640c1cdfdb6543b7cfce98d42a4c0a0e7bdb87", size = 439996, upload-time = "2026-06-11T21:55:38.123Z" },
     { url = "https://files.pythonhosted.org/packages/19/c7/5f7c636ec43e0c545e28d1f1db71990108306f7bdcb89f069ba97e428e7f/protobuf-7.35.1-py3-none-any.whl", hash = "sha256:4bc97768d8fe4ad6743c8a19403e314511ed9f6d13205b687e52421c023ac1b9", size = 171659, upload-time = "2026-06-11T21:55:39.155Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
 ]
 
 [[package]]
@@ -1122,6 +1558,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.21.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/2e/ced460408999b33da6b31b0021b0f37d329e202d4169aeb164493778f25b/pygments-2.21.0.tar.gz", hash = "sha256:610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c", size = 5005329, upload-time = "2026-08-17T08:02:48.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl", hash = "sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9", size = 1250147, upload-time = "2026-08-17T08:02:44.912Z" },
+]
+
+[[package]]
 name = "pyjwt"
 version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1133,6 +1578,18 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
 ]
 
 [[package]]
@@ -1280,6 +1737,31 @@ wheels = [
 ]
 
 [[package]]
+name = "requests-toolbelt"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481, upload-time = "2023-05-01T04:11:28.427Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
 name = "rpds-py"
 version = "2026.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1318,12 +1800,51 @@ wheels = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.19.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/43/35e4d8aa320bffe8287fe8f65f578fa2d2db0a64212f0e710dce58267854/s3transfer-0.19.2.tar.gz", hash = "sha256:ba0309fd86be3c27dbf78cdd813c13c5e1df16e5874b99d2535ebbdfb9892993", size = 165592, upload-time = "2026-07-22T19:30:44.432Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl", hash = "sha256:d8168eccca828cbb2cd573675333f3bddd254313a9c42494b84c76b539e8ba25", size = 90216, upload-time = "2026-07-22T19:30:43.251Z" },
+]
+
+[[package]]
 name = "setuptools"
 version = "83.0.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "shortuuid"
+version = "1.0.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/e2/bcf761f3bff95856203f9559baf3741c416071dd200c0fc19fad7f078f86/shortuuid-1.0.13.tar.gz", hash = "sha256:3bb9cf07f606260584b1df46399c0b87dd84773e7b25912b7e391e30797c5e72", size = 9662, upload-time = "2024-03-11T20:11:06.879Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/44/21d6bf170bf40b41396480d8d49ad640bca3f2b02139cd52aa1e272830a5/shortuuid-1.0.13-py3-none-any.whl", hash = "sha256:a482a497300b49b4953e15108a7913244e1bb0d41f9d332f5e9925dba33a3c5a", size = 10529, upload-time = "2024-03-11T20:11:04.807Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]
@@ -1434,6 +1955,30 @@ wheels = [
 ]
 
 [[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.25.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/51/9aed62104cea109b820bbd6c14245af756112017d309da813ef107d42e7e/typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc", size = 122276, upload-time = "2026-04-30T19:32:16.964Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/f9/2b3ff4e56e5fa7debfaf9eb135d0da96f3e9a1d5b27222223c7296336e5f/typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89", size = 58409, upload-time = "2026-04-30T19:32:18.271Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1474,6 +2019,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a2/65/b7c6c443ccc58678c91e1e973bbe2a878591538655d6e1d47f24ba1c51f3/uvicorn-0.51.0.tar.gz", hash = "sha256:f6f4b69b657c312f516dd2d268ab9ae6f254b11e4bac504f37b2ab58b24dd0b0", size = 94412, upload-time = "2026-07-08T10:59:05.962Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/45/ec/dbb7e5a6b91f86bfb9eb7d2988a2730907b6a729875b949c7f022e8b88fa/uvicorn-0.51.0-py3-none-any.whl", hash = "sha256:5d38af6cd620f2ae3849fb44fd4879e0890aa1febe8d47eb355fb45d93fe6a5b", size = 73219, upload-time = "2026-07-08T10:59:04.44Z" },
+]
+
+[[package]]
+name = "validators"
+version = "0.35.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/66/a435d9ae49850b2f071f7ebd8119dd4e84872b01630d6736761e6e7fd847/validators-0.35.0.tar.gz", hash = "sha256:992d6c48a4e77c81f1b4daba10d16c3a9bb0dbb79b3a19ea847ff0928e70497a", size = 73399, upload-time = "2025-05-01T05:42:06.7Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/6e/3e955517e22cbdd565f2f8b2e73d52528b14b8bcfdb04f62466b071de847/validators-0.35.0-py3-none-any.whl", hash = "sha256:e8c947097eae7892cb3d26868d637f79f47b4a0554bc6b80065dfe5aac3705dd", size = 44712, upload-time = "2025-05-01T05:42:04.203Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/57/ed58088fafdf4c55a0ad6bde846502567645424d7ebf325230b9237f4085/wcwidth-0.8.3.tar.gz", hash = "sha256:d128512515fbf4612e0ff21fd6380399210318b7b54a9af59dff8454cf9730eb", size = 1458450, upload-time = "2026-08-28T18:10:06.875Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/0e/57f6bb3024a597b2e8ec4aee710ffe62ddc95af2e2bb1ee7a7abdc22c68c/wcwidth-0.8.3-py3-none-any.whl", hash = "sha256:d5b73dba6158a595ec9370350e7f2637bcac8d6c5e4fde34f30fcffb6103a5e4", size = 331669, upload-time = "2026-08-28T18:10:04.909Z" },
 ]
 
 [[package]]

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/cli.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/cli.py
@@ -44,8 +44,8 @@ from nemo_insights_plugin.contracts.profile import (
     load_env_file,
     resolve_base_url,
 )
-from nemo_platform import NeMoPlatformError
 from nemo_platform_plugin.cli import NemoCLI
+from nemo_platform_plugin.client.errors import NemoClientError
 from nooa import GenerationError
 
 DEFAULT_WORKSPACE = "default"
@@ -54,7 +54,7 @@ _PREFLIGHT_PROBES: Probes | None = None  # test seam; None → real probes
 
 run_experimentalist = None  # lazily imported by the run command; tests monkeypatch it
 
-_PLATFORM_CLIENT_ERRORS = (NeMoPlatformError, httpx.HTTPError, OSError, RuntimeError, ValueError)
+_PLATFORM_CLIENT_ERRORS = (NemoClientError, httpx.HTTPError, OSError, RuntimeError, ValueError)
 
 # TODO: Add remote train/validation dataset support when remote experiment mode is implemented.
 
@@ -200,7 +200,7 @@ class ExperimentalistCLI(NemoCLI):
                 readable=True,
             ),
         ) -> None:
-            """Run offline optimization for a baseline agent (local dir or git source)."""
+            """Run local optimization for a baseline agent (local dir or git source)."""
 
             if no_insight and (insight is not None or insight_id is not None):
                 typer.echo("--no-insight cannot be combined with --insight or --insight-id", err=True)

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/client.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/client.py
@@ -1,27 +1,24 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Shared NeMo Platform SDK client construction for Insight consumers.
+"""Shared NeMo Platform client construction for Insight consumers.
 
 Auth lives in the active ``nemo auth login`` context in
-``~/.config/nmp/config.yaml``. The SDK only wires up that context (and the
-transparent OIDC token refresh that comes with it) when it runs its config
-bootstrap. Passing ``base_url`` *alone* puts the SDK in "direct mode", which
-skips the bootstrap and injects **no** auth headers — fine for an
-unauthenticated local ``nemo services run``, but it 401s against a remote
-deployment. To authenticate against a remote URL we must trigger the bootstrap
-(by also passing ``config_path``) so the explicit ``base_url`` is combined with
-the context's credentials.
-
-Every Platform Insight consumer takes ``base_url`` from its workflow context,
-so this helper is the one place that branch lives.
+``~/.config/nmp/config.yaml``. Passing ``base_url`` alone puts the typed client in
+"direct mode", which injects no auth headers -- fine for an unauthenticated local
+``nemo services run``, but it 401s against a remote deployment. To authenticate
+against a remote URL we combine the explicit URL with the context's credentials.
 """
 
+from pathlib import Path
 from urllib.parse import urlparse
 
-from nemo_platform import AsyncNeMoPlatform
-from nemo_platform_ext.auth.helpers import discover_nmp_config
-from nemo_platform_ext.config.config import Config
+from nemo_platform_plugin.client.auth import AsyncTokenProvider, TokenProvider
+from nemo_platform_plugin.client.client import AsyncNemoClient
+from nemo_platform_plugin.client.config.config import Config
+from nemo_platform_plugin.client.config.models import ConfigParams, OAuthUser
+from nemo_platform_plugin.client.oidc import discover_nmp_config
+from nemo_platform_plugin.client.oidc_factory import resolve_oidc_provider
 
 # Loopback hosts are served by an unauthenticated local platform; attaching
 # (and refreshing) OAuth tokens there is both unnecessary and a failure mode
@@ -29,27 +26,58 @@ from nemo_platform_ext.config.config import Config
 LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1", "0.0.0.0"})
 
 
-def make_client(base_url: str | None) -> AsyncNeMoPlatform:
-    """Construct an :class:`AsyncNeMoPlatform` honoring an optional ``base_url``.
+def _is_loopback_url(base_url: str) -> bool:
+    return (urlparse(base_url).hostname or "").lower() in LOOPBACK_HOSTS
+
+
+def _require_secure_authenticated_remote(base_url: str) -> None:
+    parsed = urlparse(base_url)
+    if _is_loopback_url(base_url):
+        return
+    if parsed.scheme != "https":
+        raise ValueError("Authenticated remote NeMo Platform URLs must use HTTPS")
+
+
+def _client_from_config_with_base_url(base_url: str, config_path: Path) -> AsyncNemoClient:
+    _require_secure_authenticated_remote(base_url)
+    overrides: ConfigParams = {"base_url": base_url}
+    config = Config.load(config_path=config_path, overrides=overrides)
+    actual_config_path = config.get_config_path() or Config.get_default_config_path()
+    ctx = config.resolve()
+    auth: TokenProvider | AsyncTokenProvider | str | None = None
+    if isinstance(ctx.user, OAuthUser):
+        auth = resolve_oidc_provider(
+            base_url=base_url,
+            context_name=ctx.context_name,
+            access_token=ctx.user.token.get_secret_value(),
+            refresh_token=ctx.user.refresh_token.get_secret_value() if ctx.user.refresh_token else None,
+            config_exists=actual_config_path.exists(),
+            config_path=actual_config_path,
+            explicit_access_token=config.access_token is not None,
+        )
+    return AsyncNemoClient(base_url=base_url, workspace=ctx.workspace, auth=auth)
+
+
+def make_client(base_url: str | None) -> AsyncNemoClient:
+    """Construct an :class:`AsyncNemoClient` honoring an optional ``base_url``.
 
     - No ``base_url``: use the active nmp context for both URL and auth.
     - Loopback ``base_url``: direct mode (local platform is unauthenticated).
     - Authenticated remote ``base_url`` with an nmp config present: combine the
-      URL with the context's auth so the SDK injects and refreshes a Bearer token.
+      URL with the context's auth so the client injects and refreshes a Bearer token.
     - Unauthenticated remote ``base_url``: direct mode, even when an unrelated
       OAuth context exists locally.
     - Remote ``base_url`` without an nmp config: direct mode (no credentials to
       use; the request will surface a clear auth error).
     """
     if not base_url:
-        return AsyncNeMoPlatform()
+        return AsyncNemoClient.from_config()
 
-    host = (urlparse(base_url).hostname or "").lower()
     config_path = Config.get_default_config_path()
-    if host in LOOPBACK_HOSTS or not config_path.exists():
-        return AsyncNeMoPlatform(base_url=base_url)
+    if _is_loopback_url(base_url) or not config_path.exists():
+        return AsyncNemoClient(base_url=base_url)
 
     if not discover_nmp_config(base_url).auth_enabled:
-        return AsyncNeMoPlatform(base_url=base_url)
+        return AsyncNemoClient(base_url=base_url)
 
-    return AsyncNeMoPlatform(base_url=base_url, config_path=config_path)
+    return _client_from_config_with_base_url(base_url, config_path)

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/eval_author/agent.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/eval_author/agent.py
@@ -38,7 +38,7 @@ from nemo_experimentalist_plugin.experimentalist.components.trace_explorer impor
 )
 from nemo_experimentalist_plugin.experimentalist.reporting import RunReporter
 from nemo_insights_plugin.entities import Insight
-from nemo_platform import AsyncNeMoPlatform
+from nemo_platform_plugin.client.client import AsyncNemoClient
 from nemo_platform_plugin.nooa_model_client import get_default_model, get_fast_model
 from nooa import Agent, CodeActStrategy, strategy
 from nooa.agentdoc import doc
@@ -79,7 +79,7 @@ class EvalAuthor(Agent):
         self.experiment_dir = experiment_dir
         # Set by the standalone entry point before it queries production traces. The
         # Experimentalist path leaves both unset and passes a client to ``run`` instead.
-        self.client: AsyncNeMoPlatform | None = None
+        self.client: AsyncNemoClient | None = None
         self.workspace: str | None = None
         self.shell = GuardedShellTools(cwd=experiment_dir)
         self.todos = TodoManager()
@@ -97,7 +97,7 @@ class EvalAuthor(Agent):
             config=TokenBudgetConfig(max_tokens=self._config.max_summary_tokens),
         )
 
-    def _intake(self) -> tuple[AsyncNeMoPlatform, str]:
+    def _intake(self) -> tuple[AsyncNemoClient, str]:
         """Return the client and workspace for Intake reads, or name what is missing."""
         if self.client is None or self.workspace is None:
             raise traces.TraceQueryError(
@@ -317,7 +317,7 @@ class EvalAuthor(Agent):
         self,
         trace_ref: str,
         task_template: Task,
-        client: AsyncNeMoPlatform,
+        client: AsyncNemoClient,
         workspace: str,
     ) -> Task:
         """Fill a pre-staged task template with values from a production trace.
@@ -370,7 +370,7 @@ class EvalAuthor(Agent):
         train_dataset: Dataset,
         validation_dataset: Dataset,
         *,
-        client: AsyncNeMoPlatform,
+        client: AsyncNemoClient,
     ) -> EvalAuthorResult:
         """Curate an evaluation suite and always close the owned shell session."""
         try:
@@ -393,7 +393,7 @@ class EvalAuthor(Agent):
         train_dataset: Dataset,
         validation_dataset: Dataset,
         *,
-        client: AsyncNeMoPlatform,
+        client: AsyncNemoClient,
     ) -> EvalAuthorResult:
         """Curate an evaluation suite from an Insight and its production traces.
 

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/eval_author/run.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/eval_author/run.py
@@ -17,7 +17,7 @@ from nemo_experimentalist_plugin.experimentalist.experimentalist_backend import 
 )
 from nemo_experimentalist_plugin.experimentalist.reporting import RunReporter
 from nemo_insights_plugin.entities import Insight
-from nemo_platform import AsyncNeMoPlatform
+from nemo_platform_plugin.client.client import AsyncNemoClient
 from nemo_platform_plugin.nooa_model_client import (
     ConfiguredModelClients,
     ConfiguredModelRefs,
@@ -36,7 +36,7 @@ class _EvalAuthorAgent(Protocol):
         train_dataset: Dataset,
         validation_dataset: Dataset,
         *,
-        client: AsyncNeMoPlatform,
+        client: AsyncNemoClient,
     ) -> EvalAuthorResult: ...
 
 

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/eval_author/traces.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/eval_author/traces.py
@@ -30,7 +30,17 @@ from typing import Any, cast
 from nemo_experimentalist_plugin.entities import ResourceRef, Task, TrialResult
 from nemo_experimentalist_plugin.experimentalist.components.trace_analyzer import Diagnostic, TraceAnalyzer
 from nemo_experimentalist_plugin.experimentalist.components.trace_explorer import TraceExplorer
-from nemo_platform import APIConnectionError, APIStatusError, AsyncNeMoPlatform
+from nemo_platform_plugin.client.client import AsyncNemoClient
+from nemo_platform_plugin.client.errors import NemoHTTPError, NemoTransportError
+from nemo_platform_plugin.intake.client import AsyncIntakeClient
+from nemo_platform_plugin.intake.types import (
+    ListSpanGroupsQueryParams,
+    ListSpansQueryParams,
+    ListTracesQueryParams,
+    SpanFilterParam,
+    TraceFilterParam,
+    TraceMode,
+)
 
 DEFAULT_ROW_LIMIT = 100
 MAX_ROW_LIMIT = 1000
@@ -48,7 +58,7 @@ class TraceQueryError(RuntimeError):
 
 def _explain(exc: Exception, *, doing: str, workspace: str) -> TraceQueryError:
     """Turn an SDK failure into an error that names a corrective action."""
-    if isinstance(exc, APIStatusError):
+    if isinstance(exc, NemoHTTPError):
         if exc.status_code in (401, 403):
             hint = (
                 "Credentials were rejected. Run `nemo auth login`, then confirm that NMP_BASE_URL "
@@ -64,7 +74,7 @@ def _explain(exc: Exception, *, doing: str, workspace: str) -> TraceQueryError:
         else:
             hint = f"Intake returned HTTP {exc.status_code}: {exc}"
         return TraceQueryError(f"{doing} failed. {hint}")
-    if isinstance(exc, APIConnectionError):
+    if isinstance(exc, NemoTransportError):
         return TraceQueryError(
             f"{doing} failed: the platform is unreachable. Check NMP_BASE_URL and that the services run."
         )
@@ -107,7 +117,7 @@ def _with_trace_ref(row: dict[str, Any]) -> dict[str, Any]:
 
 
 async def query_spans(
-    client: AsyncNeMoPlatform,
+    client: AsyncNemoClient,
     *,
     workspace: str,
     filter: dict[str, Any] | None = None,
@@ -170,17 +180,29 @@ async def query_spans(
         TraceQueryError: The Intake read failed.
     """
     limit = max(1, min(limit, MAX_ROW_LIMIT))
-    kwargs: dict[str, Any] = {"workspace": workspace, "page_size": _page_size(limit)}
-    if filter is not None:
-        kwargs["filter"] = cast(Any, filter)
-    kwargs["sort"] = sort or "-started_at"
+    intake = AsyncIntakeClient.from_client(client)
     try:
         if group_by is not None:
-            rows, truncated = await _drain(client.intake.spans.groups.list(by=group_by, **kwargs), limit=limit)
+            group_params: ListSpanGroupsQueryParams = {
+                "by": group_by,
+                "page_size": _page_size(limit),
+                "sort": sort or "-started_at",
+            }
+            if filter is not None:
+                group_params["filter"] = cast(SpanFilterParam, filter)
+            response = await intake.list_span_groups(workspace=workspace, query_params=group_params)
+            rows, truncated = await _drain(response.items(), limit=limit)
             groups = [_with_trace_ref(row) for row in rows]
             return {"groups": groups, "grouped_by": group_by, "count": len(groups), "truncated": truncated}
-        kwargs["mode"] = mode
-        rows, truncated = await _drain(client.intake.spans.list(**kwargs), limit=limit)
+        span_params: ListSpansQueryParams = {
+            "page_size": _page_size(limit),
+            "sort": sort or "-started_at",
+            "mode": cast(TraceMode, mode),
+        }
+        if filter is not None:
+            span_params["filter"] = cast(SpanFilterParam, filter)
+        response = await intake.list_spans(workspace=workspace, query_params=span_params)
+        rows, truncated = await _drain(response.items(), limit=limit)
         spans = [_with_trace_ref(row) for row in rows]
         return {"spans": spans, "count": len(spans), "truncated": truncated}
     except Exception as exc:
@@ -188,7 +210,7 @@ async def query_spans(
 
 
 async def query_traces(
-    client: AsyncNeMoPlatform,
+    client: AsyncNemoClient,
     *,
     workspace: str,
     filter: dict[str, Any] | None = None,
@@ -230,23 +252,25 @@ async def query_traces(
         TraceQueryError: The Intake read failed.
     """
     limit = max(1, min(limit, MAX_ROW_LIMIT))
-    kwargs: dict[str, Any] = {
-        "workspace": workspace,
-        "mode": mode,
+    query_params: ListTracesQueryParams = {
+        "mode": cast(TraceMode, mode),
         "sort": sort or "-started_at",
         "page_size": _page_size(limit),
     }
     if filter is not None:
-        kwargs["filter"] = cast(Any, filter)
+        query_params["filter"] = cast(TraceFilterParam, filter)
     try:
-        rows, truncated = await _drain(client.intake.traces.list(**kwargs), limit=limit)
+        response = await AsyncIntakeClient.from_client(client).list_traces(
+            workspace=workspace, query_params=query_params
+        )
+        rows, truncated = await _drain(response.items(), limit=limit)
     except Exception as exc:
         raise _explain(exc, doing="Querying traces", workspace=workspace) from exc
     return {"traces": rows, "count": len(rows), "truncated": truncated}
 
 
 async def find_agent_traces(
-    client: AsyncNeMoPlatform,
+    client: AsyncNemoClient,
     *,
     agent: str,
     workspace: str,
@@ -346,7 +370,7 @@ def _trace_entry(trace_id: str, summary: dict[str, Any] | None) -> dict[str, Any
     }
 
 
-async def read_trace(client: AsyncNeMoPlatform, ref: str, *, workspace: str) -> TraceExplorer:
+async def read_trace(client: AsyncNemoClient, ref: str, *, workspace: str) -> TraceExplorer:
     """Read one production trace in full.
 
     Args:
@@ -369,7 +393,7 @@ async def read_trace(client: AsyncNeMoPlatform, ref: str, *, workspace: str) -> 
 
 
 async def analyze_trace(
-    client: AsyncNeMoPlatform,
+    client: AsyncNemoClient,
     ref: str,
     *,
     workspace: str,

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/atif.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/atif.py
@@ -14,7 +14,7 @@ from typing import Any, cast
 from urllib.parse import urlparse
 
 from nemo_experimentalist_plugin.entities import ResourceRef
-from nemo_platform.types.intake.ingest.atif_create_params import AtifCreateParams
+from nemo_platform_plugin.intake.types import AtifCreateParams
 
 # ATIF carries agent identity on the trajectory; the Experimentalist carries it as
 # OTLP-style span attributes. This maps one onto the other.

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/dataset_staging.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/dataset_staging.py
@@ -3,13 +3,17 @@
 
 """Experiment-local staging and hydration for Eval Author inputs."""
 
+import asyncio
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import urlparse
 
+from filesets import FilesetPathError, parse_fileset_ref
 from nemo_experimentalist_plugin.entities import Dataset, DatasetRef, local_path_from_uri
-from nemo_platform import AsyncNeMoPlatform
+from nemo_platform_plugin.client.client import AsyncNemoClient
+from nemo_platform_plugin.files.client import AsyncFilesClient
+from nemo_platform_plugin.files.types import ListFilesQueryParams
 
 
 @dataclass(frozen=True, slots=True)
@@ -39,6 +43,64 @@ def distribute_insight_suite_tasks(
     train_dataset.add_tasks(tasks[validation_count:])
 
 
+def _parse_fileset_uri(uri: str, *, workspace: str) -> tuple[str, str, str]:
+    if urlparse(uri).scheme != "fileset":
+        raise ValueError(f"Not a fileset URI: {uri}")
+    try:
+        return parse_fileset_ref(uri, workspace_fallback=workspace)
+    except FilesetPathError as exc:
+        raise ValueError(f"Invalid fileset URI {uri!r}: {exc}") from exc
+
+
+def _write_downloaded_file(target: Path, content: bytes) -> None:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(content)
+
+
+def _relative_download_path(remote_path: str, prefix: str) -> str:
+    clean_remote_path = remote_path.strip("/")
+    if not clean_remote_path:
+        return ""
+    if not prefix:
+        return clean_remote_path
+
+    clean_prefix = prefix.strip("/")
+    if clean_remote_path == clean_prefix:
+        return Path(clean_remote_path).name
+    if not clean_remote_path.startswith(f"{clean_prefix}/"):
+        raise ValueError(f"Fileset listing returned path outside requested prefix {clean_prefix!r}: {remote_path!r}")
+    return clean_remote_path[len(clean_prefix) + 1 :]
+
+
+def _safe_download_target(destination: Path, relative_path: str) -> Path:
+    resolved_destination = destination.resolve()
+    target = (resolved_destination / relative_path).resolve()
+    if not target.is_relative_to(resolved_destination):
+        raise ValueError(f"Fileset path escapes staging destination: {relative_path!r}")
+    return target
+
+
+async def _download_fileset_tree(
+    client: AsyncNemoClient,
+    *,
+    uri: str,
+    workspace: str,
+    destination: Path,
+) -> None:
+    files_workspace, fileset, prefix = _parse_fileset_uri(uri, workspace=workspace)
+    files = AsyncFilesClient.from_client(client)
+    query_params: ListFilesQueryParams | None = {"path": prefix} if prefix else None
+    listing = (await files.list_files(workspace=files_workspace, name=fileset, query_params=query_params)).data()
+    for item in listing.data:
+        remote_path = item.path.strip("/")
+        relative_path = _relative_download_path(remote_path, prefix)
+        if not relative_path:
+            continue
+        target = _safe_download_target(destination, relative_path)
+        response = await files.download_file(workspace=files_workspace, name=fileset, path=remote_path)
+        await asyncio.to_thread(_write_downloaded_file, target, await response.read())
+
+
 def _local_directory(ref: DatasetRef) -> Path:
     path = local_path_from_uri(ref.uri, context="Eval Author input").resolve()
     if not path.is_dir():
@@ -57,7 +119,7 @@ async def stage_task_template(
     experiment_dir: Path,
     task_template: DatasetRef,
     *,
-    client: AsyncNeMoPlatform,
+    client: AsyncNemoClient,
     workspace: str,
 ) -> DatasetRef:
     """Refresh a local or Fileset-backed task template in experiment-local staging."""
@@ -76,10 +138,11 @@ async def stage_task_template(
 
     if urlparse(task_template.uri).scheme == "fileset":
         try:
-            await client.files.download(
-                remote_path=task_template.uri,
-                local_path=str(destination),
+            await _download_fileset_tree(
+                client,
+                uri=task_template.uri,
                 workspace=workspace,
+                destination=destination,
             )
         except BaseException:
             if destination.exists():
@@ -102,7 +165,7 @@ async def stage_eval_author_inputs(
     train_dataset: DatasetRef,
     validation_dataset: DatasetRef,
     task_template: DatasetRef,
-    client: AsyncNeMoPlatform,
+    client: AsyncNemoClient,
     workspace: str,
 ) -> _StagedEvalAuthorInputs:
     """Stage mutable Eval Author inputs beneath the experiment directory."""

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/trace_explorer.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/trace_explorer.py
@@ -10,10 +10,12 @@ import re
 from collections import Counter
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Literal, cast
+from typing import Any, Literal
 
 from nemo_experimentalist_plugin.entities import ResourceRef
-from nemo_platform import AsyncNeMoPlatform
+from nemo_platform_plugin.client.client import AsyncNemoClient
+from nemo_platform_plugin.intake.client import AsyncIntakeClient
+from nemo_platform_plugin.intake.types import ListEvaluatorResultsQueryParams, ListSpansQueryParams
 from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -1066,7 +1068,7 @@ def _load_span_models(path: str | Path) -> list[TraceSpan]:
 
 async def _fetch_intake_eval_contexts(
     *,
-    client: AsyncNeMoPlatform,
+    client: AsyncNemoClient,
     workspace: str,
     session_ids: set[str],
     page_size: int,
@@ -1074,14 +1076,15 @@ async def _fetch_intake_eval_contexts(
     results: list[EvalContextData] = []
     seen: set[str] = set()
 
+    intake = AsyncIntakeClient.from_client(client)
     for session_id in sorted(session_ids):
-        paginator = client.intake.evaluator_results.list(
-            workspace=workspace,
-            filter=cast(Any, {"session_id": session_id}),
-            page_size=max(1, page_size),
-            sort="created_at",
-        )
-        async for item in paginator:
+        query_params: ListEvaluatorResultsQueryParams = {
+            "filter": {"session_id": session_id},
+            "page_size": max(1, page_size),
+            "sort": "created_at",
+        }
+        paginator = await intake.list_evaluator_results(workspace=workspace, query_params=query_params)
+        async for item in paginator.items():
             row = item.model_dump(mode="json", exclude_none=True)
             result = _eval_context_from_record(row)
             dedupe_key = result.evaluator_result_id or json.dumps(row, sort_keys=True, default=str)
@@ -1538,7 +1541,7 @@ class TraceExplorer:
 
     @classmethod
     async def from_ref(
-        cls, ref: ResourceRef, client: AsyncNeMoPlatform | None = None, workspace: str | None = None
+        cls, ref: ResourceRef, client: AsyncNemoClient | None = None, workspace: str | None = None
     ) -> TraceExplorer:
         """Load a trace from a resource reference."""
         if ref.uri.startswith("file://"):
@@ -1562,7 +1565,7 @@ class TraceExplorer:
     @classmethod
     async def from_intake(
         cls,
-        client: AsyncNeMoPlatform,
+        client: AsyncNemoClient,
         trace_id: str,
         *,
         workspace: str,
@@ -1574,14 +1577,16 @@ class TraceExplorer:
         spans: list[TraceSpan] = []
         session_ids: set[str] = set()
 
-        paginator = client.intake.spans.list(
-            workspace=workspace,
-            filter=cast(Any, {"trace_id": trace_id}),
-            mode="detailed",
-            page_size=max(1, page_size),
-            sort="started_at",
+        query_params: ListSpansQueryParams = {
+            "filter": {"trace_id": trace_id},
+            "mode": "detailed",
+            "page_size": max(1, page_size),
+            "sort": "started_at",
+        }
+        paginator = await AsyncIntakeClient.from_client(client).list_spans(
+            workspace=workspace, query_params=query_params
         )
-        async for item in paginator:
+        async for item in paginator.items():
             row = item.model_dump(mode="json", exclude_none=True)
             if row.get("session_id"):
                 session_ids.add(str(row["session_id"]))

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/experiment_mirror.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/experiment_mirror.py
@@ -21,7 +21,13 @@ import re
 from typing import Any
 
 from nemo_experimentalist_plugin.entities import Candidate, ExperimentRun
-from nemo_platform import AsyncNeMoPlatform, ConflictError, NotFoundError, omit
+from nemo_platform_plugin.client.errors import ConflictError, NotFoundError
+from nemo_platform_plugin.intake.client import AsyncIntakeClient
+from nemo_platform_plugin.intake.types import (
+    EvaluationCreateRequest,
+    ExperimentCreateRequest,
+    ExperimentUpdateRequest,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -109,7 +115,7 @@ class ExperimentMirror:
     """Best-effort, one-way projection to native Experiments. Callers wrap each method
     so failures don't propagate (spec F)."""
 
-    def __init__(self, client: AsyncNeMoPlatform, workspace: str) -> None:
+    def __init__(self, client: AsyncIntakeClient, workspace: str) -> None:
         self._client = client
         self._workspace = workspace
         self._group_ids: dict[str, str] = {}  # run_id -> ExperimentGroup id
@@ -123,35 +129,53 @@ class ExperimentMirror:
 
     async def ensure_group(self, run: ExperimentRun) -> None:
         gname = group_name(run.id)
+        body = self._group_create_request(run, gname)
         try:
-            grp = await self._client.experiments.create(
-                workspace=self._workspace,
-                name=gname,
-                insight_id=run.insight or omit,
-                summary=run.summary or "",
-                metadata=group_metadata(run),
-            )
+            grp = (await self._client.create_experiment(workspace=self._workspace, body=body)).data()
         except ConflictError:
-            grp = await self._client.experiments.retrieve(gname, workspace=self._workspace)
+            grp = (await self._client.get_experiment(name=gname, workspace=self._workspace)).data()
         self._group_ids[run.id] = grp.id
 
     async def update_group(self, run: ExperimentRun) -> None:
         gname = group_name(run.id)
-        # experiments.update is a full-replace PUT: omitted fields reset to None
-        # server-side, so re-supply the whole body (we have the run).
-        await self._client.experiments.update(
-            gname,
+        await self._client.update_experiment(
+            name=gname,
             workspace=self._workspace,
-            body_name=gname,
+            body=self._group_update_request(run, gname),
+        )
+
+    def _group_create_request(self, run: ExperimentRun, gname: str) -> ExperimentCreateRequest:
+        if run.insight:
+            return ExperimentCreateRequest(
+                name=gname,
+                insight_id=run.insight,
+                summary=run.summary or "",
+                metadata=group_metadata(run),
+            )
+        return ExperimentCreateRequest(
+            name=gname,
             summary=run.summary or "",
-            insight_id=run.insight or omit,
+            metadata=group_metadata(run),
+        )
+
+    def _group_update_request(self, run: ExperimentRun, gname: str) -> ExperimentUpdateRequest:
+        if run.insight:
+            return ExperimentUpdateRequest(
+                name=gname,
+                insight_id=run.insight,
+                summary=run.summary or "",
+                metadata=group_metadata(run),
+            )
+        return ExperimentUpdateRequest(
+            name=gname,
+            summary=run.summary or "",
             metadata=group_metadata(run),
         )
 
     async def _group_id_for(self, run_id: str) -> str:
         gid = self._group_ids.get(run_id)
         if gid is None:  # resume path: group exists, look it up by deterministic name
-            grp = await self._client.experiments.retrieve(group_name(run_id), workspace=self._workspace)
+            grp = (await self._client.get_experiment(name=group_name(run_id), workspace=self._workspace)).data()
             gid = self._group_ids[run_id] = grp.id
         return gid
 
@@ -206,42 +230,47 @@ class ExperimentMirror:
     ) -> None:
         name = experiment_name(gname, candidate.label, split)
         link = source_link or self._source_link(gname, candidate, agent_source)
-        parent = await self._parent_experiment_id(candidate, gname)
-        parent_id = parent if parent is not None else omit
-        st = status or experiment_status(candidate)
-        md = experiment_metadata(candidate, split)  # identity only — no reward/trials (§4.3)
+        parent_id = await self._parent_experiment_id(candidate, gname)
+        body = self._evaluation_request(
+            name=name,
+            split=split,
+            group_id=group_id,
+            link=link,
+            candidate=candidate,
+            parent_id=parent_id,
+            status=status or experiment_status(candidate),
+        )
         try:
-            exp = await self._client.evaluations.create(
-                name=name,
-                dataset_name=self._dataset_name(split),
-                dataset_version="v1",
-                workspace=self._workspace,
-                experiment_ids=[group_id],
-                source_link=link,
-                description=candidate.description,
-                parent_evaluation_id=parent_id,
-                root_cause="",  # OQ-RC: left empty for now
-                status=st,
-                metadata=md,
-            )
+            exp = (await self._client.create_evaluation(workspace=self._workspace, body=body)).data()
         except ConflictError:
-            exp = await self._client.evaluations.update(
-                name,
-                workspace=self._workspace,
-                dataset_name=self._dataset_name(split),
-                dataset_version="v1",
-                body_name=name,
-                experiment_ids=[group_id],
-                source_link=link,
-                description=candidate.description,
-                parent_evaluation_id=parent_id,
-                root_cause="",  # OQ-RC: left empty for now
-                status=st,
-                metadata=md,
-            )
+            exp = (await self._client.update_evaluation(name=name, workspace=self._workspace, body=body)).data()
         if candidate.id:
             self._experiment_ids[(candidate.id, split)] = exp.id
             self._labels[candidate.id] = candidate.label
+
+    def _evaluation_request(
+        self,
+        *,
+        name: str,
+        split: str,
+        group_id: str,
+        link: str,
+        candidate: Candidate,
+        parent_id: str | None,
+        status: str,
+    ) -> EvaluationCreateRequest:
+        return EvaluationCreateRequest(
+            name=name,
+            dataset_name=self._dataset_name(split),
+            dataset_version="v1",
+            experiment_ids=[group_id],
+            source_link=link,
+            description=candidate.description,
+            root_cause="",
+            status=status,
+            metadata=experiment_metadata(candidate, split),
+            parent_evaluation_id=parent_id,
+        )
 
     def _dataset_name(self, split: str) -> str:
         return split  # OQ-8: derive a real dataset name/version later
@@ -254,13 +283,14 @@ class ExperimentMirror:
     async def _existing_source_link(self, gname: str, label: str, split: str) -> str | None:
         """The source_link already stored for this candidate/split, or None.
 
-        ``finalize`` re-upserts the winner via a full-replace update without the run's
+        ``finalize`` re-upserts the winner via update without the run's
         ``agent_source``; reusing the link written during the run keeps a round-0 seed's real
-        ``{repo}@{ref}`` from being clobbered with a pseudo link when no PR was opened."""
+        ``{repo}@{ref}`` from being clobbered with a pseudo link when no PR was opened.
+        """
         try:
-            exp = await self._client.evaluations.retrieve(
-                experiment_name(gname, label, split), workspace=self._workspace
-            )
+            exp = (
+                await self._client.get_evaluation(name=experiment_name(gname, label, split), workspace=self._workspace)
+            ).data()
         except NotFoundError:
             return None
         return exp.source_link
@@ -287,9 +317,11 @@ class ExperimentMirror:
             )
             return None
         try:  # resume / ancestor created earlier this run
-            exp = await self._client.evaluations.retrieve(
-                experiment_name(gname, ancestor_label, "train"), workspace=self._workspace
-            )
+            exp = (
+                await self._client.get_evaluation(
+                    name=experiment_name(gname, ancestor_label, "train"), workspace=self._workspace
+                )
+            ).data()
         except NotFoundError:
             logger.debug(
                 "Ancestor experiment %r not found for candidate %r; lineage link omitted",
@@ -305,19 +337,17 @@ class ExperimentMirror:
     async def finalize(self, *, run_id: str, summary: str, winner: Candidate | None, pr_url: str | None = None) -> None:
         gname = group_name(run_id)
         gid = await self._group_id_for(run_id)
-        # experiments.update is a full-replace PUT: omitted fields reset to None
-        # server-side. finalize has no `run`, so read-preserve-write the current
-        # insight_id/metadata before writing the summary (stays within the mirror; no
-        # data flows back into the loop).
-        grp = await self._client.experiments.retrieve(gname, workspace=self._workspace)
-        await self._client.experiments.update(
-            gname,
-            workspace=self._workspace,
-            body_name=gname,
-            summary=summary,
-            insight_id=grp.insight_id if grp.insight_id is not None else omit,
-            metadata=grp.metadata if grp.metadata is not None else omit,
-        )
+        grp = (await self._client.get_experiment(name=gname, workspace=self._workspace)).data()
+        if grp.insight_id is not None:
+            body = ExperimentUpdateRequest(
+                name=gname,
+                summary=summary,
+                insight_id=grp.insight_id,
+                metadata=grp.metadata,
+            )
+        else:
+            body = ExperimentUpdateRequest(name=gname, summary=summary, metadata=grp.metadata)
+        await self._client.update_experiment(name=gname, workspace=self._workspace, body=body)
         if winner is None:
             return
         # The winner's Experiment is always status="winner"; whether a PR was opened is

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/experimentalist_backend.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/experimentalist_backend.py
@@ -24,7 +24,6 @@ from pathlib import Path
 from typing import Any, TypeVar, cast
 from urllib.parse import urlparse
 
-import httpx
 from nemo_experimentalist_plugin.config import CandidateStorageConfig
 from nemo_experimentalist_plugin.entities import (
     Candidate,
@@ -48,7 +47,16 @@ from nemo_experimentalist_plugin.experimentalist.experiment_mirror import Experi
 from nemo_experimentalist_plugin.experimentalist.otlp import jsonl_to_protobuf, read_trace_id, spans_to_protobuf
 from nemo_experimentalist_plugin.experimentalist.result import ExperimentalistResult
 from nemo_insights_plugin.entities import Insight
-from nemo_platform import AsyncNeMoPlatform
+from nemo_insights_plugin.typed_client import AsyncInsightsClient
+from nemo_platform_plugin.client.client import AsyncNemoClient
+from nemo_platform_plugin.client.errors import NemoHTTPError, NotFoundError
+from nemo_platform_plugin.intake.client import AsyncIntakeClient
+from nemo_platform_plugin.intake.types import (
+    AtifCreateRequest,
+    EvaluatorResultCreateRequest,
+    ListSpansQueryParams,
+    Trace,
+)
 from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
@@ -56,7 +64,7 @@ _ModelT = TypeVar("_ModelT", bound=BaseModel)
 
 
 async def _ingest_otlp(
-    client: AsyncNeMoPlatform,
+    client: AsyncIntakeClient,
     payloads: Iterable[bytes],
     *,
     workspace: str,
@@ -70,7 +78,7 @@ async def _ingest_otlp(
     trial, so the run continues.
     """
     for payload in payloads:
-        response = await client.intake.ingest.otlp.v1.traces.create(body=payload, workspace=workspace)
+        response = (await client.create_otlp_traces(content=payload, workspace=workspace)).data()
         if response.errors:
             raise RuntimeError(
                 f"Intake rejected {len(response.errors)} span(s) for trial {trial_id}: {response.errors}"
@@ -78,7 +86,7 @@ async def _ingest_otlp(
 
 
 async def _upload_trace_otlp(
-    client: AsyncNeMoPlatform,
+    client: AsyncIntakeClient,
     workspace: str,
     ref: ResourceRef,
     *,
@@ -102,7 +110,7 @@ async def _upload_trace_otlp(
 
 
 async def _upload_trace_atif(
-    client: AsyncNeMoPlatform,
+    client: AsyncIntakeClient,
     workspace: str,
     ref: ResourceRef,
     *,
@@ -123,8 +131,8 @@ async def _upload_trace_atif(
         task_id=task_id,
         agent_attrs=extra_attrs or {},
     )
-    payload["workspace"] = workspace
-    await client.intake.ingest.atif.create(**payload)
+    payload.pop("workspace", None)
+    await client.create_atif(workspace=workspace, body=AtifCreateRequest(root=payload))
 
 
 _BASELINE_AGENT_LABEL = "agent-0"
@@ -152,7 +160,7 @@ class ExperimentalistBackend(ABC):
 
     def __init__(
         self,
-        client: AsyncNeMoPlatform | None = None,
+        client: AsyncNemoClient,
         path: Path | None = None,
         storage: CandidateStorageConfig | None = None,
     ) -> None:
@@ -239,8 +247,8 @@ class ExperimentalistBackend(ABC):
     async def get_evaluation_name(self, *, workspace: str, candidate: Candidate, split: str) -> str:
         """Best-effort Evaluation name for *candidate* × *split* in *workspace*.
 
-        Returns "" when there is no projection (offline) or it fails — the name only
-        tags Intake resource attributes, so a run must not break on it.
+        Returns "" when projection fails — the name only tags Intake resource
+        attributes, so a run must not break on it.
         """
         ...
 
@@ -368,7 +376,7 @@ def _load_entity(cls: type[_ModelT], path: Path) -> _ModelT:
 
 
 class LocalExperimentalistBackend(ExperimentalistBackend):
-    """Persist entities under the optimizer's working directory (offline mode).
+    """Persist entities under the optimizer's working directory.
 
     Entity CRUD and result persistence land in local files under the same
     ``eval-and-optimize/`` tree that AAD created::
@@ -398,19 +406,19 @@ class LocalExperimentalistBackend(ExperimentalistBackend):
     def __init__(
         self,
         *,
-        client: AsyncNeMoPlatform | None = None,
+        client: AsyncNemoClient,
         path: Path,
         storage: CandidateStorageConfig | None = None,
     ) -> None:
         super().__init__(client, path, storage)
         self.path = path
+        self.intake_client = AsyncIntakeClient.from_client(client)
         self._eo = path / "eval-and-optimize"
         for subdir in ("agents", "analysis", "candidates", "results"):
             (self._eo / subdir).mkdir(parents=True, exist_ok=True)
-        # Best-effort, one-way projection onto native platform Experiments. Active only when
-        # a platform client is present (offline/local-only runs leave it a no-op); mirrors are
-        # built lazily by ``_project_best_effort`` and cached per workspace so reusing this
-        # backend across workspaces never projects into the wrong one.
+        # Best-effort, one-way projection onto native platform Experiments. Mirrors are built
+        # lazily by ``_project_best_effort`` and cached per workspace so reusing this backend
+        # across workspaces never projects into the wrong one.
         self._mirrors: dict[str, ExperimentMirror] = {}
         # Run-level git provenance captured by get_agent_code: the fetched AgentSource (repo,
         # ref, sub-path) and the local .git clone that is the push target. archive_candidate /
@@ -425,17 +433,14 @@ class LocalExperimentalistBackend(ExperimentalistBackend):
     async def _project_best_effort(self, workspace: str, call: Callable[[ExperimentMirror], Awaitable[None]]) -> None:
         """Run a mirror projection best-effort (spec §3 / F).
 
-        No-op when the backend has no platform client (pure-offline runs). Otherwise builds
-        the workspace's mirror lazily (cached per workspace), runs *call* against it, and
+        Builds the workspace's mirror lazily (cached per workspace), runs *call* against it, and
         logs+swallows any failure so a projection problem can never fail the run or the
         local-file persistence. One-way: nothing read back into the loop.
         """
-        if self.client is None:
-            return
         mirror = self._mirrors.get(workspace)
-        if mirror is None:
-            mirror = self._mirrors[workspace] = ExperimentMirror(self.client, workspace)
         try:
+            if mirror is None:
+                mirror = self._mirrors[workspace] = ExperimentMirror(self.intake_client, workspace)
             await call(mirror)
         except Exception as exc:  # noqa: BLE001 - projection must never fail the run
             logger.warning("[MIRROR] projection failed (run continues): %s", exc)
@@ -443,7 +448,7 @@ class LocalExperimentalistBackend(ExperimentalistBackend):
     # -- Insight read --------------------------------------------------------
 
     async def get_insight(self, *, workspace: str, insight_id: str) -> Insight:
-        # A local insight file preserves offline behavior; otherwise treat
+        # A local insight file preserves local-fixture behavior; otherwise treat
         # ``insight_id`` as a platform insight id and fetch it from the Insights
         # API. The dispatch is heuristic: an id that happens to match a path in
         # the cwd is read as a file, so callers wanting the platform must use an id
@@ -451,18 +456,13 @@ class LocalExperimentalistBackend(ExperimentalistBackend):
         p = Path(insight_id)
         if p.exists():
             return _load_entity(Insight, p)
-        if self.client is None:
-            raise ValueError(
-                f"Insight {insight_id!r} is not an existing local file and no platform "
-                "client is available to fetch it from the platform."
-            )
         try:
-            return await self.client.insights.insights.get(workspace=workspace, insight_id=insight_id)
-        except httpx.HTTPStatusError as exc:
-            # Surface as ValueError so the CLI's clean-error path reports it instead
-            # of dumping a raw traceback (mirrors the local-file FileNotFoundError).
-            if exc.response.status_code == 404:
-                raise ValueError(f"Insight not found on the platform: {insight_id!r}") from exc
+            return await AsyncInsightsClient.from_client(self.client).get_insight(
+                workspace=workspace, insight_id=insight_id
+            )
+        except NotFoundError as exc:
+            raise ValueError(f"Insight not found on the platform: {insight_id!r}") from exc
+        except NemoHTTPError as exc:
             raise ValueError(f"Failed to fetch insight {insight_id!r} from the platform: {exc}") from exc
 
     # -- Agent code access ---------------------------------------------------
@@ -708,9 +708,6 @@ class LocalExperimentalistBackend(ExperimentalistBackend):
         task before _reward_trajectories (which reads intake:// URIs), or (b) fall back
         to reading local file:// traces if upload is still in progress.
         """
-        if self.client is None:
-            return  # pure-offline run: traces stay on local disk
-
         evaluation_name = await self.get_evaluation_name(workspace=workspace, candidate=candidate, split=split)
         if not evaluation_name:
             return  # projection failed (shouldn't happen, but defensive)
@@ -738,20 +735,20 @@ class LocalExperimentalistBackend(ExperimentalistBackend):
         self, trial: TrialResult, *, workspace: str, evaluation_name: str, agent_attrs: dict[str, str]
     ) -> None:
         assert trial.trace is not None
-        assert self.client is not None
         uri = trial.trace.uri
         if uri.startswith("intake://"):
             trace_id = uri.removeprefix("intake://traces/")
             trace = await self._retrieve_trace_with_retry(trace_id, workspace=workspace)
-            ctx = getattr(trace, "evaluation_context", None)
-            if ctx is None or getattr(ctx, "evaluation_name", None) != evaluation_name:
-                rows: list[dict] = []
-                async for span in self.client.intake.spans.list(
-                    workspace=workspace,
-                    filter=cast(Any, {"trace_id": trace_id}),
-                    mode="detailed",
-                    page_size=1000,
-                ):
+            ctx = trace.evaluation_context
+            if ctx is None or ctx.get("evaluation_name") != evaluation_name:
+                rows: list[dict[str, Any]] = []
+                query_params: ListSpansQueryParams = {
+                    "filter": {"trace_id": trace_id},
+                    "mode": "detailed",
+                    "page_size": 1000,
+                }
+                spans = await self.intake_client.list_spans(workspace=workspace, query_params=query_params)
+                async for span in spans.items():
                     rows.append(span.model_dump(mode="json", exclude_none=True))
                 attrs = {
                     "nemo.evaluation.name": evaluation_name,
@@ -759,7 +756,9 @@ class LocalExperimentalistBackend(ExperimentalistBackend):
                     "nemo.trial.id": trial.id,
                     **agent_attrs,
                 }
-                await _ingest_otlp(self.client, spans_to_protobuf(rows, attrs), workspace=workspace, trial_id=trial.id)
+                await _ingest_otlp(
+                    self.intake_client, spans_to_protobuf(rows, attrs), workspace=workspace, trial_id=trial.id
+                )
                 trace = await self._retrieve_trace_with_retry(trace_id, workspace=workspace)
         else:
             trace_format = str(trial.trace.metadata.get("trace_format", "otlp"))
@@ -772,7 +771,7 @@ class LocalExperimentalistBackend(ExperimentalistBackend):
             original_uri = uri
             if trace_format == "atif":
                 await _upload_trace_atif(
-                    self.client,
+                    self.intake_client,
                     workspace,
                     trial.trace,
                     evaluation_name=evaluation_name,
@@ -781,7 +780,7 @@ class LocalExperimentalistBackend(ExperimentalistBackend):
                 )
             else:
                 await _upload_trace_otlp(
-                    self.client,
+                    self.intake_client,
                     workspace,
                     trial.trace,
                     evaluation_name=evaluation_name,
@@ -796,31 +795,36 @@ class LocalExperimentalistBackend(ExperimentalistBackend):
             )
             trace = await self._retrieve_trace_with_retry(trace_id, workspace=workspace)
         for name, metric in trial.metrics.items():
-            await self.client.intake.evaluator_results.create(
+            if trace.root_span_id is None:
+                raise RuntimeError(f"Trace {trace.id!r} has no root span id; cannot attach evaluator result {name!r}")
+            await self.intake_client.create_evaluator_result(
                 workspace=workspace,
-                span_id=trace.root_span_id,
-                session_id=trace.session_id,
-                name=name,
-                value=float(metric.value),
-                data_type="NUMERIC",
+                body=EvaluatorResultCreateRequest(
+                    span_id=trace.root_span_id,
+                    session_id=trace.session_id,
+                    name=name,
+                    value=float(metric.value),
+                    data_type="NUMERIC",
+                ),
             )
 
     async def _retrieve_trace_with_retry(
         self, trace_id: str, *, workspace: str, retries: int = 5, initial_delay: float = 1.0
-    ) -> Any:
+    ) -> Trace:
         """Retrieve trace with exponential backoff.
 
         Intake indexing after OTLP upload can take several seconds. Uses exponential
         backoff: 1s, 2s, 4s, 8s, 16s (up to 31s total) by default.
         """
-        from nemo_platform import NotFoundError
-
-        assert self.client is not None
         last_exc: Exception = RuntimeError(f"trace {trace_id!r} not found after {retries} retries")
         delay = initial_delay
         for attempt in range(retries):
             try:
-                return await self.client.intake.traces.retrieve(trace_id, workspace=workspace)
+                return (
+                    await self.intake_client.get_trace(
+                        id=trace_id, workspace=workspace, query_params={"mode": "detailed"}
+                    )
+                ).data()
             except NotFoundError as exc:
                 last_exc = exc
                 if attempt < retries - 1:  # Don't sleep after the last attempt
@@ -829,12 +833,10 @@ class LocalExperimentalistBackend(ExperimentalistBackend):
         raise last_exc
 
     async def get_evaluation_name(self, *, workspace: str, candidate: Candidate, split: str) -> str:
-        if self.client is None:
-            return ""
         mirror = self._mirrors.get(workspace)
-        if mirror is None:
-            mirror = self._mirrors[workspace] = ExperimentMirror(self.client, workspace)
         try:
+            if mirror is None:
+                mirror = self._mirrors[workspace] = ExperimentMirror(self.intake_client, workspace)
             return await mirror.ensure_experiment(candidate, split=split)
         except Exception as exc:  # noqa: BLE001 - projection is best-effort
             logger.warning("[MIRROR] ensure_experiment failed: %s", exc)
@@ -865,18 +867,18 @@ class LocalExperimentalistBackend(ExperimentalistBackend):
 
 def make_experimentalist_backend(
     *,
-    client: AsyncNeMoPlatform | None,
+    client: AsyncNemoClient,
     experiments_output: str,
     storage: CandidateStorageConfig | None = None,
 ) -> ExperimentalistBackend:
     """Build the Experimentalist backend.
 
     Entity state is written under *experiments_output* using the ``eval-and-optimize/``
-    tree layout. When a platform client is supplied, evaluations and candidates are also
-    projected to native Experiments on a best-effort basis.
+    tree layout. Evaluations and candidates are also projected to native Experiments on
+    a best-effort basis.
 
     Args:
-        client(AsyncNeMoPlatform | None): Optional platform API client.
+        client(AsyncNemoClient): Platform API client.
         experiments_output(str): Local output directory.
         storage(CandidateStorageConfig | None): Candidate-archival / winner-PR settings.
     Returns:

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/run.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/run.py
@@ -15,7 +15,7 @@ from nemo_experimentalist_plugin.experimentalist.experimentalist_backend import 
 from nemo_experimentalist_plugin.experimentalist.reporting import RunReporter, Verbosity
 from nemo_experimentalist_plugin.experimentalist.runner import ExperimentRunner
 from nemo_experimentalist_plugin.experimentalist.strategies.evolutionary import EvolutionaryOptimizerConfig
-from nemo_platform import AsyncNeMoPlatform
+from nemo_platform_plugin.client.client import AsyncNemoClient
 from nemo_platform_plugin.nooa_model_client import (
     ConfiguredModelClients,
     ConfiguredModelRefs,
@@ -50,7 +50,7 @@ async def run_experimentalist(
     validation_dataset: DatasetRef,
     experiment_dir: Path,
     workspace: str,
-    client: AsyncNeMoPlatform | None,
+    client: AsyncNemoClient,
     model_refs: ConfiguredModelRefs | None = None,
     config: EvolutionaryOptimizerConfig,
     task_template: DatasetRef | None = None,
@@ -74,9 +74,7 @@ async def run_experimentalist(
         workspace: Platform workspace.
         model_refs: Optional explicit default/fast Model Entity IDs. Unset uses the
             active Platform CLI context.
-        client: Optional caller-owned Platform client. Local-only Mode 2 runs
-            may pass ``None``; Platform Insight access, mirroring, and Intake
-            persistence require a client.
+        client: Caller-owned Platform client.
         config: Evolutionary optimizer configuration.
 
     Returns:
@@ -98,18 +96,16 @@ async def run_experimentalist(
         insight=str(insight) if insight is not None else None,
     )
 
-    backend = make_experimentalist_backend(
-        client=client,
-        experiments_output=str(experiment_dir),
-        storage=config.storage,
-    )
-    # Every component resolves its models through the platform (#1159), so the resolved
-    # clients have to stay active for the whole run, not just while the runner is built.
-    model_platform_client = client or AsyncNeMoPlatform()
-    owns_model_platform_client = client is None
     model_clients: ConfiguredModelClients | None = None
     try:
-        model_clients = await resolve_model_clients(model_platform_client, model_refs)
+        backend = make_experimentalist_backend(
+            client=client,
+            experiments_output=str(experiment_dir),
+            storage=config.storage,
+        )
+        # Every component resolves its models through the platform (#1159), so the resolved
+        # clients have to stay active for the whole run, not just while the runner is built.
+        model_clients = await resolve_model_clients(client, model_refs)
         with activate_model_clients(model_clients):
             result = await ExperimentRunner(
                 backend=backend,
@@ -130,12 +126,8 @@ async def run_experimentalist(
                 reporter=reporter,
             ).run()
     finally:
-        try:
-            if model_clients is not None:
-                await model_clients.aclose()
-        finally:
-            if owns_model_platform_client:
-                await model_platform_client.close()
+        if model_clients is not None:
+            await model_clients.aclose()
 
     winner = result.winner
     reporter.run_finished(

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/runner.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/runner.py
@@ -186,8 +186,6 @@ class ExperimentRunner:
         insight = None
         if self._insight is not None:
             insight = await self._backend.get_insight(workspace=self._workspace, insight_id=str(self._insight))
-            if self._backend.client is None:
-                raise ValueError("Platform client is required for insight task template loading")
             assert template_ref is not None
             staged = await stage_eval_author_inputs(
                 self._root,
@@ -235,7 +233,6 @@ class ExperimentRunner:
 
         if insight is not None:
             assert template_ref is not None
-            assert self._backend.client is not None
             # Lazy: a run without an Insight never authors an eval suite, so it must not
             # fail to import when the Eval Author package is absent.
             from nemo_experimentalist_plugin.eval_author.agent import EvalAuthor  # noqa: PLC0415

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/strategies/evolutionary.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/strategies/evolutionary.py
@@ -987,11 +987,14 @@ class EvolutionaryStrategy(Agent, roles.Strategy):
 
     def _terminator(self, ctx: StrategyContext, config: EvolutionaryOptimizerConfig) -> roles.Terminator:
         """Resolve this run's terminator, with the run's own convergence window."""
+        terminator = config.terminator
+        if terminator is None:
+            raise ValueError("terminator must be configured before resolving the terminator component")
         return cast(
             "roles.Terminator",
             ctx.component(
                 "terminator",
-                config.terminator,
+                terminator,
                 config=config.terminator_config,
                 min_rounds_before_stopping=config.min_rounds_before_stopping,
                 objective_metrics=config.objective_function,
@@ -1001,11 +1004,14 @@ class EvolutionaryStrategy(Agent, roles.Strategy):
 
     def _trajectory_scorer(self, ctx: StrategyContext, config: EvolutionaryOptimizerConfig) -> roles.TrajectoryScorer:
         """Resolve this run's trajectory scorer, with the run's own per-round task cap."""
+        trajectory_scorer = config.trajectory_scorer
+        if trajectory_scorer is None:
+            raise ValueError("trajectory_scorer must be configured before resolving the trajectory scorer component")
         return cast(
             "roles.TrajectoryScorer",
             ctx.component(
                 "trajectory-scorer",
-                config.trajectory_scorer,
+                trajectory_scorer,
                 config=config.trajectory_scorer_config,
                 max_trajectory_tasks=config.max_trajectory_tasks,
                 framework_skills_dirs=self._framework_skills_dirs,

--- a/plugins/nemo-experimentalist/tests/doubles.py
+++ b/plugins/nemo-experimentalist/tests/doubles.py
@@ -17,9 +17,8 @@ import tempfile
 import uuid
 from collections.abc import Mapping, Sequence
 from pathlib import Path
-from types import SimpleNamespace
-from typing import cast
 
+import httpx
 from nemo_experimentalist_plugin.config import CandidateStorageConfig
 from nemo_experimentalist_plugin.entities import (
     Candidate,
@@ -29,6 +28,7 @@ from nemo_experimentalist_plugin.entities import (
     MetricTarget,
     Proposal,
     ResourceRef,
+    RewardMap,
     RewardRecord,
     TrialResult,
 )
@@ -39,12 +39,19 @@ from nemo_experimentalist_plugin.experimentalist.experimentalist_backend import 
 from nemo_experimentalist_plugin.experimentalist.reporting import RunReporter
 from nemo_experimentalist_plugin.experimentalist.result import ExperimentalistResult
 from nemo_insights_plugin.entities import Insight
-from nemo_platform import AsyncNeMoPlatform
+from nemo_platform_plugin.client.client import AsyncNemoClient
 
 
-def fake_client() -> AsyncNeMoPlatform:
+def fake_client() -> AsyncNemoClient:
     """A stand-in platform client for paths that only check whether one is present."""
-    return cast(AsyncNeMoPlatform, SimpleNamespace())
+    transport = httpx.MockTransport(
+        lambda request: httpx.Response(500, request=request, json={"detail": "fake client"})
+    )
+    return AsyncNemoClient(
+        base_url="http://platform.test",
+        workspace="default",
+        http_client=httpx.AsyncClient(transport=transport),
+    )
 
 
 class RecordedEvaluation(dict):
@@ -63,11 +70,11 @@ class FakeBackend(ExperimentalistBackend):
     def __init__(
         self,
         *,
-        client: AsyncNeMoPlatform | None = None,
+        client: AsyncNemoClient | None = None,
         storage: CandidateStorageConfig | None = None,
         insight: Insight | None = None,
     ) -> None:
-        super().__init__(client, None, storage)
+        super().__init__(client or fake_client(), None, storage)
         self.candidates: dict[str, Candidate] = {}
         self.runs: list[ExperimentRun] = []
         self.evaluations: list[RecordedEvaluation] = []
@@ -210,7 +217,7 @@ def make_candidate(
         generated_from=proposal,
         description=text,
         artifact=ResourceRef(uri=artifact or _default_artifact(run_id, label)),
-        rewards=dict(rewards or {}),
+        rewards=RewardMap(rewards or {}),
         killed_generation=killed_generation,
         workspace=workspace,
     )

--- a/plugins/nemo-experimentalist/tests/eval_author/manual/intake_tool_checks.py
+++ b/plugins/nemo-experimentalist/tests/eval_author/manual/intake_tool_checks.py
@@ -21,8 +21,8 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from nemo_experimentalist_plugin.eval_author import traces
-from nemo_platform import AsyncNeMoPlatform
-from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.client.client import AsyncNemoClient
+from nemo_platform_plugin.intake.client import AsyncIntakeClient
 from nemo_platform_plugin.workspaces.client import AsyncWorkspacesClient
 
 DISCOVERY_SPAN_BUDGET = 200
@@ -48,14 +48,18 @@ class Report:
         print(f"\n=== {title} ===")
 
 
-async def discover(client: AsyncNeMoPlatform) -> tuple[str, str] | None:
+async def discover(client: AsyncNemoClient) -> tuple[str, str] | None:
     """Find the workspace with the most agent-scoped spans, and its busiest agent."""
     best: tuple[int, str, str] | None = None
-    async for workspace in (await client_from_platform(client, AsyncWorkspacesClient).list_workspaces()).items():
+    intake = AsyncIntakeClient.from_client(client)
+    async for workspace in (await AsyncWorkspacesClient.from_client(client).list_workspaces()).items():
         counts: dict[str, int] = {}
         scanned = 0
         try:
-            async for span in client.intake.spans.list(workspace=workspace.name, mode="summary", page_size=100):
+            response = await intake.list_spans(
+                workspace=workspace.name, query_params={"mode": "summary", "page_size": 100}
+            )
+            async for span in response.items():
                 scanned += 1
                 agent = getattr(span, "agent_name", None)
                 if agent:
@@ -74,7 +78,7 @@ async def discover(client: AsyncNeMoPlatform) -> tuple[str, str] | None:
     return best[1], best[2]
 
 
-async def check_raw_span_queries(client: AsyncNeMoPlatform, report: Report, workspace: str, agent: str) -> None:
+async def check_raw_span_queries(client: AsyncNemoClient, report: Report, workspace: str, agent: str) -> None:
     report.section("query_spans: rows, order, and plain dicts")
     result = await traces.query_spans(client, workspace=workspace, limit=5)
     report.check("returns rows", result["count"] > 0, f"count={result['count']} truncated={result['truncated']}")
@@ -111,7 +115,7 @@ async def check_raw_span_queries(client: AsyncNeMoPlatform, report: Report, work
         report.check("only trace_id and session_id group", True, str(exc)[:110])
 
 
-async def check_raw_trace_queries(client: AsyncNeMoPlatform, report: Report, workspace: str) -> None:
+async def check_raw_trace_queries(client: AsyncNemoClient, report: Report, workspace: str) -> None:
     report.section("query_traces: rollups and the $in filter")
     result = await traces.query_traces(client, workspace=workspace, limit=5)
     report.check("returns rows", result["count"] > 0, f"count={result['count']}")
@@ -146,7 +150,7 @@ async def check_raw_trace_queries(client: AsyncNeMoPlatform, report: Report, wor
 
 
 async def check_find_agent_traces(
-    client: AsyncNeMoPlatform, report: Report, workspace: str, agent: str
+    client: AsyncNemoClient, report: Report, workspace: str, agent: str
 ) -> dict[str, Any] | None:
     report.section("find_agent_traces")
     found = await traces.find_agent_traces(client, agent=agent, workspace=workspace, limit=5)
@@ -206,7 +210,7 @@ async def check_find_agent_traces(
     return target
 
 
-async def check_read_trace(client: AsyncNeMoPlatform, report: Report, workspace: str, trace_id: str) -> None:
+async def check_read_trace(client: AsyncNemoClient, report: Report, workspace: str, trace_id: str) -> None:
     report.section("read_trace: all three ref spellings")
     explorer = None
     for ref in (trace_id, f"intake://{trace_id}", f"intake://traces/{trace_id}"):
@@ -218,7 +222,7 @@ async def check_read_trace(client: AsyncNeMoPlatform, report: Report, workspace:
             report.note(line)
 
 
-async def check_errors(client: AsyncNeMoPlatform, report: Report, workspace: str, agent: str) -> None:
+async def check_errors(client: AsyncNemoClient, report: Report, workspace: str, agent: str) -> None:
     report.section("errors name a corrective action")
     cases = (
         ("an unknown filter field", traces.query_spans(client, workspace=workspace, filter={"not_a_field": "x"})),
@@ -248,7 +252,7 @@ async def main() -> int:
     if bool(args.workspace) != bool(args.agent):
         parser.error("--workspace and --agent must be given together, or neither.")
 
-    async with AsyncNeMoPlatform(base_url=args.base_url) as client:
+    async with AsyncNemoClient(base_url=args.base_url) as client:
         if args.workspace and args.agent:
             workspace, agent = args.workspace, args.agent
         else:

--- a/plugins/nemo-experimentalist/tests/eval_author/manual/intake_vocabulary_probe.py
+++ b/plugins/nemo-experimentalist/tests/eval_author/manual/intake_vocabulary_probe.py
@@ -26,7 +26,7 @@ import re
 from typing import Any
 
 from nemo_experimentalist_plugin.eval_author import traces
-from nemo_platform import AsyncNeMoPlatform
+from nemo_platform_plugin.client.client import AsyncNemoClient
 
 # Every column Intake names in its "Unknown filter field" message, which is a superset of
 # what it can actually filter. Probing the superset is the point.
@@ -115,7 +115,7 @@ def uses_sentinel(field: str) -> bool:
 
 async def run(
     kind: str,
-    client: AsyncNeMoPlatform,
+    client: AsyncNemoClient,
     workspace: str,
     filter: dict[str, Any],
     *,
@@ -139,7 +139,7 @@ async def run(
     return "WORKS"
 
 
-async def probe_fields(client: AsyncNeMoPlatform, workspace: str, kind: str, fields: tuple[str, ...]) -> None:
+async def probe_fields(client: AsyncNemoClient, workspace: str, kind: str, fields: tuple[str, ...]) -> None:
     print(f"\n{'=' * 66}\n{kind.upper()} FILTER FIELDS\n{'=' * 66}")
     works: list[str] = []
     broken: list[str] = []
@@ -170,7 +170,7 @@ async def probe_fields(client: AsyncNeMoPlatform, workspace: str, kind: str, fie
         print("  Do not document them. Confirm they are still broken before removing this note.")
 
 
-async def probe_operators(client: AsyncNeMoPlatform, workspace: str) -> None:
+async def probe_operators(client: AsyncNemoClient, workspace: str) -> None:
     print(f"\n{'=' * 66}\nOPERATORS (which operators Intake accepts per field)\n{'=' * 66}")
     for kind, label, filter in OPERATOR_CASES:
         # The $in cases pass values nothing holds, so they must come back empty. The date
@@ -178,7 +178,7 @@ async def probe_operators(client: AsyncNeMoPlatform, workspace: str) -> None:
         print(f"  {kind:<6} {label:<22} {await run(kind, client, workspace, filter, expect_no_rows='$in' in label)}")
 
 
-async def probe_group_by(client: AsyncNeMoPlatform, workspace: str) -> None:
+async def probe_group_by(client: AsyncNemoClient, workspace: str) -> None:
     print(f"\n{'=' * 66}\nGROUP BY\n{'=' * 66}")
     for field in ("trace_id", "session_id", "agent_name", "kind"):
         try:
@@ -194,7 +194,7 @@ async def main() -> None:
     parser.add_argument("--workspace", default="default", help="Any workspace. It need not hold spans.")
     args = parser.parse_args()
 
-    async with AsyncNeMoPlatform(base_url=args.base_url) as client:
+    async with AsyncNemoClient(base_url=args.base_url) as client:
         await probe_fields(client, args.workspace, "span", SPAN_FIELDS)
         await probe_fields(client, args.workspace, "trace", TRACE_FIELDS)
         await probe_operators(client, args.workspace)

--- a/plugins/nemo-experimentalist/tests/eval_author/test_eval_author_run.py
+++ b/plugins/nemo-experimentalist/tests/eval_author/test_eval_author_run.py
@@ -14,6 +14,7 @@ from nemo_experimentalist_plugin.entities import Dataset, DatasetRef, ResourceRe
 from nemo_experimentalist_plugin.eval_author import run as eval_author_run
 from nemo_experimentalist_plugin.eval_author.agent import EvalAuthor
 from nemo_experimentalist_plugin.eval_author.models import EvalAuthorConfig, EvalAuthorResult
+from nemo_experimentalist_plugin.experimentalist.components import dataset_staging
 from nemo_experimentalist_plugin.experimentalist.components.evaluator.base import EvaluatorType
 from nemo_experimentalist_plugin.experimentalist.components.evaluator.harbor import HarborDataset
 from nemo_insights_plugin.entities import Insight
@@ -22,7 +23,6 @@ from nemo_insights_plugin.entities import Insight
 @dataclass
 class ClosingClient:
     closed: bool = False
-    files: Any = None
 
     async def close(self) -> None:
         self.closed = True
@@ -362,21 +362,41 @@ async def test_run_eval_author_hydrates_fileset_task_template(
     tmp_path: Path,
     evaluator_type: EvaluatorType,
 ) -> None:
+    listings: list[tuple[str, str, object]] = []
     downloads: list[tuple[str, str, str]] = []
 
-    class FakeFiles:
-        async def download(self, *, remote_path: str, local_path: str, workspace: str) -> None:
-            downloads.append((remote_path, local_path, workspace))
-            destination = Path(local_path)
-            destination.mkdir(parents=True)
-            (destination / "task.toml").write_text("template\n", encoding="utf-8")
+    @dataclass(frozen=True)
+    class _FilesetItem:
+        path: str
 
-    client = ClosingClient(files=FakeFiles())
+    @dataclass(frozen=True)
+    class _FilesetListing:
+        data: list[_FilesetItem]
+
+    class _FilesetResponse:
+        def data(self) -> _FilesetListing:
+            return _FilesetListing([_FilesetItem("task.toml")])
+
+    class _Download:
+        async def read(self) -> bytes:
+            return b"template\n"
+
+    class FakeFiles:
+        async def list_files(self, *, workspace: str, name: str, query_params: object) -> _FilesetResponse:
+            listings.append((workspace, name, query_params))
+            return _FilesetResponse()
+
+        async def download_file(self, *, workspace: str, name: str, path: str) -> _Download:
+            downloads.append((workspace, name, path))
+            return _Download()
+
+    client = ClosingClient()
     backend = FakeBackend(
         Insight(workspace="workspace-a", title="failure", description="description", agent="insight-agent")
     )
     dataset_factory = FakeDatasetFactory()
     monkeypatch.setattr(eval_author_run, "make_client", lambda _: client)
+    monkeypatch.setattr(dataset_staging.AsyncFilesClient, "from_client", lambda _: FakeFiles())
     monkeypatch.setattr(eval_author_run, "make_experimentalist_backend", lambda **_: backend)
     monkeypatch.setattr(eval_author_run, "DatasetFactory", lambda: dataset_factory)
     monkeypatch.setattr(eval_author_run, "build_eval_author_agent", lambda **_: FakeEvalAuthor())
@@ -399,7 +419,9 @@ async def test_run_eval_author_hydrates_fileset_task_template(
     )
 
     staged = (tmp_path / "experiment").resolve() / "dataset" / "task-template"
-    assert downloads == [(template_ref.uri, str(staged), "workspace-a")]
+    assert listings == [("workspace-a", "template", None)]
+    assert downloads == [("workspace-a", "template", "task.toml")]
+    assert (staged / "task.toml").read_text(encoding="utf-8") == "template\n"
     assert dataset_factory.template_calls == [(evaluator_type, template_ref.model_copy(update={"uri": str(staged)}))]
     assert [Path(ref.uri).name for _, ref in dataset_factory.dataset_calls] == ["train", "validation"]
     assert [call[0] for call in dataset_factory.dataset_calls] == [evaluator_type, evaluator_type]

--- a/plugins/nemo-experimentalist/tests/eval_author/test_traces.py
+++ b/plugins/nemo-experimentalist/tests/eval_author/test_traces.py
@@ -17,7 +17,7 @@ import httpx
 import pytest
 from nemo_experimentalist_plugin.eval_author import traces
 from nemo_experimentalist_plugin.eval_author.agent import EvalAuthor
-from nemo_platform import APIConnectionError, APIStatusError
+from nemo_platform_plugin.client.errors import NemoHTTPError, NemoTransportError, raise_for_status
 
 _BASE = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
 
@@ -83,29 +83,26 @@ class _FakeClient:
         self.span_calls: list[dict[str, Any]] = []
         self.trace_calls: list[dict[str, Any]] = []
         self.group_calls: list[dict[str, Any]] = []
-        self.intake = SimpleNamespace(
-            spans=SimpleNamespace(
-                list=self._list_spans,
-                groups=SimpleNamespace(list=self._list_groups),
-            ),
-            traces=SimpleNamespace(list=self._list_traces),
-        )
 
-    def _list_spans(self, **kwargs: Any) -> Any:
-        self.span_calls.append(kwargs)
-        return _pages(self._spans, self._error)
+    async def list_spans(self, *, workspace: str, query_params: dict[str, Any] | None = None) -> Any:
+        del workspace
+        self.span_calls.append(query_params or {})
+        return SimpleNamespace(items=lambda: _pages(self._spans, self._error))
 
-    def _list_groups(self, **kwargs: Any) -> Any:
-        self.group_calls.append(kwargs)
-        return _pages(self._groups, self._error)
+    async def list_span_groups(self, *, workspace: str, query_params: dict[str, Any] | None = None) -> Any:
+        del workspace
+        self.group_calls.append(query_params or {})
+        return SimpleNamespace(items=lambda: _pages(self._groups, self._error))
 
-    def _list_traces(self, **kwargs: Any) -> Any:
-        self.trace_calls.append(kwargs)
+    async def list_traces(self, *, workspace: str, query_params: dict[str, Any] | None = None) -> Any:
+        del workspace
+        params = query_params or {}
+        self.trace_calls.append(params)
         rows = self._summaries
-        wanted = kwargs.get("filter", {}).get("id", {}).get("$in")
+        wanted = params.get("filter", {}).get("id", {}).get("$in")
         if wanted is not None:
             rows = [row for row in rows if row.model_dump()["id"] in set(wanted)]
-        return _pages(rows, self._error)
+        return SimpleNamespace(items=lambda: _pages(rows, self._error))
 
 
 def _client(
@@ -118,9 +115,19 @@ def _client(
     return _FakeClient(spans or [], summaries or [], groups or [], error)
 
 
-def _status_error(code: int) -> APIStatusError:
+@pytest.fixture(autouse=True)
+def fake_intake_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(traces.AsyncIntakeClient, "from_client", lambda client: client)
+
+
+def _status_error(code: int) -> NemoHTTPError:
     request = httpx.Request("GET", "https://example.invalid/spans")
-    return APIStatusError("boom", response=httpx.Response(code, request=request), body=None)
+    response = httpx.Response(code, request=request, json={"detail": "boom"})
+    try:
+        raise_for_status(response)
+    except NemoHTTPError as exc:
+        return exc
+    raise AssertionError(f"HTTP {code} did not raise")
 
 
 # --- raw queries -------------------------------------------------------------------
@@ -357,7 +364,7 @@ async def test_an_unexpected_status_still_names_itself() -> None:
 
 async def test_unreachable_platform_names_the_base_url() -> None:
     request = httpx.Request("GET", "https://example.invalid/spans")
-    client = _client(error=APIConnectionError(request=request))
+    client = _client(error=NemoTransportError(httpx.ConnectError("unreachable", request=request)))
 
     with pytest.raises(traces.TraceQueryError, match="NMP_BASE_URL"):
         await traces.query_traces(client, workspace="ws")

--- a/plugins/nemo-experimentalist/tests/experimentalist/test_candidate_contract.py
+++ b/plugins/nemo-experimentalist/tests/experimentalist/test_candidate_contract.py
@@ -12,10 +12,11 @@ having built one.
 
 import json
 import shutil
+from collections.abc import Sequence
 from pathlib import Path
 
 import pytest
-from doubles import FakeBackend, make_candidate, make_context
+from doubles import FakeBackend, fake_client, make_candidate, make_context
 from nemo_experimentalist_plugin.entities import (
     Candidate,
     Dataset,
@@ -171,7 +172,7 @@ async def test_updating_a_committed_candidate_persists_the_change(tmp_path: Path
     """
     from nemo_experimentalist_plugin.experimentalist.experimentalist_backend import LocalExperimentalistBackend
 
-    ctx = make_context(root=tmp_path, backend=LocalExperimentalistBackend(path=tmp_path))
+    ctx = make_context(root=tmp_path, backend=LocalExperimentalistBackend(client=fake_client(), path=tmp_path))
     baseline = await _import_baseline(ctx)
 
     await ctx.update_candidate(baseline, killed_generation=2)
@@ -204,7 +205,7 @@ async def test_candidates_are_listed_from_the_store_not_from_a_directory_walk(tm
     """A strategy that does not produce one directory per candidate can still list them."""
     from nemo_experimentalist_plugin.experimentalist.experimentalist_backend import LocalExperimentalistBackend
 
-    backend = LocalExperimentalistBackend(path=tmp_path)
+    backend = LocalExperimentalistBackend(client=fake_client(), path=tmp_path)
     ctx = make_context(root=tmp_path, backend=backend)
     committed = await _import_baseline(ctx)
 
@@ -235,6 +236,7 @@ async def test_a_fork_does_not_inherit_the_ancestors_architecture_doc(tmp_path: 
 
     assert (fork.workdir / "main.py").read_text() == "print('ancestor')\n"
     assert not (fork.workdir / "architecture.md").exists()
+    assert fork.upstream is not None
     assert (fork.upstream / "architecture.md").exists(), "still reachable through the fork's upstream"
 
 
@@ -384,7 +386,7 @@ async def test_the_store_itself_hides_discarded_candidates(tmp_path: Path) -> No
     """
     from nemo_experimentalist_plugin.experimentalist.experimentalist_backend import LocalExperimentalistBackend
 
-    ctx = make_context(root=tmp_path, backend=LocalExperimentalistBackend(path=tmp_path))
+    ctx = make_context(root=tmp_path, backend=LocalExperimentalistBackend(client=fake_client(), path=tmp_path))
     baseline = await _import_baseline(ctx)
     await ctx.discard_candidate(baseline)
 
@@ -437,6 +439,8 @@ async def test_a_builder_documents_the_candidates_it_builds(tmp_path: Path) -> N
     bypassed it for every candidate built after.
     """
     from nemo_experimentalist_plugin.experimentalist.components.coder import CodeEditBuilder
+    from nemo_experimentalist_plugin.experimentalist.components.evaluator.base import Evaluator
+    from nemo_experimentalist_plugin.experimentalist.components.proposer import CodeChange
 
     described: list[Path] = []
 
@@ -446,19 +450,33 @@ async def test_a_builder_documents_the_candidates_it_builds(tmp_path: Path) -> N
         async def describe(self, artifact: Path) -> None:
             described.append(artifact)
 
-        async def apply_change(self, *args: object, **kwargs: object) -> None:
+        async def apply_change(self, workdir: Path, optimization: str, change: CodeChange) -> None:
             return None
 
-        async def wire_up_change(self, *args: object, **kwargs: object) -> None:
+        async def wire_up_change(self, workdir: Path, optimization: str, change: CodeChange) -> None:
             return None
 
-        async def run_pyright(self, *args: object, **kwargs: object) -> None:
+        async def run_pyright(self, workdir: Path) -> str:
+            return ""
+
+        async def optimize_subproblem(
+            self,
+            workdir: Path,
+            optimization: str,
+            change: CodeChange,
+            dataset: Dataset,
+            evaluator: Evaluator,
+        ) -> None:
             return None
 
-        async def optimize_subproblem(self, *args: object, **kwargs: object) -> None:
-            return None
-
-        async def integration_check(self, *args: object, **kwargs: object) -> bool:
+        async def integration_check(
+            self,
+            workdir: Path,
+            dataset: Dataset,
+            evaluator: Evaluator,
+            max_fix_attempts: int | None = None,
+            task_ids: Sequence[str] | None = None,
+        ) -> bool:
             return True
 
     ctx = make_context(root=tmp_path, backend=FakeBackend())

--- a/plugins/nemo-experimentalist/tests/experimentalist/test_dataset_staging.py
+++ b/plugins/nemo-experimentalist/tests/experimentalist/test_dataset_staging.py
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import tomllib
+from dataclasses import dataclass
 from pathlib import Path
-from types import SimpleNamespace
 from typing import cast
 
 import pytest
@@ -14,7 +14,7 @@ from nemo_experimentalist_plugin.experimentalist.components.dataset_staging impo
     stage_task_template,
 )
 from nemo_experimentalist_plugin.experimentalist.components.evaluator.harbor import HarborDataset
-from nemo_platform import AsyncNeMoPlatform
+from nemo_platform_plugin.client.client import AsyncNemoClient
 
 
 def _write_tree(root: Path, content: str) -> None:
@@ -26,6 +26,42 @@ def _write_tree(root: Path, content: str) -> None:
 class _MemoryDataset(Dataset):
     def add_tasks(self, tasks: list[Task]) -> None:
         self.tasks.extend(tasks)
+
+
+@dataclass(frozen=True)
+class _FilesetItem:
+    path: str
+
+
+@dataclass(frozen=True)
+class _FilesetListing:
+    data: list[_FilesetItem]
+
+
+class _FilesetResponse:
+    def __init__(self, listing: _FilesetListing) -> None:
+        self._listing = listing
+
+    def data(self) -> _FilesetListing:
+        return self._listing
+
+
+class _FilesetDownload:
+    async def read(self) -> bytes:
+        return b"fileset content"
+
+
+class _RecordingFilesClient:
+    def __init__(self, paths: list[str]) -> None:
+        self._paths = paths
+        self.downloaded_paths: list[str] = []
+
+    async def list_files(self, *, workspace: str, name: str, query_params: object) -> _FilesetResponse:
+        return _FilesetResponse(_FilesetListing([_FilesetItem(path) for path in self._paths]))
+
+    async def download_file(self, *, workspace: str, name: str, path: str) -> _FilesetDownload:
+        self.downloaded_paths.append(path)
+        return _FilesetDownload()
 
 
 def test_distribute_insight_suite_tasks_uses_a_30_70_validation_train_split() -> None:
@@ -113,7 +149,7 @@ async def test_stage_eval_author_inputs_isolates_all_mutable_sources(tmp_path: P
         train_dataset=DatasetRef(uri=str(train), metadata={"id": "train"}),
         validation_dataset=DatasetRef(uri=str(validation), metadata={"id": "validation"}),
         task_template=DatasetRef(uri=template.as_uri(), metadata={"id": "template"}),
-        client=cast(AsyncNeMoPlatform, object()),
+        client=cast(AsyncNemoClient, object()),
         workspace="default",
     )
 
@@ -151,7 +187,7 @@ async def test_stage_eval_author_inputs_keeps_train_and_validation_isolated_when
         train_dataset=shared_ref,
         validation_dataset=shared_ref,
         task_template=DatasetRef(uri=str(template)),
-        client=cast(AsyncNeMoPlatform, object()),
+        client=cast(AsyncNemoClient, object()),
         workspace="default",
     )
     staged_train_test = Path(staged.train_dataset.uri) / "task-1" / "tests" / "test.sh"
@@ -174,7 +210,7 @@ async def test_stage_eval_author_inputs_reuses_dataset_destinations_but_refreshe
         train_dataset=DatasetRef(uri=str(source)),
         validation_dataset=DatasetRef(uri=str(source)),
         task_template=DatasetRef(uri=str(template)),
-        client=cast(AsyncNeMoPlatform, object()),
+        client=cast(AsyncNemoClient, object()),
         workspace="default",
     )
     (Path(staged.train_dataset.uri) / "task-1" / "tests" / "test.sh").write_text("curated", encoding="utf-8")
@@ -185,7 +221,7 @@ async def test_stage_eval_author_inputs_reuses_dataset_destinations_but_refreshe
         train_dataset=DatasetRef(uri=str(source)),
         validation_dataset=DatasetRef(uri=str(source)),
         task_template=DatasetRef(uri=str(template)),
-        client=cast(AsyncNeMoPlatform, object()),
+        client=cast(AsyncNemoClient, object()),
         workspace="default",
     )
 
@@ -196,17 +232,42 @@ async def test_stage_eval_author_inputs_reuses_dataset_destinations_but_refreshe
 
 
 @pytest.mark.asyncio
-async def test_stage_task_template_hydrates_and_refreshes_fileset_reference(tmp_path: Path) -> None:
-    calls: list[dict[str, str]] = []
+async def test_stage_task_template_hydrates_and_refreshes_fileset_reference(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[dict[str, object]] = []
     content = "first fileset template"
 
-    class FakeFiles:
-        async def download(self, *, remote_path: str, local_path: str, workspace: str) -> None:
-            assert Path(local_path).parent.is_dir()
-            calls.append({"remote_path": remote_path, "local_path": local_path, "workspace": workspace})
-            _write_tree(Path(local_path), content)
+    class _Response:
+        def __init__(self, body: object) -> None:
+            self._body = body
 
-    client = cast(AsyncNeMoPlatform, SimpleNamespace(files=FakeFiles()))
+        def data(self) -> object:
+            return self._body
+
+    class _Download:
+        async def read(self) -> bytes:
+            return content.encode()
+
+    class _File:
+        path = "task-1/tests/test.sh"
+
+    class _Files:
+        data = [_File()]
+
+    class FakeFiles:
+        async def list_files(self, *, workspace: str, name: str, query_params: object) -> _Response:
+            calls.append({"op": "list", "workspace": workspace, "name": name, "query_params": query_params})
+            return _Response(_Files())
+
+        async def download_file(self, *, workspace: str, name: str, path: str) -> _Download:
+            calls.append({"op": "download", "workspace": workspace, "name": name, "path": path})
+            return _Download()
+
+    from nemo_experimentalist_plugin.experimentalist.components import dataset_staging
+
+    monkeypatch.setattr(dataset_staging.AsyncFilesClient, "from_client", lambda _client: FakeFiles())
+    client = cast(AsyncNemoClient, object())
     ref = DatasetRef(uri="fileset://workspace-a/task-template", metadata={"id": "template-fileset"})
 
     first = await stage_task_template(tmp_path / "experiment", ref, client=client, workspace="workspace-a")
@@ -219,14 +280,119 @@ async def test_stage_task_template_hydrates_and_refreshes_fileset_reference(tmp_
     assert second.metadata == {"id": "template-fileset"}
     assert (expected_path / "task-1" / "tests" / "test.sh").read_text(encoding="utf-8") == content
     assert calls == [
-        {
-            "remote_path": ref.uri,
-            "local_path": str(expected_path),
-            "workspace": "workspace-a",
-        },
-        {
-            "remote_path": ref.uri,
-            "local_path": str(expected_path),
-            "workspace": "workspace-a",
-        },
+        {"op": "list", "workspace": "workspace-a", "name": "task-template", "query_params": None},
+        {"op": "download", "workspace": "workspace-a", "name": "task-template", "path": "task-1/tests/test.sh"},
+        {"op": "list", "workspace": "workspace-a", "name": "task-template", "query_params": None},
+        {"op": "download", "workspace": "workspace-a", "name": "task-template", "path": "task-1/tests/test.sh"},
     ]
+
+
+async def test_stage_task_template_honors_fileset_fragment_prefix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[dict[str, object]] = []
+
+    class _Response:
+        def __init__(self, body: object) -> None:
+            self._body = body
+
+        def data(self) -> object:
+            return self._body
+
+    class _Download:
+        async def read(self) -> bytes:
+            return b"fragment-scoped template"
+
+    class _File:
+        path = "task-root/tests/test.sh"
+
+    class _Files:
+        data = [_File()]
+
+    class FakeFiles:
+        async def list_files(self, *, workspace: str, name: str, query_params: object) -> _Response:
+            calls.append({"op": "list", "workspace": workspace, "name": name, "query_params": query_params})
+            return _Response(_Files())
+
+        async def download_file(self, *, workspace: str, name: str, path: str) -> _Download:
+            calls.append({"op": "download", "workspace": workspace, "name": name, "path": path})
+            return _Download()
+
+    from nemo_experimentalist_plugin.experimentalist.components import dataset_staging
+
+    monkeypatch.setattr(dataset_staging.AsyncFilesClient, "from_client", lambda _client: FakeFiles())
+    client = AsyncNemoClient(base_url="http://test")
+    ref = DatasetRef(uri="fileset://workspace-a/task-template#task-root", metadata={"id": "template-fileset"})
+
+    try:
+        staged = await stage_task_template(tmp_path / "experiment", ref, client=client, workspace="workspace-a")
+    finally:
+        await client.close()
+
+    expected_path = tmp_path / "experiment" / "dataset" / "task-template"
+    assert staged.uri == str(expected_path)
+    assert staged.metadata == {"id": "template-fileset"}
+    assert (expected_path / "tests" / "test.sh").read_text(encoding="utf-8") == "fragment-scoped template"
+    assert calls == [
+        {"op": "list", "workspace": "workspace-a", "name": "task-template", "query_params": {"path": "task-root"}},
+        {"op": "download", "workspace": "workspace-a", "name": "task-template", "path": "task-root/tests/test.sh"},
+    ]
+
+
+async def test_stage_task_template_rejects_fileset_path_traversal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from nemo_experimentalist_plugin.experimentalist.components import dataset_staging
+
+    files_client = _RecordingFilesClient(["../escape.txt"])
+    monkeypatch.setattr(dataset_staging.AsyncFilesClient, "from_client", lambda _client: files_client)
+    client = AsyncNemoClient(base_url="http://test")
+    ref = DatasetRef(uri="fileset://workspace-a/task-template", metadata={"id": "template-fileset"})
+
+    try:
+        with pytest.raises(ValueError, match="escapes staging destination"):
+            await stage_task_template(tmp_path / "experiment", ref, client=client, workspace="workspace-a")
+    finally:
+        await client.close()
+
+    assert files_client.downloaded_paths == []
+    assert not (tmp_path / "experiment" / "dataset" / "escape.txt").exists()
+
+
+async def test_stage_task_template_rejects_prefixed_fileset_path_traversal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from nemo_experimentalist_plugin.experimentalist.components import dataset_staging
+
+    files_client = _RecordingFilesClient(["task-root/../../escape.txt"])
+    monkeypatch.setattr(dataset_staging.AsyncFilesClient, "from_client", lambda _client: files_client)
+    client = AsyncNemoClient(base_url="http://test")
+    ref = DatasetRef(uri="fileset://workspace-a/task-template#task-root", metadata={"id": "template-fileset"})
+
+    try:
+        with pytest.raises(ValueError, match="escapes staging destination"):
+            await stage_task_template(tmp_path / "experiment", ref, client=client, workspace="workspace-a")
+    finally:
+        await client.close()
+
+    assert files_client.downloaded_paths == []
+    assert not (tmp_path / "experiment" / "dataset" / "escape.txt").exists()
+
+
+async def test_stage_task_template_rejects_fileset_paths_outside_fragment_prefix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from nemo_experimentalist_plugin.experimentalist.components import dataset_staging
+
+    files_client = _RecordingFilesClient(["other-root/tests/test.sh"])
+    monkeypatch.setattr(dataset_staging.AsyncFilesClient, "from_client", lambda _client: files_client)
+    client = AsyncNemoClient(base_url="http://test")
+    ref = DatasetRef(uri="fileset://workspace-a/task-template#task-root", metadata={"id": "template-fileset"})
+
+    try:
+        with pytest.raises(ValueError, match="outside requested prefix"):
+            await stage_task_template(tmp_path / "experiment", ref, client=client, workspace="workspace-a")
+    finally:
+        await client.close()
+
+    assert files_client.downloaded_paths == []

--- a/plugins/nemo-experimentalist/tests/experimentalist/test_resume_e2e.py
+++ b/plugins/nemo-experimentalist/tests/experimentalist/test_resume_e2e.py
@@ -15,11 +15,12 @@ candidate store, a run stranded in ``status="running"`` when finalizing threw, a
 """
 
 import json
+import os
 from pathlib import Path
 from typing import Any, ClassVar
 
 import pytest
-from doubles import FakeEvaluator
+from doubles import FakeEvaluator, fake_client
 from nemo_experimentalist_plugin.config import CandidateStorageConfig, EvolutionaryOptimizerConfig
 from nemo_experimentalist_plugin.entities import Candidate, Dataset, DatasetRef, RewardRecord, Task
 from nemo_experimentalist_plugin.experimentalist import runner as runner_module
@@ -96,7 +97,7 @@ def _make_runner(tmp_path: Path, strategy: Any, monkeypatch: pytest.MonkeyPatch)
 
     config = EvolutionaryOptimizerConfig(storage=CandidateStorageConfig(archive_candidates=False, publish_winner=False))
     return ExperimentRunner(
-        backend=LocalExperimentalistBackend(path=experiment_dir),
+        backend=LocalExperimentalistBackend(client=fake_client(), path=experiment_dir),
         strategy=strategy,
         config=config,
         workspace="default",
@@ -205,7 +206,10 @@ async def test_run_json_appears_by_rename_not_by_truncating_in_place(tmp_path, m
     renamed: list[str] = []
     real_replace = backend_module.os.replace
 
-    def _recording_replace(src: object, dst: object) -> None:
+    def _recording_replace(
+        src: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+        dst: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+    ) -> None:
         renamed.append(Path(str(dst)).name)
         real_replace(src, dst)
 

--- a/plugins/nemo-experimentalist/tests/experimentalist/test_role_swap.py
+++ b/plugins/nemo-experimentalist/tests/experimentalist/test_role_swap.py
@@ -758,7 +758,7 @@ async def test_the_terminator_sees_eliminated_candidates_too(
 def test_no_component_constructor_names_a_platform_type(isolated_registry: None) -> None:
     """A component must be constructible by anyone holding a context, and nothing else.
 
-    Trace readers used to take an `AsyncNeMoPlatform` client plus a workspace name, which
+    Trace readers used to take an async platform client plus a workspace name, which
     put a platform type in the public signature of a role a third party is meant to
     implement: to write one you had to obtain a platform client, and the host had to hand
     its client to a component. They take `load_trace` from the context instead.
@@ -777,7 +777,7 @@ def test_no_component_constructor_names_a_platform_type(isolated_registry: None)
         f"{role}:{name}": [
             parameter
             for parameter, value in inspect.signature(cls.__init__).parameters.items()
-            if "NeMoPlatform" in str(value.annotation)
+            if "NemoClient" in str(value.annotation) or "NeMoPlatform" in str(value.annotation)
         ]
         for (role, name), cls in Component._registry.items()
     }

--- a/plugins/nemo-experimentalist/tests/experimentalist/test_runner.py
+++ b/plugins/nemo-experimentalist/tests/experimentalist/test_runner.py
@@ -6,7 +6,7 @@
 import json
 from pathlib import Path
 from types import SimpleNamespace
-from typing import ClassVar
+from typing import ClassVar, cast
 
 import pytest
 from doubles import FakeBackend, FakeEvaluator, fake_client, make_candidate
@@ -24,12 +24,14 @@ from nemo_experimentalist_plugin.entities import (
 from nemo_experimentalist_plugin.experimentalist import runner as runner_module
 from nemo_experimentalist_plugin.experimentalist.context import ExperimentContext
 from nemo_experimentalist_plugin.experimentalist.experimentalist_backend import LocalExperimentalistBackend
+from nemo_experimentalist_plugin.experimentalist.roles import Strategy
 from nemo_experimentalist_plugin.experimentalist.runner import ExperimentRunner
+from nemo_experimentalist_plugin.experimentalist.seam import StrategyContext
 from nemo_insights_plugin.entities import Insight
 from nemo_platform_plugin.config import Configuration
 
 
-class RecordingStrategy:
+class RecordingStrategy(Strategy):
     """Keeps the context it was handed, then returns (or raises) what it was told to."""
 
     supports_resume: ClassVar[bool] = True
@@ -39,8 +41,8 @@ class RecordingStrategy:
         self.error = error
         self.ctx: ExperimentContext | None = None
 
-    async def run(self, ctx: ExperimentContext) -> Candidate | None:
-        self.ctx = ctx
+    async def run(self, ctx: StrategyContext) -> Candidate | None:
+        self.ctx = cast(ExperimentContext, ctx)
         if self.error is not None:
             raise self.error
         if self.winner is not None:
@@ -288,7 +290,7 @@ async def test_a_failed_run_is_visible_on_disk(monkeypatch, tmp_path) -> None:
     agent_dir = tmp_path / "agent"
     agent_dir.mkdir()
     runner = ExperimentRunner(
-        backend=LocalExperimentalistBackend(path=tmp_path / "experiment"),
+        backend=LocalExperimentalistBackend(client=fake_client(), path=tmp_path / "experiment"),
         strategy=RecordingStrategy(error=ValueError("baseline failed")),
         config=EvolutionaryOptimizerConfig(),
         workspace="default",

--- a/plugins/nemo-experimentalist/tests/integration/conftest.py
+++ b/plugins/nemo-experimentalist/tests/integration/conftest.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from uuid import uuid4
 
 import pytest
-from nemo_platform import AsyncNeMoPlatform
+from nemo_platform_plugin.client.client import AsyncNemoClient
 from nmp.intake.config import ClickHouseConfig, IntakeConfig
 from nmp.intake.service import IntakeService
 from nmp.intake.spans.clickhouse_client import ClickHouseSettings, ClickHouseSpanClient, bootstrap_schema
@@ -68,7 +68,7 @@ def clickhouse_settings() -> Iterator[ClickHouseSettings]:
 
 
 @pytest.fixture
-def platform(clickhouse_settings: ClickHouseSettings) -> Iterator[AsyncNeMoPlatform]:
+def platform(clickhouse_settings: ClickHouseSettings) -> Iterator[AsyncNemoClient]:
     config = IntakeConfig(
         clickhouse_config=ClickHouseConfig(
             url=clickhouse_settings.url,
@@ -78,6 +78,6 @@ def platform(clickhouse_settings: ClickHouseSettings) -> Iterator[AsyncNeMoPlatf
         )
     )
     with create_test_client(
-        IntakeService, client_type=AsyncNeMoPlatform, service_configs={IntakeService: config}
+        IntakeService, client_type=AsyncNemoClient, service_configs={IntakeService: config}
     ) as client:
         yield client

--- a/plugins/nemo-experimentalist/tests/integration/test_persist_trial_to_intake.py
+++ b/plugins/nemo-experimentalist/tests/integration/test_persist_trial_to_intake.py
@@ -22,7 +22,9 @@ from uuid import uuid4
 import pytest
 from nemo_experimentalist_plugin.entities import ResourceRef, TrialResult
 from nemo_experimentalist_plugin.experimentalist.experimentalist_backend import LocalExperimentalistBackend
-from nemo_platform import AsyncNeMoPlatform
+from nemo_platform_plugin.client.client import AsyncNemoClient
+from nemo_platform_plugin.intake.client import AsyncIntakeClient
+from nemo_platform_plugin.intake.types import EvaluationCreateRequest, ExperimentCreateRequest
 
 pytestmark = pytest.mark.integration
 
@@ -66,20 +68,23 @@ def _otlp_trace(tmp_path: Path, span_name: str) -> tuple[ResourceRef, str]:
     return ref, trace_id
 
 
-async def _ensure_evaluation(platform: AsyncNeMoPlatform, name: str) -> None:
+async def _ensure_evaluation(platform: AsyncNemoClient, name: str) -> None:
     """Register the Evaluation these spans name, or Intake drops them."""
-    group = await platform.experiments.create(workspace=WORKSPACE, name=name)
-    await platform.evaluations.create(
+    intake = AsyncIntakeClient.from_client(platform)
+    group = (await intake.create_experiment(workspace=WORKSPACE, body=ExperimentCreateRequest(name=name))).data()
+    await intake.create_evaluation(
         workspace=WORKSPACE,
-        name=name,
-        experiment_ids=[group.id],
-        dataset_name=name,
-        dataset_version="v1",
+        body=EvaluationCreateRequest(
+            name=name,
+            experiment_ids=[group.id],
+            dataset_name=name,
+            dataset_version="v1",
+        ),
     )
 
 
 async def test_persist_trial_uploads_a_local_otlp_trace_and_repoints_it(
-    platform: AsyncNeMoPlatform, tmp_path: Path
+    platform: AsyncNemoClient, tmp_path: Path
 ) -> None:
     backend = LocalExperimentalistBackend(client=platform, path=tmp_path / "backend")
     trace, trace_id = _otlp_trace(tmp_path, "it-span")
@@ -90,8 +95,10 @@ async def test_persist_trial_uploads_a_local_otlp_trace_and_repoints_it(
     await backend._persist_trial(trial, workspace=WORKSPACE, evaluation_name=evaluation_name, agent_attrs={})
 
     # The span reached ClickHouse through the typed SDK and is readable back through it.
-    spans = await platform.intake.spans.list(workspace=WORKSPACE, filter={"trace_id": trace_id})
-    assert [span.name for span in spans.data] == ["it-span"]
+    response = await AsyncIntakeClient.from_client(platform).list_spans(
+        workspace=WORKSPACE, query_params={"filter": {"trace_id": trace_id}}
+    )
+    assert [span.name async for span in response.items()] == ["it-span"]
 
     # The trial now points at Intake, with the local file kept for reference.
     assert trial.trace is not None
@@ -100,7 +107,7 @@ async def test_persist_trial_uploads_a_local_otlp_trace_and_repoints_it(
 
 
 async def test_persist_trial_stamps_evaluation_identity_onto_the_uploaded_spans(
-    platform: AsyncNeMoPlatform, tmp_path: Path
+    platform: AsyncNemoClient, tmp_path: Path
 ) -> None:
     backend = LocalExperimentalistBackend(client=platform, path=tmp_path / "backend")
     trace, _ = _otlp_trace(tmp_path, "s")
@@ -113,5 +120,7 @@ async def test_persist_trial_stamps_evaluation_identity_onto_the_uploaded_spans(
 
     # evaluation_name is the attribute Intake indexes and the experiments rollup groups on,
     # so it has to survive the round trip rather than merely be sent.
-    spans = await platform.intake.spans.list(workspace=WORKSPACE, filter={"evaluation_name": evaluation_name})
-    assert [span.name for span in spans.data] == ["s"]
+    response = await AsyncIntakeClient.from_client(platform).list_spans(
+        workspace=WORKSPACE, query_params={"filter": {"evaluation_name": evaluation_name}}
+    )
+    assert [span.name async for span in response.items()] == ["s"]

--- a/plugins/nemo-experimentalist/tests/test_client.py
+++ b/plugins/nemo-experimentalist/tests/test_client.py
@@ -5,7 +5,9 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from nemo_experimentalist_plugin.client import make_client
-from nemo_platform_ext.auth.helpers import NMPOIDCConfig
+from nemo_platform_plugin.client.config.models import OAuthUser
+from nemo_platform_plugin.client.oidc import NMPOIDCConfig
+from pydantic import SecretStr
 
 REMOTE_URL = "https://nemo-platform.example.com"
 
@@ -13,13 +15,13 @@ REMOTE_URL = "https://nemo-platform.example.com"
 def test_no_base_url_uses_active_context() -> None:
     with (
         patch("nemo_experimentalist_plugin.client.discover_nmp_config") as discover,
-        patch("nemo_experimentalist_plugin.client.AsyncNeMoPlatform") as client_cls,
+        patch("nemo_experimentalist_plugin.client.AsyncNemoClient") as client_cls,
     ):
         client = make_client(None)
 
     discover.assert_not_called()
-    client_cls.assert_called_once_with()
-    assert client is client_cls.return_value
+    client_cls.from_config.assert_called_once_with()
+    assert client is client_cls.from_config.return_value
 
 
 @pytest.mark.parametrize("host", ["localhost", "127.0.0.1", "::1", "0.0.0.0"])
@@ -31,7 +33,7 @@ def test_loopback_uses_direct_mode_without_auth_discovery(host: str) -> None:
     with (
         patch("nemo_experimentalist_plugin.client.Config.get_default_config_path", return_value=config_path),
         patch("nemo_experimentalist_plugin.client.discover_nmp_config") as discover,
-        patch("nemo_experimentalist_plugin.client.AsyncNeMoPlatform") as client_cls,
+        patch("nemo_experimentalist_plugin.client.AsyncNemoClient") as client_cls,
     ):
         client = make_client(base_url)
 
@@ -47,7 +49,7 @@ def test_remote_without_local_config_uses_direct_mode_without_auth_discovery() -
     with (
         patch("nemo_experimentalist_plugin.client.Config.get_default_config_path", return_value=config_path),
         patch("nemo_experimentalist_plugin.client.discover_nmp_config") as discover,
-        patch("nemo_experimentalist_plugin.client.AsyncNeMoPlatform") as client_cls,
+        patch("nemo_experimentalist_plugin.client.AsyncNemoClient") as client_cls,
     ):
         client = make_client(REMOTE_URL)
 
@@ -66,7 +68,7 @@ def test_remote_no_auth_ignores_unrelated_local_oauth_context() -> None:
             "nemo_experimentalist_plugin.client.discover_nmp_config",
             return_value=NMPOIDCConfig(auth_enabled=False),
         ) as discover,
-        patch("nemo_experimentalist_plugin.client.AsyncNeMoPlatform") as client_cls,
+        patch("nemo_experimentalist_plugin.client.AsyncNemoClient") as client_cls,
     ):
         client = make_client(REMOTE_URL)
 
@@ -75,7 +77,8 @@ def test_remote_no_auth_ignores_unrelated_local_oauth_context() -> None:
     assert client is client_cls.return_value
 
 
-def test_remote_auth_uses_local_oauth_context() -> None:
+def test_remote_auth_rejects_plaintext_http() -> None:
+    base_url = "http://nemo-platform.example.com"
     config_path = MagicMock()
     config_path.exists.return_value = True
 
@@ -89,10 +92,56 @@ def test_remote_auth_uses_local_oauth_context() -> None:
                 token_endpoint="https://auth.example.com/token",
             ),
         ) as discover,
-        patch("nemo_experimentalist_plugin.client.AsyncNeMoPlatform") as client_cls,
+        patch("nemo_experimentalist_plugin.client.Config.load") as load_config,
+        patch("nemo_experimentalist_plugin.client.AsyncNemoClient") as client_cls,
+    ):
+        with pytest.raises(ValueError, match="must use HTTPS"):
+            make_client(base_url)
+
+    discover.assert_called_once_with(base_url)
+    load_config.assert_not_called()
+    client_cls.assert_not_called()
+
+
+def test_remote_auth_uses_local_oauth_context() -> None:
+    config_path = MagicMock()
+    config_path.exists.return_value = True
+    config = MagicMock()
+    config.get_config_path.return_value = config_path
+    config.access_token = None
+    ctx = MagicMock()
+    ctx.workspace = "workspace-a"
+    ctx.context_name = "ctx-a"
+    ctx.user = OAuthUser(name="user-a", token=SecretStr("access-token"), refresh_token=SecretStr("refresh-token"))
+    config.resolve.return_value = ctx
+    auth = object()
+
+    with (
+        patch("nemo_experimentalist_plugin.client.Config.get_default_config_path", return_value=config_path),
+        patch("nemo_experimentalist_plugin.client.Config.load", return_value=config) as load_config,
+        patch(
+            "nemo_experimentalist_plugin.client.discover_nmp_config",
+            return_value=NMPOIDCConfig(
+                auth_enabled=True,
+                client_id="nemo-cli",
+                token_endpoint="https://auth.example.com/token",
+            ),
+        ) as discover,
+        patch("nemo_experimentalist_plugin.client.resolve_oidc_provider", return_value=auth) as resolve_auth,
+        patch("nemo_experimentalist_plugin.client.AsyncNemoClient") as client_cls,
     ):
         client = make_client(REMOTE_URL)
 
     discover.assert_called_once_with(REMOTE_URL)
-    client_cls.assert_called_once_with(base_url=REMOTE_URL, config_path=config_path)
+    load_config.assert_called_once_with(config_path=config_path, overrides={"base_url": REMOTE_URL})
+    resolve_auth.assert_called_once_with(
+        base_url=REMOTE_URL,
+        context_name="ctx-a",
+        access_token="access-token",
+        refresh_token="refresh-token",
+        config_exists=True,
+        config_path=config_path,
+        explicit_access_token=False,
+    )
+    client_cls.assert_called_once_with(base_url=REMOTE_URL, workspace="workspace-a", auth=auth)
     assert client is client_cls.return_value

--- a/plugins/nemo-experimentalist/tests/test_experiment_cli.py
+++ b/plugins/nemo-experimentalist/tests/test_experiment_cli.py
@@ -3,15 +3,15 @@
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import cast
 
+import httpx
 import pytest
 from click.testing import Result
 from nemo_experimentalist_plugin import cli
 from nemo_experimentalist_plugin.entities import DatasetRef
 from nemo_experimentalist_plugin.experimentalist.strategies.evolutionary import EvolutionaryOptimizerConfig
 from nemo_experimentalist_plugin.preflight import Probes
-from nemo_platform import AsyncNeMoPlatform
+from nemo_platform_plugin.client.client import AsyncNemoClient
 from nooa import GenerationError
 from typer.testing import CliRunner
 
@@ -40,18 +40,27 @@ def hermetic_cwd(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.chdir(tmp_path)
 
 
-@dataclass
-class FakePlatformClient:
-    closed: bool = False
+class FakePlatformClient(AsyncNemoClient):
+    def __init__(self) -> None:
+        transport = httpx.MockTransport(
+            lambda request: httpx.Response(500, request=request, json={"detail": "fake client"})
+        )
+        super().__init__(
+            base_url="http://platform.test",
+            workspace="default",
+            http_client=httpx.AsyncClient(transport=transport),
+        )
+        self.closed = False
 
     async def close(self) -> None:
         self.closed = True
+        await super().close()
 
 
 @pytest.fixture(autouse=True)
 def platform_client(monkeypatch: pytest.MonkeyPatch) -> FakePlatformClient:
     client = FakePlatformClient()
-    monkeypatch.setattr(cli, "make_client", lambda _base_url: cast(AsyncNeMoPlatform, client))
+    monkeypatch.setattr(cli, "make_client", lambda _base_url: client)
     return client
 
 
@@ -63,7 +72,7 @@ class CapturedExperimentRun:
     task_template: DatasetRef | None
     experiment_dir: Path
     workspace: str
-    client: AsyncNeMoPlatform | None
+    client: AsyncNemoClient
     config: EvolutionaryOptimizerConfig
     insight: Path | str | None
     ethos: str | None
@@ -106,7 +115,7 @@ class ExperimentRunRecorder:
         validation_dataset: DatasetRef,
         experiment_dir: Path,
         workspace: str,
-        client: AsyncNeMoPlatform | None,
+        client: AsyncNemoClient,
         config: EvolutionaryOptimizerConfig,
         task_template: DatasetRef | None = None,
         insight: Path | str | None = None,

--- a/plugins/nemo-experimentalist/tests/test_experiment_mirror.py
+++ b/plugins/nemo-experimentalist/tests/test_experiment_mirror.py
@@ -1,7 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+from dataclasses import dataclass
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any, Generic, Protocol, TypeVar
 from unittest.mock import AsyncMock
 
 import httpx
@@ -9,20 +10,103 @@ import pytest
 from doubles import make_candidate
 from nemo_experimentalist_plugin.entities import Candidate, ExperimentRun, RewardRecord
 from nemo_experimentalist_plugin.experimentalist.experiment_mirror import ExperimentMirror, group_metadata
-from nemo_platform import AsyncNeMoPlatform, ConflictError, NotFoundError, omit
+from nemo_platform_plugin.client.errors import ConflictError, NotFoundError
+from nemo_platform_plugin.intake.client import AsyncIntakeClient
+from nemo_platform_plugin.intake.types import EvaluationCreateRequest, ExperimentCreateRequest, ExperimentUpdateRequest
 
 pytestmark = pytest.mark.asyncio
 
-_CONFLICT = ConflictError(
-    "conflict", response=httpx.Response(409, request=httpx.Request("POST", "http://x/y")), body=None
-)
-_NOTFOUND = NotFoundError(
-    "not found", response=httpx.Response(404, request=httpx.Request("GET", "http://x/y")), body=None
-)
+_CONFLICT = ConflictError(httpx.Response(409, request=httpx.Request("POST", "http://x/y")))
+_NOTFOUND = NotFoundError(httpx.Response(404, request=httpx.Request("GET", "http://x/y")))
+
+T = TypeVar("T")
 
 
-def _client(groups: object, experiments: object) -> AsyncNeMoPlatform:
-    return cast(AsyncNeMoPlatform, SimpleNamespace(experiments=groups, evaluations=experiments))
+@dataclass(frozen=True)
+class _Response(Generic[T]):
+    body: T
+
+    def data(self) -> T:
+        return self.body
+
+
+class _GroupClient(Protocol):
+    async def create(self, *, workspace: str, body: ExperimentCreateRequest) -> _Response[object]: ...
+
+    async def retrieve(self, name: str, *, workspace: str) -> _Response[object]: ...
+
+    async def update(self, name: str, *, workspace: str, body: ExperimentUpdateRequest) -> _Response[object]: ...
+
+
+class _EvaluationClient(Protocol):
+    async def create(self, *, workspace: str, body: EvaluationCreateRequest) -> _Response[object]: ...
+
+    async def retrieve(self, name: str, *, workspace: str) -> _Response[object]: ...
+
+    async def update(self, name: str, *, workspace: str, body: EvaluationCreateRequest) -> _Response[object]: ...
+
+
+class _MirrorClient(AsyncIntakeClient):
+    def __init__(self, groups: _GroupClient, experiments: _EvaluationClient) -> None:
+        super().__init__(base_url="http://test")
+        self._groups = groups
+        self._experiments = experiments
+
+    async def create_experiment(
+        self,
+        *,
+        workspace: str | None = None,
+        body: ExperimentCreateRequest,
+    ) -> _Response[object]:
+        return await self._groups.create(workspace=workspace or "default", body=body)
+
+    async def get_experiment(
+        self,
+        *,
+        workspace: str | None = None,
+        name: str,
+    ) -> _Response[object]:
+        return await self._groups.retrieve(name, workspace=workspace or "default")
+
+    async def update_experiment(
+        self,
+        *,
+        workspace: str | None = None,
+        name: str,
+        body: ExperimentUpdateRequest,
+    ) -> _Response[object]:
+        return await self._groups.update(name, workspace=workspace or "default", body=body)
+
+    async def create_evaluation(
+        self,
+        *,
+        workspace: str | None = None,
+        body: EvaluationCreateRequest,
+    ) -> _Response[object]:
+        return await self._experiments.create(workspace=workspace or "default", body=body)
+
+    async def get_evaluation(
+        self,
+        *,
+        workspace: str | None = None,
+        name: str,
+    ) -> _Response[object]:
+        return await self._experiments.retrieve(name, workspace=workspace or "default")
+
+    async def update_evaluation(
+        self,
+        *,
+        workspace: str | None = None,
+        name: str,
+        body: EvaluationCreateRequest,
+    ) -> _Response[object]:
+        return await self._experiments.update(name, workspace=workspace or "default", body=body)
+
+
+def _client(groups: _GroupClient, experiments: _EvaluationClient) -> AsyncIntakeClient:
+    if isinstance(groups, AsyncMock) and isinstance(groups.retrieve.return_value, AsyncMock):
+        groups.retrieve.return_value = _Response(SimpleNamespace(id="grp-1", name="opt-run-1"))
+    return _MirrorClient(groups, experiments)
 
 
 class _StatefulGroups:
@@ -31,27 +115,32 @@ class _StatefulGroups:
     as "field became None". This is what catches accidental field-wiping on update."""
 
     _TRACKED = ("insight_id", "summary", "metadata")
+    calls: list[dict[str, object]]
 
     def __init__(self) -> None:
         self.name: str | None = None
         self.body: dict[str, object | None] = {}
+        self.calls = []
 
-    def _apply(self, **kwargs: object) -> None:
+    def _apply(self, body: ExperimentCreateRequest | ExperimentUpdateRequest) -> None:
+        dumped = body.model_dump(exclude_unset=True)
         for field in self._TRACKED:
-            value = kwargs.get(field, omit)
-            self.body[field] = None if value is omit else value
+            self.body[field] = dumped.get(field)
 
-    async def create(self, *, name: str, **kwargs: object) -> object:
-        self.name = name
-        self._apply(**kwargs)
-        return SimpleNamespace(id="grp-1", name=name, **self.body)
+    async def create(self, *, workspace: str, body: ExperimentCreateRequest) -> _Response[object]:
+        self.calls.append({"workspace": workspace, "body": body})
+        self.name = body.name
+        self._apply(body)
+        return _Response(SimpleNamespace(id="grp-1", name=body.name, **self.body))
 
-    async def retrieve(self, name: str, **kwargs: object) -> object:
-        return SimpleNamespace(id="grp-1", name=self.name, **self.body)
+    async def retrieve(self, name: str, *, workspace: str) -> _Response[object]:
+        self.calls.append({"workspace": workspace, "name": name})
+        return _Response(SimpleNamespace(id="grp-1", name=self.name, **self.body))
 
-    async def update(self, path_name: str, **kwargs: object) -> object:
-        self._apply(**kwargs)
-        return SimpleNamespace(id="grp-1", name=self.name, **self.body)
+    async def update(self, name: str, *, workspace: str, body: ExperimentUpdateRequest) -> _Response[object]:
+        self.calls.append({"workspace": workspace, "name": name, "body": body})
+        self._apply(body)
+        return _Response(SimpleNamespace(id="grp-1", name=self.name, **self.body))
 
 
 def _run(**kw: Any) -> ExperimentRun:
@@ -78,18 +167,18 @@ def _cand(**kw: Any) -> Candidate:
 
 async def test_ensure_group_creates_with_insight_and_metadata():
     groups = AsyncMock()
-    groups.create.return_value = SimpleNamespace(id="grp-1", name="opt-run-1")
+    groups.create.return_value = _Response(SimpleNamespace(id="grp-1", name="opt-run-1"))
     mirror = ExperimentMirror(_client(groups, AsyncMock()), workspace="default")
     await mirror.ensure_group(_run())
-    kwargs = groups.create.await_args.kwargs
-    assert kwargs["name"] == "opt-run-1" and kwargs["insight_id"] == "ins-1"
-    assert kwargs["metadata"]["agent"] == "a"
+    body = groups.create.await_args.kwargs["body"]
+    assert body.name == "opt-run-1" and body.insight_id == "ins-1"
+    assert body.metadata["agent"] == "a"
 
 
 async def test_ensure_group_conflict_retrieves():
     groups = AsyncMock()
     groups.create.side_effect = _CONFLICT
-    groups.retrieve.return_value = SimpleNamespace(id="grp-1", name="opt-run-1")
+    groups.retrieve.return_value = _Response(SimpleNamespace(id="grp-1", name="opt-run-1"))
     mirror = ExperimentMirror(_client(groups, AsyncMock()), workspace="default")
     await mirror.ensure_group(_run())
     groups.retrieve.assert_awaited_once()
@@ -97,21 +186,21 @@ async def test_ensure_group_conflict_retrieves():
 
 async def test_project_candidate_upserts_experiment_per_evaluated_split():
     experiments = AsyncMock()
-    experiments.create.return_value = SimpleNamespace(id="exp-train")
+    experiments.create.return_value = _Response(SimpleNamespace(id="exp-train"))
     mirror = ExperimentMirror(_client(AsyncMock(), experiments), workspace="default")
     cand = _cand(generation=0, rewards={"train": RewardRecord(metrics={"reward": 1.0}, trials=[])})
     await mirror.project_candidate(cand)
-    kwargs = experiments.create.await_args.kwargs
-    assert kwargs["name"] == "opt-run-1-agent-0-train"
-    assert kwargs["status"] == "baseline"
+    body = experiments.create.await_args.kwargs["body"]
+    assert body.name == "opt-run-1-agent-0-train"
+    assert body.status == "baseline"
     # metadata is identity-only — reward/trials are NOT copied (§4.3)
-    assert kwargs["metadata"] == {
+    assert body.metadata == {
         "generation": "0",
         "candidate_id": "id-agent-0",
         "candidate_label": "agent-0",
         "split": "train",
     }
-    assert "aggregate_metrics" not in kwargs["metadata"] and "trials" not in kwargs["metadata"]
+    assert "aggregate_metrics" not in body.metadata and "trials" not in body.metadata
     # validation not evaluated → not created
     assert experiments.create.await_count == 1
 
@@ -125,16 +214,16 @@ async def test_project_candidate_skips_when_no_reward():
 
 async def test_project_candidate_creates_experiment_for_custom_reward_channel():
     experiments = AsyncMock()
-    experiments.create.return_value = SimpleNamespace(id="exp-custom")
+    experiments.create.return_value = _Response(SimpleNamespace(id="exp-custom"))
     mirror = ExperimentMirror(_client(AsyncMock(), experiments), workspace="default")
     candidate = _cand(rewards={"custom": RewardRecord(metrics={"custom_score": 0.5}, trials=[])})
 
     await mirror.project_candidate(candidate)
 
-    kwargs = experiments.create.await_args.kwargs
-    assert kwargs["name"] == "opt-run-1-agent-0-custom"
-    assert kwargs["dataset_name"] == "custom"
-    assert kwargs["metadata"] == {
+    body = experiments.create.await_args.kwargs["body"]
+    assert body.name == "opt-run-1-agent-0-custom"
+    assert body.dataset_name == "custom"
+    assert body.metadata == {
         "generation": "0",
         "candidate_id": "id-agent-0",
         "candidate_label": "agent-0",
@@ -144,18 +233,18 @@ async def test_project_candidate_creates_experiment_for_custom_reward_channel():
 
 async def test_project_candidate_conflict_updates_experiment():
     groups = AsyncMock()
-    groups.retrieve.return_value = SimpleNamespace(id="grp-1", name="opt-run-1")
+    groups.retrieve.return_value = _Response(SimpleNamespace(id="grp-1", name="opt-run-1"))
     experiments = AsyncMock()
     experiments.create.side_effect = _CONFLICT
-    experiments.update.return_value = SimpleNamespace(id="exp-train")
+    experiments.update.return_value = _Response(SimpleNamespace(id="exp-train"))
     mirror = ExperimentMirror(_client(groups, experiments), workspace="default")
     cand = _cand(generation=0, rewards={"train": RewardRecord(metrics={"reward": 1.0}, trials=[])})
     await mirror.project_candidate(cand)
     experiments.update.assert_awaited_once()
     # update is a full-replace: dataset_version must be re-supplied (symmetric with create)
-    kwargs = experiments.update.await_args.kwargs
-    assert kwargs["dataset_version"] == "v1"
-    assert kwargs["metadata"] == {
+    body = experiments.update.await_args.kwargs["body"]
+    assert body.dataset_version == "v1"
+    assert body.metadata == {
         "generation": "0",
         "candidate_id": "id-agent-0",
         "candidate_label": "agent-0",
@@ -165,11 +254,11 @@ async def test_project_candidate_conflict_updates_experiment():
 
 async def test_parent_experiment_id_cache_hit():
     groups = AsyncMock()
-    groups.retrieve.return_value = SimpleNamespace(id="grp-1", name="opt-run-1")
+    groups.retrieve.return_value = _Response(SimpleNamespace(id="grp-1", name="opt-run-1"))
     experiments = AsyncMock()
     experiments.create.side_effect = [
-        SimpleNamespace(id="exp-ancestor-train"),  # ancestor train experiment
-        SimpleNamespace(id="exp-child-train"),  # child train experiment
+        _Response(SimpleNamespace(id="exp-ancestor-train")),  # ancestor train experiment
+        _Response(SimpleNamespace(id="exp-child-train")),  # child train experiment
     ]
     mirror = ExperimentMirror(_client(groups, experiments), workspace="default")
     ancestor = _cand(label="agent-0", generation=0, rewards={"train": RewardRecord(metrics={"reward": 1.0}, trials=[])})
@@ -181,8 +270,8 @@ async def test_parent_experiment_id_cache_hit():
         rewards={"train": RewardRecord(metrics={"reward": 1.0}, trials=[])},
     )
     await mirror.project_candidate(child)
-    child_kwargs = experiments.create.await_args.kwargs  # last call == child
-    assert child_kwargs["parent_evaluation_id"] == "exp-ancestor-train"
+    child_body = experiments.create.await_args.kwargs["body"]  # last call == child
+    assert child_body.parent_evaluation_id == "exp-ancestor-train"
     experiments.retrieve.assert_not_awaited()  # resolved from cache, no lookup
 
 
@@ -195,9 +284,9 @@ async def test_parent_experiment_id_omits_the_link_for_an_unprojected_ancestor()
     honest outcome.
     """
     groups = AsyncMock()
-    groups.retrieve.return_value = SimpleNamespace(id="grp-1", name="opt-run-1")
+    groups.retrieve.return_value = _Response(SimpleNamespace(id="grp-1", name="opt-run-1"))
     experiments = AsyncMock()
-    experiments.create.return_value = SimpleNamespace(id="exp-child-train")
+    experiments.create.return_value = _Response(SimpleNamespace(id="exp-child-train"))
     mirror = ExperimentMirror(_client(groups, experiments), workspace="default")
     child = _cand(
         label="agent-1",
@@ -207,15 +296,15 @@ async def test_parent_experiment_id_omits_the_link_for_an_unprojected_ancestor()
     )
     await mirror.project_candidate(child)
     experiments.retrieve.assert_not_awaited()
-    assert isinstance(experiments.create.await_args.kwargs["parent_evaluation_id"], type(omit))
+    assert experiments.create.await_args.kwargs["body"].parent_evaluation_id is None
 
 
 async def test_parent_experiment_id_not_found_omits():
     groups = AsyncMock()
-    groups.retrieve.return_value = SimpleNamespace(id="grp-1", name="opt-run-1")
+    groups.retrieve.return_value = _Response(SimpleNamespace(id="grp-1", name="opt-run-1"))
     experiments = AsyncMock()
     experiments.retrieve.side_effect = _NOTFOUND
-    experiments.create.return_value = SimpleNamespace(id="exp-child-train")
+    experiments.create.return_value = _Response(SimpleNamespace(id="exp-child-train"))
     mirror = ExperimentMirror(_client(groups, experiments), workspace="default")
     child = _cand(
         label="agent-1",
@@ -224,24 +313,26 @@ async def test_parent_experiment_id_not_found_omits():
         rewards={"train": RewardRecord(metrics={"reward": 1.0}, trials=[])},
     )
     await mirror.project_candidate(child)
-    kwargs = experiments.create.await_args.kwargs
-    assert kwargs["parent_evaluation_id"] is omit
+    body = experiments.create.await_args.kwargs["body"]
+    assert body.parent_evaluation_id is None
 
 
 async def test_finalize_round0_winner_preserves_existing_source_link():
     # A round-0 winner with no PR must keep the source_link written during the run (e.g. a
     # real {repo}@{ref}), not have it clobbered with a pseudo link by the full-replace update.
     groups = AsyncMock()
-    groups.retrieve.return_value = SimpleNamespace(id="grp-1", name="opt-run-1", insight_id=None, metadata=None)
+    groups.retrieve.return_value = _Response(
+        SimpleNamespace(id="grp-1", name="opt-run-1", insight_id=None, metadata=None)
+    )
     experiments = AsyncMock()
-    experiments.retrieve.return_value = SimpleNamespace(id="exp-w", source_link="https://git/repo.git@main")
-    experiments.create.return_value = SimpleNamespace(id="exp-w")
+    experiments.retrieve.return_value = _Response(SimpleNamespace(id="exp-w", source_link="https://git/repo.git@main"))
+    experiments.create.return_value = _Response(SimpleNamespace(id="exp-w"))
     mirror = ExperimentMirror(_client(groups, experiments), workspace="default")
     winner = _cand(label="agent-0", generation=0, rewards={"train": RewardRecord(metrics={"reward": 1.0}, trials=[])})
     await mirror.finalize(run_id="run-1", summary="done", winner=winner, pr_url=None)
-    kwargs = experiments.create.await_args.kwargs
-    assert kwargs["source_link"] == "https://git/repo.git@main"  # preserved, not pseudo
-    assert kwargs["status"] == "winner"
+    body = experiments.create.await_args.kwargs["body"]
+    assert body.source_link == "https://git/repo.git@main"  # preserved, not pseudo
+    assert body.status == "winner"
 
 
 async def test_group_update_and_finalize_do_not_wipe_insight_or_metadata():
@@ -266,7 +357,7 @@ async def test_mirror_projects_every_measured_channel_without_an_allowlist() -> 
     explicit per-field dict, so an unknown channel was invisible.
     """
     experiments = AsyncMock()
-    experiments.create.return_value = SimpleNamespace(id="exp-x")
+    experiments.create.return_value = _Response(SimpleNamespace(id="exp-x"))
     mirror = ExperimentMirror(_client(AsyncMock(), experiments), workspace="default")
     candidate = _cand(
         rewards={
@@ -279,6 +370,6 @@ async def test_mirror_projects_every_measured_channel_without_an_allowlist() -> 
 
     # The channel the mirror never knew about must still reach Studio. Asserting on the
     # entity alone would pass even if project_candidate went back to a fixed allowlist.
-    projected = {call.kwargs["metadata"]["split"] for call in experiments.create.await_args_list}
+    projected = {call.kwargs["body"].metadata["split"] for call in experiments.create.await_args_list}
     assert projected == {"validation", "some-new-channel"}
     assert candidate.rewards["never-measured"].metrics == {}

--- a/plugins/nemo-experimentalist/tests/test_experimentalist_backend.py
+++ b/plugins/nemo-experimentalist/tests/test_experimentalist_backend.py
@@ -19,7 +19,7 @@ from typing import Any, cast
 
 import httpx
 import pytest
-from doubles import make_candidate
+from doubles import fake_client, make_candidate
 from nemo_experimentalist_plugin.entities import Candidate
 from nemo_experimentalist_plugin.experimentalist import experimentalist_backend as beim
 from nemo_experimentalist_plugin.experimentalist.components.repository import AgentCloneError, AgentSource
@@ -28,29 +28,26 @@ from nemo_experimentalist_plugin.experimentalist.experimentalist_backend import 
     LocalExperimentalistBackend,
 )
 from nemo_insights_plugin.entities import Insight
-from nemo_platform import AsyncNeMoPlatform
+from nemo_platform_plugin.client.client import AsyncNemoClient
+from nemo_platform_plugin.client.errors import NotFoundError
 
 
 def _local_backend(tmp_path: Path) -> LocalExperimentalistBackend:
-    return LocalExperimentalistBackend(path=tmp_path / "backend")
-
-
-def _as_platform_client(value: object) -> AsyncNeMoPlatform:
-    return cast(AsyncNeMoPlatform, value)
+    return LocalExperimentalistBackend(client=fake_client(), path=tmp_path / "backend")
 
 
 # ---------------------------------------------------------------------------
-# get_insight — local file (offline) vs platform id fetch
+# get_insight — local file fixture vs platform id fetch
 # ---------------------------------------------------------------------------
 
 
-class _StubInsightResource:
+class _StubInsightsClient:
     def __init__(self, insight: Insight | None, error: Exception | None = None) -> None:
         self._insight = insight
         self._error = error
         self.calls: list[dict[str, str]] = []
 
-    async def get(self, *, workspace: str, insight_id: str) -> Insight:
+    async def get_insight(self, *, workspace: str, insight_id: str) -> Insight:
         self.calls.append({"workspace": workspace, "insight_id": insight_id})
         if self._error is not None:
             raise self._error
@@ -58,58 +55,34 @@ class _StubInsightResource:
         return self._insight
 
 
-class _StubInsights:
-    def __init__(self, insight: Insight) -> None:
-        self.insights = _StubInsightResource(insight)
-
-
-class _StubClient:
-    def __init__(self, insight: Insight) -> None:
-        self.insights = _StubInsights(insight)
-
-
-class _ErrorStubClient:
-    def __init__(self, error: Exception) -> None:
-        self.insights = type("_StubInsights", (), {"insights": _StubInsightResource(None, error=error)})()
-
-
 async def test_get_insight_reads_local_file(tmp_path: Path) -> None:
     insight_file = tmp_path / "insight.json"
     insight_file.write_text(
         json.dumps({"id": "insight-local", "workspace": "w", "title": "t", "description": "d", "agent": "a"})
     )
-    backend = LocalExperimentalistBackend(path=tmp_path / "backend")
+    backend = LocalExperimentalistBackend(client=fake_client(), path=tmp_path / "backend")
 
     insight = await backend.get_insight(workspace="w", insight_id=str(insight_file))
 
     assert insight.id == "insight-local"
 
 
-async def test_get_insight_fetches_platform_id_via_client(tmp_path: Path) -> None:
+async def test_get_insight_fetches_platform_id_via_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     platform_insight = Insight(workspace="ws", title="platform", description="d", agent="a")
-    client = _StubClient(platform_insight)
-    backend = LocalExperimentalistBackend(client=_as_platform_client(client), path=tmp_path / "backend")
+    insights_client = _StubInsightsClient(platform_insight)
+    monkeypatch.setattr(beim.AsyncInsightsClient, "from_client", lambda _client: insights_client)
+    backend = LocalExperimentalistBackend(client=fake_client(), path=tmp_path / "backend")
 
     insight = await backend.get_insight(workspace="ws", insight_id="insight-remote-123")
 
     assert insight is platform_insight
-    assert client.insights.insights.calls == [{"workspace": "ws", "insight_id": "insight-remote-123"}]
+    assert insights_client.calls == [{"workspace": "ws", "insight_id": "insight-remote-123"}]
 
 
-async def test_get_insight_platform_id_without_client_raises(tmp_path: Path) -> None:
-    backend = LocalExperimentalistBackend(path=tmp_path / "backend")
-    with pytest.raises(ValueError, match="no platform client is available"):
-        await backend.get_insight(workspace="w", insight_id="insight-remote-123")
-
-
-async def test_get_insight_platform_404_raises_value_error(tmp_path: Path) -> None:
-    request = httpx.Request("GET", "http://platform.test/insights/missing")
-    response = httpx.Response(404, request=request)
-    error = httpx.HTTPStatusError("not found", request=request, response=response)
-    backend = LocalExperimentalistBackend(
-        client=_as_platform_client(_ErrorStubClient(error)),
-        path=tmp_path / "backend",
-    )
+async def test_get_insight_platform_404_raises_value_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    error = NotFoundError(httpx.Response(404, request=httpx.Request("GET", "http://platform.test/insights/missing")))
+    monkeypatch.setattr(beim.AsyncInsightsClient, "from_client", lambda _client: _StubInsightsClient(None, error))
+    backend = LocalExperimentalistBackend(client=fake_client(), path=tmp_path / "backend")
 
     with pytest.raises(ValueError, match="Insight not found on the platform"):
         await backend.get_insight(workspace="w", insight_id="missing")
@@ -245,7 +218,7 @@ def _cand(label: str = "agent-2", run_id: str = "run-1") -> Candidate:
 
 
 def _git_backend(tmp_path: Path, storage: CandidateStorageConfig | None = None) -> LocalExperimentalistBackend:
-    backend = LocalExperimentalistBackend(path=tmp_path / "backend", storage=storage)
+    backend = LocalExperimentalistBackend(client=fake_client(), path=tmp_path / "backend", storage=storage)
     backend._agent_source = AgentSource(repo_url="ssh://git@h/g/r.git", ref="main", agent_path="pkg/agent")
     backend._agent_checkout = tmp_path / "clone"
     return backend
@@ -397,28 +370,50 @@ def _atif_ref(tmp_path, session_id="sess-1"):
     return ResourceRef(uri=f"file://{path}", description="", metadata={"trace_format": "atif"})
 
 
-class _RecordingResource:
-    def __init__(self, result: object = None) -> None:
-        self.calls: list[dict] = []
-        self._result = result
+class _Response:
+    def __init__(self, body: object) -> None:
+        self._body = body
 
-    async def create(self, **kwargs):
-        self.calls.append(kwargs)
-        return self._result
+    def data(self) -> object:
+        return self._body
 
 
 class _RecordingIntakeClient:
-    """Exposes only the ingest chains the trace uploads reach through."""
+    """Exposes only the async typed Intake methods the trace uploads reach through."""
 
     def __init__(self) -> None:
-        self.traces = _RecordingResource(SimpleNamespace(errors=[]))
-        self.atif = _RecordingResource()
-        self.intake = SimpleNamespace(
-            ingest=SimpleNamespace(
-                otlp=SimpleNamespace(v1=SimpleNamespace(traces=self.traces)),
-                atif=self.atif,
-            )
-        )
+        self.traces = SimpleNamespace(calls=[])
+        self.atif = SimpleNamespace(calls=[])
+        self.evaluator_results: list[dict[str, object]] = []
+        self._otlp_result = SimpleNamespace(errors=[])
+
+    async def create_otlp_traces(self, *, content: bytes, workspace: str) -> _Response:
+        self.traces.calls.append({"workspace": workspace, "body": content})
+        return _Response(self._otlp_result)
+
+    async def create_atif(self, *, workspace: str, body: object) -> _Response:
+        self.atif.calls.append({"workspace": workspace, "body": body})
+        return _Response(None)
+
+    async def create_evaluator_result(self, *, workspace: str, body: object) -> _Response:
+        self.evaluator_results.append({"workspace": workspace, "body": body})
+        return _Response(object())
+
+
+def test_backend_stores_intake_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _RecordingIntakeClient()
+    factory_calls: list[AsyncNemoClient] = []
+
+    def from_client(platform_client: AsyncNemoClient) -> beim.AsyncIntakeClient:
+        factory_calls.append(platform_client)
+        return cast(beim.AsyncIntakeClient, client)
+
+    monkeypatch.setattr(beim.AsyncIntakeClient, "from_client", from_client)
+    platform_client = fake_client()
+    backend = LocalExperimentalistBackend(client=platform_client, path=tmp_path / "backend")
+
+    assert backend.intake_client is client
+    assert factory_calls == [platform_client]
 
 
 def _otlp_ref(tmp_path):
@@ -470,7 +465,7 @@ async def test_upload_trace_otlp_raises_when_intake_rejects_spans(tmp_path):
     from nemo_experimentalist_plugin.experimentalist.experimentalist_backend import _upload_trace_otlp
 
     client = _RecordingIntakeClient()
-    client.traces._result = SimpleNamespace(errors=["span 00a1: bad trace_id"])
+    client._otlp_result = SimpleNamespace(errors=["span 00a1: bad trace_id"])
 
     with pytest.raises(RuntimeError, match="bad trace_id"):
         await _upload_trace_otlp(
@@ -483,13 +478,16 @@ async def test_upload_trace_otlp_raises_when_intake_rejects_spans(tmp_path):
         )
 
 
-async def test_persist_trial_leaves_the_local_trace_ref_when_ingest_is_rejected(tmp_path):
+async def test_persist_trial_leaves_the_local_trace_ref_when_ingest_is_rejected(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
     """A partial ingest must not repoint the trial at a trace that never fully landed."""
     from nemo_experimentalist_plugin.entities import TrialResult
 
     client = _RecordingIntakeClient()
-    client.traces._result = SimpleNamespace(errors=["span 00a1: bad trace_id"])
-    backend = LocalExperimentalistBackend(client=cast(Any, client), path=tmp_path / "backend")
+    client._otlp_result = SimpleNamespace(errors=["span 00a1: bad trace_id"])
+    monkeypatch.setattr(beim.AsyncIntakeClient, "from_client", lambda _client: client)
+    backend = LocalExperimentalistBackend(client=fake_client(), path=tmp_path / "backend")
     ref = _otlp_ref(tmp_path)
     trial = TrialResult(id="trial-9", task_id="case-z", status="completed", trace=ref)
 
@@ -517,20 +515,21 @@ class _ReingestClient(_RecordingIntakeClient):
     def __init__(self, rows: list[dict]) -> None:
         super().__init__()
         self.list_calls: list[dict] = []
-        self.intake.spans = SimpleNamespace(list=self._list)
         self._rows = rows
 
-    def _list(self, **kwargs):
+    async def list_spans(self, **kwargs):
         self.list_calls.append(kwargs)
 
         async def _iter():
             for row in self._rows:
                 yield _SpanRow(row)
 
-        return _iter()
+        return SimpleNamespace(items=_iter)
 
 
-async def test_persist_trial_reingests_intake_traces_with_evaluation_attributes(tmp_path, monkeypatch):
+async def test_persist_trial_reingests_intake_traces_with_evaluation_attributes(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
     from nemo_experimentalist_plugin.entities import ResourceRef, TrialResult
 
     row = {
@@ -540,7 +539,8 @@ async def test_persist_trial_reingests_intake_traces_with_evaluation_attributes(
         "started_at": "2026-08-14T00:00:00Z",
     }
     client = _ReingestClient([row])
-    backend = LocalExperimentalistBackend(client=cast(Any, client), path=tmp_path / "backend")
+    monkeypatch.setattr(beim.AsyncIntakeClient, "from_client", lambda _client: client)
+    backend = LocalExperimentalistBackend(client=fake_client(), path=tmp_path / "backend")
     # The trace already exists in Intake but carries no evaluation context, which is the
     # condition that triggers the re-ingest.
     monkeypatch.setattr(
@@ -558,7 +558,7 @@ async def test_persist_trial_reingests_intake_traces_with_evaluation_attributes(
     await backend._persist_trial(trial, workspace="ws-1", evaluation_name="exp-1", agent_attrs={})
 
     assert client.list_calls[0]["workspace"] == "ws-1"
-    assert client.list_calls[0]["filter"] == {"trace_id": "abc123"}
+    assert client.list_calls[0]["query_params"]["filter"] == {"trace_id": "abc123"}
     assert len(client.traces.calls) == 1
     body = client.traces.calls[0]["body"]
     assert client.traces.calls[0]["workspace"] == "ws-1"
@@ -581,11 +581,12 @@ async def test_upload_trace_atif_sends_evaluation_context_and_agent_identity(tmp
     assert len(client.atif.calls) == 1
     call = client.atif.calls[0]
     assert call["workspace"] == "ws-1"
-    assert call["evaluation_context"] == {
+    body = call["body"].root
+    assert body["evaluation_context"] == {
         "evaluation_name": "exp-1",
         "test_case_name": "case-a",
     }
-    assert call["agent"]["model_name"] == "gpt-5-mini"
+    assert body["agent"]["model_name"] == "gpt-5-mini"
 
 
 async def test_upload_trace_atif_sends_a_trajectory_not_bytes(tmp_path):
@@ -595,7 +596,7 @@ async def test_upload_trace_atif_sends_a_trajectory_not_bytes(tmp_path):
     await _upload_trace_atif(cast(Any, client), "ws-1", _atif_ref(tmp_path), evaluation_name="exp-1", task_id="case-a")
 
     assert client.traces.calls == []
-    assert client.atif.calls[0]["schema_version"].startswith("ATIF-")
+    assert client.atif.calls[0]["body"].root["schema_version"].startswith("ATIF-")
 
 
 @pytest.mark.parametrize("bad_id", ["../run", "a/b", "..", ".", "nested/../../run"])

--- a/plugins/nemo-experimentalist/tests/test_experimentalist_run.py
+++ b/plugins/nemo-experimentalist/tests/test_experimentalist_run.py
@@ -9,24 +9,35 @@ the hand-off, and that the caller keeps ownership of its platform client.
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
+import httpx
 import pytest
+from doubles import fake_client
 from nemo_experimentalist_plugin.entities import DatasetRef
 from nemo_experimentalist_plugin.experimentalist import run as experimentalist_run
 from nemo_experimentalist_plugin.experimentalist.experimentalist_backend import LocalExperimentalistBackend
 from nemo_experimentalist_plugin.experimentalist.result import ExperimentalistResult
 from nemo_experimentalist_plugin.experimentalist.strategies.evolutionary import EvolutionaryOptimizerConfig
-from nemo_platform import AsyncNeMoPlatform
+from nemo_platform_plugin.client.client import AsyncNemoClient
 from nemo_platform_plugin.nooa_model_client import ConfiguredModelRefs
 
 
-@dataclass
-class ClosingClient:
-    closed: bool = False
+class ClosingClient(AsyncNemoClient):
+    def __init__(self) -> None:
+        transport = httpx.MockTransport(
+            lambda request: httpx.Response(500, request=request, json={"detail": "fake client"})
+        )
+        super().__init__(
+            base_url="http://platform.test",
+            workspace="default",
+            http_client=httpx.AsyncClient(transport=transport),
+        )
+        self.closed = False
 
     async def close(self) -> None:
         self.closed = True
+        await super().close()
 
 
 @dataclass
@@ -63,7 +74,7 @@ class ExperimentRunPaths:
 
 @dataclass
 class BackendFactoryCall:
-    client: ClosingClient | None
+    client: AsyncNemoClient
     experiments_output: str
 
 
@@ -109,7 +120,7 @@ async def test_run_experimentalist_builds_and_runs_complete_local_contract(
 ) -> None:
     paths = _make_run_paths(tmp_path)
     client = ClosingClient()
-    backend = LocalExperimentalistBackend(path=tmp_path / "backend")
+    backend = LocalExperimentalistBackend(client=fake_client(), path=tmp_path / "backend")
     optimizer_config = EvolutionaryOptimizerConfig(max_rounds=2)
     strategy = object()
     runner = RecordingRunner()
@@ -118,7 +129,7 @@ async def test_run_experimentalist_builds_and_runs_complete_local_contract(
 
     def make_backend(
         *,
-        client: ClosingClient | None,
+        client: AsyncNemoClient,
         experiments_output: str,
         storage: object = None,
     ) -> LocalExperimentalistBackend:
@@ -149,7 +160,7 @@ async def test_run_experimentalist_builds_and_runs_complete_local_contract(
         validation_dataset=validation_dataset,
         experiment_dir=paths.experiment,
         workspace="workspace-a",
-        client=cast(AsyncNeMoPlatform, client),
+        client=client,
         config=optimizer_config,
     )
 
@@ -193,7 +204,7 @@ async def test_run_experimentalist_forwards_platform_insight_id_verbatim(
         task_template=DatasetRef(uri=str(paths.train)),
         experiment_dir=paths.experiment,
         workspace="workspace-a",
-        client=cast(AsyncNeMoPlatform, ClosingClient()),
+        client=ClosingClient(),
         config=EvolutionaryOptimizerConfig(),
     )
 
@@ -223,7 +234,7 @@ async def test_run_experimentalist_forwards_ethos_uri(
         validation_dataset=DatasetRef(uri=str(paths.validation)),
         experiment_dir=paths.experiment,
         workspace="default",
-        client=None,
+        client=ClosingClient(),
         config=EvolutionaryOptimizerConfig(),
     )
 
@@ -252,7 +263,7 @@ async def test_run_experimentalist_does_not_close_caller_client_when_backend_cre
             validation_dataset=DatasetRef(uri=str(paths.validation)),
             experiment_dir=paths.experiment,
             workspace="default",
-            client=cast(AsyncNeMoPlatform, client),
+            client=client,
             config=EvolutionaryOptimizerConfig(),
         )
 

--- a/plugins/nemo-experimentalist/tests/test_local_backend_projection.py
+++ b/plugins/nemo-experimentalist/tests/test_local_backend_projection.py
@@ -2,9 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """LocalExperimentalistBackend's best-effort projection onto native platform Experiments.
 
-The projection is active only when the backend has a platform client (the real-world
-local-mode-with-a-live-platform run); without a client it is a no-op. A projection failure
-must never fail the run or the local-file persistence (spec §3 / F).
+Projection failures must never fail the run or the local-file persistence (spec §3 / F).
 """
 
 from pathlib import Path
@@ -25,17 +23,7 @@ def _run() -> ExperimentRun:
     return ExperimentRun(workspace="default", agent="a", config_snapshot={}, status="running", progress_completed=0)
 
 
-async def test_no_projection_without_client(tmp_path: Path) -> None:
-    # No platform client → projection is a no-op; local files still written, no mirror built.
-    be = LocalExperimentalistBackend(client=None, path=tmp_path)
-    out = await be.create_run(workspace="default", run=_run())
-    assert out.id
-    assert (tmp_path / "eval-and-optimize" / "run.json").exists()
-    assert be._mirrors == {}  # never constructed a mirror
-
-
 async def test_create_run_projects_when_client_present(tmp_path: Path) -> None:
-    # A platform client is present → create_run best-effort projects (ensure_group).
     be = LocalExperimentalistBackend(client=fake_client(), path=tmp_path)
     be._mirrors["default"] = AsyncMock()  # injected so no real SDK call is made
     await be.create_run(workspace="default", run=_run())

--- a/plugins/nemo-insights/src/nemo_insights_plugin/analyst/run.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/analyst/run.py
@@ -22,6 +22,8 @@ from nemo_insights_plugin.analyst.observability import (
 )
 from nemo_insights_plugin.analyst.result import AnalystResult
 from nemo_platform import AsyncNeMoPlatform
+from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.models.client import AsyncModelsClient
 from nemo_platform_plugin.nooa_model_client import (
     ConfiguredModelClients,
     ConfiguredModelRefs,
@@ -134,7 +136,8 @@ async def run_analyst_change_set(
     model_clients: ConfiguredModelClients | None = None
     insights_output_path = str(insights_output) if insights_output else None
     try:
-        model_clients = await resolve_model_clients(client, model_refs)
+        models_client = client_from_platform(client, AsyncModelsClient)
+        model_clients = await resolve_model_clients(models_client, model_refs)
         backend = make_analyst_backend(
             client=client,
             insights_output=insights_output_path,

--- a/plugins/nemo-insights/src/nemo_insights_plugin/typed_client.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/typed_client.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Typed HTTP client for the Insights plugin APIs used outside the plugin."""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+
+from nemo_insights_plugin.entities import Insight
+from nemo_insights_plugin.sdk_resources._entity import entity_from_response
+from nemo_platform_plugin.client.client import AsyncNemoClient, NemoClient
+from nemo_platform_plugin.client.endpoint import get
+from nemo_platform_plugin.client.method import method
+
+_INSIGHTS_BASE = "/apis/insights/v2/workspaces/{workspace}"
+
+
+@get(f"{_INSIGHTS_BASE}/insights/{{insight_id}}")
+@abstractmethod
+def get_insight_endpoint(*, workspace: str | None = None, insight_id: str) -> Insight: ...
+
+
+class _InsightsMethods:
+    get_insight_response = method(get_insight_endpoint)
+
+
+class InsightsClient(_InsightsMethods, NemoClient):
+    """Sync client for the Insights API subset Experimentalist uses."""
+
+    def get_insight(self, *, workspace: str | None = None, insight_id: str) -> Insight:
+        response = self.get_insight_response(workspace=workspace, insight_id=insight_id)
+        return entity_from_response(Insight, response.http_response.json())
+
+
+class AsyncInsightsClient(_InsightsMethods, AsyncNemoClient):
+    """Async client for the Insights API subset Experimentalist uses."""
+
+    async def get_insight(self, *, workspace: str | None = None, insight_id: str) -> Insight:
+        response = await self.get_insight_response(workspace=workspace, insight_id=insight_id)
+        return entity_from_response(Insight, response.http_response.json())

--- a/plugins/nemo-insights/tests/test_analyst_run.py
+++ b/plugins/nemo-insights/tests/test_analyst_run.py
@@ -36,9 +36,22 @@ class FakeBackend:
         return "REPORT"
 
 
+def _stub_model_adapter(monkeypatch: pytest.MonkeyPatch, seen: dict[str, object]) -> None:
+    models_client = object()
+    seen["adapted_model_client"] = models_client
+
+    def fake_client_from_platform(client: object, client_cls: object) -> object:
+        seen["platform_client"] = client
+        seen["models_client_cls"] = client_cls
+        return models_client
+
+    monkeypatch.setattr(run_module, "client_from_platform", fake_client_from_platform)
+
+
 def _stub_pipeline(monkeypatch: pytest.MonkeyPatch, seen: dict[str, object]) -> None:
     default = FakeModelClient()
     fast = FakeModelClient()
+    _stub_model_adapter(monkeypatch, seen)
     model_clients = ConfiguredModelClients(
         default=cast(Any, default),
         fast=cast(Any, fast),
@@ -92,7 +105,9 @@ async def test_injected_client_is_used_and_closed(monkeypatch: pytest.MonkeyPatc
     assert seen["backend_client"] is client
     build_kwargs = cast(dict[str, object], seen["build_kwargs"])
     assert cast(AnalystDeps, build_kwargs["deps"]).backend is not None
-    assert seen["model_client"] is client
+    assert seen["platform_client"] is client
+    assert seen["models_client_cls"] is run_module.AsyncModelsClient
+    assert seen["model_client"] is seen["adapted_model_client"]
     model_clients = cast(ConfiguredModelClients, seen["model_clients"])
     assert cast(FakeModelClient, model_clients.default).closed
     assert cast(FakeModelClient, model_clients.fast).closed
@@ -113,6 +128,7 @@ async def test_client_closed_when_backend_construction_raises(monkeypatch: pytes
     def raising_backend(*, client: FakeClient, insights_output: str | None, local_only: bool) -> FakeBackend:
         raise RuntimeError("backend failed")
 
+    _stub_model_adapter(monkeypatch, {})
     monkeypatch.setattr(run_module, "resolve_model_clients", fake_resolve_model_clients)
     monkeypatch.setattr(run_module, "make_analyst_backend", raising_backend)
 
@@ -135,6 +151,7 @@ async def test_client_closed_when_model_resolution_raises(monkeypatch: pytest.Mo
     async def raising_model_resolution(client: object, refs: object) -> ConfiguredModelClients:
         raise RuntimeError("model resolution failed")
 
+    _stub_model_adapter(monkeypatch, {})
     monkeypatch.setattr(run_module, "resolve_model_clients", raising_model_resolution)
 
     with pytest.raises(RuntimeError, match="model resolution failed"):


### PR DESCRIPTION
## TL;DR

Migrates Experimentalist off the Stainless-generated platform SDK and onto the typed `nemo_platform_plugin` clients. The branch adds the typed Intake and Insights surfaces Experimentalist needs, updates Experimentalist call sites and tests to use those clients, and tightens typed-client transport ownership so shared sync/async transports are not accidentally closed by child clients or option clones.

## What changed

Experimentalist now constructs and passes `AsyncNemoClient` instances instead of `AsyncNeMoPlatform` instances. Remote authenticated platform URLs still use the active NeMo Platform config and OIDC token refresh path, while unauthenticated loopback/direct-mode behavior is preserved for local services.

The remote authenticated client path now rejects non-loopback plaintext HTTP before attaching credentials. Loopback HTTP remains supported for local unauthenticated services, and authenticated remote URLs must use HTTPS.

The Intake typed client now covers the APIs that Experimentalist uses to persist and inspect trials: trace retrieval, span listing, span grouping, experiment create/update, evaluation create/update, ATIF ingest, OTLP ingest, and evaluator-result creation. The wire models were expanded to represent experiments, evaluations, spans, span groups, and the query parameters needed by those flows.

Experimentalist's backend, experiment mirror, trace upload, insight fetch, examples, and tests now call typed resource clients directly. The native experiment projection path still treats Intake projection failures as best-effort, keeps existing source-link preservation behavior, and continues to stamp evaluation/trial identity onto uploaded traces.

The Tau3 NOOA example now declares `nemo-platform-plugin` as an editable local dependency and updates its standalone `uv.lock`, so its typed-client imports resolve when the example is run outside the monorepo workspace.

Fileset-backed task template staging now validates listed paths before writing downloaded content. It rejects traversal outside the staging destination and rejects paths outside a requested Fileset fragment prefix.

Typed client lifecycle support was added for sync and async clients. Root clients own their underlying HTTP transport; resource clients and `with_options`/`with_headers` clones share that transport without owning it, so closing a child client does not close the parent.

## Reviewer notes

The main compatibility surface is the client boundary: code that needs a generated SDK still uses the generated SDK, while Experimentalist-specific platform calls now use typed clients. Sync and async paths are intentionally separate throughout the migrated code.

Nooa model clients now preserve refreshable Platform authentication for completion calls by resolving auth at the Nooa call boundary, rather than relying only on static default headers.

The test harness can now yield an `AsyncNemoClient` backed by the same in-process ASGI transport used by existing SDK tests, and `ClientContext` exposes that typed async client directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Intake support for traces, spans, span groups, experiments, and evaluations.
  - Added synchronous and asynchronous Insights retrieval.
  - Added configurable fast-model support with fallback behavior.
  - Added client lifecycle management, including explicit closing and context-manager support.
- **Security**
  - Added authentication handling for model requests and HTTPS enforcement for authenticated remote connections.
- **Improvements**
  - Improved dataset staging with recursive fileset downloads and path-traversal protection.
  - Added clearer validation errors for missing Experimentalist configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
