### PR TITLE
refactor(guardrails): migrate plugin to typed clients

### DIFF
--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/client_provider.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/client_provider.py
@@ -448,3 +448,14 @@ def get_task_nemo_client(service_name: str, *, workspace: str | None = None) -> 
 def get_async_task_nemo_client(service_name: str, *, workspace: str | None = None) -> AsyncNemoClient:
     """Async counterpart of :func:`get_task_nemo_client`."""
     return _resolve_provider().get_async_task_nemo_client(service_name, workspace=workspace)
+
+
+def get_forwarding_headers(client: NemoClient | AsyncNemoClient) -> dict[str, str]:
+    """Return default headers that should be forwarded to nested platform calls.
+
+    This is the NemoClient equivalent of
+    :func:`nemo_platform_plugin.sdk_provider.get_forwarding_headers`. Guardrails
+    middleware uses it to propagate service-principal and tracing headers into
+    model calls made by cached LangChain clients.
+    """
+    return dict(client.default_headers)

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/guardrail/types.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/guardrail/types.py
@@ -9,27 +9,187 @@ Single source of truth for the HTTP contract. Replaces the Stainless-generated
 
 from __future__ import annotations
 
+from collections.abc import ItemsView, KeysView
 from datetime import datetime
-from typing import Any, NotRequired, TypedDict
+from typing import Any, Literal, NotRequired, TypedDict
 
 from nemo_platform_plugin.schema import Page
 from pydantic import BaseModel, ConfigDict, Field
+
+
+class _GuardrailValue(BaseModel):
+    """Forward-compatible base for guardrails wire DTOs."""
+
+    model_config = ConfigDict(extra="allow", validate_assignment=True)
+
+    def _mapping_values(self) -> dict[str, Any]:
+        return self.model_dump(exclude_unset=True)
+
+    def __getitem__(self, key: str) -> Any:
+        values = self._mapping_values()
+        try:
+            return values[key]
+        except KeyError:
+            raise KeyError(key) from None
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        setattr(self, key, value)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self._mapping_values().get(key, default)
+
+    def keys(self) -> KeysView[str]:
+        return self._mapping_values().keys()
+
+    def items(self) -> ItemsView[str, Any]:
+        return self._mapping_values().items()
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, dict):
+            return self._mapping_values() == other
+        return super().__eq__(other)
+
+
+# ---------------------------------------------------------------------------
+# Rails config value types
+# ---------------------------------------------------------------------------
+
+
+class ModelParameters(_GuardrailValue):
+    """Parameters for configuring how to interact with a model in a guardrails config."""
+
+    base_url: str | None = None
+    default_headers: dict[str, str] | None = None
+
+
+class Model(_GuardrailValue):
+    """Configuration of a model used by the rails engine."""
+
+    engine: str
+    type: str
+    cache: dict[str, Any] | None = None
+    mode: Literal["chat", "text"] | None = None
+    model: str | None = None
+    parameters: ModelParameters | None = None
+
+
+class InputRails(_GuardrailValue):
+    """Configuration of input rails."""
+
+    flows: list[str] | None = None
+    parallel: bool | None = None
+
+
+class OutputRailsStreamingConfig(_GuardrailValue):
+    """Configuration for managing streaming output of LLM tokens."""
+
+    chunk_size: int | None = None
+    context_size: int | None = None
+    enabled: bool | None = None
+    stream_first: bool | None = None
+
+
+class OutputRails(_GuardrailValue):
+    """Configuration of output rails."""
+
+    apply_to_reasoning_traces: bool | None = None
+    flows: list[str] | None = None
+    parallel: bool | None = None
+    streaming: OutputRailsStreamingConfig | None = None
+
+
+class Rails(_GuardrailValue):
+    """Configuration of specific rails."""
+
+    actions: dict[str, Any] | None = None
+    config: dict[str, Any] | None = None
+    dialog: dict[str, Any] | None = None
+    input: InputRails | None = None
+    output: OutputRails | None = None
+    retrieval: dict[str, Any] | None = None
+    tool_input: dict[str, Any] | None = None
+    tool_output: dict[str, Any] | None = None
+
+
+class RailsConfig(_GuardrailValue):
+    """Configuration object for the models and the rails."""
+
+    actions_server_url: str | None = None
+    colang_version: str | None = None
+    custom_data: dict[str, Any] | None = None
+    enable_multi_step_generation: bool | None = None
+    enable_rails_exceptions: bool | None = None
+    instructions: list[dict[str, Any]] | None = None
+    lowest_temperature: float | None = None
+    models: list[Model] | None = None
+    passthrough: bool | None = None
+    prompting_mode: str | None = None
+    prompts: list[dict[str, Any]] | None = None
+    rails: Rails | None = None
+    sample_conversation: str | None = None
+    tracing: dict[str, Any] | None = None
+
+
+# ---------------------------------------------------------------------------
+# Generation / guardrails data types
+# ---------------------------------------------------------------------------
+
+
+class GenerationLogOptionsParam(TypedDict, total=False):
+    """Options for what should be included in the generation log."""
+
+    activated_rails: bool
+    colang_history: bool
+    internal_events: bool
+    llm_calls: bool
+    stats: bool
+
+
+class GenerationStats(_GuardrailValue):
+    """General stats about a guardrails generation."""
+
+    dialog_rails_duration: float | None = None
+    generation_rails_duration: float | None = None
+    input_rails_duration: float | None = None
+    llm_calls_count: int | None = None
+    llm_calls_duration: float | None = None
+    llm_calls_total_completion_tokens: int | None = None
+    llm_calls_total_prompt_tokens: int | None = None
+    llm_calls_total_tokens: int | None = None
+    output_rails_duration: float | None = None
+    total_duration: float | None = None
+
+
+class LLMCallInfo(_GuardrailValue):
+    """Information about an LLM call made while evaluating rails."""
+
+    id: str | None = None
+    completion: str | None = None
+    completion_tokens: int | None = None
+    duration: float | None = None
+    finished_at: float | None = None
+    llm_model_name: str | None = None
+    prompt: str | None = None
+    prompt_tokens: int | None = None
+    raw_response: dict[str, Any] | None = None
+    started_at: float | None = None
+    task: str | None = None
+    total_tokens: int | None = None
+
 
 # ---------------------------------------------------------------------------
 # Response types
 # ---------------------------------------------------------------------------
 
 
-class GuardrailConfig(BaseModel):
+class GuardrailConfig(_GuardrailValue):
     """A guardrail configuration entity."""
-
-    model_config = ConfigDict(extra="allow")
 
     name: str = ""
     workspace: str
     project: str | None = None
     description: str | None = None
-    data: dict[str, Any] = Field(default_factory=dict, description="Guardrail configuration data")
+    data: RailsConfig = Field(default_factory=RailsConfig, description="Guardrail configuration data")
     id: str
     created_at: datetime
     created_by: str | None = None
@@ -40,36 +200,38 @@ class GuardrailConfig(BaseModel):
 GuardrailConfigPage = Page[GuardrailConfig]
 
 
-class RailStatus(BaseModel):
+class RailStatus(_GuardrailValue):
     """Status of an individual rail."""
-
-    model_config = ConfigDict(extra="allow")
 
     status: str = Field(description="Status of the individual rail: success, blocked, or unknown.")
 
 
-class ActivatedRail(BaseModel):
+class ActivatedRail(_GuardrailValue):
     """A rail that ran during a check, as reported in the generation log."""
-
-    model_config = ConfigDict(extra="allow")
 
     name: str = ""
     type: str = ""
-    stop: bool = False
+    additional_info: dict[str, Any] | None = None
+    decisions: list[str] | None = None
+    duration: float | None = None
+    executed_actions: list[dict[str, Any]] | None = None
+    finished_at: float | None = None
+    started_at: float | None = None
+    stop: bool | None = None
 
 
-class GenerationLog(BaseModel):
+class GenerationLog(_GuardrailValue):
     """Logging information about a guardrails generation."""
 
-    model_config = ConfigDict(extra="allow")
+    activated_rails: list[ActivatedRail] | None = None
+    colang_history: str | None = None
+    internal_events: list[dict[str, Any]] | None = None
+    llm_calls: list[LLMCallInfo] | None = None
+    stats: GenerationStats | None = None
 
-    activated_rails: list[ActivatedRail] = Field(default_factory=list)
 
-
-class GuardrailsDataOutput(BaseModel):
+class GuardrailsData(_GuardrailValue):
     """Guardrails-specific output attached to a check or chat response."""
-
-    model_config = ConfigDict(extra="allow")
 
     llm_output: dict[str, Any] | None = None
     config_ids: list[str] | None = Field(default=None, description="Configuration ids that were used.")
@@ -77,10 +239,12 @@ class GuardrailsDataOutput(BaseModel):
     log: GenerationLog | None = Field(default=None, description="Populated when guardrails log options are requested.")
 
 
-class GuardrailCheckResponse(BaseModel):
-    """Response from a guardrail check request."""
+class GuardrailsDataOutput(GuardrailsData):
+    """Guardrails-specific output returned by the check API."""
 
-    model_config = ConfigDict(extra="allow")
+
+class GuardrailCheckResponse(_GuardrailValue):
+    """Response from a guardrail check request."""
 
     status: str = Field(description="Overall status: success if all rails passed, blocked if any failed.")
     rails_status: dict[str, RailStatus] = Field(
@@ -99,24 +263,22 @@ class CreateGuardrailConfigRequest(BaseModel):
 
     name: str
     description: str | None = None
-    data: dict[str, Any] = Field(default_factory=dict, description="Guardrail configuration data")
+    data: RailsConfig | dict[str, Any] | None = Field(default=None, description="Guardrail configuration data")
 
 
 class UpdateGuardrailConfigRequest(BaseModel):
     """Input schema for updating a guardrail config."""
 
     description: str | None = None
-    data: dict[str, Any] | None = None
+    data: RailsConfig | dict[str, Any] | None = None
 
 
-class GuardrailCheckRequest(BaseModel):
+class GuardrailCheckRequest(_GuardrailValue):
     """Guardrail check request body.
 
     Shaped like an OpenAI chat-completions request. ``extra="allow"`` passes
     through any additional sampling parameters the backend accepts.
     """
-
-    model_config = ConfigDict(extra="allow")
 
     model: str = Field(description="The model the checked conversation targets.")
     messages: list[dict[str, Any]] = Field(description="The conversation to check, in OpenAI chat format.")

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/inference_middleware.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/inference_middleware.py
@@ -74,11 +74,10 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING, Any, AsyncIterator, Protocol, TypeAlias, Union, runtime_checkable
 
-from nemo_platform_plugin.client.client import AsyncNemoClient
-
 if TYPE_CHECKING:
-    # Keep this public base import-light; importing the generated SDK loads pydantic.
+    # Keep this public base import-light; these imports pull in heavy SDK modules.
     from nemo_platform import AsyncNeMoPlatform
+    from nemo_platform_plugin.client.client import AsyncNemoClient
 
 
 class BackendFormat(str, Enum):

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/inference_middleware.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/inference_middleware.py
@@ -74,6 +74,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING, Any, AsyncIterator, Protocol, TypeAlias, Union, runtime_checkable
 
+from nemo_platform_plugin.client.client import AsyncNemoClient
+
 if TYPE_CHECKING:
     # Keep this public base import-light; importing the generated SDK loads pydantic.
     from nemo_platform import AsyncNeMoPlatform
@@ -365,6 +367,9 @@ class InferenceMiddlewareContext:
             :attr:`InferenceResponse.response_body_annotations` when it builds
             the response envelope, and final serialization uses the
             ``InferenceResponse`` field.
+        request_nemo_client: Request-scoped typed client carrying the caller's
+            delegated identity and trace headers. Middleware can use it for
+            nested platform calls that must preserve request context.
     """
 
     request_id: str
@@ -374,6 +379,7 @@ class InferenceMiddlewareContext:
     proxied_request: InferenceRequest | None = None
     backend_format: BackendFormat | None = None
     response_body_annotations: dict[str, Any] = field(default_factory=dict)
+    request_nemo_client: AsyncNemoClient | None = None
     _state: dict[str, Any] = field(default_factory=dict, init=False, repr=False)
 
     def state(self, plugin_name: str) -> PluginStateNamespace:
@@ -752,6 +758,7 @@ class NemoInferenceMiddleware(ABC):
     def __init__(self) -> None:
         self._cache: InferenceMiddlewareCacheAccessor | None = None
         self._platform_sdk: AsyncNeMoPlatform | None = None
+        self._platform_client: AsyncNemoClient | None = None
 
     # ------------------------------------------------------------------
     # IGW-called injection point (not part of the plugin author API)
@@ -771,6 +778,13 @@ class NemoInferenceMiddleware(ABC):
         """
         self._platform_sdk = sdk
 
+    def _inject_platform_client(self, client: AsyncNemoClient) -> None:
+        """Called by IGW to inject a caller-owned typed client before on_startup().
+
+        Plugin authors must not call or close this client directly.
+        """
+        self._platform_client = client
+
     def _get_platform_sdk(self, method_name: str) -> AsyncNeMoPlatform:
         if self._platform_sdk is None:
             raise RuntimeError(
@@ -778,6 +792,14 @@ class NemoInferenceMiddleware(ABC):
                 f"Call {method_name}() from on_startup() or later."
             )
         return self._platform_sdk
+
+    def _get_platform_client(self, method_name: str) -> AsyncNemoClient:
+        if self._platform_client is None:
+            raise RuntimeError(
+                f"{method_name}() is not available before IGW injects the platform client. "
+                f"Call {method_name}() from on_startup() or later."
+            )
+        return self._platform_client
 
     def _get_cache(self, method_name: str) -> InferenceMiddlewareCacheAccessor:
         if self._cache is None:

--- a/packages/nemo_platform_plugin/tests/guardrail/test_client.py
+++ b/packages/nemo_platform_plugin/tests/guardrail/test_client.py
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for GuardrailClient via mocked httpx transport."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+from nemo_platform_plugin.client.errors import NotFoundError
+from nemo_platform_plugin.guardrail.client import AsyncGuardrailClient, GuardrailClient
+from nemo_platform_plugin.guardrail.types import (
+    CreateGuardrailConfigRequest,
+    GuardrailCheckRequest,
+    GuardrailCheckResponse,
+    GuardrailConfig,
+    RailsConfig,
+)
+
+BASE = "http://test:8000"
+
+
+def _config_json(name: str = "safe", **extra: object) -> dict:
+    base = {
+        "id": f"guardrail-{name}",
+        "name": name,
+        "workspace": "default",
+        "description": "Content safety",
+        "data": {
+            "models": [{"type": "content_safety", "engine": "nim", "model": "default/safety"}],
+            "rails": {"output": {"flows": ["self check output"], "streaming": {"enabled": False}}},
+        },
+        "created_at": "2020-01-01T00:00:00Z",
+        "updated_at": "2020-01-01T00:00:00Z",
+    }
+    base.update(extra)
+    return base
+
+
+def test_create_guardrail_config_round_trip() -> None:
+    http = MagicMock(spec=httpx.Client)
+    http.request.return_value = httpx.Response(201, request=httpx.Request("POST", BASE), json=_config_json())
+    client = GuardrailClient(base_url=BASE, workspace="default", http_client=http)
+
+    out = client.create_guardrail_config(
+        body=CreateGuardrailConfigRequest(
+            name="safe",
+            data=RailsConfig.model_validate({"rails": {"input": {"flows": ["flow"]}}}),
+        )
+    ).data()
+
+    assert isinstance(out, GuardrailConfig)
+    assert out.name == "safe"
+    assert out.data is not None
+    assert out.data.rails is not None
+    assert out.data.rails.output is not None
+    assert out.data.rails.output.streaming is not None
+    assert out.data.rails.output.streaming.enabled is False
+    args, kwargs = http.request.call_args
+    assert args == ("POST", f"{BASE}/apis/guardrails/v2/workspaces/default/configs")
+    assert kwargs["content"] == b'{"name":"safe","data":{"rails":{"input":{"flows":["flow"]}}}}'
+
+
+def test_list_guardrail_configs_paginates() -> None:
+    http = MagicMock(spec=httpx.Client)
+    page1 = {
+        "data": [_config_json("a")],
+        "pagination": {
+            "page": 1,
+            "page_size": 1,
+            "current_page_size": 1,
+            "total_pages": 2,
+            "total_results": 2,
+        },
+    }
+    page2 = {
+        "data": [_config_json("b")],
+        "pagination": {
+            "page": 2,
+            "page_size": 1,
+            "current_page_size": 1,
+            "total_pages": 2,
+            "total_results": 2,
+        },
+    }
+    http.request.side_effect = [
+        httpx.Response(200, request=httpx.Request("GET", BASE), json=page1),
+        httpx.Response(200, request=httpx.Request("GET", BASE), json=page2),
+    ]
+    client = GuardrailClient(base_url=BASE, workspace="default", http_client=http)
+
+    assert [config.name for config in client.list_guardrail_configs().items()] == ["a", "b"]
+
+
+def test_get_guardrail_config_not_found_raises() -> None:
+    http = MagicMock(spec=httpx.Client)
+    http.request.return_value = httpx.Response(404, request=httpx.Request("GET", BASE), json={"detail": "not found"})
+    client = GuardrailClient(base_url=BASE, workspace="default", http_client=http)
+
+    with pytest.raises(NotFoundError) as exc:
+        client.get_guardrail_config(name="missing")
+    assert exc.value.status_code == 404
+
+
+def test_check_guardrail_round_trip() -> None:
+    http = MagicMock(spec=httpx.Client)
+    http.request.return_value = httpx.Response(
+        200,
+        request=httpx.Request("POST", BASE),
+        json={
+            "status": "blocked",
+            "rails_status": {"self check input": {"status": "blocked"}},
+            "guardrails_data": {
+                "config_ids": ["default/safe"],
+                "log": {"activated_rails": [{"name": "self check input", "type": "input", "stop": True}]},
+            },
+        },
+    )
+    client = GuardrailClient(base_url=BASE, workspace="default", http_client=http)
+
+    out = client.check_guardrail(
+        body=GuardrailCheckRequest(
+            model="default/app",
+            messages=[{"role": "user", "content": "hello"}],
+            guardrails={"config_id": "default/safe"},
+        )
+    ).data()
+
+    assert isinstance(out, GuardrailCheckResponse)
+    assert out.status == "blocked"
+    assert out.guardrails_data is not None
+    assert out.guardrails_data.config_ids == ["default/safe"]
+    assert out.guardrails_data.log is not None
+    assert out.guardrails_data.log.activated_rails is not None
+    assert out.guardrails_data.log.activated_rails[0].stop is True
+
+
+@pytest.mark.asyncio
+async def test_async_get_guardrail_config_round_trip() -> None:
+    http = AsyncMock(spec=httpx.AsyncClient)
+    http.request.return_value = httpx.Response(200, request=httpx.Request("GET", BASE), json=_config_json())
+    client = AsyncGuardrailClient(base_url=BASE, workspace="default", http_client=http)
+
+    out = (await client.get_guardrail_config(name="safe")).data()
+
+    assert isinstance(out, GuardrailConfig)
+    assert out.data is not None
+    assert out.data.rails is not None
+    http.request.assert_awaited_once()

--- a/packages/nemo_platform_plugin/tests/guardrail/test_endpoints.py
+++ b/packages/nemo_platform_plugin/tests/guardrail/test_endpoints.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for Guardrails service endpoint definitions."""
+
+from __future__ import annotations
+
+import json
+from typing import get_origin
+
+from nemo_platform_plugin.client.types import Paginated, PreparedRequest
+from nemo_platform_plugin.entities.types import DeleteResponse
+from nemo_platform_plugin.guardrail import endpoints
+from nemo_platform_plugin.guardrail.types import (
+    CreateGuardrailConfigRequest,
+    GuardrailCheckRequest,
+    GuardrailCheckResponse,
+    GuardrailConfig,
+    RailsConfig,
+    UpdateGuardrailConfigRequest,
+)
+
+_CONFIGS = "/apis/guardrails/v2/workspaces/{workspace}/configs"
+_CHECKS = "/apis/guardrails/v2/workspaces/{workspace}/checks"
+
+
+def _json_body(prepared: PreparedRequest) -> dict:
+    assert isinstance(prepared.content, bytes)
+    return json.loads(prepared.content)
+
+
+def _rails_config() -> RailsConfig:
+    return RailsConfig.model_validate(
+        {
+            "models": [{"type": "content_safety", "engine": "nim", "model": "default/safety"}],
+            "rails": {"input": {"flows": ["self check input"]}},
+        }
+    )
+
+
+def test_create_guardrail_config() -> None:
+    body = CreateGuardrailConfigRequest(name="safe", description="Content safety", data=_rails_config())
+
+    prepared = endpoints.create_guardrail_config(workspace="default", body=body)
+
+    assert isinstance(prepared, PreparedRequest)
+    assert prepared.method == "POST"
+    assert prepared.path_template == _CONFIGS
+    assert prepared.path_params == {"workspace": "default"}
+    assert prepared.content_type == "application/json"
+    assert prepared.response_type is GuardrailConfig
+    assert _json_body(prepared) == {
+        "name": "safe",
+        "description": "Content safety",
+        "data": {
+            "models": [{"engine": "nim", "type": "content_safety", "model": "default/safety"}],
+            "rails": {"input": {"flows": ["self check input"]}},
+        },
+    }
+
+
+def test_create_guardrail_config_accepts_raw_dict_data() -> None:
+    prepared = endpoints.create_guardrail_config(
+        body=CreateGuardrailConfigRequest(
+            name="safe",
+            data={"rails": {"output": {"flows": ["self check output"], "streaming": {"enabled": False}}}},
+        )
+    )
+
+    assert prepared.path_params == {}
+    assert _json_body(prepared) == {
+        "name": "safe",
+        "data": {"rails": {"output": {"flows": ["self check output"], "streaming": {"enabled": False}}}},
+    }
+
+
+def test_create_guardrail_config_conflict_resolver() -> None:
+    prepared = endpoints.create_guardrail_config(
+        workspace="default",
+        body=CreateGuardrailConfigRequest(name="safe"),
+        exist_ok=True,
+    )
+
+    assert prepared.on_conflict_get is not None
+    assert prepared.on_conflict_get.method == "GET"
+    assert prepared.on_conflict_get.path_template == _CONFIGS + "/{name}"
+    assert prepared.on_conflict_get.path_params == {"workspace": "default", "name": "safe"}
+    assert prepared.client_options == {"exist_ok": True}
+
+
+def test_list_guardrail_configs() -> None:
+    prepared = endpoints.list_guardrail_configs(
+        workspace="default",
+        query_params={"page": 2, "page_size": 10, "filter": "name:safe", "project": "p"},
+    )
+
+    assert prepared.method == "GET"
+    assert prepared.path_template == _CONFIGS
+    assert prepared.path_params == {"workspace": "default"}
+    assert prepared.query_params == {"page": 2, "page_size": 10, "filter": "name:safe", "project": "p"}
+    assert get_origin(prepared.response_type) is Paginated
+
+
+def test_get_update_delete_guardrail_config() -> None:
+    get_prepared = endpoints.get_guardrail_config(workspace="default", name="safe")
+    update_prepared = endpoints.update_guardrail_config(
+        workspace="default",
+        name="safe",
+        body=UpdateGuardrailConfigRequest(description="updated"),
+    )
+    delete_prepared = endpoints.delete_guardrail_config(workspace="default", name="safe")
+
+    assert get_prepared.method == "GET"
+    assert get_prepared.path_params == {"workspace": "default", "name": "safe"}
+    assert get_prepared.response_type is GuardrailConfig
+
+    assert update_prepared.method == "PATCH"
+    assert update_prepared.path_params == {"workspace": "default", "name": "safe"}
+    assert _json_body(update_prepared) == {"description": "updated"}
+    assert update_prepared.response_type is GuardrailConfig
+
+    assert delete_prepared.method == "DELETE"
+    assert delete_prepared.content is None
+    assert delete_prepared.response_type is DeleteResponse
+
+
+def test_check_guardrail() -> None:
+    prepared = endpoints.check_guardrail(
+        workspace="default",
+        body=GuardrailCheckRequest(
+            model="default/app",
+            messages=[{"role": "user", "content": "hello"}],
+            guardrails={"config_id": "default/safe"},
+        ),
+    )
+
+    assert prepared.method == "POST"
+    assert prepared.path_template == _CHECKS
+    assert prepared.path_params == {"workspace": "default"}
+    assert prepared.response_type is GuardrailCheckResponse
+    assert _json_body(prepared) == {
+        "model": "default/app",
+        "messages": [{"role": "user", "content": "hello"}],
+        "guardrails": {"config_id": "default/safe"},
+    }

--- a/packages/nemo_platform_plugin/tests/guardrail/test_types.py
+++ b/packages/nemo_platform_plugin/tests/guardrail/test_types.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from nemo_platform_plugin.guardrail.types import ActivatedRail, Rails, RailsConfig
+
+
+def test_guardrail_value_assignment_validates_nested_models() -> None:
+    config = RailsConfig()
+
+    config["rails"] = {"input": {"flows": ["self check input"]}}
+
+    assert isinstance(config.rails, Rails)
+    assert config.rails.input is not None
+    assert config.rails.input.flows == ["self check input"]
+
+
+def test_guardrail_mapping_access_preserves_explicit_none() -> None:
+    rail = ActivatedRail(stop=None)
+
+    assert rail["stop"] is None
+    assert rail.get("stop") is None
+    assert list(rail.keys()) == ["stop"]
+    assert dict(rail.items()) == {"stop": None}
+    assert rail == {"stop": None}

--- a/packages/nemo_platform_plugin/tests/test_client_provider.py
+++ b/packages/nemo_platform_plugin/tests/test_client_provider.py
@@ -21,6 +21,7 @@ from nemo_platform_plugin.client_provider import (
     _build_headers,
     _read_principal_from_env,
     get_async_nemo_client,
+    get_forwarding_headers,
     get_nemo_client,
     set_nemo_client_provider,
 )
@@ -175,6 +176,24 @@ class TestDefaultNemoClientProvider:
         assert client.workspace == "team-a"
 
 
+class TestForwardingHeaders:
+    def test_returns_copy_of_sync_client_default_headers(self) -> None:
+        client = NemoClient(base_url="http://test:8000", default_headers={"traceparent": "00-platform"})
+
+        headers = get_forwarding_headers(client)
+        headers["traceparent"] = "mutated"
+
+        assert get_forwarding_headers(client) == {"traceparent": "00-platform"}
+
+    def test_returns_copy_of_async_client_default_headers(self) -> None:
+        client = AsyncNemoClient(base_url="http://test:8000", default_headers={"X-NMP-Internal": "true"})
+
+        headers = get_forwarding_headers(client)
+        headers["X-NMP-Internal"] = "false"
+
+        assert get_forwarding_headers(client) == {"X-NMP-Internal": "true"}
+
+
 # ---------------------------------------------------------------------------
 # Provider resolution
 # ---------------------------------------------------------------------------
@@ -327,13 +346,45 @@ class TestProviderResolution:
         captured: dict[str, object] = {}
 
         class _CapturingProvider:
-            def get_nemo_client(self, **kwargs):
+            def get_nemo_client(
+                self,
+                *,
+                as_service: str | None = None,
+                internal: bool = False,
+                on_behalf_of: str | None = None,
+                workspace: str | None = None,
+            ) -> NemoClient:
+                kwargs = {
+                    "as_service": as_service,
+                    "internal": internal,
+                    "on_behalf_of": on_behalf_of,
+                    "workspace": workspace,
+                }
                 captured.update(kwargs)
                 return NemoClient(base_url="http://x")
 
-            def get_async_nemo_client(self, **kwargs):
+            def get_async_nemo_client(
+                self,
+                *,
+                as_service: str | None = None,
+                internal: bool = False,
+                on_behalf_of: str | None = None,
+                workspace: str | None = None,
+            ) -> AsyncNemoClient:
+                kwargs = {
+                    "as_service": as_service,
+                    "internal": internal,
+                    "on_behalf_of": on_behalf_of,
+                    "workspace": workspace,
+                }
                 captured.update(kwargs)
                 return AsyncNemoClient(base_url="http://x")
+
+            def get_task_nemo_client(self, service_name: str, *, workspace: str | None = None) -> NemoClient:
+                return NemoClient(base_url="http://x", workspace=workspace)
+
+            def get_async_task_nemo_client(self, service_name: str, *, workspace: str | None = None) -> AsyncNemoClient:
+                return AsyncNemoClient(base_url="http://x", workspace=workspace)
 
         set_nemo_client_provider(_CapturingProvider())
         get_nemo_client(as_service="svc", internal=True, on_behalf_of="u@x", workspace="ws1")

--- a/packages/nemo_platform_plugin/tests/test_inference_middleware.py
+++ b/packages/nemo_platform_plugin/tests/test_inference_middleware.py
@@ -10,8 +10,10 @@ from typing import Any, get_args
 from unittest.mock import MagicMock, patch
 
 import anthropic.types as anthropic_types
+import httpx
 import openai.types.chat as openai_chat_types
 import pytest
+from nemo_platform_plugin.client.client import AsyncNemoClient
 from nemo_platform_plugin.discovery import (
     _ALL_SURFACE_GROUPS,
     discover,
@@ -313,6 +315,19 @@ class TestPluginImplementedConfigMethods:
 
         with pytest.raises(ValueError, match="Unknown config_type"):
             await _StrictPlugin().validate_middleware_config("bad_type", {})
+
+    def test_get_platform_client_requires_injection(self, plugin: _MinimalMiddleware):
+        with pytest.raises(RuntimeError, match="platform client"):
+            plugin._get_platform_client("on_startup")
+
+    async def test_get_platform_client_returns_injected_client(self, plugin: _MinimalMiddleware):
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(lambda request: httpx.Response(200, request=request))
+        ) as http_client:
+            client = AsyncNemoClient(base_url="http://test", http_client=http_client)
+            plugin._inject_platform_client(client)
+
+            assert plugin._get_platform_client("on_startup") is client
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/nemo-guardrails/src/nemo_guardrails_plugin/benchmarks/run.py
+++ b/plugins/nemo-guardrails/src/nemo_guardrails_plugin/benchmarks/run.py
@@ -60,7 +60,7 @@ from nemo_guardrails_plugin.benchmarks.processes import (
     wait_http,
 )
 from nemo_guardrails_plugin.benchmarks.seeding import SeededResources, seed_benchmark
-from nemo_platform import APIStatusError, NeMoPlatform
+from nemo_platform import APIConnectionError, APIStatusError, NeMoPlatform
 
 log = logging.getLogger("nemo_guardrails_plugin.benchmarks")
 
@@ -189,7 +189,7 @@ def _build_aiperf_shim_process(paths: RunPaths) -> SupervisedProcess:
     )
 
 
-def _smoke_test(client: NeMoPlatform, seeded: SeededResources) -> None:
+def _smoke_test(sdk: NeMoPlatform, seeded: SeededResources) -> None:
     """Verify the VirtualModel is reachable and returns a chat completion,
     before running the AIPerf sweep.
     """
@@ -203,7 +203,7 @@ def _smoke_test(client: NeMoPlatform, seeded: SeededResources) -> None:
 
     for attempt in range(60):
         try:
-            body = client.inference.gateway.openai.post(
+            body = sdk.inference.gateway.openai.post(
                 "v1/chat/completions",
                 workspace=WORKSPACE,
                 body=payload,
@@ -213,6 +213,9 @@ def _smoke_test(client: NeMoPlatform, seeded: SeededResources) -> None:
             last_error = f"response missing choices: {body}"
         except APIStatusError as exc:
             last_error = f"HTTP {exc.status_code}: {str(exc)[:500]}"
+            log.info("Smoke test attempt %d: %s; retrying", attempt + 1, last_error)
+        except APIConnectionError as exc:
+            last_error = f"transport error: {str(exc)[:500]}"
             log.info("Smoke test attempt %d: %s; retrying", attempt + 1, last_error)
         time.sleep(1.0)
 
@@ -441,15 +444,15 @@ def main(argv: list[str] | None = None) -> int:
 
         log.info(f"All services are ready. Seeding benchmark resources in workspace {WORKSPACE}...")
 
-        client = NeMoPlatform(base_url=NMP_BASE_URL)
+        sdk = NeMoPlatform(base_url=NMP_BASE_URL)
         seeded = seed_benchmark(
-            client,
+            sdk,
             nemoguardrails_repo_root=paths.nemoguardrails_repo_root,
             generated_dir=paths.generated_dir,
         )
 
         log.info("Waiting for VirtualModel %s to be ready...", seeded.vm_ref)
-        _smoke_test(client, seeded)
+        _smoke_test(sdk, seeded)
 
         # Variants run sequentially against the same NMP; only the targeted
         # VirtualModel differs, so the delta isolates middleware overhead.

--- a/plugins/nemo-guardrails/src/nemo_guardrails_plugin/benchmarks/seeding.py
+++ b/plugins/nemo-guardrails/src/nemo_guardrails_plugin/benchmarks/seeding.py
@@ -1,12 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Seed NMP with the workspace, providers, guardrail config, and VirtualModel
-required by the IGW guardrails benchmark.
-
-Replaces the previous ``setup_nmp_guardrails_benchmark.sh`` flow with direct
-NMP SDK calls (``client.workspaces``, ``client.inference``, ``client.guardrail``).
-"""
+"""Seed NMP with resources required by the IGW guardrails benchmark."""
 
 from __future__ import annotations
 
@@ -32,12 +27,21 @@ from nemo_guardrails_plugin.benchmarks.constants import (
     VM_NAME,
     WORKSPACE,
 )
-from nemo_platform import NeMoPlatform, NotFoundError
-from nemo_platform.types.inference.middleware_call_param import MiddlewareCallParam
-from nemo_platform.types.inference.virtual_model_inference_config_param import (
-    VirtualModelInferenceConfigParam,
-)
+from nemo_platform import NeMoPlatform
 from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.client.errors import ConflictError, NotFoundError
+from nemo_platform_plugin.guardrail.client import GuardrailClient
+from nemo_platform_plugin.guardrail.types import CreateGuardrailConfigRequest
+from nemo_platform_plugin.inference_middleware import BackendFormat
+from nemo_platform_plugin.models.client import ModelsClient
+from nemo_platform_plugin.models.types import CreateModelProviderRequest, ModelProvider
+from nemo_platform_plugin.virtual_models.client import VirtualModelsClient
+from nemo_platform_plugin.virtual_models.types import (
+    CreateVirtualModelRequest,
+    MiddlewareCall,
+    VirtualModel,
+    VirtualModelInferenceConfig,
+)
 from nemo_platform_plugin.workspaces.client import WorkspacesClient
 from nemo_platform_plugin.workspaces.types import CreateWorkspaceRequest
 
@@ -73,7 +77,7 @@ class SeededResources:
 
 
 def seed_benchmark(
-    client: NeMoPlatform,
+    sdk: NeMoPlatform,
     *,
     nemoguardrails_repo_root: Path,
     generated_dir: Path,
@@ -85,42 +89,50 @@ def seed_benchmark(
     rerun against a reused NMP instance.
     """
     generated_dir.mkdir(parents=True, exist_ok=True)
+    workspaces_client = client_from_platform(sdk, WorkspacesClient)
+    models_client = client_from_platform(sdk, ModelsClient)
+    guardrail_client = client_from_platform(sdk, GuardrailClient)
+    virtual_models_client = client_from_platform(sdk, VirtualModelsClient)
 
     log.info("Creating workspace %s", WORKSPACE)
-    client_from_platform(client, WorkspacesClient).create_workspace(
+    workspaces_client.create_workspace(
         exist_ok=True,
         body=CreateWorkspaceRequest(name=WORKSPACE, description="Local IGW guardrails benchmark workspace"),
     ).data()
 
     log.info("Registering app mock provider %s", APP_PROVIDER)
-    client.inference.providers.create(
+    models_client.create_provider(
         workspace=WORKSPACE,
-        name=APP_PROVIDER,
-        host_url=APP_PROVIDER_URL,
-        enabled_models=[APP_MODEL_NAME],
-        description=f"Benchmark mock app LLM on {APP_PROVIDER_URL}",
+        body=CreateModelProviderRequest(
+            name=APP_PROVIDER,
+            host_url=APP_PROVIDER_URL,
+            enabled_models=[APP_MODEL_NAME],
+            description=f"Benchmark mock app LLM on {APP_PROVIDER_URL}",
+        ),
         exist_ok=True,
     )
 
     log.info("Registering content-safety mock provider %s", CS_PROVIDER)
-    client.inference.providers.create(
+    models_client.create_provider(
         workspace=WORKSPACE,
-        name=CS_PROVIDER,
-        host_url=CS_PROVIDER_URL,
-        enabled_models=[CS_MODEL_NAME],
-        description=f"Benchmark mock content-safety LLM on {CS_PROVIDER_URL}",
+        body=CreateModelProviderRequest(
+            name=CS_PROVIDER,
+            host_url=CS_PROVIDER_URL,
+            enabled_models=[CS_MODEL_NAME],
+            description=f"Benchmark mock content-safety LLM on {CS_PROVIDER_URL}",
+        ),
         exist_ok=True,
     )
 
     log.info("Waiting for provider discovery")
     app_provider = _wait_for_served_model(
-        client,
+        models_client,
         provider_name=APP_PROVIDER,
         served_model_name=APP_MODEL_NAME,
         timeout_seconds=provider_wait_timeout,
     )
     cs_provider = _wait_for_served_model(
-        client,
+        models_client,
         provider_name=CS_PROVIDER,
         served_model_name=CS_MODEL_NAME,
         timeout_seconds=provider_wait_timeout,
@@ -153,44 +165,50 @@ def seed_benchmark(
     )
 
     log.info("Creating GuardrailConfig %s", GUARDRAIL_CONFIG)
-    client.guardrail.configs.create(
+    guardrail_client.create_guardrail_config(
         workspace=WORKSPACE,
-        name=GUARDRAIL_CONFIG,
-        description="Benchmark content_safety_local config routed through IGW",
-        data=config_data,
+        body=CreateGuardrailConfigRequest(
+            name=GUARDRAIL_CONFIG,
+            description="Benchmark content_safety_local config routed through IGW",
+            data=config_data,
+        ),
         exist_ok=True,
     )
 
-    middleware_call: MiddlewareCallParam = {
-        "name": GUARDRAILS_MIDDLEWARE_NAME,
-        "config_type": GUARDRAILS_MIDDLEWARE_CONFIG_TYPE,
-        "config_id": f"{WORKSPACE}/{GUARDRAIL_CONFIG}",
-    }
-    vm_models: list[VirtualModelInferenceConfigParam] = [{"model": app_entity, "backend_format": "OPENAI_CHAT"}]
+    middleware_call = MiddlewareCall(
+        name=GUARDRAILS_MIDDLEWARE_NAME,
+        config_type=GUARDRAILS_MIDDLEWARE_CONFIG_TYPE,
+        config_id=f"{WORKSPACE}/{GUARDRAIL_CONFIG}",
+    )
+    vm_models = [VirtualModelInferenceConfig(model=app_entity, backend_format=BackendFormat.OPENAI_CHAT)]
 
     log.info("Creating VirtualModel %s/%s", WORKSPACE, VM_NAME)
-    vm = client.inference.virtual_models.create(
+    vm = _create_virtual_model_exist_ok(
+        virtual_models_client,
         workspace=WORKSPACE,
-        name=VM_NAME,
-        default_model_entity=app_entity,
-        models=vm_models,
-        request_middleware=[middleware_call],
-        response_middleware=[middleware_call],
-        exist_ok=True,
+        body=CreateVirtualModelRequest(
+            name=VM_NAME,
+            default_model_entity=app_entity,
+            models=vm_models,
+            request_middleware=[middleware_call],
+            response_middleware=[middleware_call],
+        ),
     )
     _dump_model(generated_dir / "virtual_model.json", vm)
 
     # Control VM: identical to the guardrails VM but no middleware, so the
     # with-vs-without delta isolates middleware overhead.
     log.info("Creating control VirtualModel %s/%s", WORKSPACE, NO_GUARDRAILS_VM_NAME)
-    no_guardrails_vm = client.inference.virtual_models.create(
+    no_guardrails_vm = _create_virtual_model_exist_ok(
+        virtual_models_client,
         workspace=WORKSPACE,
-        name=NO_GUARDRAILS_VM_NAME,
-        default_model_entity=app_entity,
-        models=vm_models,
-        request_middleware=[],
-        response_middleware=[],
-        exist_ok=True,
+        body=CreateVirtualModelRequest(
+            name=NO_GUARDRAILS_VM_NAME,
+            default_model_entity=app_entity,
+            models=vm_models,
+            request_middleware=[],
+            response_middleware=[],
+        ),
     )
     _dump_model(generated_dir / "virtual_model_no_guardrails.json", no_guardrails_vm)
 
@@ -207,12 +225,12 @@ def seed_benchmark(
 
 
 def _wait_for_served_model(
-    client: NeMoPlatform,
+    client: ModelsClient,
     *,
     provider_name: str,
     served_model_name: str,
     timeout_seconds: float,
-) -> Any:
+) -> ModelProvider:
     """Poll a provider until ``served_models`` lists the expected entry.
 
     Gateway readiness alone is not enough: VirtualModel creation needs the
@@ -223,14 +241,14 @@ def _wait_for_served_model(
     last_error: Exception | None = None
     while time.monotonic() < deadline:
         try:
-            provider = client.inference.providers.retrieve(provider_name, workspace=WORKSPACE)
+            provider = client.get_provider(name=provider_name, workspace=WORKSPACE).data()
         except NotFoundError as exc:
             last_error = exc
             time.sleep(_PROVIDER_POLL_INTERVAL_SECONDS)
             continue
-        served_models = getattr(provider, "served_models", None) or []
-        for m in served_models:
-            if getattr(m, "served_model_name", None) == served_model_name and getattr(m, "model_entity_id", None):
+        served_models = provider.served_models or []
+        for served_model in served_models:
+            if served_model.served_model_name == served_model_name and served_model.model_entity_id:
                 return provider
         time.sleep(_PROVIDER_POLL_INTERVAL_SECONDS)
 
@@ -240,12 +258,22 @@ def _wait_for_served_model(
     )
 
 
-def _extract_model_entity(provider: Any, served_model_name: str, *, provider_name: str) -> str:
-    for m in getattr(provider, "served_models", None) or []:
-        if getattr(m, "served_model_name", None) == served_model_name:
-            entity = getattr(m, "model_entity_id", None)
-            if entity:
-                return entity
+def _create_virtual_model_exist_ok(
+    client: VirtualModelsClient,
+    *,
+    workspace: str,
+    body: CreateVirtualModelRequest,
+) -> VirtualModel:
+    try:
+        return client.create_virtual_model(workspace=workspace, body=body).data()
+    except ConflictError:
+        return client.get_virtual_model(workspace=workspace, name=body.name).data()
+
+
+def _extract_model_entity(provider: ModelProvider, served_model_name: str, *, provider_name: str) -> str:
+    for served_model in provider.served_models or []:
+        if served_model.served_model_name == served_model_name and served_model.model_entity_id:
+            return served_model.model_entity_id
     raise RuntimeError(f"Provider {provider_name!r} does not expose served model {served_model_name!r}")
 
 

--- a/plugins/nemo-guardrails/src/nemo_guardrails_plugin/llm_clients.py
+++ b/plugins/nemo-guardrails/src/nemo_guardrails_plugin/llm_clients.py
@@ -24,8 +24,8 @@ from types import MappingProxyType
 from typing import Any, cast
 
 from langchain_core.language_models import BaseChatModel
-from nemo_platform import AsyncNeMoPlatform
-from nemo_platform_plugin.sdk_provider import get_forwarding_headers
+from nemo_platform_plugin.client.client import AsyncNemoClient
+from nemo_platform_plugin.client_provider import get_forwarding_headers
 from nemoguardrails.integrations.langchain.llm_adapter import LangChainLLMAdapter
 from nemoguardrails.llm.providers import register_provider
 from nemoguardrails.types import LLMModel
@@ -49,7 +49,7 @@ def get_request_headers() -> RequestHeaders:
 
 
 @contextmanager
-def platform_headers_context(sdk: AsyncNeMoPlatform) -> Iterator[None]:
+def platform_headers_context(client: AsyncNemoClient) -> Iterator[None]:
     """Make platform headers visible to rail model calls in this context.
 
     Model calls happen deep inside nemoguardrails/LangChain library code that
@@ -58,13 +58,13 @@ def platform_headers_context(sdk: AsyncNeMoPlatform) -> Iterator[None]:
     on the cached LangChain client itself.
 
     Args:
-        sdk: The SDK whose forwarding headers should be propagated.
-            For per-request auth, pass a request-scoped SDK built via
-            ``sdk.with_options(set_default_headers=...)``.
+        client: The client whose forwarding headers should be propagated.
+            For per-request auth, pass a request-scoped client built via
+            ``client.with_options(headers=...)``.
 
     The data flow is:
 
-    1. ``get_forwarding_headers(sdk)`` extracts the per-request
+    1. ``get_forwarding_headers(client)`` extracts the per-request
        service-principal, on-behalf-of, and tracing headers.
     2. This context manager stores them in ``_request_headers_ctx`` for the
        current execution context.
@@ -78,7 +78,7 @@ def platform_headers_context(sdk: AsyncNeMoPlatform) -> Iterator[None]:
        ``_prepare_inputs_and_payload`` override reads ``_request_headers_ctx``
        and merges those headers into the request.
     """
-    headers = _request_headers_ctx.set(get_forwarding_headers(sdk))
+    headers = _request_headers_ctx.set(get_forwarding_headers(client))
     try:
         yield
     finally:

--- a/plugins/nemo-guardrails/src/nemo_guardrails_plugin/llmrails_cache.py
+++ b/plugins/nemo-guardrails/src/nemo_guardrails_plugin/llmrails_cache.py
@@ -36,8 +36,8 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import Any, Protocol, cast
 
-from nemo_platform.types.guardrail import OutputRailsStreamingConfig
-from nemo_platform.types.guardrail import RailsConfig as PlatformRailsConfig
+from nemo_platform_plugin.guardrail.types import OutputRailsStreamingConfig
+from nemo_platform_plugin.guardrail.types import RailsConfig as PlatformRailsConfig
 from nemo_platform_plugin.inference_middleware import OpenAICompatibleInferenceTarget
 from nemoguardrails import RailsConfig as LibraryRailsConfig
 from nemoguardrails.rails.llm.config import Model

--- a/plugins/nemo-guardrails/src/nemo_guardrails_plugin/middleware.py
+++ b/plugins/nemo-guardrails/src/nemo_guardrails_plugin/middleware.py
@@ -7,7 +7,6 @@ import logging
 from collections.abc import AsyncIterator
 from typing import Any
 
-import nemo_platform
 from nemo_guardrails_plugin.constants import (
     GUARDRAILS_PLUGIN_CONFIG_TYPE,
     PROCESS_REQUEST_RAIL_TYPES,
@@ -62,9 +61,12 @@ from nemo_guardrails_plugin.streaming import (
     strings_to_chunks,
 )
 from nemo_guardrails_plugin.transforms import GenerationResponseMapper
-from nemo_platform.types.guardrail import GenerationLogOptionsParam
-from nemo_platform.types.guardrail import RailsConfig as PlatformRailsConfig
+from nemo_platform_plugin.client.client import AsyncNemoClient
+from nemo_platform_plugin.client.errors import NotFoundError
 from nemo_platform_plugin.config import get_common_service_config
+from nemo_platform_plugin.guardrail.client import AsyncGuardrailClient
+from nemo_platform_plugin.guardrail.types import GenerationLogOptionsParam
+from nemo_platform_plugin.guardrail.types import RailsConfig as PlatformRailsConfig
 from nemo_platform_plugin.inference_middleware import (
     ImmediateResponse,
     InferenceMiddlewareContext,
@@ -172,10 +174,10 @@ def handle_streaming_output_check(
 class GuardrailsMiddleware(NemoInferenceMiddleware):
     # Class-level ``None`` defaults let the per-request checks raise a clean
     # RuntimeError if a request arrives before on_startup ran.
-    _sdk: nemo_platform.AsyncNeMoPlatform | None = None
+    _client: AsyncNemoClient | None = None
     # Cache of ``LLMRails`` instances keyed by stabilized content hash.
     _rails_cache: LLMRailsCache | None = None
-    # Memoization of ``PlatformRailsConfig`` → ``StableRailsConfig``
+    # Memoization of ``PlatformRailsConfig`` to ``StableRailsConfig``
     # transform by entity identity ``(workspace, name, updated_at)``.
     _stable_cache: StabilizedRailsConfigCache | None = None
 
@@ -189,7 +191,7 @@ class GuardrailsMiddleware(NemoInferenceMiddleware):
         # Use our custom header-aware NIM provider adapter for library-initiated model calls.
         register_header_aware_nim_provider()
 
-        self._sdk = self._get_platform_sdk("on_startup")
+        self._client = self._get_platform_client("on_startup")
         self._rails_cache = LLMRailsCache(builder=DefaultLLMRailsBuilder())
         self._stable_cache = StabilizedRailsConfigCache()
 
@@ -197,7 +199,7 @@ class GuardrailsMiddleware(NemoInferenceMiddleware):
         # Detach attributes before awaiting close so a partial close can't
         # leave a half-torn-down cache visible to a later request.
         cache, self._rails_cache = self._rails_cache, None
-        self._sdk = None
+        self._client = None
         self._stable_cache = None
         if cache is not None:
             await cache.close()
@@ -265,12 +267,13 @@ class GuardrailsMiddleware(NemoInferenceMiddleware):
         resolved config.
         """
         self._require_supported_config_type(config_type)
-        sdk = self._ensure_sdk()
+        client = self._ensure_client()
+        guardrail_client = AsyncGuardrailClient.from_client(client)
 
         ref = parse_entity_ref(config_id)
         try:
-            entity = await sdk.guardrail.configs.retrieve(name=ref.name, workspace=ref.workspace)
-        except nemo_platform.NotFoundError as exc:
+            entity = (await guardrail_client.get_guardrail_config(name=ref.name, workspace=ref.workspace)).data()
+        except NotFoundError as exc:
             raise MiddlewareConfigNotFoundError(config_id) from exc
         # (workspace, name, updated_at) form the ``StabilizedRailsConfigCache`` key,
         # so an empty value would collide entries across unrelated entities. Fail fast here.
@@ -377,6 +380,7 @@ class GuardrailsMiddleware(NemoInferenceMiddleware):
         # pending actions and prevent the current turn from reaching the input rails.
         current_messages = messages[-1:]
         generation_response = await self._run_rails(
+            ctx,
             source,
             request.body,
             request.headers,
@@ -524,8 +528,8 @@ class GuardrailsMiddleware(NemoInferenceMiddleware):
             # on a never-iterated generator is a no-op — so an eager lease
             # would leak a Pool slot any time IGW drops the returned
             # iterator without iterating.
-            cache, stable, lease_provenance, main_llm, sdk = await self._prepare_lease_with_503(
-                source, request_body, request_headers, "Failed to run streaming output rails"
+            cache, stable, lease_provenance, main_llm, client = await self._prepare_lease_with_503(
+                ctx, source, request_body, request_headers, "Failed to run streaming output rails"
             )
 
             # Output rails need the latest user message for ``user_input``. Do not
@@ -537,13 +541,7 @@ class GuardrailsMiddleware(NemoInferenceMiddleware):
 
             async def _streaming_with_lease() -> AsyncIterator[dict[str, Any]]:
                 try:
-                    # TODO: self._sdk carries static startup headers (service principal
-                    # + internal marker). For full per-request auth propagation, IGW
-                    # should pass a request-scoped SDK on InferenceMiddlewareContext
-                    # (built via sdk.with_options(set_default_headers=...)) so the
-                    # forwarded headers include the current user's on-behalf-of
-                    # identity and OTEL trace context.
-                    with platform_headers_context(sdk):
+                    with platform_headers_context(client):
                         async with cache.lease(stable, main_llm=main_llm, provenance=lease_provenance) as llm_rails:
                             inner = handle_streaming_output_check(
                                 llm_rails,
@@ -586,6 +584,7 @@ class GuardrailsMiddleware(NemoInferenceMiddleware):
         output_messages = _latest_user_message(messages)
         output_messages.append(build_assistant_message_from_response_result(response_result))
         generation_response = await self._run_rails(
+            ctx,
             source,
             request_body,
             request_headers,
@@ -637,17 +636,17 @@ class GuardrailsMiddleware(NemoInferenceMiddleware):
         if config_type != GUARDRAILS_PLUGIN_CONFIG_TYPE:
             raise ValueError(f"Unsupported config_type {config_type!r}.")
 
-    def _ensure_sdk(self) -> nemo_platform.AsyncNeMoPlatform:
-        """Narrow ``self._sdk`` to non-``None``, raising a clean error otherwise.
+    def _ensure_client(self) -> AsyncNemoClient:
+        """Narrow ``self._client`` to non-``None``, raising a clean error otherwise.
 
         A request arriving before ``on_startup`` ran (or after ``on_shutdown``
         detached it) is a lifecycle bug, not a per-request failure, so we should
         surface it as a ``RuntimeError``.
         """
-        sdk = self._sdk
-        if sdk is None:
-            raise RuntimeError("NeMo Platform SDK is not initialized. Was on_startup() called?")
-        return sdk
+        client = self._client
+        if client is None:
+            raise RuntimeError("NeMo Platform client is not initialized. Was on_startup() called?")
+        return client
 
     async def _resolve_call(self, call: MiddlewareCall) -> GuardrailConfigSource | None:
         """Bridge a ``MiddlewareCall`` to a ``GuardrailConfigSource`` for warming.
@@ -699,6 +698,7 @@ class GuardrailsMiddleware(NemoInferenceMiddleware):
 
     async def _run_rails(
         self,
+        ctx: InferenceMiddlewareContext,
         source: GuardrailConfigSource,
         request_body: dict[str, Any],
         request_headers: dict[str, str],
@@ -723,13 +723,11 @@ class GuardrailsMiddleware(NemoInferenceMiddleware):
           propagated so caller-set ``status_code`` survives.
         - Anything else below the lease → 503 with ``error_msg``.
         """
-        cache, stable, provenance, main_llm, sdk = await self._prepare_lease_with_503(
-            source, request_body, request_headers, error_msg
+        cache, stable, provenance, main_llm, client = await self._prepare_lease_with_503(
+            ctx, source, request_body, request_headers, error_msg
         )
         try:
-            # TODO: same as streaming path — use a request-scoped SDK from ctx
-            # once IGW threads one through InferenceMiddlewareContext.
-            with platform_headers_context(sdk):
+            with platform_headers_context(client):
                 async with cache.lease(stable, main_llm=main_llm, provenance=provenance) as llm_rails:
                     raw_generation_response = await asyncio.to_thread(
                         run_generate_in_new_loop,
@@ -760,11 +758,12 @@ class GuardrailsMiddleware(NemoInferenceMiddleware):
 
     async def _prepare_lease_with_503(
         self,
+        ctx: InferenceMiddlewareContext,
         source: GuardrailConfigSource,
         request_body: dict[str, Any],
         request_headers: dict[str, str],
         error_msg: str,
-    ) -> tuple[LLMRailsCache, StableRailsConfig, Provenance, LLMModel, nemo_platform.AsyncNeMoPlatform]:
+    ) -> tuple[LLMRailsCache, StableRailsConfig, Provenance, LLMModel, AsyncNemoClient]:
         """Run :meth:`_prepare_lease` with the plugin's error-mapping policy.
 
         Single source of truth for "lease setup → HTTP status" so non-streaming
@@ -772,8 +771,8 @@ class GuardrailsMiddleware(NemoInferenceMiddleware):
         stays local to the plugin (IGW only catches
         :class:`InferenceMiddlewareError`).
 
-        Also resolves the SDK via :meth:`_ensure_sdk` inside the same boundary
-        so a request that races ``on_shutdown`` (SDK detached) maps to 503
+        Also resolves the client via :meth:`_ensure_client` inside the same boundary
+        so a request that races ``on_shutdown`` (client detached) maps to 503
         rather than escaping as a raw ``RuntimeError``.
 
         - ``ValueError`` → 400 (caller-shape: missing ``model``, malformed inline config).
@@ -782,8 +781,8 @@ class GuardrailsMiddleware(NemoInferenceMiddleware):
         """
         try:
             cache, stable, provenance, main_llm = await self._prepare_lease(source, request_body, request_headers)
-            sdk = self._ensure_sdk()
-            return cache, stable, provenance, main_llm, sdk
+            client = ctx.request_nemo_client or self._ensure_client()
+            return cache, stable, provenance, main_llm, client
         except InferenceMiddlewareError:
             raise
         except ValueError as exc:

--- a/plugins/nemo-guardrails/src/nemo_guardrails_plugin/rails.py
+++ b/plugins/nemo-guardrails/src/nemo_guardrails_plugin/rails.py
@@ -23,11 +23,10 @@ from typing import Any
 from nemo_guardrails_plugin.constants import DEFAULT_MAIN_ENGINE, W3C_TRACE_CONTEXT_HEADERS
 from nemo_guardrails_plugin.llmrails_cache import InferenceTargetResolver
 from nemo_guardrails_plugin.transforms import GenerationResponseMapper
-from nemo_platform.types.guardrail import GenerationLog, GenerationLogOptionsParam
-from nemo_platform.types.guardrail import (
+from nemo_platform_plugin.guardrail.types import GenerationLog, GenerationLogOptionsParam, GuardrailsData
+from nemo_platform_plugin.guardrail.types import (
     GenerationStats as PlatformGenerationStats,
 )
-from nemo_platform.types.guardrail.guardrails_data import GuardrailsData
 from nemoguardrails.llm.models.initializer import init_llm_model
 from nemoguardrails.rails.llm.config import Model
 from nemoguardrails.rails.llm.llmrails import LLMRails

--- a/plugins/nemo-guardrails/src/nemo_guardrails_plugin/requests.py
+++ b/plugins/nemo-guardrails/src/nemo_guardrails_plugin/requests.py
@@ -4,7 +4,7 @@
 from typing import Any
 
 from nemo_guardrails_plugin.schemas import GuardrailsRequest
-from nemo_platform.types.guardrail import GenerationLogOptionsParam
+from nemo_platform_plugin.guardrail.types import GenerationLogOptionsParam
 from nemo_platform_plugin.inference_middleware import InferenceMiddlewareError
 from pydantic import ValidationError
 

--- a/plugins/nemo-guardrails/src/nemo_guardrails_plugin/responses.py
+++ b/plugins/nemo-guardrails/src/nemo_guardrails_plugin/responses.py
@@ -10,7 +10,7 @@ from typing import Any
 
 from nemo_guardrails_plugin.constants import GUARDRAILS_DATA_MESSAGE_ROLE
 from nemo_guardrails_plugin.rails import build_guardrails_data
-from nemo_platform.types.guardrail import GenerationLogOptionsParam
+from nemo_platform_plugin.guardrail.types import GenerationLogOptionsParam
 from nemo_platform_plugin.inference_middleware import (
     ImmediateResponse,
     InferenceMiddlewareError,
@@ -366,7 +366,8 @@ def build_output_response_body(
     # Output rails validate choices[0].message, so return only the choice that was checked.
     if generation_response is not None and choices:
         choice = {**choices[0], "index": 0}
-        message = dict(choice.get("message") or {}) if isinstance(choice.get("message"), dict) else {}
+        raw_message = choice.get("message")
+        message: dict[str, Any] = dict(raw_message) if isinstance(raw_message, dict) else {}
         original_content = message.get("content")
 
         # If the output rail modified the message content, write it back onto the choice.

--- a/plugins/nemo-guardrails/src/nemo_guardrails_plugin/transforms.py
+++ b/plugins/nemo-guardrails/src/nemo_guardrails_plugin/transforms.py
@@ -3,16 +3,16 @@
 
 from typing import Any, TypeAlias
 
-from nemo_platform.types.guardrail import (
+from nemo_platform_plugin.guardrail.types import (
     ActivatedRail as PlatformActivatedRail,
 )
-from nemo_platform.types.guardrail import (
+from nemo_platform_plugin.guardrail.types import (
     GenerationLog as PlatformGenerationLog,
 )
-from nemo_platform.types.guardrail import (
+from nemo_platform_plugin.guardrail.types import (
     GenerationStats as PlatformGenerationStats,
 )
-from nemo_platform.types.guardrail import (
+from nemo_platform_plugin.guardrail.types import (
     LLMCallInfo as PlatformLLMCallInfo,
 )
 from nemoguardrails.logging.explain import LLMCallInfo as LibraryLLMCallInfo
@@ -35,7 +35,7 @@ GenerateAsyncResponse: TypeAlias = (
 
 
 class GenerationResponseMapper:
-    """Transforms nemoguardrails Generation-related models into the corresponding nemo_platform models."""
+    """Transforms nemoguardrails generation models into guardrail client DTOs."""
 
     @staticmethod
     def parse(value: GenerateAsyncResponse) -> LibraryGenerationResponse:

--- a/plugins/nemo-guardrails/tests/integration/test_injection_detection_rails.py
+++ b/plugins/nemo-guardrails/tests/integration/test_injection_detection_rails.py
@@ -10,17 +10,17 @@ responses that match built-in or custom injection rules.
 from collections.abc import Callable
 from typing import Any
 
-import nemo_platform
 import pytest
 from nemo_guardrails_plugin.constants import GUARDRAILS_PLUGIN_CONFIG_TYPE
-from nemo_platform.types.inference.middleware_call_param import MiddlewareCallParam
 from nmp.core.inference_gateway.testing.harness import IGWLoopbackHarness
 from nmp.testing.mock_chat_completions import ChatCompletion, chat_completion
 
 from .utils import (
     GUARDRAILS_PLUGIN_NAME,
+    EntityGuardrailsMiddlewareCall,
     GuardrailsTestDataNames,
-    detach_guardrail_config,
+    create_guardrail_config,
+    delete_guardrail_config_if_present,
     make_guardrails_test_data_names,
 )
 
@@ -45,7 +45,7 @@ class TestInjectionDetection:
     REFUSAL_PREFIX = "I'm sorry, the desired output triggered rule(s) designed to mitigate exploitation of"
 
     @staticmethod
-    def _middleware_call(workspace: str, config_name: str) -> MiddlewareCallParam:
+    def _middleware_call(workspace: str, config_name: str) -> EntityGuardrailsMiddlewareCall:
         return {
             "name": GUARDRAILS_PLUGIN_NAME,
             "config_type": GUARDRAILS_PLUGIN_CONFIG_TYPE,
@@ -56,11 +56,7 @@ class TestInjectionDetection:
     def _delete_config_if_present(harness: IGWLoopbackHarness, config_name: str) -> None:
         # The service refuses to delete a config a VirtualModel still applies; harness
         # cleanup removes those routes, but it runs after this teardown.
-        detach_guardrail_config(harness, config_name)
-        try:
-            harness.sdk.guardrail.configs.delete(name=config_name, workspace=harness.workspace)
-        except nemo_platform.NotFoundError:
-            pass
+        delete_guardrail_config_if_present(harness, config_name)
 
     @staticmethod
     def _builtin_injection_detection_config() -> dict[str, Any]:
@@ -116,8 +112,8 @@ class TestInjectionDetection:
             name=test_data_names.model_provider_name,
             served_models={test_data_names.main_model_served_name: test_data_names.main_model_served_name},
         )
-        harness.sdk.guardrail.configs.create(
-            workspace=harness.workspace,
+        create_guardrail_config(
+            harness,
             name=test_data_names.guardrail_config_name,
             description="Entity-backed injection detection config for integration tests",
             data=config_data,

--- a/plugins/nemo-guardrails/tests/integration/test_llmrails_cache_real_build.py
+++ b/plugins/nemo-guardrails/tests/integration/test_llmrails_cache_real_build.py
@@ -31,7 +31,7 @@ from nemo_guardrails_plugin.llmrails_cache import (
     Provenance,
     stabilize,
 )
-from nemo_platform.types.guardrail import RailsConfig as PlatformRailsConfig
+from nemo_platform_plugin.guardrail.types import RailsConfig as PlatformRailsConfig
 from nemo_platform_plugin.inference_middleware import OpenAICompatibleInferenceTarget
 from nemoguardrails.integrations.langchain.llm_adapter import LangChainLLMAdapter
 from nemoguardrails.rails.llm.llmrails import LLMRails

--- a/plugins/nemo-guardrails/tests/integration/test_middleware_config_caching.py
+++ b/plugins/nemo-guardrails/tests/integration/test_middleware_config_caching.py
@@ -9,20 +9,22 @@ middleware cache and the Guardrails plugin's in-memory LLMRails cache.
 
 from collections.abc import Callable
 from http import HTTPStatus
-from typing import Any, cast
+from typing import Any
 
-import nemo_platform
 import pytest
 from nemo_guardrails_plugin.constants import GUARDRAILS_PLUGIN_CONFIG_TYPE
-from nemo_platform.types.inference.middleware_call_param import MiddlewareCallParam
 from nmp.core.inference_gateway.testing.harness import IGWLoopbackHarness, IGWPluginHarness
 from nmp.testing.mock_chat_completions import ChatCompletion, chat_completion
 
 from .utils import (
     GUARDRAILS_PLUGIN_NAME,
+    EntityGuardrailsMiddlewareCall,
     GuardrailsTestDataNames,
-    detach_guardrail_config,
+    create_guardrail_config,
+    delete_guardrail_config_if_present,
+    expect_harness_http_error,
     make_guardrails_test_data_names,
+    update_guardrail_config,
 )
 
 pytestmark = [pytest.mark.integration]
@@ -96,7 +98,7 @@ class TestMiddlewareConfigCaching:
         return "Paris is the capital of France."
 
     @staticmethod
-    def _middleware_call(workspace: str, config_name: str) -> MiddlewareCallParam:
+    def _middleware_call(workspace: str, config_name: str) -> EntityGuardrailsMiddlewareCall:
         return {
             "name": GUARDRAILS_PLUGIN_NAME,
             "config_type": GUARDRAILS_PLUGIN_CONFIG_TYPE,
@@ -123,11 +125,7 @@ class TestMiddlewareConfigCaching:
     def _delete_config_if_present(harness: IGWPluginHarness, config_name: str) -> None:
         # The service refuses to delete a config a VirtualModel still applies; harness
         # cleanup removes those routes, but it runs after this teardown.
-        detach_guardrail_config(harness, config_name)
-        try:
-            harness.sdk.guardrail.configs.delete(name=config_name, workspace=harness.workspace)
-        except nemo_platform.NotFoundError:
-            pass
+        delete_guardrail_config_if_present(harness, config_name)
 
     @staticmethod
     def _refresh_caches(harness: IGWPluginHarness) -> None:
@@ -142,18 +140,19 @@ class TestMiddlewareConfigCaching:
         *,
         model: str,
     ) -> None:
-        with pytest.raises(nemo_platform.APIStatusError) as exc_info:
-            harness.chat_completions(
+        error = expect_harness_http_error(
+            lambda: harness.chat_completions(
                 workspace=harness.workspace,
                 body={
                     "model": model,
                     "messages": [{"role": "user", "content": cls.USER_INPUT}],
                 },
-            )
+            ),
+            HTTPStatus.SERVICE_UNAVAILABLE,
+        )
 
-        assert exc_info.value.status_code == HTTPStatus.SERVICE_UNAVAILABLE
-        assert isinstance(exc_info.value.body, dict)
-        body = cast(dict[str, Any], exc_info.value.body)
+        body = error.body
+        assert isinstance(body, dict)
         detail = body.get("detail")
         assert isinstance(detail, str)
         assert "Middleware configuration unavailable" in detail
@@ -182,8 +181,8 @@ class TestMiddlewareConfigCaching:
             served_models={test_data_names.main_model_served_name: test_data_names.main_model_served_name},
         )
 
-        harness.sdk.guardrail.configs.create(
-            workspace=harness.workspace,
+        create_guardrail_config(
+            harness,
             name=test_data_names.guardrail_config_name,
             description="Entity-backed self-check config for middleware cache tests",
             data=self._config_data(version=config_version, main_base_url=harness.nim_base_url),
@@ -267,9 +266,9 @@ class TestMiddlewareConfigCaching:
                 )
 
                 # Update the config referenced by the VirtualModel
-                harness.sdk.guardrail.configs.update(
+                update_guardrail_config(
+                    harness,
                     name=test_data_names.guardrail_config_name,
-                    workspace=harness.workspace,
                     data=self._config_data(version="v2", main_base_url=harness.nim_base_url),
                 )
 
@@ -346,8 +345,8 @@ class TestMiddlewareConfigCaching:
                 )
 
                 # Recreate the config referenced by the VirtualModel.
-                harness.sdk.guardrail.configs.create(
-                    workspace=harness.workspace,
+                create_guardrail_config(
+                    harness,
                     name=test_data_names.guardrail_config_name,
                     description="Recreated self-check config for middleware cache tests",
                     data=self._config_data(version="v2", main_base_url=harness.nim_base_url),

--- a/plugins/nemo-guardrails/tests/integration/test_multimodal_rails.py
+++ b/plugins/nemo-guardrails/tests/integration/test_multimodal_rails.py
@@ -11,16 +11,16 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, ClassVar
 
-import nemo_platform
 import pytest
 from nemo_guardrails_plugin.constants import GUARDRAILS_PLUGIN_CONFIG_TYPE
-from nemo_platform.types.inference.middleware_call_param import MiddlewareCallParam
 from nmp.core.inference_gateway.testing.harness import IGWLoopbackHarness
 from nmp.testing.mock_chat_completions import ChatCompletion, chat_completion
 
 from .utils import (
     GUARDRAILS_PLUGIN_NAME,
-    detach_guardrail_config,
+    EntityGuardrailsMiddlewareCall,
+    create_guardrail_config,
+    delete_guardrail_config_if_present,
     make_guardrails_test_data_names,
     make_served_model,
 )
@@ -109,7 +109,7 @@ class TestMultimodalContentSafety:
     }
 
     @staticmethod
-    def _middleware_call(workspace: str, config_name: str) -> MiddlewareCallParam:
+    def _middleware_call(workspace: str, config_name: str) -> EntityGuardrailsMiddlewareCall:
         return {
             "name": GUARDRAILS_PLUGIN_NAME,
             "config_type": GUARDRAILS_PLUGIN_CONFIG_TYPE,
@@ -120,11 +120,7 @@ class TestMultimodalContentSafety:
     def _delete_config_if_present(harness: IGWLoopbackHarness, config_name: str) -> None:
         # The service refuses to delete a config a VirtualModel still applies; harness
         # cleanup removes those routes, but it runs after this teardown.
-        detach_guardrail_config(harness, config_name)
-        try:
-            harness.sdk.guardrail.configs.delete(name=config_name, workspace=harness.workspace)
-        except nemo_platform.NotFoundError:
-            pass
+        delete_guardrail_config_if_present(harness, config_name)
 
     @classmethod
     def _config_data(cls, *, vision_model_entity_ref: str, vision_base_url: str) -> dict[str, Any]:
@@ -166,8 +162,8 @@ class TestMultimodalContentSafety:
                 test_data_names.vision_model_served_name: test_data_names.vision_model_served_name,
             },
         )
-        harness.sdk.guardrail.configs.create(
-            workspace=harness.workspace,
+        create_guardrail_config(
+            harness,
             name=test_data_names.guardrail_config_name,
             description="Entity-backed multimodal input rail config for integration tests",
             data=self._config_data(

--- a/plugins/nemo-guardrails/tests/integration/test_parallel_rails.py
+++ b/plugins/nemo-guardrails/tests/integration/test_parallel_rails.py
@@ -12,16 +12,16 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, ClassVar
 
-import nemo_platform
 import pytest
 from nemo_guardrails_plugin.constants import GUARDRAILS_PLUGIN_CONFIG_TYPE
-from nemo_platform.types.inference.middleware_call_param import MiddlewareCallParam
 from nmp.core.inference_gateway.testing.harness import IGWLoopbackHarness
 from nmp.testing.mock_chat_completions import ChatCompletion, chat_completion
 
 from .utils import (
     GUARDRAILS_PLUGIN_NAME,
-    detach_guardrail_config,
+    EntityGuardrailsMiddlewareCall,
+    create_guardrail_config,
+    delete_guardrail_config_if_present,
     make_guardrails_test_data_names,
     make_served_model,
 )
@@ -130,7 +130,7 @@ class TestParallelRails:
         return "on-topic"
 
     @staticmethod
-    def _middleware_call(workspace: str, config_name: str) -> MiddlewareCallParam:
+    def _middleware_call(workspace: str, config_name: str) -> EntityGuardrailsMiddlewareCall:
         return {
             "name": GUARDRAILS_PLUGIN_NAME,
             "config_type": GUARDRAILS_PLUGIN_CONFIG_TYPE,
@@ -141,11 +141,7 @@ class TestParallelRails:
     def _delete_config_if_present(harness: IGWLoopbackHarness, config_name: str) -> None:
         # The service refuses to delete a config a VirtualModel still applies; harness
         # cleanup removes those routes, but it runs after this teardown.
-        detach_guardrail_config(harness, config_name)
-        try:
-            harness.sdk.guardrail.configs.delete(name=config_name, workspace=harness.workspace)
-        except nemo_platform.NotFoundError:
-            pass
+        delete_guardrail_config_if_present(harness, config_name)
 
     @classmethod
     def _expected_content_safety_prompt(cls) -> str:
@@ -213,8 +209,8 @@ class TestParallelRails:
                 test_data_names.topic_control_model_served_name: test_data_names.topic_control_model_served_name,
             },
         )
-        harness.sdk.guardrail.configs.create(
-            workspace=harness.workspace,
+        create_guardrail_config(
+            harness,
             name=test_data_names.guardrail_config_name,
             description="Entity-backed parallel rails config for integration tests",
             data=self._config_data(

--- a/plugins/nemo-guardrails/tests/integration/test_request_logging.py
+++ b/plugins/nemo-guardrails/tests/integration/test_request_logging.py
@@ -9,9 +9,9 @@ serialized response.
 """
 
 import json
+from http import HTTPStatus
 from typing import Any
 
-import nemo_platform
 import pytest
 from nemo_guardrails_plugin.constants import GUARDRAILS_DATA_MESSAGE_ROLE
 from nmp.core.inference_gateway.testing.harness import IGWPluginHarness
@@ -19,6 +19,8 @@ from nmp.testing.mock_chat_completions import ChatCompletion, chat_completion
 
 from .utils import (
     GUARDRAILS_PLUGIN_NAME,
+    GuardrailsTestDataNames,
+    expect_harness_http_error,
     make_guardrail_config,
     make_guardrails_test_data_names,
     make_middleware_call,
@@ -140,7 +142,7 @@ class TestRequestLogging:
         *,
         log_options: dict[str, bool] | None = None,
         return_choice: bool = False,
-    ) -> tuple[dict[str, Any], Any]:
+    ) -> tuple[dict[str, Any], GuardrailsTestDataNames]:
         test_data_names = make_guardrails_test_data_names(workspace=harness.workspace)
 
         harness.mock_chat_completions(
@@ -287,14 +289,14 @@ class TestRequestLogging:
                 default_model_entity=test_data_names.main_model_entity_ref,
                 request_middleware=[make_middleware_call(guardrail_config)],
             )
-            with pytest.raises(nemo_platform.APIStatusError) as exc_info:
-                harness.chat_completions(
+            expect_harness_http_error(
+                lambda: harness.chat_completions(
                     workspace=harness.workspace,
                     body={
                         "model": test_data_names.request_virtual_model_name,
                         "messages": [{"role": "user", "content": self.USER_INPUT}],
                         "guardrails": {"options": {"log": {"unknown": True}}},
                     },
-                )
-
-        assert exc_info.value.status_code == 422
+                ),
+                HTTPStatus.UNPROCESSABLE_ENTITY,
+            )

--- a/plugins/nemo-guardrails/tests/integration/test_topic_control_rails.py
+++ b/plugins/nemo-guardrails/tests/integration/test_topic_control_rails.py
@@ -11,17 +11,17 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, ClassVar
 
-import nemo_platform
 import pytest
 from nemo_guardrails_plugin.constants import GUARDRAILS_PLUGIN_CONFIG_TYPE
-from nemo_platform.types.inference.middleware_call_param import MiddlewareCallParam
 from nmp.core.inference_gateway.testing.harness import IGWLoopbackHarness
 from nmp.testing.mock_chat_completions import ChatCompletion, chat_completion
 
 from .utils import (
     GUARDRAILS_PLUGIN_NAME,
+    EntityGuardrailsMiddlewareCall,
     RailType,
-    detach_guardrail_config,
+    create_guardrail_config,
+    delete_guardrail_config_if_present,
     make_guardrails_test_data_names,
     make_served_model,
 )
@@ -115,7 +115,7 @@ class TestTopicControl:
         return "off-topic"
 
     @staticmethod
-    def _middleware_call(workspace: str, config_name: str) -> MiddlewareCallParam:
+    def _middleware_call(workspace: str, config_name: str) -> EntityGuardrailsMiddlewareCall:
         return {
             "name": GUARDRAILS_PLUGIN_NAME,
             "config_type": GUARDRAILS_PLUGIN_CONFIG_TYPE,
@@ -126,11 +126,7 @@ class TestTopicControl:
     def _delete_config_if_present(harness: IGWLoopbackHarness, config_name: str) -> None:
         # The service refuses to delete a config a VirtualModel still applies; harness
         # cleanup removes those routes, but it runs after this teardown.
-        detach_guardrail_config(harness, config_name)
-        try:
-            harness.sdk.guardrail.configs.delete(name=config_name, workspace=harness.workspace)
-        except nemo_platform.NotFoundError:
-            pass
+        delete_guardrail_config_if_present(harness, config_name)
 
     @classmethod
     def _config_data(
@@ -176,8 +172,8 @@ class TestTopicControl:
                 test_data_names.topic_control_model_served_name: test_data_names.topic_control_model_served_name,
             },
         )
-        harness.sdk.guardrail.configs.create(
-            workspace=harness.workspace,
+        create_guardrail_config(
+            harness,
             name=test_data_names.guardrail_config_name,
             description="Entity-backed topic-control config for integration tests",
             data=self._config_data(

--- a/plugins/nemo-guardrails/tests/integration/test_upstream_error_surfacing.py
+++ b/plugins/nemo-guardrails/tests/integration/test_upstream_error_surfacing.py
@@ -15,16 +15,17 @@ from dataclasses import dataclass
 from http import HTTPStatus
 from typing import Any
 
-import nemo_platform
 import pytest
 from nemo_guardrails_plugin.constants import GUARDRAILS_PLUGIN_CONFIG_TYPE
-from nemo_platform.types.inference.middleware_call_param import MiddlewareCallParam
 from nmp.core.inference_gateway.testing.harness import IGWLoopbackHarness
 from nmp.testing.mock_chat_completions import ErrorResponse
 
 from .utils import (
     GUARDRAILS_PLUGIN_NAME,
-    detach_guardrail_config,
+    EntityGuardrailsMiddlewareCall,
+    create_guardrail_config,
+    delete_guardrail_config_if_present,
+    expect_harness_http_error,
     make_guardrails_test_data_names,
     make_served_model,
 )
@@ -85,7 +86,7 @@ class TestUpstreamErrorSurfacing:
         }
 
     @staticmethod
-    def _middleware_call(workspace: str, config_name: str) -> MiddlewareCallParam:
+    def _middleware_call(workspace: str, config_name: str) -> EntityGuardrailsMiddlewareCall:
         return {
             "name": GUARDRAILS_PLUGIN_NAME,
             "config_type": GUARDRAILS_PLUGIN_CONFIG_TYPE,
@@ -96,11 +97,7 @@ class TestUpstreamErrorSurfacing:
     def _delete_config_if_present(harness: IGWLoopbackHarness, config_name: str) -> None:
         # The service refuses to delete a config a VirtualModel still applies; harness
         # cleanup removes those routes, but it runs after this teardown.
-        detach_guardrail_config(harness, config_name)
-        try:
-            harness.sdk.guardrail.configs.delete(name=config_name, workspace=harness.workspace)
-        except nemo_platform.NotFoundError:
-            pass
+        delete_guardrail_config_if_present(harness, config_name)
 
     def _setup(self, harness: IGWLoopbackHarness) -> _Fixture:
         """Wire a vision-judge model + guarded VirtualModel."""
@@ -119,8 +116,8 @@ class TestUpstreamErrorSurfacing:
                 vision_model.served_name: vision_model.served_name,
             },
         )
-        harness.sdk.guardrail.configs.create(
-            workspace=harness.workspace,
+        create_guardrail_config(
+            harness,
             name=test_data_names.guardrail_config_name,
             description="Upstream error surfacing test config",
             data=self._config_data(
@@ -190,11 +187,11 @@ class TestUpstreamErrorSurfacing:
                     responses=[ErrorResponse(status_code=400, body=TOO_MANY_IMAGES_BODY)],
                 )
 
-                with pytest.raises(nemo_platform.APIStatusError) as exc_info:
-                    self._send_message(harness, fixture.vm_name)
-
-                assert exc_info.value.status_code == HTTPStatus.BAD_REQUEST
-                body = exc_info.value.body
+                error = expect_harness_http_error(
+                    lambda: self._send_message(harness, fixture.vm_name),
+                    HTTPStatus.BAD_REQUEST,
+                )
+                body = error.body
                 assert isinstance(body, dict)
                 detail = body.get("detail")
                 assert isinstance(detail, str)
@@ -225,9 +222,9 @@ class TestUpstreamErrorSurfacing:
                     ],
                 )
 
-                with pytest.raises(nemo_platform.APIStatusError) as exc_info:
-                    self._send_message(harness, fixture.vm_name)
-
-                assert exc_info.value.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+                expect_harness_http_error(
+                    lambda: self._send_message(harness, fixture.vm_name),
+                    HTTPStatus.INTERNAL_SERVER_ERROR,
+                )
             finally:
                 self._delete_config_if_present(harness, fixture.config_name)

--- a/plugins/nemo-guardrails/tests/integration/utils.py
+++ b/plugins/nemo-guardrails/tests/integration/utils.py
@@ -5,15 +5,26 @@
 Common functions shared by the nemo-guardrails plugin integration tests.
 """
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any
+from http import HTTPStatus
+from typing import Any, TypedDict
 
+import httpx
 from nemo_guardrails_plugin.constants import GUARDRAILS_PLUGIN_CONFIG_TYPE
-from nemo_platform import NotFoundError
-from nemo_platform.types.guardrail import GuardrailConfig
-from nemo_platform.types.inference.middleware_call_param import MiddlewareCallParam
+from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.client.errors import NotFoundError
+from nemo_platform_plugin.guardrail.client import GuardrailClient
+from nemo_platform_plugin.guardrail.types import (
+    CreateGuardrailConfigRequest,
+    GuardrailConfig,
+    UpdateGuardrailConfigRequest,
+)
+from nemo_platform_plugin.virtual_models.client import VirtualModelsClient
+from nemo_platform_plugin.virtual_models.types import UpdateVirtualModelRequest
 from nmp.testing.utils import short_unique_name
+from typing_extensions import Required
 
 DEFAULT_WORKSPACE = "default"
 """Default workspace seeded by the module-scoped IGW fixture. Helpers
@@ -39,6 +50,51 @@ class GuardrailsTestDataNames:
     request_virtual_model_name: str
     guardrail_config_name: str
     model_provider_name: str
+
+
+@dataclass(frozen=True)
+class HarnessHTTPError:
+    status_code: int
+    body: object | None
+
+
+class GuardrailsMiddlewareCall(TypedDict, total=False):
+    name: Required[str]
+    config_type: Required[str]
+    config: dict[str, object]
+    config_id: str
+
+
+EntityGuardrailsMiddlewareCall = GuardrailsMiddlewareCall
+InlineGuardrailsMiddlewareCall = GuardrailsMiddlewareCall
+
+
+def expect_harness_http_error(action: Callable[[], object], expected_status: HTTPStatus) -> HarnessHTTPError:
+    """Run a harness action and return HTTP error details.
+
+    The IGW integration harness raises generated SDK HTTP errors for sync SDK
+    calls and ``httpx.HTTPStatusError`` for direct TestClient streaming calls.
+    Keep that dynamic boundary here so tests assert typed status/body values
+    without importing generated SDK errors in the plugin suite.
+    """
+    try:
+        action()
+    except httpx.HTTPStatusError as exc:
+        try:
+            body = exc.response.json()
+        except ValueError:
+            body = exc.response.text
+        error = HarnessHTTPError(status_code=exc.response.status_code, body=body)
+    except Exception as exc:
+        status_code = getattr(exc, "status_code", None)
+        if not isinstance(status_code, int):
+            raise AssertionError(f"Expected HTTP error with status_code, got {type(exc).__name__}") from exc
+        error = HarnessHTTPError(status_code=status_code, body=getattr(exc, "body", None))
+    else:
+        raise AssertionError(f"Expected HTTP {expected_status.value}, but request succeeded")
+
+    assert error.status_code == expected_status
+    return error
 
 
 def make_served_model(
@@ -87,10 +143,11 @@ def detach_guardrail_config(harness: Any, config_name: str) -> None:
     """
     config_ref = f"{harness.workspace}/{config_name}"
     phases = ("request_middleware", "response_middleware", "post_response_middleware")
+    virtual_models_client = client_from_platform(harness.sdk, VirtualModelsClient)
 
     for workspace, name in harness.virtual_models:
         try:
-            virtual_model = harness.sdk.inference.virtual_models.retrieve(name=name, workspace=workspace)
+            virtual_model = virtual_models_client.get_virtual_model(name=name, workspace=workspace).data()
         except NotFoundError:
             continue
 
@@ -111,7 +168,58 @@ def detach_guardrail_config(harness: Any, config_name: str) -> None:
         if not remaining:
             continue
 
-        harness.sdk.inference.virtual_models.patch(name=name, workspace=workspace, **remaining)
+        virtual_models_client.update_virtual_model(
+            name=name,
+            workspace=workspace,
+            body=UpdateVirtualModelRequest.model_validate(remaining),
+        ).data()
+
+
+def guardrail_client(harness: Any) -> GuardrailClient:
+    return client_from_platform(harness.sdk, GuardrailClient)
+
+
+def create_guardrail_config(
+    harness: Any,
+    *,
+    name: str,
+    description: str | None,
+    data: dict[str, Any],
+) -> GuardrailConfig:
+    return (
+        guardrail_client(harness)
+        .create_guardrail_config(
+            workspace=harness.workspace,
+            body=CreateGuardrailConfigRequest(name=name, description=description, data=data),
+        )
+        .data()
+    )
+
+
+def update_guardrail_config(
+    harness: Any,
+    *,
+    name: str,
+    description: str | None = None,
+    data: dict[str, Any] | None = None,
+) -> GuardrailConfig:
+    return (
+        guardrail_client(harness)
+        .update_guardrail_config(
+            workspace=harness.workspace,
+            name=name,
+            body=UpdateGuardrailConfigRequest(description=description, data=data),
+        )
+        .data()
+    )
+
+
+def delete_guardrail_config_if_present(harness: Any, config_name: str) -> None:
+    detach_guardrail_config(harness, config_name)
+    try:
+        guardrail_client(harness).delete_guardrail_config(name=config_name, workspace=harness.workspace).data()
+    except NotFoundError:
+        pass
 
 
 class RailType(str, Enum):
@@ -151,15 +259,12 @@ def make_guardrail_config(
     )
 
 
-def make_middleware_call(config: GuardrailConfig) -> MiddlewareCallParam:
+def make_middleware_call(config: GuardrailConfig) -> InlineGuardrailsMiddlewareCall:
     # validate_middleware_config expects the inner PlatformRailsConfig data
     # block (models / rails / prompts), not the entity envelope. The full
     # GuardrailConfig dump silently absorbs envelope fields into model_extra
     # and rails.rails ends up None, so the plugin's input rail gets bypassed.
-    if config.data is None:
-        raise ValueError("GuardrailConfig.data is required for inline middleware calls.")
-
-    payload = config.data.model_dump(mode="json", exclude_none=True)
+    payload: dict[str, object] = config.data.model_dump(mode="json", exclude_none=True)
 
     # Thread the config name through as the inline diagnostic label so
     # log lines and the response's guardrails_data carry ``<inline:<name>>``

--- a/plugins/nemo-guardrails/tests/unit/benchmarks/test_run.py
+++ b/plugins/nemo-guardrails/tests/unit/benchmarks/test_run.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import httpx
+from nemo_guardrails_plugin.benchmarks.run import _smoke_test
+from nemo_guardrails_plugin.benchmarks.seeding import SeededResources
+from nemo_platform import NeMoPlatform
+
+
+def _seeded_resources() -> SeededResources:
+    return SeededResources(
+        workspace="benchmark",
+        app_provider_name="app-provider",
+        cs_provider_name="cs-provider",
+        app_model_entity="benchmark/app-model",
+        cs_model_entity="benchmark/cs-model",
+        guardrail_config_name="content-safety",
+        vm_name="guardrails-vm",
+        no_guardrails_vm_name="control-vm",
+    )
+
+
+def test_smoke_test_retries_until_virtual_model_route_is_ready(monkeypatch) -> None:
+    attempts = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return httpx.Response(404, request=request, json={"error": "not ready"})
+        return httpx.Response(200, request=request, json={"choices": [{"message": {"content": "ok"}}]})
+
+    monkeypatch.setattr("nemo_guardrails_plugin.benchmarks.run.time.sleep", lambda _seconds: None)
+    with httpx.Client(transport=httpx.MockTransport(handler)) as http_client:
+        sdk = NeMoPlatform(base_url="http://platform.test", http_client=http_client, max_retries=0)
+
+        _smoke_test(sdk, _seeded_resources())
+
+    assert attempts == 2

--- a/plugins/nemo-guardrails/tests/unit/benchmarks/test_seeding.py
+++ b/plugins/nemo-guardrails/tests/unit/benchmarks/test_seeding.py
@@ -2,8 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Generic, TypeVar
 from unittest.mock import MagicMock
 
 import pytest
@@ -22,22 +24,65 @@ from nemo_guardrails_plugin.benchmarks.seeding import (
     build_guardrail_config_data,
     seed_benchmark,
 )
+from nemo_platform import NeMoPlatform
+from nemo_platform_plugin.guardrail.client import GuardrailClient
+from nemo_platform_plugin.guardrail.types import CreateGuardrailConfigRequest
+from nemo_platform_plugin.inference_middleware import BackendFormat
+from nemo_platform_plugin.models.client import ModelsClient
+from nemo_platform_plugin.models.types import CreateModelProviderRequest, ModelProvider, ServedModelMapping
+from nemo_platform_plugin.virtual_models.client import VirtualModelsClient
+from nemo_platform_plugin.virtual_models.types import (
+    CreateVirtualModelRequest,
+    MiddlewareCall,
+    VirtualModel,
+    VirtualModelInferenceConfig,
+)
+from nemo_platform_plugin.workspaces.client import WorkspacesClient
 from nemo_platform_plugin.workspaces.types import CreateWorkspaceRequest
 
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
 
+ResponseT = TypeVar("ResponseT")
+_TIMESTAMP = datetime(2026, 1, 1, tzinfo=UTC)
 
-def _make_provider(*, provider_name: str, served_model_name: str, entity_suffix: str = "entity") -> SimpleNamespace:
-    return SimpleNamespace(
+
+class _ClientResponse(Generic[ResponseT]):
+    def __init__(self, value: ResponseT) -> None:
+        self._value = value
+
+    def data(self) -> ResponseT:
+        return self._value
+
+
+def _make_provider(*, provider_name: str, served_model_name: str, entity_suffix: str = "entity") -> ModelProvider:
+    return ModelProvider(
+        id=f"provider-{provider_name}",
         name=provider_name,
+        workspace=WORKSPACE,
+        host_url="http://test-provider:8000",
         served_models=[
-            SimpleNamespace(
+            ServedModelMapping(
                 served_model_name=served_model_name,
                 model_entity_id=f"{WORKSPACE}/{served_model_name.replace('/', '-')}-{entity_suffix}",
             )
         ],
+        created_at=_TIMESTAMP,
+        updated_at=_TIMESTAMP,
+    )
+
+
+def _make_virtual_model(*, workspace: str, body: CreateVirtualModelRequest) -> VirtualModel:
+    return VirtualModel(
+        name=body.name,
+        workspace=workspace,
+        default_model_entity=body.default_model_entity,
+        models=body.models,
+        request_middleware=body.request_middleware,
+        response_middleware=body.response_middleware,
+        post_response_middleware=body.post_response_middleware,
+        override_proxy=body.override_proxy,
     )
 
 
@@ -67,40 +112,41 @@ def _write_upstream_configs(ng_root: Path) -> Path:
     return cs_dir
 
 
-@pytest.fixture
-def stub_workspaces(monkeypatch) -> MagicMock:
-    """Point seed_benchmark's client_from_platform at a recording WorkspacesClient stub.
-
-    seed_benchmark creates the benchmark workspace through the typed
-    WorkspacesClient (client_from_platform), which a MagicMock platform cannot
-    drive (client_from_platform reads real SDK internals such as max_retries
-    to build its transport). The stub records create_workspace calls instead.
-    """
-    stub = MagicMock()
-    stub.create_workspace.return_value = SimpleNamespace(data=lambda: SimpleNamespace(name=WORKSPACE))
-    monkeypatch.setattr(
-        "nemo_guardrails_plugin.benchmarks.seeding.client_from_platform",
-        lambda platform, client_cls: stub,
-    )
-    return stub
+def _response(data: ResponseT) -> _ClientResponse[ResponseT]:
+    return _ClientResponse(data)
 
 
 @pytest.fixture
-def fake_client() -> MagicMock:
-    client = MagicMock()
-    client.inference.providers.create = MagicMock()
-    client.inference.providers.retrieve = MagicMock(
-        side_effect=lambda name, workspace=None: _make_provider(
-            provider_name=name,
-            served_model_name=APP_MODEL_NAME if name == APP_PROVIDER else CS_MODEL_NAME,
-        )
+def sdk() -> NeMoPlatform:
+    return NeMoPlatform(base_url="http://test:8000")
+
+
+@pytest.fixture
+def typed_client_mocks(monkeypatch) -> SimpleNamespace:
+    mocks = SimpleNamespace(
+        create_workspace=MagicMock(return_value=_response(SimpleNamespace(name=WORKSPACE))),
+        create_provider=MagicMock(),
+        get_provider=MagicMock(
+            side_effect=lambda *, name, workspace=None: _response(
+                _make_provider(
+                    provider_name=name,
+                    served_model_name=APP_MODEL_NAME if name == APP_PROVIDER else CS_MODEL_NAME,
+                )
+            )
+        ),
+        create_guardrail_config=MagicMock(return_value=_response(SimpleNamespace(name=GUARDRAIL_CONFIG))),
+        create_virtual_model=MagicMock(
+            side_effect=lambda *, workspace, body: _response(_make_virtual_model(workspace=workspace, body=body))
+        ),
+        get_virtual_model=MagicMock(),
     )
-    client.inference.virtual_models.create = MagicMock(
-        return_value=SimpleNamespace(name=VM_NAME, default_model_entity=f"{WORKSPACE}/app")
-    )
-    client.guardrail.configs.create = MagicMock(return_value=SimpleNamespace(name=GUARDRAIL_CONFIG))
-    client.workspaces.create = MagicMock(return_value=SimpleNamespace(name=WORKSPACE))
-    return client
+    monkeypatch.setattr(WorkspacesClient, "create_workspace", mocks.create_workspace)
+    monkeypatch.setattr(ModelsClient, "create_provider", mocks.create_provider)
+    monkeypatch.setattr(ModelsClient, "get_provider", mocks.get_provider)
+    monkeypatch.setattr(GuardrailClient, "create_guardrail_config", mocks.create_guardrail_config)
+    monkeypatch.setattr(VirtualModelsClient, "create_virtual_model", mocks.create_virtual_model)
+    monkeypatch.setattr(VirtualModelsClient, "get_virtual_model", mocks.get_virtual_model)
+    return mocks
 
 
 # ---------------------------------------------------------------------------
@@ -137,20 +183,20 @@ class TestBuildGuardrailConfigData:
 
 class TestSeedBenchmark:
     def test_calls_sdk_with_expected_payloads(
-        self, fake_client: MagicMock, stub_workspaces: MagicMock, tmp_path: Path
+        self, sdk: NeMoPlatform, typed_client_mocks: SimpleNamespace, tmp_path: Path
     ) -> None:
         ng_root = tmp_path / "NeMo-Guardrails"
         _write_upstream_configs(ng_root)
         generated_dir = tmp_path / "generated"
 
         seeded = seed_benchmark(
-            fake_client,
+            sdk,
             nemoguardrails_repo_root=ng_root,
             generated_dir=generated_dir,
             provider_wait_timeout=1.0,
         )
 
-        stub_workspaces.create_workspace.assert_called_once_with(
+        typed_client_mocks.create_workspace.assert_called_once_with(
             exist_ok=True,
             body=CreateWorkspaceRequest(
                 name=WORKSPACE,
@@ -158,54 +204,62 @@ class TestSeedBenchmark:
             ),
         )
         # Both providers registered.
-        provider_create_names = [c.kwargs["name"] for c in fake_client.inference.providers.create.call_args_list]
+        provider_create_names = [c.kwargs["body"].name for c in typed_client_mocks.create_provider.call_args_list]
         assert sorted(provider_create_names) == sorted([APP_PROVIDER, CS_PROVIDER])
+        for call in typed_client_mocks.create_provider.call_args_list:
+            assert call.kwargs["workspace"] == WORKSPACE
+            assert isinstance(call.kwargs["body"], CreateModelProviderRequest)
+            assert call.kwargs["exist_ok"] is True
 
         # Guardrail config payload uses the discovered content-safety entity.
-        gc_call = fake_client.guardrail.configs.create.call_args
-        assert gc_call.kwargs["name"] == GUARDRAIL_CONFIG
+        gc_call = typed_client_mocks.create_guardrail_config.call_args
         assert gc_call.kwargs["workspace"] == WORKSPACE
+        assert isinstance(gc_call.kwargs["body"], CreateGuardrailConfigRequest)
+        assert gc_call.kwargs["body"].name == GUARDRAIL_CONFIG
         assert gc_call.kwargs["exist_ok"] is True
         cs_entity = seeded.cs_model_entity
-        assert gc_call.kwargs["data"]["models"][0]["model"] == cs_entity
+        assert gc_call.kwargs["body"].data.models[0].model == cs_entity
 
         # Two VirtualModels are created: the guardrails VM (with middleware) and
         # a control VM (no middleware) used by the without-guardrails benchmark
         # variant.
-        vm_calls = fake_client.inference.virtual_models.create.call_args_list
+        vm_calls = typed_client_mocks.create_virtual_model.call_args_list
         assert len(vm_calls) == 2
 
         guardrails_vm_call = vm_calls[0]
-        assert guardrails_vm_call.kwargs["name"] == VM_NAME
-        assert guardrails_vm_call.kwargs["default_model_entity"] == seeded.app_model_entity
-        assert guardrails_vm_call.kwargs["models"] == [
-            {"model": seeded.app_model_entity, "backend_format": "OPENAI_CHAT"}
+        guardrails_body = guardrails_vm_call.kwargs["body"]
+        assert isinstance(guardrails_body, CreateVirtualModelRequest)
+        assert guardrails_body.name == VM_NAME
+        assert guardrails_body.default_model_entity == seeded.app_model_entity
+        assert guardrails_body.models == [
+            VirtualModelInferenceConfig(model=seeded.app_model_entity, backend_format=BackendFormat.OPENAI_CHAT)
         ]
         expected_middleware = [
-            {
-                "name": "nemo-guardrails",
-                "config_type": "guardrail_config",
-                "config_id": f"{WORKSPACE}/{GUARDRAIL_CONFIG}",
-            }
+            MiddlewareCall(
+                name="nemo-guardrails",
+                config_type="guardrail_config",
+                config_id=f"{WORKSPACE}/{GUARDRAIL_CONFIG}",
+            )
         ]
-        assert guardrails_vm_call.kwargs["request_middleware"] == expected_middleware
-        assert guardrails_vm_call.kwargs["response_middleware"] == expected_middleware
+        assert guardrails_body.request_middleware == expected_middleware
+        assert guardrails_body.response_middleware == expected_middleware
 
         control_vm_call = vm_calls[1]
-        assert control_vm_call.kwargs["name"] == NO_GUARDRAILS_VM_NAME
-        assert control_vm_call.kwargs["default_model_entity"] == seeded.app_model_entity
-        assert control_vm_call.kwargs["request_middleware"] == []
-        assert control_vm_call.kwargs["response_middleware"] == []
+        control_body = control_vm_call.kwargs["body"]
+        assert control_body.name == NO_GUARDRAILS_VM_NAME
+        assert control_body.default_model_entity == seeded.app_model_entity
+        assert control_body.request_middleware == []
+        assert control_body.response_middleware == []
 
     def test_generated_dir_contains_artifacts(
-        self, fake_client: MagicMock, stub_workspaces: MagicMock, tmp_path: Path
+        self, sdk: NeMoPlatform, typed_client_mocks: SimpleNamespace, tmp_path: Path
     ) -> None:
         ng_root = tmp_path / "NeMo-Guardrails"
         _write_upstream_configs(ng_root)
         generated_dir = tmp_path / "generated"
 
         seed_benchmark(
-            fake_client,
+            sdk,
             nemoguardrails_repo_root=ng_root,
             generated_dir=generated_dir,
             provider_wait_timeout=1.0,
@@ -223,12 +277,14 @@ class TestSeedBenchmark:
         assert request_payload["exist_ok"] is True
         assert request_payload["data"]["models"][0]["type"] == "content_safety"
 
-    def test_returns_seeded_resources(self, fake_client: MagicMock, stub_workspaces: MagicMock, tmp_path: Path) -> None:
+    def test_returns_seeded_resources(
+        self, sdk: NeMoPlatform, typed_client_mocks: SimpleNamespace, tmp_path: Path
+    ) -> None:
         ng_root = tmp_path / "NeMo-Guardrails"
         _write_upstream_configs(ng_root)
 
         seeded = seed_benchmark(
-            fake_client,
+            sdk,
             nemoguardrails_repo_root=ng_root,
             generated_dir=tmp_path / "generated",
             provider_wait_timeout=1.0,
@@ -239,18 +295,28 @@ class TestSeedBenchmark:
         assert seeded.no_guardrails_vm_name == NO_GUARDRAILS_VM_NAME
         assert seeded.guardrail_config_ref == f"{WORKSPACE}/{GUARDRAIL_CONFIG}"
 
-    def test_raises_if_served_models_never_populated(self, stub_workspaces: MagicMock, tmp_path: Path) -> None:
+    def test_raises_if_served_models_never_populated(
+        self, sdk: NeMoPlatform, typed_client_mocks: SimpleNamespace, tmp_path: Path
+    ) -> None:
         ng_root = tmp_path / "NeMo-Guardrails"
         _write_upstream_configs(ng_root)
 
-        client = MagicMock()
-        client.workspaces.create = MagicMock()
-        client.inference.providers.create = MagicMock()
-        client.inference.providers.retrieve = MagicMock(return_value=SimpleNamespace(served_models=[]))
+        typed_client_mocks.get_provider.return_value = _response(
+            ModelProvider(
+                id="provider-empty",
+                name=APP_PROVIDER,
+                workspace=WORKSPACE,
+                host_url="http://test-provider:8000",
+                served_models=[],
+                created_at=_TIMESTAMP,
+                updated_at=_TIMESTAMP,
+            )
+        )
+        typed_client_mocks.get_provider.side_effect = None
 
         with pytest.raises(TimeoutError, match="served model"):
             seed_benchmark(
-                client,
+                sdk,
                 nemoguardrails_repo_root=ng_root,
                 generated_dir=tmp_path / "generated",
                 provider_wait_timeout=0.1,

--- a/plugins/nemo-guardrails/tests/unit/test_llm_clients.py
+++ b/plugins/nemo-guardrails/tests/unit/test_llm_clients.py
@@ -4,7 +4,6 @@
 """Unit tests for request-scoped LLM client header plumbing."""
 
 from typing import Any, Protocol, cast
-from unittest.mock import MagicMock
 
 from nemo_guardrails_plugin import llm_clients
 from nemo_guardrails_plugin.llm_clients import (
@@ -13,7 +12,8 @@ from nemo_guardrails_plugin.llm_clients import (
     platform_headers_context,
     register_header_aware_nim_provider,
 )
-from nemo_platform_plugin.sdk_provider import get_forwarding_headers
+from nemo_platform_plugin.client.client import AsyncNemoClient
+from nemo_platform_plugin.client_provider import get_forwarding_headers
 from nemoguardrails.integrations.langchain.llm_adapter import LangChainLLMAdapter
 from nemoguardrails.llm.models.initializer import init_llm_model
 
@@ -45,29 +45,26 @@ def assert_and_get_header_aware_client(client: object) -> HeaderAwareClientForTe
     return cast(HeaderAwareClientForTest, client)
 
 
-def _make_fake_sdk(**custom_headers: str) -> MagicMock:
-    """Build a mock SDK with the given ``_custom_headers``."""
-    sdk = MagicMock()
-    sdk._custom_headers = custom_headers
-    return sdk
+def _make_client(**custom_headers: str) -> AsyncNemoClient:
+    return AsyncNemoClient(base_url="http://test:8000", default_headers=custom_headers)
 
 
 class TestGetForwardingHeaders:
     def test_returns_custom_headers_from_sdk(self) -> None:
-        sdk = _make_fake_sdk(
+        client = _make_client(
             **{
                 "X-NMP-Principal-Id": "service:guardrails-test",
                 "traceparent": "00-platform",
             }
         )
-        assert get_forwarding_headers(sdk) == {
+        assert get_forwarding_headers(client) == {
             "X-NMP-Principal-Id": "service:guardrails-test",
             "traceparent": "00-platform",
         }
 
     def test_returns_empty_for_sdk_with_no_custom_headers(self) -> None:
-        sdk = _make_fake_sdk()
-        assert get_forwarding_headers(sdk) == {}
+        client = _make_client()
+        assert get_forwarding_headers(client) == {}
 
 
 class TestRequestHeadersContext:
@@ -75,7 +72,7 @@ class TestRequestHeadersContext:
         assert get_request_headers() == {}
 
     def test_sets_platform_headers_and_resets_after_exit(self) -> None:
-        sdk = _make_fake_sdk(
+        client = _make_client(
             **{
                 "X-NMP-Principal-Id": "service:guardrails-test",
                 "traceparent": "00-platform",
@@ -84,7 +81,7 @@ class TestRequestHeadersContext:
 
         assert get_request_headers() == {}
 
-        with platform_headers_context(sdk):
+        with platform_headers_context(client):
             assert get_request_headers() == {
                 "traceparent": "00-platform",
                 "X-NMP-Principal-Id": "service:guardrails-test",
@@ -93,13 +90,13 @@ class TestRequestHeadersContext:
         assert get_request_headers() == {}
 
     def test_nested_contexts_restore_previous_headers(self) -> None:
-        outer_sdk = _make_fake_sdk(traceparent="outer")
-        inner_sdk = _make_fake_sdk(traceparent="inner")
+        outer_client = _make_client(traceparent="outer")
+        inner_client = _make_client(traceparent="inner")
 
-        with platform_headers_context(outer_sdk):
+        with platform_headers_context(outer_client):
             assert get_request_headers() == {"traceparent": "outer"}
 
-            with platform_headers_context(inner_sdk):
+            with platform_headers_context(inner_client):
                 assert get_request_headers() == {"traceparent": "inner"}
 
             assert get_request_headers() == {"traceparent": "outer"}
@@ -129,13 +126,13 @@ class TestHeaderAwareChatNVIDIA:
         assert client.model == "default/safety"
         assert client.default_headers == {"X-Static": "yes"}
 
-        sdk = _make_fake_sdk(
+        client_context = _make_client(
             **{
                 "X-NMP-Principal-Id": "service:guardrails-test",
                 "traceparent": "00-platform",
             }
         )
-        with platform_headers_context(sdk):
+        with platform_headers_context(client_context):
             _inputs, _payload, headers = client._prepare_inputs_and_payload([])
             assert headers == {
                 "X-Static": "yes",
@@ -164,8 +161,8 @@ class TestHeaderAwareChatNVIDIA:
             )
         )
 
-        sdk = _make_fake_sdk(**{"X-NMP-Principal-Id": "service:guardrails-test"})
-        with platform_headers_context(sdk):
+        client_context = _make_client(**{"X-NMP-Principal-Id": "service:guardrails-test"})
+        with platform_headers_context(client_context):
             _inputs, _payload, headers = client._prepare_inputs_and_payload([])
 
         assert headers == {
@@ -205,8 +202,8 @@ class TestRegisterHeaderAwareNimProvider:
         assert client.model == "default/safety"
         assert client.default_headers == {"X-Static": "yes"}
 
-        sdk = _make_fake_sdk(traceparent="00-platform")
-        with platform_headers_context(sdk):
+        client_context = _make_client(traceparent="00-platform")
+        with platform_headers_context(client_context):
             # The registered client must keep static config headers and merge
             # request-scoped platform headers at call time.
             _inputs, _payload, headers = client._prepare_inputs_and_payload([])

--- a/plugins/nemo-guardrails/tests/unit/test_llmrails_cache.py
+++ b/plugins/nemo-guardrails/tests/unit/test_llmrails_cache.py
@@ -44,7 +44,7 @@ from nemo_guardrails_plugin.llmrails_cache import (
     source_has_output_flows,
     stabilize,
 )
-from nemo_platform.types.guardrail import RailsConfig as PlatformRailsConfig
+from nemo_platform_plugin.guardrail.types import RailsConfig as PlatformRailsConfig
 from nemo_platform_plugin.inference_middleware import OpenAICompatibleInferenceTarget
 from nemoguardrails import RailsConfig
 from nemoguardrails.rails.llm.config import Model

--- a/plugins/nemo-guardrails/tests/unit/test_middleware.py
+++ b/plugins/nemo-guardrails/tests/unit/test_middleware.py
@@ -21,11 +21,11 @@ from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
-import nemo_platform
 import openai
 import pytest
 import pytest_asyncio
 from nemo_guardrails_plugin.constants import GUARDRAILS_PLUGIN_CONFIG_TYPE
+from nemo_guardrails_plugin.llm_clients import get_request_headers
 from nemo_guardrails_plugin.llmrails_cache import (
     EntityGuardrailConfigSource,
     InlineGuardrailConfigSource,
@@ -43,8 +43,11 @@ from nemo_guardrails_plugin.middleware import (
 )
 from nemo_guardrails_plugin.requests import parse_guardrails_request
 from nemo_guardrails_plugin.streaming import close_async_iterator
-from nemo_platform.types.guardrail import GuardrailConfig
-from nemo_platform.types.guardrail import RailsConfig as SDKRailsConfig
+from nemo_platform_plugin.client.client import AsyncNemoClient
+from nemo_platform_plugin.client.errors import NotFoundError
+from nemo_platform_plugin.guardrail.client import AsyncGuardrailClient
+from nemo_platform_plugin.guardrail.types import GuardrailConfig
+from nemo_platform_plugin.guardrail.types import RailsConfig as SDKRailsConfig
 from nemo_platform_plugin.inference_middleware import (
     ImmediateResponse,
     InferenceMiddlewareContext,
@@ -164,6 +167,45 @@ def _make_entity(
     )
 
 
+def _client_response(data: Any) -> MagicMock:
+    response = MagicMock()
+    response.data.return_value = data
+    return response
+
+
+def _patch_get_guardrail_config(
+    *,
+    return_value: Any = None,
+    side_effect: Any = None,
+) -> Any:
+    if return_value is not None:
+        mock = AsyncMock(return_value=_client_response(return_value))
+    elif callable(side_effect):
+
+        async def _wrapped_side_effect(*args: Any, **kwargs: Any) -> MagicMock:
+            result = side_effect(*args, **kwargs)
+            if hasattr(result, "__await__"):
+                result = await result
+            return _client_response(result)
+
+        mock = AsyncMock(side_effect=_wrapped_side_effect)
+    elif side_effect is not None:
+        mock = AsyncMock(side_effect=side_effect)
+    else:
+        mock = AsyncMock()
+    return patch.object(AsyncGuardrailClient, "get_guardrail_config", new=mock)
+
+
+def _not_found_error() -> NotFoundError:
+    return NotFoundError(
+        httpx.Response(
+            404,
+            request=httpx.Request("GET", "http://test:8000/apis/guardrails/v2/workspaces/ws/configs/missing"),
+            json={"detail": "not found"},
+        )
+    )
+
+
 def _make_generation_response(
     *,
     is_blocked: bool = False,
@@ -202,6 +244,12 @@ def _make_ctx(
         workspace="test-ws",
         original_request=_make_request(original_body or {}, original_headers),
     )
+
+
+def _request_scoped_client(mw: GuardrailsMiddleware, headers: dict[str, str]) -> AsyncNemoClient:
+    client = mw._client
+    assert client is not None
+    return client.with_options(headers=headers)
 
 
 async def _process_request(
@@ -290,22 +338,23 @@ def _patch_prepare_lease(rails: Any | None = None):
 
 @pytest_asyncio.fixture
 async def middleware() -> AsyncIterator[GuardrailsMiddleware]:
-    """A started middleware with a mocked SDK and a real cache.
+    """A started middleware with a mocked platform client and a real cache.
 
     Owns startup AND shutdown so any pool-owned resources are released
-    between tests. The platform SDK is injected the same way IGW injects
-    its caller-owned SDK at runtime.
+    between tests.
     """
     instance = GuardrailsMiddleware()
     instance._inject_cache(MagicMock())
-    mock_sdk = AsyncMock()
-    mock_sdk._custom_headers = {}
-    instance._inject_platform_sdk(mock_sdk)
-    await instance.on_startup()
-    try:
-        yield instance
-    finally:
-        await instance.on_shutdown()
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda request: httpx.Response(200, request=request))
+    ) as http_client:
+        client = AsyncNemoClient(base_url="http://test:8000", http_client=http_client)
+        instance._inject_platform_client(client)
+        await instance.on_startup()
+        try:
+            yield instance
+        finally:
+            await instance.on_shutdown()
 
 
 # ---------------------------------------------------------------------------
@@ -321,10 +370,10 @@ class TestGetMiddlewareConfig:
     async def test_returns_entity_source(self, middleware: GuardrailsMiddleware) -> None:
         """The resolver sets the discriminator: returns :class:`EntityGuardrailConfigSource`
         carrying provenance fields plus the SDK rails payload."""
-        assert middleware._sdk is not None
+        assert middleware._client is not None
         entity = _make_entity()
 
-        with patch.object(middleware._sdk.guardrail.configs, "retrieve", new=AsyncMock(return_value=entity)):
+        with _patch_get_guardrail_config(return_value=entity):
             result = await middleware.get_middleware_config(GUARDRAILS_PLUGIN_CONFIG_TYPE, "my-workspace/my-config")
 
         assert isinstance(result, EntityGuardrailConfigSource)
@@ -334,10 +383,9 @@ class TestGetMiddlewareConfig:
         assert result.rails is entity.data
 
     async def test_splits_config_id_correctly(self, middleware: GuardrailsMiddleware) -> None:
-        assert middleware._sdk is not None
-        retrieve_mock = AsyncMock(return_value=_make_entity())
-
-        with patch.object(middleware._sdk.guardrail.configs, "retrieve", new=retrieve_mock):
+        assert middleware._client is not None
+        entity = _make_entity()
+        with _patch_get_guardrail_config(return_value=entity) as retrieve_mock:
             await middleware.get_middleware_config(GUARDRAILS_PLUGIN_CONFIG_TYPE, "my-workspace/my-config")
 
         retrieve_mock.assert_awaited_once_with(name="my-config", workspace="my-workspace")
@@ -351,11 +399,10 @@ class TestGetMiddlewareConfig:
         """
         from nemo_platform_plugin.inference_middleware import MiddlewareConfigNotFoundError
 
-        assert middleware._sdk is not None
-        not_found = nemo_platform.NotFoundError("not found", response=MagicMock(), body=None)
-        retrieve_mock = AsyncMock(side_effect=not_found)
+        assert middleware._client is not None
+        not_found = _not_found_error()
 
-        with patch.object(middleware._sdk.guardrail.configs, "retrieve", new=retrieve_mock):
+        with _patch_get_guardrail_config(side_effect=not_found):
             with pytest.raises(MiddlewareConfigNotFoundError) as exc_info:
                 await middleware.get_middleware_config(GUARDRAILS_PLUGIN_CONFIG_TYPE, "ws/missing")
 
@@ -385,10 +432,9 @@ class TestGetMiddlewareConfig:
         name). ``parse_entity_ref`` rejects all of them with a clear
         ValueError → 400 at the plugin boundary. Pinning so a future
         "let's just split here, it's simpler" regression can't ship."""
-        assert middleware._sdk is not None
-        retrieve_mock = AsyncMock()
+        assert middleware._client is not None
 
-        with patch.object(middleware._sdk.guardrail.configs, "retrieve", new=retrieve_mock):
+        with _patch_get_guardrail_config() as retrieve_mock:
             with pytest.raises(ValueError):
                 await middleware.get_middleware_config(GUARDRAILS_PLUGIN_CONFIG_TYPE, config_id)
 
@@ -398,11 +444,13 @@ class TestGetMiddlewareConfig:
         """An entity whose ``data`` is ``None`` cannot be turned into a source —
         the structural check moves up here so the per-request path never has
         to defend against it."""
-        assert middleware._sdk is not None
+        assert middleware._client is not None
         entity = _make_entity()
-        entity.data = None
+        # Deliberately violates the model's non-null data contract to exercise
+        # the resolver guard against a malformed SDK/entity-store response.
+        object.__setattr__(entity, "data", None)
 
-        with patch.object(middleware._sdk.guardrail.configs, "retrieve", new=AsyncMock(return_value=entity)):
+        with _patch_get_guardrail_config(return_value=entity):
             with pytest.raises(ValueError, match="no data"):
                 await middleware.get_middleware_config(GUARDRAILS_PLUGIN_CONFIG_TYPE, "ws/my-config")
 
@@ -410,22 +458,22 @@ class TestGetMiddlewareConfig:
         """An entity carrying ``""`` for ``updated_at`` would seed a
         :class:`StabilizedRailsConfigCache` slot that can never collide cleanly
         with a real entity revision; reject at the resolver boundary."""
-        assert middleware._sdk is not None
+        assert middleware._client is not None
         entity = _make_entity()
         # Deliberately violates the model's ``datetime`` type to exercise the
         # "empty updated_at" guard against a malformed entity.
-        cast(Any, entity).updated_at = ""
+        object.__setattr__(entity, "updated_at", "")
 
-        with patch.object(middleware._sdk.guardrail.configs, "retrieve", new=AsyncMock(return_value=entity)):
+        with _patch_get_guardrail_config(return_value=entity):
             with pytest.raises(ValueError, match="empty updated_at"):
                 await middleware.get_middleware_config(GUARDRAILS_PLUGIN_CONFIG_TYPE, "ws/my-config")
 
     async def test_empty_name_raises_value_error(self, middleware: GuardrailsMiddleware) -> None:
-        assert middleware._sdk is not None
+        assert middleware._client is not None
         entity = _make_entity()
         entity.name = ""
 
-        with patch.object(middleware._sdk.guardrail.configs, "retrieve", new=AsyncMock(return_value=entity)):
+        with _patch_get_guardrail_config(return_value=entity):
             with pytest.raises(ValueError, match="no name"):
                 await middleware.get_middleware_config(GUARDRAILS_PLUGIN_CONFIG_TYPE, "ws/my-config")
 
@@ -434,11 +482,11 @@ class TestGetMiddlewareConfig:
         (different workspaces, same name + ``updated_at``) share a
         :class:`StabilizedRailsConfigCache` slot. Fail closed at the
         resolver boundary so the upstream never observes the collision."""
-        assert middleware._sdk is not None
+        assert middleware._client is not None
         entity = _make_entity()
         entity.workspace = ""
 
-        with patch.object(middleware._sdk.guardrail.configs, "retrieve", new=AsyncMock(return_value=entity)):
+        with _patch_get_guardrail_config(return_value=entity):
             with pytest.raises(ValueError, match="empty workspace"):
                 await middleware.get_middleware_config(GUARDRAILS_PLUGIN_CONFIG_TYPE, "ws/my-config")
 
@@ -1880,6 +1928,43 @@ class TestStreamingLeaseLifecycle:
         assert observed_active == [True, True]
         assert active is False
 
+    async def test_streaming_uses_request_scoped_client_headers(self, middleware: GuardrailsMiddleware) -> None:
+        request_body = self._streaming_request()
+        request_headers = {
+            "traceparent": "00-stream-request-trace",
+            "X-NMP-Principal-On-Behalf-Of": "user:bob",
+        }
+        ctx = _make_ctx(request_body)
+        ctx.request_nemo_client = _request_scoped_client(middleware, request_headers)
+        observed_headers: list[dict[str, str]] = []
+
+        def _handle_streaming_output_check(*_args: Any, **_kwargs: Any) -> AsyncIterator[dict[str, Any]]:
+            async def _inner() -> AsyncIterator[dict[str, Any]]:
+                observed_headers.append(dict(get_request_headers()))
+                yield {"choices": [{"delta": {"content": "checked"}}]}
+
+            return _inner()
+
+        with patch.object(middleware, "_prepare_lease", new=_patch_prepare_lease()):
+            with patch(
+                "nemo_guardrails_plugin.middleware.handle_streaming_output_check",
+                new=_handle_streaming_output_check,
+            ):
+                result = await _process_response(
+                    middleware,
+                    self._stream_one_chunk(),
+                    request_body,
+                    {},
+                    {},
+                    _entity_source(output_flows=["self check output"]),
+                    ctx=ctx,
+                )
+                assert is_streaming_response_result(result)
+                chunks = [chunk async for chunk in result]
+
+        assert chunks == [{"choices": [{"delta": {"content": "checked"}}]}]
+        assert observed_headers == [request_headers]
+
     async def test_natural_completion_returns_rails_to_pool(self, middleware: GuardrailsMiddleware) -> None:
         async def stream_async_impl(generator: Any, messages: Any) -> AsyncIterator[str]:
             async for token in generator:
@@ -2123,10 +2208,9 @@ class TestLifecycle:
         original_level = library_logger.level
         instance = GuardrailsMiddleware()
 
-        mock_sdk = AsyncMock()
-        mock_sdk._custom_headers = {}
-        instance._inject_platform_sdk(mock_sdk)
+        mock_client = AsyncMock(spec=AsyncNemoClient)
         try:
+            instance._inject_platform_client(mock_client)
             with (
                 patch(
                     "nemo_guardrails_plugin.middleware.get_common_service_config",
@@ -2138,31 +2222,31 @@ class TestLifecycle:
             assert library_logger.level == expected_library_level
         finally:
             library_logger.setLevel(original_level)
-            if instance._sdk is not None:
+            if instance._client is not None:
                 await instance.on_shutdown()
 
-    async def test_on_shutdown_detaches_sdk_and_closes_cache(self) -> None:
+    async def test_on_shutdown_clears_client_and_closes_cache(self) -> None:
         instance = GuardrailsMiddleware()
         instance._inject_cache(MagicMock())
 
-        mock_sdk = AsyncMock()
-        instance._inject_platform_sdk(mock_sdk)
+        mock_client = AsyncMock(spec=AsyncNemoClient)
+        instance._inject_platform_client(mock_client)
         await instance.on_startup()
 
         assert instance._rails_cache is not None
         assert instance._stable_cache is not None
         await instance.on_shutdown()
 
-        mock_sdk.close.assert_not_awaited()
+        assert instance._client is None
         assert instance._rails_cache is None
         assert instance._stable_cache is None
 
-    async def test_on_shutdown_detaches_sdk_even_when_cache_close_raises(self) -> None:
+    async def test_on_shutdown_clears_client_when_cache_close_raises(self) -> None:
         instance = GuardrailsMiddleware()
         instance._inject_cache(MagicMock())
 
-        mock_sdk = AsyncMock()
-        instance._inject_platform_sdk(mock_sdk)
+        mock_client = AsyncMock(spec=AsyncNemoClient)
+        instance._inject_platform_client(mock_client)
         await instance.on_startup()
 
         assert instance._rails_cache is not None
@@ -2170,8 +2254,7 @@ class TestLifecycle:
             with pytest.raises(RuntimeError, match="cache boom"):
                 await instance.on_shutdown()
 
-        mock_sdk.close.assert_not_awaited()
-        assert instance._sdk is None
+        assert instance._client is None
         assert instance._rails_cache is None
         assert instance._stable_cache is None
 
@@ -2254,10 +2337,10 @@ class TestVirtualModelLifecycle:
     async def test_upsert_warms_cache_for_each_unique_config(
         self, middleware: GuardrailsMiddleware, lifecycle_cache: Any
     ) -> None:
-        assert middleware._sdk is not None
+        assert middleware._client is not None
         entity = _make_entity(workspace="ws", name="guard-A")
 
-        with patch.object(middleware._sdk.guardrail.configs, "retrieve", new=AsyncMock(return_value=entity)):
+        with _patch_get_guardrail_config(return_value=entity):
             vm = _make_virtual_model(request_calls=[_guardrail_call("ws/guard-A")])
             await middleware.on_virtual_model_upserted(vm)
             await lifecycle_cache.await_warms()
@@ -2277,10 +2360,10 @@ class TestVirtualModelLifecycle:
         is by :attr:`StableRailsConfig.content_hash` at the warming layer,
         which catches both same-entity-twice (this test) and inline-vs-
         entity collisions where the rails happen to be identical."""
-        assert middleware._sdk is not None
+        assert middleware._client is not None
         entity = _make_entity(workspace="ws", name="guard-A")
 
-        with patch.object(middleware._sdk.guardrail.configs, "retrieve", new=AsyncMock(return_value=entity)):
+        with _patch_get_guardrail_config(return_value=entity):
             vm = _make_virtual_model(
                 request_calls=[_guardrail_call("ws/guard-A")],
                 response_calls=[_guardrail_call("ws/guard-A")],
@@ -2300,14 +2383,14 @@ class TestVirtualModelLifecycle:
         them to one warm (covered by
         :meth:`test_upsert_dedupes_inline_against_entity_with_same_content`).
         """
-        assert middleware._sdk is not None
+        assert middleware._client is not None
         entity_a = _make_entity(workspace="ws", name="guard-A", input_flows=["check-a"])
         entity_b = _make_entity(workspace="ws", name="guard-B", input_flows=["check-b"])
 
         async def _resolve(*, name: str, workspace: str) -> GuardrailConfig:
             return entity_a if name == "guard-A" else entity_b
 
-        with patch.object(middleware._sdk.guardrail.configs, "retrieve", new=AsyncMock(side_effect=_resolve)):
+        with _patch_get_guardrail_config(side_effect=_resolve):
             vm = _make_virtual_model(
                 request_calls=[
                     _guardrail_call("ws/guard-A"),
@@ -2324,8 +2407,8 @@ class TestVirtualModelLifecycle:
         }
 
     async def test_upsert_ignores_other_plugins(self, middleware: GuardrailsMiddleware, lifecycle_cache: Any) -> None:
-        assert middleware._sdk is not None
-        with patch.object(middleware._sdk.guardrail.configs, "retrieve", new=AsyncMock()) as mock_get:
+        assert middleware._client is not None
+        with _patch_get_guardrail_config() as mock_get:
             vm = _make_virtual_model(
                 request_calls=[
                     {
@@ -2345,12 +2428,8 @@ class TestVirtualModelLifecycle:
         self, middleware: GuardrailsMiddleware, lifecycle_cache: Any
     ) -> None:
         """A failing resolution must not break the IGW polling cycle."""
-        assert middleware._sdk is not None
-        with patch.object(
-            middleware._sdk.guardrail.configs,
-            "retrieve",
-            new=AsyncMock(side_effect=RuntimeError("sdk down")),
-        ):
+        assert middleware._client is not None
+        with _patch_get_guardrail_config(side_effect=RuntimeError("client down")):
             vm = _make_virtual_model(request_calls=[_guardrail_call("ws/guard-X")])
             # Must not raise; the next polling cycle retries.
             await middleware.on_virtual_model_upserted(vm)
@@ -2361,18 +2440,14 @@ class TestVirtualModelLifecycle:
     async def test_upsert_skips_when_config_id_has_been_deleted(
         self, middleware: GuardrailsMiddleware, lifecycle_cache: Any
     ) -> None:
-        """A 404 from the SDK during warming must not raise — the same
+        """A 404 from the client during warming must not raise — the same
         :class:`MiddlewareConfigNotFoundError` that IGW uses as the eviction
         signal would otherwise bubble up and stall the upsert hook for any
         other configs the VM references. ``_resolve_call`` swallows it the
         same way it swallows :class:`ValueError`."""
-        assert middleware._sdk is not None
-        not_found = nemo_platform.NotFoundError("not found", response=MagicMock(), body=None)
-        with patch.object(
-            middleware._sdk.guardrail.configs,
-            "retrieve",
-            new=AsyncMock(side_effect=not_found),
-        ):
+        assert middleware._client is not None
+        not_found = _not_found_error()
+        with _patch_get_guardrail_config(side_effect=not_found):
             vm = _make_virtual_model(request_calls=[_guardrail_call("ws/guard-deleted")])
             await middleware.on_virtual_model_upserted(vm)
             await lifecycle_cache.await_warms()
@@ -2419,14 +2494,14 @@ class TestVirtualModelLifecycle:
         this so the dedup-by-hash can't silently regress to dedup-by-(entity-
         identity OR inline-label) (which wouldn't catch the cross-arm
         collision and would warm two pool slots that share an LLMRails)."""
-        assert middleware._sdk is not None
+        assert middleware._client is not None
         rails_payload: dict[str, Any] = {"rails": {"input": {"flows": ["custom check"]}}}
         entity = _make_entity(workspace="ws", name="guard-A")
         # Make the entity's rails identical to the inline payload so they
         # produce the same ``content_hash``.
         entity.data = SDKRailsConfig.model_validate(rails_payload)
 
-        with patch.object(middleware._sdk.guardrail.configs, "retrieve", new=AsyncMock(return_value=entity)):
+        with _patch_get_guardrail_config(return_value=entity):
             vm = _make_virtual_model(
                 request_calls=[
                     _guardrail_call("ws/guard-A"),
@@ -2582,6 +2657,29 @@ class TestProcessRequestErrorSurfacing:
         assert observed_active == [True]
         assert active is False
 
+    async def test_run_rails_uses_request_scoped_client_headers(self, middleware: GuardrailsMiddleware) -> None:
+        request_body = {
+            "messages": [{"role": "user", "content": "Hi"}],
+            "model": "ws/llama",
+        }
+        request_headers = {
+            "traceparent": "00-request-trace",
+            "X-NMP-Principal-On-Behalf-Of": "user:alice",
+        }
+        ctx = _make_ctx(request_body)
+        ctx.request_nemo_client = _request_scoped_client(middleware, request_headers)
+        observed_headers: list[dict[str, str]] = []
+
+        def _generate(*_args: Any, **_kwargs: Any) -> GenerationResponse:
+            observed_headers.append(dict(get_request_headers()))
+            return _make_generation_response(is_blocked=False)
+
+        with patch.object(middleware, "_prepare_lease", new=_patch_prepare_lease()):
+            with patch("nemo_guardrails_plugin.middleware.run_generate_in_new_loop", side_effect=_generate):
+                await _process_request(middleware, request_body, {}, _entity_source(), ctx=ctx)
+
+        assert observed_headers == [request_headers]
+
     async def test_runtime_error_from_prepare_lease_wraps_to_503(self, middleware: GuardrailsMiddleware) -> None:
         """A non-caller-shape failure during eager lease setup (here: a
         ``RuntimeError`` simulating "cache not initialized" or a
@@ -2607,13 +2705,13 @@ class TestProcessRequestErrorSurfacing:
         assert isinstance(exc_info.value.__cause__, RuntimeError)
         assert "cache exploded" in str(exc_info.value.__cause__)
 
-    async def test_sdk_not_initialized_wraps_to_503(self, middleware: GuardrailsMiddleware) -> None:
-        """SDK detached after ``on_shutdown`` must map to 503, not a raw
+    async def test_client_not_initialized_wraps_to_503(self, middleware: GuardrailsMiddleware) -> None:
+        """Client detached after ``on_shutdown`` must map to 503, not a raw
         ``RuntimeError``, on both the non-streaming and streaming paths.
 
-        ``_ensure_sdk`` lives inside :meth:`_prepare_lease_with_503` so the
+        ``_ensure_client`` lives inside :meth:`_prepare_lease_with_503` so the
         same lifecycle boundary that wraps cache/stabilize failures also
-        covers SDK validation — without this, a shutdown race escaped as
+        covers client validation — without this, a shutdown race escaped as
         IGW 500.
         """
         request_body = {
@@ -2621,14 +2719,14 @@ class TestProcessRequestErrorSurfacing:
             "model": "ws/llama",
         }
 
-        middleware._sdk = None
+        middleware._client = None
 
         with patch.object(middleware, "_prepare_lease", new=_patch_prepare_lease()):
             with pytest.raises(InferenceMiddlewareUnavailableError) as exc_info:
                 await _process_request(middleware, request_body, {}, _entity_source())
 
         assert isinstance(exc_info.value.__cause__, RuntimeError)
-        assert "SDK is not initialized" in str(exc_info.value.__cause__)
+        assert "client is not initialized" in str(exc_info.value.__cause__)
 
         async def _stream() -> AsyncIterator[dict[str, Any]]:
             yield {"choices": []}
@@ -2645,7 +2743,7 @@ class TestProcessRequestErrorSurfacing:
                 )
 
         assert isinstance(stream_exc.value.__cause__, RuntimeError)
-        assert "SDK is not initialized" in str(stream_exc.value.__cause__)
+        assert "client is not initialized" in str(stream_exc.value.__cause__)
 
     async def test_bracketed_upstream_400_from_rail_task_llm_preserved(self, middleware: GuardrailsMiddleware) -> None:
         """A rail-task LLM call (e.g. a vision-safety judge, via

--- a/plugins/nemo-guardrails/tests/unit/test_rails.py
+++ b/plugins/nemo-guardrails/tests/unit/test_rails.py
@@ -35,8 +35,8 @@ from nemo_guardrails_plugin.requests import (
     sanitize_request_body_for_proxy,
 )
 from nemo_guardrails_plugin.responses import extract_response_content
-from nemo_platform.types.guardrail import GenerationLogOptionsParam
-from nemo_platform.types.guardrail import RailsConfig as SDKRailsConfig
+from nemo_platform_plugin.guardrail.types import GenerationLogOptionsParam
+from nemo_platform_plugin.guardrail.types import RailsConfig as SDKRailsConfig
 from nemo_platform_plugin.inference_middleware import InferenceMiddlewareError, OpenAICompatibleInferenceTarget
 from nemoguardrails.rails.llm.config import Model
 from nemoguardrails.rails.llm.options import (

--- a/services/core/inference-gateway/src/nmp/core/inference_gateway/api/middleware_registry.py
+++ b/services/core/inference-gateway/src/nmp/core/inference_gateway/api/middleware_registry.py
@@ -19,6 +19,8 @@ from fastapi import HTTPException
 from nemo_platform import AsyncNeMoPlatform
 from nemo_platform.types.inference.middleware_call import MiddlewareCall as SDKMiddlewareCall
 from nemo_platform.types.inference.virtual_model import VirtualModel as SDKVirtualModel
+from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.client.client import AsyncNemoClient
 from nemo_platform_plugin.discovery import discover_inference_middleware
 from nemo_platform_plugin.inference_middleware import (
     BackendFormat,
@@ -769,7 +771,9 @@ async def load_middleware_plugins(
             instance = cls()
             instance._inject_cache(accessor)
             if plugin_sdk_factory is not None:
-                instance._inject_platform_sdk(plugin_sdk_factory(name))
+                sdk = plugin_sdk_factory(name)
+                instance._inject_platform_sdk(sdk)
+                instance._inject_platform_client(client_from_platform(sdk, AsyncNemoClient))
             await instance.on_startup()
             plugins[name] = instance
             logger.info("Loaded inference middleware plugin %r (%s)", name, cls.__qualname__)

--- a/services/core/inference-gateway/src/nmp/core/inference_gateway/api/proxy.py
+++ b/services/core/inference-gateway/src/nmp/core/inference_gateway/api/proxy.py
@@ -20,6 +20,7 @@ from multidict import CIMultiDict, CIMultiDictProxy
 from nemo_platform import AsyncNeMoPlatform
 from nemo_platform.types.inference.virtual_model import VirtualModel as SDKVirtualModel
 from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.client.client import AsyncNemoClient
 from nemo_platform_plugin.client.errors import NotFoundError as ClientNotFoundError
 from nemo_platform_plugin.inference_middleware import (
     BackendFormat,
@@ -771,16 +772,16 @@ def _build_inference_response_with_annotations(inference_response: InferenceResp
     if not annotations:
         return inference_response
 
+    response_result = inference_response.result
     # For streaming responses, annotations are accumulated but not serialized
     # in the initial implementation.
-    if not isinstance(inference_response.result, dict):
+    if not isinstance(response_result, dict):
         return inference_response
 
-    result_with_annotations: dict[str, Any] = {}
     if isinstance(inference_response.typed_body, BaseModel):
-        result_with_annotations.update(inference_response.typed_body.model_dump(mode="json"))
+        result_with_annotations: dict[str, Any] = inference_response.typed_body.model_dump(mode="json")
     else:
-        result_with_annotations.update(inference_response.result)
+        result_with_annotations = dict(response_result)
 
     # Merge annotations into the result, only if the key is not already present.
     result_with_annotations.update(
@@ -851,6 +852,7 @@ async def virtual_model_proxy(
     http_client: ClientSession,
     model_cache: "ModelCache",
     registry: "MiddlewareRegistry",
+    request_nemo_client: AsyncNemoClient | None = None,
 ) -> Response:
     """Execute the full VirtualModel middleware pipeline and return a streaming response.
 
@@ -911,6 +913,7 @@ async def virtual_model_proxy(
         virtual_model_name=vm_name,
         workspace=workspace,
         original_request=original_request,
+        request_nemo_client=request_nemo_client,
     )
     initial_request = build_inference_request(
         body=json_body,

--- a/services/core/inference-gateway/src/nmp/core/inference_gateway/api/v2/models.py
+++ b/services/core/inference-gateway/src/nmp/core/inference_gateway/api/v2/models.py
@@ -6,6 +6,8 @@ from typing import Annotated
 
 from aiohttp import ClientSession
 from fastapi import APIRouter, Depends, Request, Response, status
+from nemo_platform_plugin.client.client import AsyncNemoClient
+from nmp.common.service.dependencies import get_nemo_client
 from nmp.core.inference_gateway.api.authz import (
     MODEL_EXEC_PERMISSION,
     enforce_delegated_workspace_access,
@@ -80,6 +82,7 @@ async def model_entity_proxy(
     name: str,
     trailing_uri: str,
     http_client: Annotated[ClientSession, Depends(global_http_client)],
+    nemo_client: Annotated[AsyncNemoClient, Depends(get_nemo_client)],
     model_cache: Annotated[ModelCache, Depends(global_model_cache)],
     virtual_model_cache: Annotated[VirtualModelCache, Depends(global_virtual_model_cache)],
     registry: Annotated[MiddlewareRegistry, Depends(global_middleware_registry)],
@@ -134,4 +137,5 @@ async def model_entity_proxy(
         http_client=http_client,
         model_cache=model_cache,
         registry=registry,
+        request_nemo_client=nemo_client,
     )

--- a/services/core/inference-gateway/src/nmp/core/inference_gateway/api/v2/openai.py
+++ b/services/core/inference-gateway/src/nmp/core/inference_gateway/api/v2/openai.py
@@ -7,6 +7,8 @@ from typing import Annotated
 
 from aiohttp import ClientSession
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from nemo_platform_plugin.client.client import AsyncNemoClient
+from nmp.common.service.dependencies import get_nemo_client
 from nmp.core.inference_gateway.api.authz import (
     OPENAI_EXEC_PERMISSION,
     enforce_delegated_workspace_access,
@@ -207,6 +209,7 @@ async def openai_proxy(
     workspace: str,
     trailing_uri: str,
     http_client: Annotated[ClientSession, Depends(global_http_client)],
+    nemo_client: Annotated[AsyncNemoClient, Depends(get_nemo_client)],
     model_cache: Annotated[ModelCache, Depends(global_model_cache)],
     virtual_model_cache: Annotated[VirtualModelCache, Depends(global_virtual_model_cache)],
     registry: Annotated[MiddlewareRegistry, Depends(global_middleware_registry)],
@@ -271,4 +274,5 @@ async def openai_proxy(
         http_client=http_client,
         model_cache=model_cache,
         registry=registry,
+        request_nemo_client=nemo_client,
     )

--- a/services/core/inference-gateway/src/nmp/core/inference_gateway/testing/harness.py
+++ b/services/core/inference-gateway/src/nmp/core/inference_gateway/testing/harness.py
@@ -36,6 +36,7 @@ from nemo_platform.types.inference.middleware_call_param import MiddlewareCallPa
 from nemo_platform.types.inference.virtual_model import VirtualModel as SDKVirtualModel
 from nemo_platform.types.inference.virtual_model_inference_config_param import VirtualModelInferenceConfigParam
 from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.client.client import AsyncNemoClient
 from nemo_platform_plugin.discovery import discover_inference_middleware
 from nemo_platform_plugin.inference_middleware import NemoInferenceMiddleware
 from nemo_platform_plugin.secrets.client import SecretsClient
@@ -329,7 +330,9 @@ class IGWPluginHarness:
         original = self._registry.plugins.get(name)
 
         plugin._inject_cache(self._cache_accessor)
-        plugin._inject_platform_sdk(self._plugin_sdk(name))
+        sdk = self._plugin_sdk(name)
+        plugin._inject_platform_sdk(sdk)
+        plugin._inject_platform_client(client_from_platform(sdk, AsyncNemoClient))
         if call_lifecycle:
             asyncio.run(plugin.on_startup())
         self._registry.plugins[name] = plugin
@@ -373,7 +376,9 @@ class IGWPluginHarness:
         original = self._registry.plugins.get(name)
 
         plugin._inject_cache(self._cache_accessor)
-        plugin._inject_platform_sdk(self._plugin_sdk(name))
+        sdk = self._plugin_sdk(name)
+        plugin._inject_platform_sdk(sdk)
+        plugin._inject_platform_client(client_from_platform(sdk, AsyncNemoClient))
         if call_lifecycle:
             await plugin.on_startup()
         self._registry.plugins[name] = plugin

--- a/services/core/inference-gateway/tests/unit/test_middleware_registry.py
+++ b/services/core/inference-gateway/tests/unit/test_middleware_registry.py
@@ -764,6 +764,33 @@ class TestLoadMiddlewarePlugins:
         injected = instance._inject_cache.call_args[0][0]
         assert isinstance(injected, InferenceMiddlewareCacheAccessorImpl)
 
+    @pytest.mark.asyncio
+    async def test_load_injects_typed_client_from_plugin_sdk(self):
+        plugin_cls = MagicMock()
+        instance = _make_mock_plugin()
+        plugin_cls.return_value = instance
+        sdk = MagicMock()
+        client = MagicMock()
+
+        with patch(
+            "nmp.core.inference_gateway.api.middleware_registry.discover_inference_middleware",
+            return_value={"my-plugin": plugin_cls},
+        ):
+            with patch(
+                "nmp.core.inference_gateway.api.middleware_registry.client_from_platform",
+                return_value=client,
+            ) as adapt:
+                await load_middleware_plugins(
+                    ModelCache(),
+                    VirtualModelCache(),
+                    plugin_sdk_factory=lambda _name: sdk,
+                )
+
+        adapt.assert_called_once()
+        assert adapt.call_args.args[0] is sdk
+        instance._inject_platform_sdk.assert_called_once_with(sdk)
+        instance._inject_platform_client.assert_called_once_with(client)
+
     @skip_flaky_caplog
     @pytest.mark.asyncio
     async def test_load_fault_isolation_broken_import(self, caplog):

--- a/services/core/inference-gateway/tests/unit/test_proxy.py
+++ b/services/core/inference-gateway/tests/unit/test_proxy.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, Mock
 
 import aiohttp
 import anthropic.types as anthropic_types
+import httpx
 import openai.types.chat as openai_chat_types
 import pytest
 import pytest_asyncio
@@ -22,6 +23,7 @@ from fastapi.responses import StreamingResponse
 from multidict import CIMultiDict, CIMultiDictProxy
 from nemo_platform.types.inference import ModelProvider, ServedModelMapping
 from nemo_platform.types.inference.virtual_model import VirtualModel as SDKVirtualModel
+from nemo_platform_plugin.client.client import AsyncNemoClient
 from nemo_platform_plugin.inference_middleware import (
     BackendFormat,
     ImmediateResponse,
@@ -367,6 +369,68 @@ async def test_virtual_model_proxy_typed_context_defaults_unset_backend_format_t
 
     assert response.status_code == 200
     assert seen_backend_formats == [BackendFormat.OPENAI_CHAT]
+
+
+@pytest.mark.asyncio
+async def test_virtual_model_proxy_adds_request_nemo_client_to_middleware_context(mock_proxy_client):
+    seen_clients: list[AsyncNemoClient | None] = []
+
+    class _ContextPlugin(NemoInferenceMiddleware):
+        async def process_request(
+            self,
+            ctx: InferenceMiddlewareContext,
+            request: InferenceRequest,
+            middleware_config: object,
+        ) -> ImmediateResponse:
+            seen_clients.append(ctx.request_nemo_client)
+            return ImmediateResponse(data={"ok": True})
+
+    workspace = "e2e-test"
+    vm_name = "my-router"
+    registry = MiddlewareRegistry(plugins={"test-plugin": _ContextPlugin()})
+    registry.request_middleware_calls[(workspace, vm_name)] = [
+        ResolvedMiddlewareCall(plugin_name="test-plugin", config_type="t", resolved_config={})
+    ]
+
+    request = Mock(spec=Request)
+    request.method = "POST"
+    request.headers = {"content-type": "application/json"}
+    request.query_params = {}
+
+    async with httpx.AsyncClient() as http_client:
+        request_nemo_client = AsyncNemoClient(
+            base_url="http://platform.test",
+            default_headers={"traceparent": "00-request"},
+            http_client=http_client,
+        )
+
+        response = await virtual_model_proxy(
+            request=request,
+            workspace=workspace,
+            vm_name=vm_name,
+            virtual_model=SDKVirtualModel(
+                id=f"{workspace}/{vm_name}",
+                entity_id=f"{workspace}/{vm_name}",
+                name=vm_name,
+                workspace=workspace,
+                parent=workspace,
+                db_version=1,
+                created_at="2026-01-01T00:00:00Z",
+                updated_at="2026-01-01T00:00:00Z",
+            ),
+            trailing_uri="v1/chat/completions",
+            json_body={"model": vm_name, "messages": [{"role": "user", "content": "hi"}]},
+            http_client=mock_proxy_client,
+            model_cache=ModelCache(),
+            registry=registry,
+            request_nemo_client=request_nemo_client,
+        )
+
+    assert isinstance(response, StreamingResponse)
+    body = json.loads(await _read_streaming_response(response))
+    assert body == {"ok": True}
+    assert seen_clients == [request_nemo_client]
+    mock_proxy_client.request.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
Migrates the NeMo Guardrails plugin to the in-repo `nemo_platform_plugin` typed clients while preserving `NeMoPlatform` as the SDK instantiation boundary where that is the correct entry point. IGW now injects a request-scoped typed platform client into middleware so Guardrails can resolve stored configs during VirtualModel validation while preserving caller trace/delegation headers.

## Changes
- Expanded typed Guardrails DTOs for rails config, generation logs, stats, activated rails, and guardrails response data.
- Added typed client provider helpers and middleware context plumbing for request-scoped client access in IGW middleware.
- Updated Guardrails middleware, cache and rails helpers, request/response transforms, LLM client header forwarding, and benchmark seeding to use typed-client APIs behind the appropriate `NeMoPlatform`/typed-client boundary.
- Restored the Guardrails benchmark analysis thresholds and docs so this PR does not relax the existing performance gate.
- Added and updated package, plugin, and IGW coverage around typed DTOs, middleware config lookup, header forwarding, benchmark behavior, config caching, rail execution, and import boundaries.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `uv run pre-commit run -a` — passed.
- `uv run --frozen pytest packages/nemo_platform_plugin/tests/test_inference_middleware_imports.py packages/nemo_platform_plugin/tests/test_inference_middleware.py -v` — passed, 64 passed.
- `uv run --frozen pytest plugins/nemo-guardrails/tests/unit/test_benchmark_analyze.py plugins/nemo-guardrails/tests/unit/benchmarks` — passed, 31 passed.
- `uv run --frozen ruff check packages/nemo_platform_plugin/src/nemo_platform_plugin/inference_middleware.py packages/nemo_platform_plugin/tests/test_inference_middleware_imports.py packages/nemo_platform_plugin/tests/test_inference_middleware.py` — passed.
- `uv run --frozen ty check packages/nemo_platform_plugin/src/nemo_platform_plugin/inference_middleware.py packages/nemo_platform_plugin/tests/test_inference_middleware_imports.py packages/nemo_platform_plugin/tests/test_inference_middleware.py` — passed.
- `uv lock --check` — passed.
- `make benchmark-guardrails NEMO_GUARDRAILS_REPO_ROOT=/private/tmp/nemo-guardrails-benchmark-src BENCHMARK_ARGS="--run-id codex-retest-platform-sdk-20260911"` — passed; `with-guardrails` and `without-guardrails` each completed 7/7 runs with 0 failures.
- `python3 plugins/nemo-guardrails/src/nemo_guardrails_plugin/benchmarks/analyze.py plugins/nemo-guardrails/benchmarks/artifacts/runs/codex-retest-platform-sdk-20260911 --strict` — passed.
- GitHub `Secrets Scan` — passed.
