### PR TITLE
refactor(customization): migrate plugins to typed clients

### DIFF
--- a/packages/nemo_platform/pyproject.toml
+++ b/packages/nemo_platform/pyproject.toml
@@ -85,7 +85,6 @@ automodel-service = [
   "nmp-common",
   "nmp-customization-common",
   "nemo-platform-plugin",
-  "nemo-platform-sdk",
   "pydantic>=2.10.6",
   "pydantic-settings>=2.6.1",
   "httpx>=0.27.0",
@@ -531,8 +530,8 @@ nmp-common = [
 # Generated from [tool.bundle-package]; do not edit by hand.
 nmp-customization-common = [
   "nmp-common",
-  "nemo-platform-sdk",
   "nemo-platform-plugin",
+  "filesets",
   "pydantic>=2.10.6",
   "pydantic-settings>=2.6.1",
   "httpx>=0.27.0",
@@ -573,7 +572,6 @@ rl-service = [
   "nmp-common",
   "nmp-customization-common",
   "nemo-platform-plugin",
-  "nemo-platform-sdk",
   "pydantic>=2.10.6",
   "pydantic-settings>=2.6.1",
   "httpx>=0.27.0",

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/client/adapter.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/client/adapter.py
@@ -3,7 +3,7 @@
 
 """Adapter to create a :class:`NemoClient` from an existing :class:`NeMoPlatform`.
 
-This bridges the legacy ``NeMoPlatform`` SDK with the new typed client,
+This bridges the generated ``NeMoPlatform`` SDK with the new typed client,
 allowing plugins registered via ``NemoPluginSDKResources`` to use the
 new endpoint/client infrastructure internally.
 
@@ -28,6 +28,17 @@ SyncT = TypeVar("SyncT", bound=NemoClient)
 AsyncT = TypeVar("AsyncT", bound=AsyncNemoClient)
 
 
+def _platform_default_headers(platform: NeMoPlatform | AsyncNeMoPlatform) -> dict[str, str] | None:
+    # Prefer _custom_headers (set via with_options/set_default_headers),
+    # fall back to the httpx client's actual headers (set at construction,
+    # e.g. TestClient(headers={...})), filtering out httpx defaults.
+    headers = {key: value for key, value in platform._custom_headers.items() if isinstance(value, str)}
+    if not headers:
+        skip = {"accept", "accept-encoding", "connection", "user-agent", "host"}
+        headers = {key: value for key, value in platform._client.headers.items() if key.lower() not in skip}
+    return headers or None
+
+
 @overload
 def client_from_platform(platform: NeMoPlatform, client_cls: type[SyncT]) -> SyncT: ...
 @overload
@@ -42,14 +53,7 @@ def client_from_platform(
 
     The overloads preserve the sync/async pairing between platform and client.
     """
-    # Prefer _custom_headers (set via with_options/set_default_headers),
-    # fall back to the httpx client's actual headers (set at construction,
-    # e.g. TestClient(headers={...})), filtering out httpx defaults.
-    headers = platform._custom_headers
-    if not headers:
-        _skip = {"accept", "accept-encoding", "connection", "user-agent", "host"}
-        headers = {k: v for k, v in platform._client.headers.items() if k.lower() not in _skip}
-
+    headers = _platform_default_headers(platform)
     retry = RetryPolicy(
         max_retries=platform.max_retries,
         retryable_status_codes=(408, 409, 429),
@@ -77,10 +81,11 @@ def client_from_platform(
         return client_cls(
             base_url=str(platform.base_url).rstrip("/"),
             workspace=platform.workspace,
-            default_headers=headers or None,
+            default_headers=headers,
             timeout=timeout,
             retry=retry,
             http_client=platform._client,
+            owns_http_client=False,
             url_resolver=url_resolver,
         )
 
@@ -89,9 +94,10 @@ def client_from_platform(
     return client_cls(
         base_url=str(platform.base_url).rstrip("/"),
         workspace=platform.workspace,
-        default_headers=headers or None,
+        default_headers=headers,
         timeout=timeout,
         retry=retry,
         http_client=platform._client,
+        owns_http_client=False,
         url_resolver=url_resolver,
     )

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/client/client.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/client/client.py
@@ -386,6 +386,7 @@ class BaseNemoClient(Generic[HttpClientT]):
     """
 
     _http: HttpClientT
+    _owns_http: bool
 
     def __init__(
         self,
@@ -512,6 +513,7 @@ class BaseNemoClient(Generic[HttpClientT]):
             client.with_options(timeout=300).update_fileset(...)
         """
         clone = copy.copy(self)
+        clone._owns_http = False
         if headers:
             clone._default_headers = {**self._default_headers, **headers}
         if retry is not None:
@@ -657,6 +659,7 @@ class NemoClient(BaseNemoClient[httpx.Client]):
         timeout: float | httpx.Timeout | None = None,
         retry: RetryPolicy | None = None,
         http_client: httpx.Client | None = None,
+        owns_http_client: bool | None = None,
         url_resolver: Callable[[str], str | httpx.URL] | None = None,
     ) -> None:
         """Create a client.
@@ -682,6 +685,7 @@ class NemoClient(BaseNemoClient[httpx.Client]):
             timeout=timeout,
             url_resolver=url_resolver,
         )
+        self._owns_http = http_client is None if owns_http_client is None else owns_http_client
         self._http = http_client or httpx.Client(
             headers=dict(default_headers) if default_headers else None,
             timeout=timeout if timeout is not None else DEFAULT_TIMEOUT,
@@ -699,8 +703,14 @@ class NemoClient(BaseNemoClient[httpx.Client]):
             timeout=client._timeout,
             retry=client._retry,
             http_client=client._http,
+            owns_http_client=False,
             url_resolver=client._url_resolver,
         )
+
+    def close(self) -> None:
+        """Close the underlying sync HTTP transport."""
+        if self._owns_http:
+            self._http.close()
 
     @overload
     def send(
@@ -922,6 +932,7 @@ class AsyncNemoClient(BaseNemoClient[httpx.AsyncClient]):
         timeout: float | httpx.Timeout | None = None,
         retry: RetryPolicy | None = None,
         http_client: httpx.AsyncClient | None = None,
+        owns_http_client: bool | None = None,
         url_resolver: Callable[[str], str | httpx.URL] | None = None,
     ) -> None:
         """Create a client. See :meth:`NemoClient.__init__` for *timeout*."""
@@ -940,6 +951,7 @@ class AsyncNemoClient(BaseNemoClient[httpx.AsyncClient]):
             timeout=timeout,
             url_resolver=url_resolver,
         )
+        self._owns_http = http_client is None if owns_http_client is None else owns_http_client
         self._http = http_client or httpx.AsyncClient(
             headers=dict(default_headers) if default_headers else None,
             timeout=timeout if timeout is not None else DEFAULT_TIMEOUT,
@@ -957,6 +969,7 @@ class AsyncNemoClient(BaseNemoClient[httpx.AsyncClient]):
             timeout=client._timeout,
             retry=client._retry,
             http_client=client._http,
+            owns_http_client=False,
             url_resolver=client._url_resolver,
         )
 
@@ -970,9 +983,15 @@ class AsyncNemoClient(BaseNemoClient[httpx.AsyncClient]):
             timeout=self._timeout,
             retry=self._retry,
             http_client=http_client,
+            owns_http_client=False,
             url_resolver=self._url_resolver,
         )
         return type(self).from_client(transport_owner)
+
+    async def aclose(self) -> None:
+        """Close the underlying async HTTP transport."""
+        if self._owns_http:
+            await self._http.aclose()
 
     @overload
     async def send(

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/entities/base.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/entities/base.py
@@ -536,7 +536,7 @@ class EntityClient:
 
         This should be called during shutdown to properly close HTTP connections.
         """
-        await self._client._http.aclose()
+        await self._client.aclose()
 
     def _convert_api_entity_to_model(self, entity: Entity, entity_type: EntityTypeLike) -> EntityT:
         """Convert an API entity to an EntityBase model."""
@@ -1067,7 +1067,7 @@ class SyncEntityClient:
 
         This should be called during shutdown to properly close HTTP connections.
         """
-        self._client._http.close()
+        self._client.close()
 
     def _convert_api_entity_to_model(self, entity: Entity, entity_type: EntityTypeLike) -> EntityT:
         """Convert an API entity to an EntityBase model."""

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/job_results.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/job_results.py
@@ -29,8 +29,6 @@ import shutil
 from abc import ABC, abstractmethod
 from pathlib import Path
 
-from nemo_platform import NeMoPlatform
-from nemo_platform_plugin.client.adapter import client_from_platform
 from nemo_platform_plugin.client.client import NemoClient
 from nemo_platform_plugin.files.client import FilesClient
 from nemo_platform_plugin.jobs.client import JobsClient
@@ -158,8 +156,8 @@ class PlatformJobResults(JobResults):
     Args:
         job_name: Platform job name this sink publishes results for.
         workspace: Workspace the job lives in.
-        sdk: :class:`NeMoPlatform` handle used for both file uploads and
-            the jobs-results registration.
+        client: Typed root client used for both file uploads and the jobs-results
+            registration.
         attempt_id: Optional override for the job attempt id; when
             omitted, looked up lazily via the typed Jobs client.
     """
@@ -169,13 +167,13 @@ class PlatformJobResults(JobResults):
         *,
         job_name: str,
         workspace: str,
-        sdk: NeMoPlatform,
+        client: NemoClient,
         attempt_id: str | None = None,
     ) -> None:
         self._configure_manager(
             job_name=job_name,
             workspace=workspace,
-            client=client_from_platform(sdk, NemoClient),
+            client=client,
             attempt_id=attempt_id,
         )
 

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/sdk.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/sdk.py
@@ -32,7 +32,5 @@ class NemoPluginSDKResources(Generic[SyncResourceT, AsyncResourceT]):
 
 
 __all__ = [
-    "AsyncNeMoPlatform",
-    "NeMoPlatform",
     "NemoPluginSDKResources",
 ]

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/seed.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/seed.py
@@ -47,9 +47,9 @@ from __future__ import annotations
 from abc import abstractmethod
 from typing import ClassVar
 
+from nemo_platform import AsyncNeMoPlatform
 from nemo_platform_plugin._base import _NamedPlugin
 from nemo_platform_plugin.entity_client import NemoEntitiesClient
-from nemo_platform_plugin.sdk import AsyncNeMoPlatform
 
 
 class NemoSeedJob(_NamedPlugin):

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/tasks/dispatcher.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/tasks/dispatcher.py
@@ -47,6 +47,8 @@ from pathlib import Path
 from typing import Any
 
 from nemo_platform import NeMoPlatform
+from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.client.client import NemoClient
 from nemo_platform_plugin.job import NemoJob
 from nemo_platform_plugin.job_context import JobContext, StoragePaths
 from nemo_platform_plugin.job_results import PlatformJobResults
@@ -235,7 +237,11 @@ def build_ctx_from_env(sdk: NeMoPlatform) -> JobContext:
             ephemeral=Path(ephemeral_str),
             persistent=Path(persistent_str) if persistent_str else None,
         ),
-        results=PlatformJobResults(job_name=job_id, workspace=workspace, sdk=sdk),
+        results=PlatformJobResults(
+            job_name=job_id,
+            workspace=workspace,
+            client=client_from_platform(sdk, NemoClient),
+        ),
         job_id=job_id,
     )
 

--- a/packages/nemo_platform_plugin/tests/client/test_adapter.py
+++ b/packages/nemo_platform_plugin/tests/client/test_adapter.py
@@ -36,6 +36,21 @@ def test_client_from_platform_preserves_stainless_retry_policy() -> None:
     )
 
 
+def test_client_from_platform_close_does_not_close_platform_transport() -> None:
+    http_client = httpx.Client(transport=httpx.MockTransport(lambda request: httpx.Response(200, request=request)))
+    platform = NeMoPlatform(
+        base_url="http://test",
+        workspace="default",
+        http_client=http_client,
+    )
+
+    client = client_from_platform(platform, JobsClient)
+    client.close()
+
+    assert not http_client.is_closed
+    http_client.close()
+
+
 def test_client_from_platform_uses_platform_prepare_url() -> None:
     http_client = httpx.Client(transport=httpx.MockTransport(lambda request: httpx.Response(200, request=request)))
 
@@ -98,6 +113,24 @@ async def test_async_client_from_platform_uses_async_transport() -> None:
         assert_type(client, AsyncJobsClient)
         assert isinstance(client, AsyncJobsClient)
         assert client._client is http_client
+    finally:
+        await platform.close()
+
+
+@pytest.mark.asyncio
+async def test_async_client_from_platform_aclose_does_not_close_platform_transport() -> None:
+    http_client = httpx.AsyncClient(transport=httpx.MockTransport(lambda request: httpx.Response(200, request=request)))
+    platform = AsyncNeMoPlatform(
+        base_url="http://gateway",
+        workspace="default",
+        http_client=http_client,
+    )
+
+    try:
+        client = client_from_platform(platform, AsyncJobsClient)
+        await client.aclose()
+
+        assert not http_client.is_closed
     finally:
         await platform.close()
 

--- a/packages/nemo_platform_plugin/tests/client/test_client.py
+++ b/packages/nemo_platform_plugin/tests/client/test_client.py
@@ -546,6 +546,26 @@ def test_owned_transport_is_built_with_the_default_timeout() -> None:
     assert client._http.timeout == httpx.Timeout(DEFAULT_TIMEOUT)
 
 
+def test_close_skips_external_transport() -> None:
+    mock_http = MagicMock(spec=httpx.Client)
+    client = NemoClient(base_url=BASE, http_client=mock_http)
+
+    client.close()
+
+    mock_http.close.assert_not_called()
+
+
+def test_from_client_close_does_not_close_parent_transport() -> None:
+    parent = NemoClient(base_url=BASE)
+    child = NemoClient.from_client(parent)
+
+    child.close()
+
+    assert not parent._http.is_closed
+    parent.close()
+    assert parent._http.is_closed
+
+
 def test_from_client_carries_the_timeout() -> None:
     """The clone shares the transport, so it must carry the override too."""
     upload_timeout = httpx.Timeout(30.0, write=10 * 60, read=5 * 60)
@@ -572,6 +592,28 @@ async def test_constructor_timeout_is_sent_with_every_request_async() -> None:
     await client.send(GET_ITEM(name="alice"))
 
     assert mock_http.request.call_args.kwargs["timeout"] == upload_timeout
+
+
+@pytest.mark.asyncio
+async def test_aclose_skips_external_transport_async() -> None:
+    mock_http = AsyncMock(spec=httpx.AsyncClient)
+    client = AsyncNemoClient(base_url=BASE, http_client=mock_http)
+
+    await client.aclose()
+
+    mock_http.aclose.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_from_client_aclose_does_not_close_parent_transport_async() -> None:
+    parent = AsyncNemoClient(base_url=BASE)
+    child = AsyncNemoClient.from_client(parent)
+
+    await child.aclose()
+
+    assert not parent._http.is_closed
+    await parent.aclose()
+    assert parent._http.is_closed
 
 
 # ---------------------------------------------------------------------------

--- a/packages/nemo_platform_plugin/tests/test_job_results.py
+++ b/packages/nemo_platform_plugin/tests/test_job_results.py
@@ -24,7 +24,6 @@ from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
-from nemo_platform import NeMoPlatform
 from nemo_platform_plugin.client.client import NemoClient
 from nemo_platform_plugin.files.client import AsyncFilesClient, FilesClient
 from nemo_platform_plugin.job_results import (
@@ -170,10 +169,10 @@ def _platform_record(name: str = "metrics", url: str = "fileset://ws/fs#results/
     return record
 
 
-def _task_sdk() -> tuple[NeMoPlatform, httpx.Client]:
+def _task_client() -> tuple[NemoClient, httpx.Client]:
     http_client = httpx.Client(transport=httpx.MockTransport(lambda request: httpx.Response(200, request=request)))
-    sdk = NeMoPlatform(base_url="http://platform.test", workspace="ws", http_client=http_client)
-    return sdk, http_client
+    client = NemoClient(base_url="http://platform.test", workspace="ws", http_client=http_client)
+    return client, http_client
 
 
 def test_result_manager_factory_explicit_workspace_overrides_client_workspace() -> None:
@@ -222,19 +221,19 @@ async def test_async_result_manager_factory_ignores_job_env_and_uses_client_work
 
 class TestPlatformJobResults:
     def test_platform_job_results_is_a_job_results(self) -> None:
-        sdk = NeMoPlatform(base_url="http://platform.test", workspace="ws")
+        client = NemoClient(base_url="http://platform.test", workspace="ws")
         with patch("nemo_platform_plugin.job_results.result_manager_factory") as factory:
             factory.return_value = MagicMock()
-            sink = PlatformJobResults(job_name="j", workspace="ws", sdk=sdk)
+            sink = PlatformJobResults(job_name="j", workspace="ws", client=client)
         assert isinstance(sink, JobResults)
 
-    def test_platform_job_results_adapts_generated_sdk(self) -> None:
+    def test_platform_job_results_uses_typed_client_transport(self) -> None:
         http_client = httpx.Client(transport=httpx.MockTransport(lambda request: httpx.Response(200, request=request)))
-        sdk = NeMoPlatform(base_url="http://platform.test", workspace="ws", http_client=http_client)
+        client = NemoClient(base_url="http://platform.test", workspace="ws", http_client=http_client)
 
         with patch("nemo_platform_plugin.job_results.result_manager_factory") as factory:
             factory.return_value = MagicMock()
-            PlatformJobResults(job_name="j", workspace="ws", sdk=sdk)
+            PlatformJobResults(job_name="j", workspace="ws", client=client)
 
         files_client = factory.call_args.kwargs["files_client"]
         jobs_client = factory.call_args.kwargs["jobs_client"]
@@ -244,7 +243,7 @@ class TestPlatformJobResults:
         assert jobs_client._http is http_client
 
     def test_save_delegates_to_result_manager(self, tmp_path: Path) -> None:
-        sdk, http_client = _task_sdk()
+        client, http_client = _task_client()
         local = tmp_path / "out.json"
         local.write_text("{}")
         manager = MagicMock()
@@ -253,7 +252,7 @@ class TestPlatformJobResults:
             url="fileset://ws/fs#results/A1/metrics",
         )
         with patch("nemo_platform_plugin.job_results.result_manager_factory", return_value=manager) as factory:
-            sink = PlatformJobResults(job_name="j", workspace="ws", sdk=sdk, attempt_id="A1")
+            sink = PlatformJobResults(job_name="j", workspace="ws", client=client, attempt_id="A1")
             ref = sink.save("metrics", local, ignore_patterns=["cache.db"])
 
         factory.assert_called_once()
@@ -273,24 +272,24 @@ class TestPlatformJobResults:
         assert ref == ResultRef(name="metrics", artifact_url="fileset://ws/fs#results/A1/metrics")
 
     def test_save_forwards_directory_path_unchanged(self, tmp_path: Path) -> None:
-        sdk, _http_client = _task_sdk()
+        client, _http_client = _task_client()
         payload_dir = tmp_path / "payload"
         payload_dir.mkdir()
         manager = MagicMock()
         manager.create_result.return_value = _platform_record()
         with patch("nemo_platform_plugin.job_results.result_manager_factory", return_value=manager):
-            sink = PlatformJobResults(job_name="j", workspace="ws", sdk=sdk)
+            sink = PlatformJobResults(job_name="j", workspace="ws", client=client)
             sink.save("artifacts", payload_dir, ignore_patterns=["cache.db", "cache/"])
         call = manager.create_result.call_args
         assert call.kwargs["artifact_local_path"] == payload_dir
         assert call.kwargs["ignore_patterns"] == ["cache.db", "cache/"]
 
     def test_save_propagates_manager_errors(self) -> None:
-        sdk, _http_client = _task_sdk()
+        client, _http_client = _task_client()
         manager = MagicMock()
         manager.create_result.side_effect = RuntimeError("boom")
         with patch("nemo_platform_plugin.job_results.result_manager_factory", return_value=manager):
-            sink = PlatformJobResults(job_name="j", workspace="ws", sdk=sdk)
+            sink = PlatformJobResults(job_name="j", workspace="ws", client=client)
             with pytest.raises(RuntimeError, match="boom"):
                 sink.save("metrics", Path("/tmp/whatever"))
 
@@ -324,12 +323,12 @@ def test_result_manager_fetches_metadata_from_typed_task_client() -> None:
         )
 
     http_client = httpx.Client(transport=httpx.MockTransport(handler))
-    sdk = NemoClient(base_url="http://platform.test", workspace="test-ws", http_client=http_client)
+    client = NemoClient(base_url="http://platform.test", workspace="test-ws", http_client=http_client)
     manager = ResultManager(
         job_name="test-job",
         workspace="test-ws",
-        files_client=FilesClient.from_client(sdk),
-        jobs_client=JobsClient.from_client(sdk),
+        files_client=FilesClient.from_client(client),
+        jobs_client=JobsClient.from_client(client),
     )
 
     assert manager._fetch_job_metadata() == ("att-123", "test-fileset", "shared-fs")

--- a/packages/nmp_customization_common/pyproject.toml
+++ b/packages/nmp_customization_common/pyproject.toml
@@ -8,8 +8,8 @@ readme = "README.md"
 requires-python = ">=3.11,<3.14"
 dependencies = [
     "nmp-common",
-    "nemo-platform-sdk",
     "nemo-platform-plugin",
+    "filesets",
     "pydantic>=2.10.6",
     "pydantic-settings>=2.6.1",
     "httpx>=0.27.0",
@@ -27,8 +27,8 @@ packages = ["src/nmp"]
 
 [tool.uv.sources]
 nmp-common = { workspace = true }
-nemo-platform-sdk = { workspace = true }
 nemo-platform-plugin = { workspace = true }
+filesets = { workspace = true }
 
 
 [dependency-groups]

--- a/packages/nmp_customization_common/src/nmp/customization_common/contributor/jobs.py
+++ b/packages/nmp_customization_common/src/nmp/customization_common/contributor/jobs.py
@@ -11,14 +11,21 @@ call convention, schema validation, profile resolution) and stays per-backend.
 
 from __future__ import annotations
 
-from typing import ClassVar, cast
+from typing import ClassVar, Generic, TypeVar
 
 from nemo_platform import AsyncNeMoPlatform
 from nemo_platform_plugin.capabilities import probe_docker
 from nemo_platform_plugin.config import NemoPlatformConfig, Runtime
 from nemo_platform_plugin.job import NemoJob
 from nemo_platform_plugin.jobs.exceptions import PlatformJobCompilationError
+from nmp.customization_common.service.platform_client import (
+    AsyncCustomizationPlatformClients,
+    async_customization_platform_clients_from_platform,
+)
 from pydantic import BaseModel
+
+JobInputT = TypeVar("JobInputT", bound=BaseModel)
+JobOutputT = TypeVar("JobOutputT", bound=BaseModel)
 
 
 def require_container_runtime(backend_label: str, *, num_nodes: int = 1) -> None:
@@ -86,7 +93,7 @@ def require_distributed_runtime(backend_label: str) -> None:
         )
 
 
-class BaseSubmitJob(NemoJob):
+class BaseSubmitJob(NemoJob, Generic[JobInputT, JobOutputT]):
     """Shared submit-only job scaffold.
 
     Subclasses set the ``NemoJob`` ClassVars (``name``, ``description``,
@@ -99,7 +106,17 @@ class BaseSubmitJob(NemoJob):
     runtime_label: ClassVar[str] = "Training"
 
     @classmethod
-    async def _transform(cls, job_input: BaseModel, workspace: str, async_sdk: AsyncNeMoPlatform) -> BaseModel:
+    def _job_input_schema(cls) -> type[JobInputT]:
+        """Return the concrete submitter-facing schema for this backend."""
+        raise PlatformJobCompilationError(f"{cls.__name__} is missing an input_spec_schema.")
+
+    @classmethod
+    async def _transform(
+        cls,
+        job_input: JobInputT,
+        workspace: str,
+        platform: AsyncCustomizationPlatformClients,
+    ) -> JobOutputT:
         """Validate platform refs and return the canonical output spec. Per backend."""
         raise NotImplementedError
 
@@ -109,13 +126,12 @@ class BaseSubmitJob(NemoJob):
         input_spec: BaseModel,
         workspace: str,
         entity_client: object,
-        async_sdk: object,
+        async_sdk: AsyncNeMoPlatform,
         is_local: bool,
-    ) -> BaseModel:
+    ) -> JobOutputT:
         """Validate platform refs, resolve naming, return the canonical spec."""
         del entity_client, is_local
-        schema = cls.input_spec_schema
-        if schema is None:
-            raise PlatformJobCompilationError(f"{cls.__name__} is missing an input_spec_schema.")
+        schema = cls._job_input_schema()
         job_input = input_spec if isinstance(input_spec, schema) else schema.model_validate(input_spec.model_dump())
-        return await cls._transform(job_input, workspace, cast(AsyncNeMoPlatform, async_sdk))
+        platform = async_customization_platform_clients_from_platform(async_sdk)
+        return await cls._transform(job_input, workspace, platform)

--- a/packages/nmp_customization_common/src/nmp/customization_common/service/platform_client.py
+++ b/packages/nmp_customization_common/src/nmp/customization_common/service/platform_client.py
@@ -8,6 +8,8 @@ handler / ``to_spec`` flow) to validate that the submitter's ``model`` and
 ``dataset`` references exist before the job moves on to compile / run.
 """
 
+from dataclasses import dataclass
+
 from nemo_platform import AsyncNeMoPlatform
 from nemo_platform_plugin.client.adapter import client_from_platform
 from nemo_platform_plugin.client.errors import NotFoundError, PermissionDeniedError
@@ -19,8 +21,26 @@ from nmp.common.entities.utils import parse_entity_ref
 from nmp.customization_common.schemas.file_io import FileSetRef
 
 
+@dataclass(frozen=True, slots=True)
+class AsyncCustomizationPlatformClients:
+    """Typed async service clients needed while compiling customization jobs."""
+
+    files: AsyncFilesClient
+    models: AsyncModelsClient
+
+
+def async_customization_platform_clients_from_platform(
+    platform: AsyncNeMoPlatform,
+) -> AsyncCustomizationPlatformClients:
+    """Build the customization compile-time client bundle from the generated SDK."""
+    return AsyncCustomizationPlatformClients(
+        files=client_from_platform(platform, AsyncFilesClient),
+        models=client_from_platform(platform, AsyncModelsClient),
+    )
+
+
 async def check_fileset_access(
-    sdk: AsyncNeMoPlatform,
+    platform: AsyncCustomizationPlatformClients,
     fileset_uri: str,
     default_workspace: str,
     *,
@@ -29,9 +49,8 @@ async def check_fileset_access(
     """Verify the caller can access a fileset reference and return the fileset."""
     ref = FileSetRef.model_validate(fileset_uri)
     workspace = ref.workspace or default_workspace
-    files = client_from_platform(sdk, AsyncFilesClient)
     try:
-        return await files.get_fileset(workspace=workspace, name=ref.name)
+        return await platform.files.get_fileset(workspace=workspace, name=ref.name)
     except PermissionDeniedError:
         raise PermissionError(f"Access denied to {label} fileset '{workspace}/{ref.name}'") from None
     except NotFoundError:
@@ -41,25 +60,29 @@ async def check_fileset_access(
         ) from None
 
 
-async def check_dataset_access(sdk: AsyncNeMoPlatform, dataset_uri: str, default_workspace: str) -> None:
+async def check_dataset_access(
+    platform: AsyncCustomizationPlatformClients,
+    dataset_uri: str,
+    default_workspace: str,
+) -> None:
     """Verify the caller can access the dataset fileset.
 
     Raises:
         ValueError: If the fileset is not found.
         PermissionError: If access is denied.
     """
-    await check_fileset_access(sdk, dataset_uri, default_workspace, label="dataset")
+    await check_fileset_access(platform, dataset_uri, default_workspace, label="dataset")
 
 
 async def check_environment_access(
-    sdk: AsyncNeMoPlatform,
+    platform: AsyncCustomizationPlatformClients,
     environment_uri: str,
     default_workspace: str,
 ) -> None:
     """Verify the caller can access the environment fileset (GRPO)."""
     ref = FileSetRef.model_validate(environment_uri)
     workspace = ref.workspace or default_workspace
-    response = await check_fileset_access(sdk, environment_uri, default_workspace, label="environment")
+    response = await check_fileset_access(platform, environment_uri, default_workspace, label="environment")
 
     fs = response.data() if hasattr(response, "data") and callable(response.data) else response
     purpose = getattr(fs, "purpose", None)
@@ -74,16 +97,15 @@ async def check_environment_access(
 
 
 async def check_gym_dataset_layout(
-    sdk: AsyncNeMoPlatform,
+    platform: AsyncCustomizationPlatformClients,
     dataset_uri: str,
     default_workspace: str,
 ) -> None:
     """Ensure a GRPO Gym dataset fileset contains training.jsonl."""
     ref = FileSetRef.model_validate(dataset_uri)
     workspace = ref.workspace or default_workspace
-    files = client_from_platform(sdk, AsyncFilesClient)
     try:
-        listing = (await files.list_files(workspace=workspace, name=ref.name)).data()
+        listing = (await platform.files.list_files(workspace=workspace, name=ref.name)).data()
     except PermissionDeniedError:
         raise PermissionError(f"Access denied to dataset fileset '{workspace}/{ref.name}'") from None
     except NotFoundError:
@@ -102,13 +124,12 @@ async def check_gym_dataset_layout(
 async def fetch_model_entity(
     model_ref: str,
     default_workspace: str,
-    sdk: AsyncNeMoPlatform,
+    platform: AsyncCustomizationPlatformClients,
 ) -> ModelEntity:
     """Retrieve a model entity and verify its weights fileset is accessible."""
     resolved_ref = parse_entity_ref(model_ref, default_workspace)
-    models = client_from_platform(sdk, AsyncModelsClient)
     try:
-        response = await models.get_model(
+        response = await platform.models.get_model(
             name=resolved_ref.name,
             workspace=resolved_ref.workspace,
             query_params={"verbose": True},
@@ -123,7 +144,7 @@ async def fetch_model_entity(
 
     if model.fileset:
         await check_fileset_access(
-            sdk,
+            platform,
             model.fileset,
             resolved_ref.workspace,
             label=f"weights for model '{resolved_ref.workspace}/{resolved_ref.name}'",

--- a/packages/nmp_customization_common/src/nmp/customization_common/tasks/file_io/run.py
+++ b/packages/nmp_customization_common/src/nmp/customization_common/tasks/file_io/run.py
@@ -23,14 +23,12 @@ import logging
 from pathlib import Path
 
 import httpx
-from nemo_platform import (
-    NeMoPlatform,
-    NotFoundError,
-)
-from nemo_platform_plugin.client.adapter import client_from_platform
+from filesets.filesystem.filesystem import FilesetFileSystem, build_fileset_ref
+from nemo_platform_plugin.client.client import NemoClient
 from nemo_platform_plugin.client.errors import (
     ConflictError,
     NemoTransportError,
+    NotFoundError,
     RateLimitError,
 )
 from nemo_platform_plugin.client.errors import (
@@ -40,8 +38,9 @@ from nemo_platform_plugin.client.types import RetryPolicy
 from nemo_platform_plugin.files.client import FilesClient
 from nemo_platform_plugin.files.metadata import FilesetMetadata
 from nemo_platform_plugin.files.types import CreateFilesetRequest, FilesetFileOutput, UpdateFilesetRequest
+from nemo_platform_plugin.jobs.client import JobsClient
+from nmp.common.client_factory import get_task_nemo_client
 from nmp.common.jobs.schemas import PlatformJobStatus
-from nmp.common.sdk_factory import get_task_sdk
 from nmp.customization_common.schemas.file_io import (
     DownloadItem,
     DownloadStats,
@@ -108,24 +107,31 @@ class FileIORunner:
 
     def __init__(
         self,
-        sdk: NeMoPlatform,
+        files: FilesClient,
         progress_reporter: ProgressReporter,
         job_ctx: NMPJobContext,
         *,
         service_source: str,
     ):
-        self.sdk = sdk
+        self.files = files
         self.progress_reporter = progress_reporter
         self.job_ctx = job_ctx
         self.service_source = service_source
+
+    def _workspace_for(self, fileset: FileSetRef) -> str:
+        return fileset.workspace or self.job_ctx.workspace
 
     def list_fileset_files(self, fileset: FileSetRef) -> list[FilesetFileOutput]:
         """List files in a FileSet. Returns a list of ``FilesetFileOutput`` objects."""
         try:
             with sdk_error_handler(FileDownloadError, f"list files in fileset {fileset}", passthrough=(NotFoundError,)):
-                response = self.sdk.with_options(timeout=LIST_FILES_TIMEOUT).files.list(
-                    fileset=fileset.name,
-                    workspace=fileset.workspace,
+                response = (
+                    self.files.with_options(timeout=LIST_FILES_TIMEOUT)
+                    .list_files(
+                        name=fileset.name,
+                        workspace=self._workspace_for(fileset),
+                    )
+                    .data()
                 )
                 logger.info(f"Found {len(response.data)} files in FileSet {fileset!s}")
                 return response.data
@@ -157,7 +163,7 @@ class FileIORunner:
         ):
             stats = self._download_with_retry(
                 fileset_name=fileset.name,
-                fileset_workspace=fileset.workspace,
+                fileset_workspace=self._workspace_for(fileset),
                 dest_dir=str(dest_dir),
                 fileset_display_name=fileset_name,
                 dest_path=dest_dir,
@@ -179,7 +185,7 @@ class FileIORunner:
     def _download_with_retry(
         self,
         fileset_name: str,
-        fileset_workspace: str | None,
+        fileset_workspace: str,
         dest_dir: str,
         fileset_display_name: str,
         dest_path: Path,
@@ -203,10 +209,10 @@ class FileIORunner:
         )
         composite_callback = CompositeCallback(tqdm_callback, jobs_callback)
 
-        self.sdk.with_options(timeout=DOWNLOAD_TIMEOUT).files.download(
-            fileset=fileset_name,
-            workspace=fileset_workspace,
-            local_path=dest_dir,
+        FilesetFileSystem(client=self.files.with_options(timeout=DOWNLOAD_TIMEOUT)).get(
+            build_fileset_ref("", workspace=fileset_workspace, fileset=fileset_name),
+            dest_dir,
+            recursive=True,
             callback=composite_callback,
         )
         return stats
@@ -230,7 +236,7 @@ class FileIORunner:
                 local_path=local_path,
                 remote_path=remote_path,
                 fileset_name=fileset.name,
-                fileset_workspace=fileset.workspace,
+                fileset_workspace=self._workspace_for(fileset),
                 fileset_display_name=fileset_name,
                 src_path=src_path,
             )
@@ -250,7 +256,7 @@ class FileIORunner:
         local_path: str,
         remote_path: str,
         fileset_name: str,
-        fileset_workspace: str | None,
+        fileset_workspace: str,
         fileset_display_name: str,
         src_path: Path,
     ) -> UploadStats:
@@ -265,11 +271,10 @@ class FileIORunner:
         )
         composite_callback = CompositeCallback(tqdm_callback, jobs_callback)
 
-        self.sdk.with_options(timeout=UPLOAD_TIMEOUT).files.upload(
-            local_path=local_path,
-            remote_path=remote_path,
-            fileset=fileset_name,
-            workspace=fileset_workspace,
+        FilesetFileSystem(client=self.files.with_options(timeout=UPLOAD_TIMEOUT)).put(
+            local_path,
+            build_fileset_ref(remote_path, workspace=fileset_workspace, fileset=fileset_name),
+            recursive=True,
             callback=composite_callback,
         )
         return stats
@@ -288,9 +293,8 @@ class FileIORunner:
     )
     def _create_fileset_with_retry(self, fileset: FileSetRef, metadata: dict | None = None) -> None:
         """Internal method with retry logic for creating a FileSet."""
-        files = client_from_platform(self.sdk, FilesClient).with_options(
-            timeout=CREATE_FILESET_TIMEOUT, retry=RetryPolicy(max_retries=0)
-        )
+        files = self.files.with_options(timeout=CREATE_FILESET_TIMEOUT, retry=RetryPolicy(max_retries=0))
+        workspace = self._workspace_for(fileset)
         try:
             body_kwargs: dict = {
                 "name": fileset.name,
@@ -298,10 +302,9 @@ class FileIORunner:
             }
             if metadata is not None:
                 body_kwargs["metadata"] = FilesetMetadata.model_validate(metadata)
-            result = files.create_fileset(workspace=fileset.workspace, body=CreateFilesetRequest(**body_kwargs)).data()
+            result = files.create_fileset(workspace=workspace, body=CreateFilesetRequest(**body_kwargs)).data()
             logger.info(f"Created FileSet: {result.workspace}/{result.name}")
         except ConflictError:
-            workspace = fileset.workspace or self.job_ctx.workspace
             if metadata is not None:
                 try:
                     files.update_fileset(
@@ -421,7 +424,7 @@ class FileIORunner:
 
 
 def run(
-    sdk: NeMoPlatform | None = None,
+    client: NemoClient | None = None,
     job_ctx: NMPJobContext | None = None,
     *,
     service_source: str,
@@ -431,13 +434,15 @@ def run(
     job_ctx = job_ctx or NMPJobContext.from_env()
     validate_storage_path(job_ctx.storage_path)
 
-    sdk_owned = sdk is None
+    client_owned = client is None
     progress_reporter: ProgressReporter | None = None
     try:
-        sdk = sdk or get_task_sdk(service_name)
-        progress_reporter = JobsServiceProgressReporter.create_progress_reporter(sdk, job_ctx)
+        client = client or get_task_nemo_client(service_name)
+        files = FilesClient.from_client(client)
+        jobs = JobsClient.from_client(client)
+        progress_reporter = JobsServiceProgressReporter.create_progress_reporter(jobs, job_ctx)
         runner = FileIORunner(
-            sdk=sdk,
+            files=files,
             progress_reporter=progress_reporter,
             job_ctx=job_ctx,
             service_source=service_source,
@@ -447,7 +452,7 @@ def run(
 
         logger.info(f"Starting file I/O task with job context: {job_ctx}")
         logger.info(f"Config: {config.model_dump_json(indent=2)}")
-        logger.info(f"NeMo Platform service URL: {sdk.base_url}")
+        logger.info(f"NeMo Platform service URL: {client.base_url}")
 
         runner.run_upload(config.upload)
         runner.run_download(config.download)
@@ -483,5 +488,8 @@ def run(
             )
         return 1
     finally:
-        if sdk_owned and sdk is not None:
-            sdk.close()
+        if client_owned and client is not None:
+            try:
+                client.close()
+            except Exception:
+                logger.warning("Failed to close sync platform client during file I/O task cleanup", exc_info=True)

--- a/packages/nmp_customization_common/src/nmp/customization_common/tasks/file_io_progress_reporter.py
+++ b/packages/nmp_customization_common/src/nmp/customization_common/tasks/file_io_progress_reporter.py
@@ -6,8 +6,6 @@
 import logging
 from typing import Any, Protocol
 
-from nemo_platform import NeMoPlatform
-from nemo_platform_plugin.client.adapter import client_from_platform
 from nemo_platform_plugin.client.errors import NemoHTTPError
 from nemo_platform_plugin.jobs.client import JobsClient
 from nemo_platform_plugin.jobs.types import PlatformJobTaskUpdate
@@ -48,8 +46,8 @@ class NoOpProgressReporter:
 class JobsServiceProgressReporter:
     """Reports progress to the Jobs service via SDK."""
 
-    def __init__(self, sdk: NeMoPlatform, workspace: str, job_id: str, step_name: str, task_id: str):
-        self.sdk = sdk
+    def __init__(self, jobs: JobsClient, workspace: str, job_id: str, step_name: str, task_id: str):
+        self.jobs = jobs
         self.workspace = workspace
         self.job_id = job_id
         self.step_name = step_name
@@ -79,8 +77,7 @@ class JobsServiceProgressReporter:
                 if error_stack:
                     task_update["error_stack"] = error_stack
 
-                jobs = client_from_platform(self.sdk, JobsClient)
-                jobs.update_job_step_task(
+                self.jobs.update_job_step_task(
                     name=self.task_id,
                     workspace=self.workspace,
                     job=self.job_id,
@@ -94,12 +91,12 @@ class JobsServiceProgressReporter:
             )
 
     @staticmethod
-    def create_progress_reporter(sdk: NeMoPlatform, job_ctx: NMPJobContext) -> ProgressReporter:
+    def create_progress_reporter(jobs: JobsClient, job_ctx: NMPJobContext) -> ProgressReporter:
         """Build a JobsServiceProgressReporter when jobs_url is set, else NoOpProgressReporter."""
         if job_ctx.jobs_url:
             logger.info(f"Progress reporting enabled: {job_ctx.jobs_url}")
             return JobsServiceProgressReporter(
-                sdk, job_ctx.workspace, job_ctx.job_id, job_ctx.step, job_ctx.normalized_task
+                jobs, job_ctx.workspace, job_ctx.job_id, job_ctx.step, job_ctx.normalized_task
             )
         logger.info("Progress reporting disabled: jobs_url not configured")
         return NoOpProgressReporter()

--- a/packages/nmp_customization_common/src/nmp/customization_common/tasks/file_io_utils.py
+++ b/packages/nmp_customization_common/src/nmp/customization_common/tasks/file_io_utils.py
@@ -12,13 +12,10 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import httpx
-
-# https://docs.nvidia.com/nemo/microservices/latest/pysdk/index.html#handling-errors
-from nemo_platform import (
-    APIConnectionError,
-    APIStatusError,
-    APITimeoutError,
+from nemo_platform_plugin.client.errors import (
     AuthenticationError,
+    NemoHTTPError,
+    NemoTransportError,
     PermissionDeniedError,
 )
 from nmp.customization_common.schemas.file_io import (
@@ -124,19 +121,15 @@ def sdk_error_handler(
         yield
     except passthrough:
         raise
-    except APITimeoutError as e:
-        raise error_class(
-            f"Failed to {operation} due to request timeout error. Cause: {e.__cause__}. Error: {e}",
-        ) from e
-    except APIConnectionError as e:
-        raise error_class(f"Failed to {operation} due to connection error. Cause: {e.__cause__}. Error: {e}") from e
-    # AuthenticationError / PermissionDeniedError are subclasses of APIStatusError,
-    # so they must be caught before APIStatusError.
+    except NemoTransportError as e:
+        raise error_class(f"Failed to {operation} due to connection error. Cause: {e.error}. Error: {e}") from e
+    # AuthenticationError / PermissionDeniedError are subclasses of NemoHTTPError,
+    # so they must be caught before NemoHTTPError.
     except AuthenticationError as e:
         raise error_class(f"Failed to {operation} due to authentication error. Error: {e}") from e
     except PermissionDeniedError as e:
         raise error_class(f"Failed to {operation} due to permission denied error. Error: {e}") from e
-    except APIStatusError as e:
+    except NemoHTTPError as e:
         raise error_class(f"Failed to {operation} due to API error. Status code: {e.status_code}. Error: {e}") from e
     except Exception as e:
         raise error_class(f"Failed to {operation} due to unexpected error {type(e).__name__}: {e}") from e

--- a/packages/nmp_customization_common/src/nmp/customization_common/tasks/model_entity/run.py
+++ b/packages/nmp_customization_common/src/nmp/customization_common/tasks/model_entity/run.py
@@ -14,8 +14,7 @@ import re
 import time
 from pathlib import Path
 
-from nemo_platform import NeMoPlatform
-from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.client.client import NemoClient
 from nemo_platform_plugin.client.errors import (
     ConflictError,
     InternalServerError,
@@ -46,7 +45,7 @@ from nemo_platform_plugin.models.types import (
 from nemo_platform_plugin.models.types import (
     FinetuningType as ModelsFinetuningType,
 )
-from nmp.common.sdk_factory import get_task_sdk
+from nmp.common.client_factory import get_task_nemo_client
 from nmp.customization_common.schemas.model_entity import (
     DeploymentParameters,
     ModelEntityCreationError,
@@ -88,9 +87,9 @@ def sanitize_name(prefix: str, name: str) -> str:
 class ModelEntityRunner:
     """Runner for creating (and optionally deploying) model entities."""
 
-    def __init__(self, sdk: NeMoPlatform, job_ctx: NMPJobContext):
-        self.sdk = sdk
-        self.models = client_from_platform(sdk, ModelsClient)
+    def __init__(self, models: ModelsClient, files: FilesClient, job_ctx: NMPJobContext):
+        self.models = models
+        self.files = files
         self.job_ctx = job_ctx
 
     def _wait_for_spec(self, workspace: str, name: str) -> ModelEntity:
@@ -161,9 +160,7 @@ class ModelEntityRunner:
 
         logger.info(f"Validating fileset exists: {fileset_workspace}/{config.fileset.name}")
         try:
-            client_from_platform(self.sdk, FilesClient).get_fileset(
-                workspace=fileset_workspace, name=config.fileset.name
-            )
+            self.files.get_fileset(workspace=fileset_workspace, name=config.fileset.name)
             logger.info(f"Fileset validation successful: {fileset_workspace}/{config.fileset.name}")
         except TRANSIENT_RETRYABLE_EXCEPTIONS:
             raise
@@ -432,7 +429,7 @@ class ModelEntityRunner:
 
 
 def run(
-    sdk: NeMoPlatform | None = None,
+    client: NemoClient | None = None,
     job_ctx: NMPJobContext | None = None,
     *,
     service_name: str,
@@ -440,10 +437,14 @@ def run(
     """Execute the model entity creation task."""
     job_ctx = job_ctx or NMPJobContext.from_env()
 
-    sdk_owned = sdk is None
+    client_owned = client is None
     try:
-        sdk = sdk or get_task_sdk(service_name).with_options(workspace=job_ctx.workspace)
-        runner = ModelEntityRunner(sdk=sdk, job_ctx=job_ctx)
+        client = client or get_task_nemo_client(service_name)
+        runner = ModelEntityRunner(
+            models=ModelsClient.from_client(client),
+            files=FilesClient.from_client(client),
+            job_ctx=job_ctx,
+        )
 
         config = get_config(job_ctx.config_path)
 
@@ -456,7 +457,7 @@ def run(
             config.fileset.name,
             config.deployment_config is not None,
         )
-        logger.info(f"NeMo Platform service URL: {sdk.base_url}")
+        logger.info(f"NeMo Platform service URL: {client.base_url}")
 
         result, deploy_target = runner.create_model_entity(config)
         logger.info(f"Model entity creation complete: {result}")
@@ -471,5 +472,5 @@ def run(
         logger.exception(f"Model entity task failed: {e}")
         return 1
     finally:
-        if sdk_owned and sdk is not None:
-            sdk.close()
+        if client_owned and client is not None:
+            client.close()

--- a/packages/nmp_customization_common/src/nmp/customization_common/training/progress.py
+++ b/packages/nmp_customization_common/src/nmp/customization_common/training/progress.py
@@ -29,12 +29,11 @@ from collections.abc import Mapping
 from typing import Any, cast
 
 import httpx
-from nemo_platform_plugin.client.adapter import client_from_platform
 from nemo_platform_plugin.client.errors import NotFoundError
 from nemo_platform_plugin.jobs.client import JobsClient
 from nemo_platform_plugin.jobs.schemas import PlatformJobStatus
 from nemo_platform_plugin.jobs.types import PlatformJobTaskUpdate
-from nmp.common.sdk_factory import get_task_sdk
+from nmp.common.client_factory import get_task_nemo_client
 from nmp.customization_common.service.context import NMPJobContext
 
 logger = logging.getLogger(__name__)
@@ -55,11 +54,12 @@ class JobsServiceProgressReporter:
 
     def __init__(self, job_ctx: NMPJobContext, service_name: str):
         self._job_ctx = job_ctx
-        # with_options rather than handing get_task_sdk a client: that function
+        # with_options rather than handing get_task_nemo_client a client: that function
         # skips its workload-identity branch entirely when passed one, so
         # supplying a client just to set a timeout would quietly change how the
         # task authenticates.
-        self._sdk = get_task_sdk(service_name).with_options(timeout=_REPORT_TIMEOUT)
+        self._client = get_task_nemo_client(service_name)
+        self._jobs = JobsClient.from_client(self._client).with_options(timeout=_REPORT_TIMEOUT)
         self._is_main_rank = int(os.environ.get("RANK", "0")) == 0
         self._max_steps = 0
         self._num_epochs = 0
@@ -94,8 +94,7 @@ class JobsServiceProgressReporter:
             return
 
         try:
-            jobs = client_from_platform(self._sdk, JobsClient)
-            jobs.update_job_step_task(
+            self._jobs.update_job_step_task(
                 name=self._job_ctx.normalized_task,
                 workspace=self._job_ctx.workspace,
                 job=self._job_ctx.job_id,
@@ -148,8 +147,7 @@ class JobsServiceProgressReporter:
             return {}
 
         try:
-            jobs = client_from_platform(self._sdk, JobsClient)
-            task = jobs.get_job_step_task(
+            task = self._jobs.get_job_step_task(
                 name=self._job_ctx.normalized_task,
                 workspace=self._job_ctx.workspace,
                 job=self._job_ctx.job_id,
@@ -193,4 +191,4 @@ class JobsServiceProgressReporter:
         self.update_task(status="error", error_details=error_details)
 
     def close(self) -> None:
-        self._sdk.close()
+        self._client.close()

--- a/packages/nmp_customization_common/tests/tasks/test_file_io.py
+++ b/packages/nmp_customization_common/tests/tasks/test_file_io.py
@@ -7,18 +7,16 @@ from __future__ import annotations
 
 import types
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import httpx
 import pytest
 
 
-def _make_runner(sdk, *, service_source: str = "unsloth", workspace: str = "default", storage_path: Path | None = None):
+def _make_job_ctx(*, workspace: str = "default", storage_path: Path | None = None):
     from nmp.customization_common.service.context import NMPJobContext
-    from nmp.customization_common.tasks.file_io.run import FileIORunner
-    from nmp.customization_common.tasks.file_io_progress_reporter import NoOpProgressReporter
 
-    job_ctx = NMPJobContext(
+    return NMPJobContext(
         workspace=workspace,
         job_id="job-1",
         attempt_id="attempt-0",
@@ -29,18 +27,31 @@ def _make_runner(sdk, *, service_source: str = "unsloth", workspace: str = "defa
         storage_path=storage_path or Path("/tmp"),
         config_path=Path("/tmp/cfg.json"),
     )
+
+
+def _make_runner(
+    files,
+    *,
+    service_source: str = "unsloth",
+    workspace: str = "default",
+    storage_path: Path | None = None,
+):
+    from nmp.customization_common.tasks.file_io.run import FileIORunner
+    from nmp.customization_common.tasks.file_io_progress_reporter import NoOpProgressReporter
+
+    job_ctx = _make_job_ctx(workspace=workspace, storage_path=storage_path)
     return FileIORunner(
-        sdk=sdk,
+        files=files,
         progress_reporter=NoOpProgressReporter(),
         job_ctx=job_ctx,
         service_source=service_source,
     )
 
 
-def _make_sdk() -> MagicMock:
-    sdk = MagicMock()
-    sdk.with_options.return_value = sdk
-    return sdk
+def _make_files_client() -> MagicMock:
+    files = MagicMock()
+    files.with_options.return_value = files
+    return files
 
 
 def _raise_runner_conflict() -> None:
@@ -59,23 +70,19 @@ def _make_dir(tmp_path: Path) -> Path:
 
 
 class TestCreateFileset:
-    @patch("nmp.customization_common.tasks.file_io.run.client_from_platform")
-    def test_creates_fileset_with_service_source_and_metadata(self, mock_cfp) -> None:
+    def test_creates_fileset_with_service_source_and_metadata(self) -> None:
         from nemo_platform_plugin.files.types import CreateFilesetRequest
         from nmp.customization_common.schemas.file_io import FileSetRef
 
-        mock_fc = MagicMock()
-        mock_fc.with_options.return_value = mock_fc
-        mock_cfp.return_value = mock_fc
-        sdk = _make_sdk()
-        runner = _make_runner(sdk, service_source="automodel")
+        files = _make_files_client()
+        runner = _make_runner(files, service_source="automodel")
         metadata = {"model": {"tool_calling": {"tool_call_parser": "llama3_json"}}}
         dest = FileSetRef(workspace="default", name="qwen-test")
 
         runner.create_fileset(dest, metadata=metadata)
 
-        mock_fc.create_fileset.assert_called_once()
-        call = mock_fc.create_fileset.call_args
+        files.create_fileset.assert_called_once()
+        call = files.create_fileset.call_args
         assert call.kwargs["workspace"] == "default"
         body = call.kwargs["body"]
         assert isinstance(body, CreateFilesetRequest)
@@ -85,24 +92,20 @@ class TestCreateFileset:
         assert body.metadata.model is not None
         assert body.metadata.model.tool_calling.tool_call_parser == "llama3_json"
 
-    @patch("nmp.customization_common.tasks.file_io.run.client_from_platform")
-    def test_conflict_patches_metadata_on_existing(self, mock_cfp) -> None:
+    def test_conflict_patches_metadata_on_existing(self) -> None:
         from nemo_platform_plugin.files.types import UpdateFilesetRequest
         from nmp.customization_common.schemas.file_io import FileSetRef
 
-        mock_fc = MagicMock()
-        mock_fc.with_options.return_value = mock_fc
-        mock_fc.create_fileset.side_effect = lambda **_: _raise_runner_conflict()
-        mock_cfp.return_value = mock_fc
-        sdk = _make_sdk()
-        runner = _make_runner(sdk, service_source="rl")
+        files = _make_files_client()
+        files.create_fileset.side_effect = lambda **_: _raise_runner_conflict()
+        runner = _make_runner(files, service_source="rl")
         dest = FileSetRef(workspace="default", name="exists")
         metadata = {"model": {"tool_calling": {"tool_call_parser": "hermes"}}}
 
         runner.create_fileset(dest, metadata=metadata)
 
-        mock_fc.update_fileset.assert_called_once()
-        update_call = mock_fc.update_fileset.call_args
+        files.update_fileset.assert_called_once()
+        update_call = files.update_fileset.call_args
         assert update_call.kwargs["workspace"] == "default"
         assert update_call.kwargs["name"] == "exists"
         body = update_call.kwargs["body"]
@@ -111,47 +114,62 @@ class TestCreateFileset:
         assert body.metadata.model is not None
         assert body.metadata.model.tool_calling.tool_call_parser == "hermes"
 
-    @patch("nmp.customization_common.tasks.file_io.run.client_from_platform")
-    def test_conflict_no_metadata_skips_update(self, mock_cfp) -> None:
+    def test_conflict_no_metadata_skips_update(self) -> None:
         from nmp.customization_common.schemas.file_io import FileSetRef
 
-        mock_fc = MagicMock()
-        mock_fc.with_options.return_value = mock_fc
-        mock_fc.create_fileset.side_effect = lambda **_: _raise_runner_conflict()
-        mock_cfp.return_value = mock_fc
-        sdk = _make_sdk()
-        runner = _make_runner(sdk)
+        files = _make_files_client()
+        files.create_fileset.side_effect = lambda **_: _raise_runner_conflict()
+        runner = _make_runner(files)
         dest = FileSetRef(workspace="default", name="exists")
 
         runner.create_fileset(dest, metadata=None)
 
-        mock_fc.update_fileset.assert_not_called()
+        files.update_fileset.assert_not_called()
 
 
 class TestUploadFileset:
-    def test_directory_uploads_with_trailing_slash(self, tmp_path: Path) -> None:
+    @patch("nmp.customization_common.tasks.file_io.run.FilesetFileSystem")
+    def test_uses_files_client_for_transfer(self, mock_fs_cls, tmp_path: Path) -> None:
+        from nmp.customization_common.schemas.file_io import FileSetRef
+        from nmp.customization_common.tasks.file_io.run import UPLOAD_TIMEOUT
+
+        files = _make_files_client()
+        fs = MagicMock()
+        mock_fs_cls.return_value = fs
+        runner = _make_runner(files)
+        src = _make_dir(tmp_path)
+
+        runner.upload_fileset(FileSetRef(workspace="default", name="qwen-test"), src.resolve())
+
+        files.with_options.assert_called_once_with(timeout=UPLOAD_TIMEOUT)
+        mock_fs_cls.assert_called_once_with(client=files)
+
+    @patch("nmp.customization_common.tasks.file_io.run.FilesetFileSystem")
+    def test_directory_uploads_with_trailing_slash(self, mock_fs_cls, tmp_path: Path) -> None:
         from nmp.customization_common.schemas.file_io import FileSetRef
 
-        sdk = _make_sdk()
-        runner = _make_runner(sdk)
+        fs = MagicMock()
+        mock_fs_cls.return_value = fs
+        runner = _make_runner(_make_files_client())
         src = _make_dir(tmp_path)
         dest = FileSetRef(workspace="default", name="qwen-test")
 
         runner.upload_fileset(dest, src.resolve())
 
-        sdk.files.upload.assert_called_once()
-        call = sdk.files.upload.call_args
-        assert call.kwargs["local_path"] == f"{src.resolve()}/"
-        assert call.kwargs["remote_path"] == ""
-        assert call.kwargs["fileset"] == "qwen-test"
-        assert call.kwargs["workspace"] == "default"
+        fs.put.assert_called_once()
+        put_call = fs.put.call_args
+        assert put_call.args[0] == f"{src.resolve()}/"
+        assert put_call.args[1] == "default/qwen-test"
+        assert put_call.kwargs["recursive"] is True
 
-    def test_upload_failure_propagates_as_file_upload_error(self, tmp_path: Path) -> None:
+    @patch("nmp.customization_common.tasks.file_io.run.FilesetFileSystem")
+    def test_upload_failure_propagates_as_file_upload_error(self, mock_fs_cls, tmp_path: Path) -> None:
         from nmp.customization_common.schemas.file_io import FileSetRef, FileUploadError
 
-        sdk = _make_sdk()
-        sdk.files.upload.side_effect = RuntimeError("upload broke")
-        runner = _make_runner(sdk)
+        fs = MagicMock()
+        fs.put.side_effect = RuntimeError("upload broke")
+        mock_fs_cls.return_value = fs
+        runner = _make_runner(_make_files_client())
         src = _make_dir(tmp_path)
         dest = FileSetRef(workspace="default", name="x")
 
@@ -160,36 +178,57 @@ class TestUploadFileset:
 
 
 class TestDownloadFileset:
-    def test_lists_then_downloads(self, tmp_path: Path) -> None:
+    @patch("nmp.customization_common.tasks.file_io.run.FilesetFileSystem")
+    def test_uses_files_client_for_transfer(self, mock_fs_cls, tmp_path: Path) -> None:
+        from nmp.customization_common.schemas.file_io import FileSetRef
+        from nmp.customization_common.tasks.file_io.run import DOWNLOAD_TIMEOUT, LIST_FILES_TIMEOUT
+
+        fs = MagicMock()
+        mock_fs_cls.return_value = fs
+        files = _make_files_client()
+        files.list_files.return_value.data.return_value = types.SimpleNamespace(
+            data=[types.SimpleNamespace(path="model.safetensors", size=100)]
+        )
+        runner = _make_runner(files)
+
+        runner.download_fileset(FileSetRef(workspace="default", name="qwen"), tmp_path / "downloads")
+
+        files.with_options.assert_has_calls([call(timeout=LIST_FILES_TIMEOUT), call(timeout=DOWNLOAD_TIMEOUT)])
+        mock_fs_cls.assert_called_once_with(client=files)
+
+    @patch("nmp.customization_common.tasks.file_io.run.FilesetFileSystem")
+    def test_lists_then_downloads(self, mock_fs_cls, tmp_path: Path) -> None:
         from nmp.customization_common.schemas.file_io import FileSetRef
 
-        sdk = _make_sdk()
-        sdk.files.list.return_value = types.SimpleNamespace(
+        fs = MagicMock()
+        mock_fs_cls.return_value = fs
+        files = _make_files_client()
+        files.list_files.return_value.data.return_value = types.SimpleNamespace(
             data=[
                 types.SimpleNamespace(path="model.safetensors", size=100),
                 types.SimpleNamespace(path="config.json", size=20),
             ]
         )
-        runner = _make_runner(sdk)
+        runner = _make_runner(files)
         dest = tmp_path / "downloads"
         fileset = FileSetRef(workspace="default", name="qwen")
 
         runner.download_fileset(fileset, dest)
 
-        sdk.files.list.assert_called_once()
-        sdk.files.download.assert_called_once()
-        call = sdk.files.download.call_args
-        assert call.kwargs["fileset"] == "qwen"
-        assert call.kwargs["workspace"] == "default"
-        assert call.kwargs["local_path"] == str(dest.resolve())
+        files.list_files.assert_called_once()
+        fs.get.assert_called_once()
+        get_call = fs.get.call_args
+        assert get_call.args[0] == "default/qwen"
+        assert get_call.args[1] == str(dest)
+        assert get_call.kwargs["recursive"] is True
         assert dest.exists()
 
     def test_empty_fileset_returns_zero_stats_without_downloading(self, tmp_path: Path) -> None:
         from nmp.customization_common.schemas.file_io import FileSetRef
 
-        sdk = _make_sdk()
-        sdk.files.list.return_value = types.SimpleNamespace(data=[])
-        runner = _make_runner(sdk)
+        files = _make_files_client()
+        files.list_files.return_value.data.return_value = types.SimpleNamespace(data=[])
+        runner = _make_runner(files)
         dest = tmp_path / "downloads"
         fileset = FileSetRef(workspace="default", name="empty")
 
@@ -197,7 +236,89 @@ class TestDownloadFileset:
 
         assert stats.files_downloaded == 0
         assert stats.total_bytes == 0
-        sdk.files.download.assert_not_called()
+
+
+class TestRun:
+    def test_builds_sync_files_task_client_for_filesystem_transfers(self) -> None:
+        import importlib
+
+        file_io_run = importlib.import_module("nmp.customization_common.tasks.file_io.run")
+
+        sync_client = MagicMock()
+        sync_client.base_url = "http://nemo-platform.local"
+        files = MagicMock()
+        jobs = MagicMock()
+        progress_reporter = MagicMock()
+        runner = MagicMock()
+        config = types.SimpleNamespace(
+            upload=[],
+            download=[],
+            model_dump_json=lambda indent: "{}",
+        )
+        job_ctx = _make_job_ctx()
+
+        with (
+            patch.object(file_io_run, "get_config", return_value=config),
+            patch.object(file_io_run, "get_task_nemo_client", return_value=sync_client) as get_task_nemo_client,
+            patch.object(file_io_run.FilesClient, "from_client", return_value=files) as files_from_client,
+            patch.object(file_io_run.JobsClient, "from_client", return_value=jobs) as jobs_from_client,
+            patch.object(
+                file_io_run.JobsServiceProgressReporter,
+                "create_progress_reporter",
+                return_value=progress_reporter,
+            ) as create_progress_reporter,
+            patch.object(file_io_run, "FileIORunner", return_value=runner) as runner_cls,
+        ):
+            result = file_io_run.run(
+                job_ctx=job_ctx,
+                service_source="rl",
+                service_name="rl",
+            )
+
+        assert result == 0
+        get_task_nemo_client.assert_called_once_with("rl")
+        files_from_client.assert_called_once_with(sync_client)
+        jobs_from_client.assert_called_once_with(sync_client)
+        create_progress_reporter.assert_called_once_with(jobs, job_ctx)
+        runner_cls.assert_called_once_with(
+            files=files,
+            progress_reporter=progress_reporter,
+            job_ctx=job_ctx,
+            service_source="rl",
+        )
+        runner.run_upload.assert_called_once_with([])
+        runner.run_download.assert_called_once_with([])
+        sync_client.close.assert_called_once()
+
+    def test_owned_sync_client_closes(self) -> None:
+        import importlib
+
+        file_io_run = importlib.import_module("nmp.customization_common.tasks.file_io.run")
+
+        sync_client = MagicMock()
+        sync_client.base_url = "http://nemo-platform.local"
+        config = types.SimpleNamespace(
+            upload=[],
+            download=[],
+            model_dump_json=lambda indent: "{}",
+        )
+
+        with (
+            patch.object(file_io_run, "get_config", return_value=config),
+            patch.object(file_io_run, "get_task_nemo_client", return_value=sync_client),
+            patch.object(file_io_run.FilesClient, "from_client", return_value=MagicMock()),
+            patch.object(file_io_run.JobsClient, "from_client", return_value=MagicMock()),
+            patch.object(file_io_run.JobsServiceProgressReporter, "create_progress_reporter", return_value=MagicMock()),
+            patch.object(file_io_run, "FileIORunner", return_value=MagicMock()),
+        ):
+            result = file_io_run.run(
+                job_ctx=_make_job_ctx(),
+                service_source="rl",
+                service_name="rl",
+            )
+
+        assert result == 0
+        sync_client.close.assert_called_once()
 
 
 @pytest.fixture
@@ -213,36 +334,30 @@ def no_retry_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
 class TestCreateFilesetRetry:
     """Create goes through the typed client, so it must catch the typed client's errors."""
 
-    @patch("nmp.customization_common.tasks.file_io.run.client_from_platform")
-    def test_retries_transport_error_wrapped_by_the_client(self, mock_cfp, no_retry_backoff) -> None:
+    def test_retries_transport_error_wrapped_by_the_client(self, no_retry_backoff) -> None:
         from nemo_platform_plugin.client.errors import NemoTransportError
         from nmp.customization_common.schemas.file_io import FileSetRef
 
-        mock_fc = MagicMock()
-        mock_fc.with_options.return_value = mock_fc
-        mock_fc.create_fileset.side_effect = [NemoTransportError(httpx.ConnectError("refused")), MagicMock()]
-        mock_cfp.return_value = mock_fc
-        runner = _make_runner(_make_sdk())
+        files = _make_files_client()
+        files.create_fileset.side_effect = [NemoTransportError(httpx.ConnectError("refused")), MagicMock()]
+        runner = _make_runner(files)
 
         runner.create_fileset(FileSetRef(workspace="default", name="models"))
 
-        assert mock_fc.create_fileset.call_count == 2
+        assert files.create_fileset.call_count == 2
 
-    @patch("nmp.customization_common.tasks.file_io.run.client_from_platform")
-    def test_retries_rate_limit_wrapped_by_the_client(self, mock_cfp, no_retry_backoff) -> None:
+    def test_retries_rate_limit_wrapped_by_the_client(self, no_retry_backoff) -> None:
         from nemo_platform_plugin.client.errors import RateLimitError
         from nmp.customization_common.schemas.file_io import FileSetRef
 
         response = httpx.Response(429, request=httpx.Request("POST", "http://test/filesets"), json={"detail": "slow"})
-        mock_fc = MagicMock()
-        mock_fc.with_options.return_value = mock_fc
-        mock_fc.create_fileset.side_effect = [RateLimitError(response), MagicMock()]
-        mock_cfp.return_value = mock_fc
-        runner = _make_runner(_make_sdk())
+        files = _make_files_client()
+        files.create_fileset.side_effect = [RateLimitError(response), MagicMock()]
+        runner = _make_runner(files)
 
         runner.create_fileset(FileSetRef(workspace="default", name="models"))
 
-        assert mock_fc.create_fileset.call_count == 2
+        assert files.create_fileset.call_count == 2
 
 
 class TestUploadRetry:
@@ -254,58 +369,66 @@ class TestUploadRetry:
     request from the source file on every attempt, is where the retry belongs.
     """
 
-    def test_retries_transport_error_wrapped_by_the_client(self, tmp_path: Path, no_retry_backoff) -> None:
+    @patch("nmp.customization_common.tasks.file_io.run.FilesetFileSystem")
+    def test_retries_transport_error_wrapped_by_the_client(self, mock_fs_cls, tmp_path: Path, no_retry_backoff) -> None:
         from nemo_platform_plugin.client.errors import NemoTransportError
         from nmp.customization_common.schemas.file_io import FileSetRef
 
         src = _make_dir(tmp_path)
-        sdk = _make_sdk()
-        sdk.files.upload.side_effect = [NemoTransportError(httpx.ReadTimeout("timed out")), None]
-        runner = _make_runner(sdk)
+        fs = MagicMock()
+        fs.put.side_effect = [NemoTransportError(httpx.ReadTimeout("timed out")), None]
+        mock_fs_cls.return_value = fs
+        runner = _make_runner(_make_files_client())
 
         runner.upload_fileset(FileSetRef(workspace="default", name="models"), src.resolve())
 
-        assert sdk.files.upload.call_count == 2
+        assert fs.put.call_count == 2
 
-    def test_retries_server_error_wrapped_by_the_client(self, tmp_path: Path, no_retry_backoff) -> None:
+    @patch("nmp.customization_common.tasks.file_io.run.FilesetFileSystem")
+    def test_retries_server_error_wrapped_by_the_client(self, mock_fs_cls, tmp_path: Path, no_retry_backoff) -> None:
         from nemo_platform_plugin.client.errors import InternalServerError
         from nmp.customization_common.schemas.file_io import FileSetRef
 
         src = _make_dir(tmp_path)
-        sdk = _make_sdk()
         response = httpx.Response(503, request=httpx.Request("PUT", "http://test/upload"), json={"detail": "down"})
-        sdk.files.upload.side_effect = [InternalServerError(response), None]
-        runner = _make_runner(sdk)
+        fs = MagicMock()
+        fs.put.side_effect = [InternalServerError(response), None]
+        mock_fs_cls.return_value = fs
+        runner = _make_runner(_make_files_client())
 
         runner.upload_fileset(FileSetRef(workspace="default", name="models"), src.resolve())
 
-        assert sdk.files.upload.call_count == 2
+        assert fs.put.call_count == 2
 
-    def test_retries_rate_limit_wrapped_by_the_client(self, tmp_path: Path, no_retry_backoff) -> None:
+    @patch("nmp.customization_common.tasks.file_io.run.FilesetFileSystem")
+    def test_retries_rate_limit_wrapped_by_the_client(self, mock_fs_cls, tmp_path: Path, no_retry_backoff) -> None:
         """429 is in the client's retryable statuses, but it cannot act on it here."""
         from nemo_platform_plugin.client.errors import RateLimitError
         from nmp.customization_common.schemas.file_io import FileSetRef
 
         src = _make_dir(tmp_path)
-        sdk = _make_sdk()
         response = httpx.Response(429, request=httpx.Request("PUT", "http://test/upload"), json={"detail": "slow down"})
-        sdk.files.upload.side_effect = [RateLimitError(response), None]
-        runner = _make_runner(sdk)
+        fs = MagicMock()
+        fs.put.side_effect = [RateLimitError(response), None]
+        mock_fs_cls.return_value = fs
+        runner = _make_runner(_make_files_client())
 
         runner.upload_fileset(FileSetRef(workspace="default", name="models"), src.resolve())
 
-        assert sdk.files.upload.call_count == 2
+        assert fs.put.call_count == 2
 
-    def test_gives_up_as_a_file_upload_error(self, tmp_path: Path, no_retry_backoff) -> None:
+    @patch("nmp.customization_common.tasks.file_io.run.FilesetFileSystem")
+    def test_gives_up_as_a_file_upload_error(self, mock_fs_cls, tmp_path: Path, no_retry_backoff) -> None:
         from nemo_platform_plugin.client.errors import NemoTransportError
         from nmp.customization_common.schemas.file_io import FileSetRef, FileUploadError
 
         src = _make_dir(tmp_path)
-        sdk = _make_sdk()
-        sdk.files.upload.side_effect = NemoTransportError(httpx.ReadTimeout("timed out"))
-        runner = _make_runner(sdk)
+        fs = MagicMock()
+        fs.put.side_effect = NemoTransportError(httpx.ReadTimeout("timed out"))
+        mock_fs_cls.return_value = fs
+        runner = _make_runner(_make_files_client())
 
         with pytest.raises(FileUploadError):
             runner.upload_fileset(FileSetRef(workspace="default", name="models"), src.resolve())
 
-        assert sdk.files.upload.call_count == 3
+        assert fs.put.call_count == 3

--- a/packages/nmp_customization_common/tests/test_models_client_migration.py
+++ b/packages/nmp_customization_common/tests/test_models_client_migration.py
@@ -3,9 +3,9 @@
 
 """Model-entity resolution through the typed Models client, over a mocked httpx transport.
 
-Driving a real ``NeMoPlatform`` -> ``client_from_platform`` -> ``ModelsClient``
-chain asserts the wire contract (method, path, query string, parsed model and
-error mapping) rather than restating the call the implementation happens to make.
+Driving real ``NemoClient`` / ``AsyncNemoClient`` instances asserts the wire
+contract (method, path, query string, parsed model and error mapping) rather
+than restating the call the implementation happens to make.
 """
 
 from __future__ import annotations
@@ -14,10 +14,16 @@ from unittest.mock import MagicMock
 
 import httpx
 import pytest
-from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
+from nemo_platform_plugin.client.client import AsyncNemoClient, NemoClient
 from nemo_platform_plugin.client.errors import NemoTransportError
+from nemo_platform_plugin.client.types import RetryPolicy
+from nemo_platform_plugin.files.client import AsyncFilesClient, FilesClient
+from nemo_platform_plugin.models.client import AsyncModelsClient, ModelsClient
 from nemo_platform_plugin.models.types import ModelEntity
-from nmp.customization_common.service.platform_client import fetch_model_entity
+from nmp.customization_common.service.platform_client import (
+    AsyncCustomizationPlatformClients,
+    fetch_model_entity,
+)
 from nmp.customization_common.tasks.model_entity.run import (
     TRANSIENT_RETRYABLE_EXCEPTIONS,
     ModelEntityCreationError,
@@ -51,12 +57,33 @@ def _recording_transport(
     return httpx.MockTransport(handler), seen
 
 
+def _async_platform(transport: httpx.MockTransport) -> AsyncCustomizationPlatformClients:
+    client = AsyncNemoClient(base_url=BASE, workspace="default", http_client=httpx.AsyncClient(transport=transport))
+    return AsyncCustomizationPlatformClients(
+        files=AsyncFilesClient.from_client(client),
+        models=AsyncModelsClient.from_client(client),
+    )
+
+
+def _runner(transport: httpx.MockTransport, *, retry: RetryPolicy | None = None) -> ModelEntityRunner:
+    client = NemoClient(
+        base_url=BASE,
+        workspace="default",
+        http_client=httpx.Client(transport=transport),
+        retry=retry,
+    )
+    return ModelEntityRunner(
+        models=ModelsClient.from_client(client),
+        files=FilesClient.from_client(client),
+        job_ctx=MagicMock(),
+    )
+
+
 @pytest.mark.asyncio
 async def test_fetch_model_entity_requests_verbose_model() -> None:
     transport, seen = _recording_transport()
-    sdk = AsyncNeMoPlatform(base_url=BASE, workspace="default", http_client=httpx.AsyncClient(transport=transport))
 
-    result = await fetch_model_entity("other/model", "default", sdk)
+    result = await fetch_model_entity("other/model", "default", _async_platform(transport))
 
     assert isinstance(result, ModelEntity)
     assert (result.workspace, result.name) == ("other", "model")
@@ -69,26 +96,23 @@ async def test_fetch_model_entity_requests_verbose_model() -> None:
 @pytest.mark.asyncio
 async def test_fetch_model_entity_maps_403_to_permission_error() -> None:
     transport, _ = _recording_transport(403, {"detail": "denied"})
-    sdk = AsyncNeMoPlatform(base_url=BASE, workspace="default", http_client=httpx.AsyncClient(transport=transport))
 
     with pytest.raises(PermissionError, match="other/model"):
-        await fetch_model_entity("other/model", "default", sdk)
+        await fetch_model_entity("other/model", "default", _async_platform(transport))
 
 
 @pytest.mark.asyncio
 async def test_fetch_model_entity_maps_404_to_value_error() -> None:
     transport, _ = _recording_transport(404, {"detail": "missing"})
-    sdk = AsyncNeMoPlatform(base_url=BASE, workspace="default", http_client=httpx.AsyncClient(transport=transport))
 
     with pytest.raises(ValueError, match="other/model"):
-        await fetch_model_entity("other/model", "default", sdk)
+        await fetch_model_entity("other/model", "default", _async_platform(transport))
 
 
 def test_model_entity_runner_resolves_qualified_ref() -> None:
     transport, seen = _recording_transport()
-    sdk = NeMoPlatform(base_url=BASE, workspace="default", http_client=httpx.Client(transport=transport))
 
-    result = ModelEntityRunner(sdk, MagicMock()).get_model_entity("other/model", "default")
+    result = _runner(transport).get_model_entity("other/model", "default")
 
     assert isinstance(result, ModelEntity)
     assert (result.workspace, result.name) == ("other", "model")
@@ -99,19 +123,17 @@ def test_model_entity_runner_resolves_qualified_ref() -> None:
 def test_model_entity_runner_falls_back_to_fileset_workspace() -> None:
     """A bare ``name`` resolves against the fileset workspace, not the client default."""
     transport, seen = _recording_transport(payload=_model_json(workspace="fs-ws"))
-    sdk = NeMoPlatform(base_url=BASE, workspace="default", http_client=httpx.Client(transport=transport))
 
-    ModelEntityRunner(sdk, MagicMock()).get_model_entity("model", "fs-ws")
+    _runner(transport).get_model_entity("model", "fs-ws")
 
     assert seen[0].url.path == "/apis/models/v2/workspaces/fs-ws/models/model"
 
 
 def test_model_entity_runner_maps_404_to_creation_error() -> None:
     transport, _ = _recording_transport(404, {"detail": "missing"})
-    sdk = NeMoPlatform(base_url=BASE, workspace="default", http_client=httpx.Client(transport=transport))
 
     with pytest.raises(ModelEntityCreationError, match="other/model not found"):
-        ModelEntityRunner(sdk, MagicMock()).get_model_entity("other/model", "default")
+        _runner(transport).get_model_entity("other/model", "default")
 
 
 def test_transport_failures_surface_as_retryable_nemo_errors() -> None:
@@ -124,14 +146,9 @@ def test_transport_failures_surface_as_retryable_nemo_errors() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         raise httpx.ConnectError("connection refused", request=request)
 
-    sdk = NeMoPlatform(
-        base_url=BASE,
-        workspace="default",
-        max_retries=0,
-        http_client=httpx.Client(transport=httpx.MockTransport(handler)),
-    )
+    transport = httpx.MockTransport(handler)
 
     with pytest.raises(NemoTransportError) as exc:
-        ModelEntityRunner(sdk, MagicMock()).get_model_entity("other/model", "default")
+        _runner(transport, retry=RetryPolicy(max_retries=0)).get_model_entity("other/model", "default")
 
     assert isinstance(exc.value, TRANSIENT_RETRYABLE_EXCEPTIONS)

--- a/packages/nmp_customization_common/tests/test_platform_client.py
+++ b/packages/nmp_customization_common/tests/test_platform_client.py
@@ -1,16 +1,13 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from collections.abc import Callable
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
 from nemo_platform_plugin.client.errors import NotFoundError
-from nemo_platform_plugin.files.client import AsyncFilesClient
-from nemo_platform_plugin.models.client import AsyncModelsClient
-from nmp.customization_common.service.platform_client import fetch_model_entity
+from nmp.customization_common.service.platform_client import AsyncCustomizationPlatformClients, fetch_model_entity
 
 
 def _not_found() -> NotFoundError:
@@ -21,7 +18,7 @@ def _clients(
     model: SimpleNamespace,
     *,
     fileset_error: Exception | None = None,
-) -> tuple[MagicMock, MagicMock, Callable[[object, type], MagicMock]]:
+) -> tuple[MagicMock, MagicMock, AsyncCustomizationPlatformClients]:
     models = MagicMock()
     models.get_model = AsyncMock(return_value=SimpleNamespace(data=lambda: model))
     files = MagicMock()
@@ -29,25 +26,14 @@ def _clients(
     if fileset_error is not None:
         files.get_fileset.side_effect = fileset_error
 
-    def dispatch(_sdk: object, client_type: type):
-        if client_type is AsyncModelsClient:
-            return models
-        if client_type is AsyncFilesClient:
-            return files
-        raise AssertionError(f"Unexpected client type: {client_type}")
-
-    return models, files, dispatch
+    return models, files, AsyncCustomizationPlatformClients(files=files, models=models)
 
 
 async def test_fetch_model_entity_verifies_weights_fileset() -> None:
     model = SimpleNamespace(name="base", workspace="default", fileset="weights/default-base")
-    models, files, dispatch = _clients(model)
+    models, files, platform = _clients(model)
 
-    with patch(
-        "nmp.customization_common.service.platform_client.client_from_platform",
-        side_effect=dispatch,
-    ):
-        result = await fetch_model_entity("default/base", "default", MagicMock())
+    result = await fetch_model_entity("default/base", "default", platform)
 
     assert result is model
     models.get_model.assert_awaited_once_with(
@@ -60,27 +46,17 @@ async def test_fetch_model_entity_verifies_weights_fileset() -> None:
 
 async def test_fetch_model_entity_rejects_missing_weights_fileset() -> None:
     model = SimpleNamespace(name="base", workspace="default", fileset="default/missing")
-    _, _, dispatch = _clients(model, fileset_error=_not_found())
+    _, _, platform = _clients(model, fileset_error=_not_found())
 
-    with (
-        patch(
-            "nmp.customization_common.service.platform_client.client_from_platform",
-            side_effect=dispatch,
-        ),
-        pytest.raises(ValueError, match="Weights for model 'default/base' fileset 'missing' not found"),
-    ):
-        await fetch_model_entity("default/base", "default", MagicMock())
+    with pytest.raises(ValueError, match="Weights for model 'default/base' fileset 'missing' not found"):
+        await fetch_model_entity("default/base", "default", platform)
 
 
 async def test_fetch_model_entity_without_weights_fileset_skips_files_service() -> None:
     model = SimpleNamespace(name="api-model", workspace="default", fileset=None)
-    _, files, dispatch = _clients(model)
+    _, files, platform = _clients(model)
 
-    with patch(
-        "nmp.customization_common.service.platform_client.client_from_platform",
-        side_effect=dispatch,
-    ):
-        result = await fetch_model_entity("api-model", "default", MagicMock())
+    result = await fetch_model_entity("api-model", "default", platform)
 
     assert result is model
     files.get_fileset.assert_not_awaited()

--- a/packages/nmp_customization_common/tests/training/test_progress.py
+++ b/packages/nmp_customization_common/tests/training/test_progress.py
@@ -63,17 +63,17 @@ class _JobCtx:
 class _Reporter(JobsServiceProgressReporter):
     """Reporter with the SDK and job context stubbed out.
 
-    Bypasses ``__init__`` rather than mocking the SDK factory: what is under test
-    is the status_details logic, and the real constructor calls ``get_task_sdk``,
-    which wants credentials. Every attribute ``update_task`` touches is set here.
+    Bypasses ``__init__`` rather than mocking the client factory: what is under
+    test is the status_details logic, and the real constructor wants task
+    credentials. Every attribute ``update_task`` touches is set here.
 
-    The SDK client itself is patched (see the ``jobs`` fixture) rather than
-    ``fetch_current_metrics``, so the real fetch runs.
+    The Jobs client itself is injected rather than ``fetch_current_metrics``, so
+    the real fetch runs.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, jobs: "_Jobs") -> None:
         self._job_ctx = _JobCtx()  # type: ignore[assignment] - duck-typed stand-in
-        self._sdk = type("S", (), {"close": lambda self: None})()  # type: ignore[assignment]
+        self._jobs = jobs.client()  # type: ignore[assignment] - duck-typed stand-in
         self._is_main_rank = True
         self._enabled = True
         self._max_steps = 0
@@ -121,13 +121,9 @@ class _Jobs:
 
 
 @pytest.fixture
-def jobs(monkeypatch: pytest.MonkeyPatch) -> _Jobs:
-    """Patch the SDK client seam so update_task and the fetch both run for real."""
+def jobs() -> _Jobs:
+    """Return a Jobs service harness so update_task and fetch both run for real."""
     harness = _Jobs()
-    monkeypatch.setattr(
-        "nmp.customization_common.training.progress.client_from_platform",
-        lambda _sdk, _cls: harness.client(),
-    )
     return harness
 
 
@@ -135,7 +131,7 @@ def _reporter(jobs: _Jobs, stored: dict[str, Any] | None = None) -> _Reporter:
     """A reporter over the harness, with the server pre-seeded if given."""
     if stored is not None:
         jobs.stored = stored
-    return _Reporter()
+    return _Reporter(jobs)
 
 
 def _details(jobs: _Jobs, index: int = -1) -> dict[str, Any]:
@@ -289,7 +285,7 @@ def test_a_malformed_blob_seeds_nothing_instead_of_raising(jobs: _Jobs, stored: 
     """
     jobs.stored = stored
 
-    assert _Reporter().fetch_current_metrics() == {}
+    assert _reporter(jobs).fetch_current_metrics() == {}
 
 
 # --------------------------------------------------------------------------- #
@@ -401,54 +397,105 @@ def test_progress_updates_use_a_short_timeout(monkeypatch: pytest.MonkeyPatch) -
     Asserted against the SDK the reporter actually built, not against the
     constant, so that wiring the constant to nothing would fail here.
     """
-    built: dict[str, Any] = {}
+    timeouts: list[httpx.Timeout] = []
+    optioned_clients: list[_JobsClient] = []
 
-    class _Sdk:
+    class _JobsClient:
         def __init__(self, optioned: bool = False) -> None:
             self.optioned = optioned
 
-        def with_options(self, **kwargs: Any) -> "_Sdk":
-            built.update(kwargs)
-            return _Sdk(optioned=True)
-
-        def close(self) -> None: ...
+        def with_options(self, *, timeout: httpx.Timeout) -> "_JobsClient":
+            timeouts.append(timeout)
+            client = _JobsClient(optioned=True)
+            optioned_clients.append(client)
+            return client
 
     monkeypatch.setattr(
-        "nmp.customization_common.training.progress.get_task_sdk",
-        lambda service_name: _Sdk(),
+        "nmp.customization_common.training.progress.get_task_nemo_client",
+        lambda service_name: object(),
     )
-    reporter = JobsServiceProgressReporter(_JobCtx(), service_name="customizer")  # ty: ignore[invalid-argument-type] # duck-typed stub
+    monkeypatch.setattr(
+        "nmp.customization_common.training.progress.JobsClient.from_client",
+        lambda client: _JobsClient(),
+    )
+    JobsServiceProgressReporter(_JobCtx(), service_name="customizer")  # ty: ignore[invalid-argument-type] # duck-typed stub
 
-    timeout = built["timeout"]
     # A 12 MB blob -- far past anything a real run produces -- costs 46ms plus
     # 0.31ms/KB, so about 4s on the wire. 15s leaves room and still bounds the stall.
-    assert timeout.read <= 15, "long enough for a 12 MB blob, short enough to give the step back"
-    assert timeout.write <= 15
-    assert timeout.connect <= 5
-    assert reporter._sdk.optioned, "kept the un-optioned SDK, so the timeout never applies"
+    assert timeouts == [httpx.Timeout(10.0, connect=5.0)]
+    assert len(optioned_clients) == 1
+    assert optioned_clients[0].optioned, "kept the un-optioned Jobs client, so the timeout never applies"
 
 
-def test_the_sdk_is_not_rebuilt_with_a_custom_client(monkeypatch: pytest.MonkeyPatch) -> None:
-    """`get_task_sdk` skips its workload-identity branch when handed a client.
+def test_the_task_client_is_not_rebuilt_with_a_custom_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`get_task_nemo_client` skips workload identity when handed a client.
 
     Setting the timeout by passing our own `http_client` would therefore change
     how a task authenticates, silently and only in the deployment that uses
     workload identity -- which is the one hardest to test. `with_options` leaves
     that path alone.
     """
-    seen: dict[str, Any] = {}
+    seen: dict[str, object | None] = {}
 
-    class _Sdk:
-        def with_options(self, **kwargs: Any) -> "_Sdk":
+    class _JobsClient:
+        def with_options(self, *, timeout: httpx.Timeout) -> "_JobsClient":
             return self
 
-        def close(self) -> None: ...
-
-    def _factory(service_name: str, http_client: Any = None) -> _Sdk:
+    def _factory(service_name: str, *, http_client: object | None = None, workspace: str | None = None) -> object:
         seen["http_client"] = http_client
-        return _Sdk()
+        seen["workspace"] = workspace
+        return object()
 
-    monkeypatch.setattr("nmp.customization_common.training.progress.get_task_sdk", _factory)
+    monkeypatch.setattr("nmp.customization_common.training.progress.get_task_nemo_client", _factory)
+    monkeypatch.setattr(
+        "nmp.customization_common.training.progress.JobsClient.from_client",
+        lambda client: _JobsClient(),
+    )
     JobsServiceProgressReporter(_JobCtx(), service_name="customizer")  # ty: ignore[invalid-argument-type] # duck-typed stub
 
     assert seen["http_client"] is None, "no client passed, so the auth path is untouched"
+
+
+def test_close_closes_the_owning_task_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Derived service clients share transport, so the root task client owns close."""
+
+    class _TaskClient:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    class _JobsClient:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def with_options(self, *, timeout: httpx.Timeout) -> "_JobsClient":
+            return self
+
+        def close(self) -> None:
+            self.closed = True
+
+    task_client = _TaskClient()
+    jobs_client = _JobsClient()
+    seen_clients: list[_TaskClient] = []
+
+    def _from_client(client: _TaskClient) -> _JobsClient:
+        seen_clients.append(client)
+        return jobs_client
+
+    monkeypatch.setattr(
+        "nmp.customization_common.training.progress.get_task_nemo_client",
+        lambda service_name: task_client,
+    )
+    monkeypatch.setattr(
+        "nmp.customization_common.training.progress.JobsClient.from_client",
+        _from_client,
+    )
+
+    reporter = JobsServiceProgressReporter(_JobCtx(), service_name="customizer")  # ty: ignore[invalid-argument-type] # duck-typed stub
+    reporter.close()
+
+    assert seen_clients == [task_client]
+    assert task_client.closed
+    assert not jobs_client.closed

--- a/plugins/nemo-agents/tests/integration/test_execute_job_integration.py
+++ b/plugins/nemo-agents/tests/integration/test_execute_job_integration.py
@@ -14,6 +14,8 @@ import pytest
 from nemo_agents_plugin.fabric.runtime import FabricRuntimeResult
 from nemo_agents_plugin.jobs.execute import ExecuteAgentJob
 from nemo_agents_plugin.service import AgentsService
+from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.client.client import NemoClient
 from nemo_platform_plugin.job_context import JobContext, StoragePaths
 from nemo_platform_plugin.job_results import PlatformJobResults
 from nmp.core.files.service import FilesService
@@ -130,7 +132,11 @@ def test_execute_job_materializes_layered_input_workspace(tmp_path: Path) -> Non
         job_ctx = JobContext(
             workspace="default",
             storage=StoragePaths(ephemeral=ephemeral, persistent=persistent),
-            results=PlatformJobResults(job_name=job_name, workspace="default", sdk=ctx.sdk),
+            results=PlatformJobResults(
+                job_name=job_name,
+                workspace="default",
+                client=client_from_platform(ctx.sdk, NemoClient),
+            ),
             job_id=job["id"],
         )
 
@@ -239,7 +245,11 @@ def test_execute_job_saves_error_results_when_fabric_raises(tmp_path: Path) -> N
         job_ctx = JobContext(
             workspace="default",
             storage=StoragePaths(ephemeral=ephemeral, persistent=persistent),
-            results=PlatformJobResults(job_name=job_name, workspace="default", sdk=ctx.sdk),
+            results=PlatformJobResults(
+                job_name=job_name,
+                workspace="default",
+                client=client_from_platform(ctx.sdk, NemoClient),
+            ),
             job_id=job["id"],
         )
 

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/tasks/anonymizer/run.py
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/tasks/anonymizer/run.py
@@ -21,6 +21,7 @@ from nemo_anonymizer_plugin.app.task_config import AnonymizerStepConfig
 from nemo_anonymizer_plugin.app.upstream_logging import preserve_root_logging
 from nemo_platform import NeMoPlatform
 from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.client.client import NemoClient
 from nemo_platform_plugin.job_context import JobContext, StoragePaths
 from nemo_platform_plugin.job_results import PlatformJobResults
 from nemo_platform_plugin.jobs.constants import (
@@ -199,7 +200,7 @@ def _get_ctx(sdk: NeMoPlatform) -> JobContext:
     results = PlatformJobResults(
         workspace=workspace,
         job_name=job_name,
-        sdk=sdk,
+        client=client_from_platform(sdk, NemoClient),
     )
     return JobContext(
         workspace=workspace,

--- a/plugins/nemo-automodel/pyproject.toml
+++ b/plugins/nemo-automodel/pyproject.toml
@@ -8,7 +8,6 @@ readme = "README.md"
 requires-python = ">=3.11,<3.14"
 dependencies = [
     "nemo-platform-plugin",
-    "nemo-platform",
     "nmp-automodel",
     "nmp-customization-common",
     "pydantic>=2.10.6",
@@ -33,7 +32,6 @@ packages = ["src/nemo_automodel_plugin"]
 
 [tool.uv.sources]
 nemo-platform-plugin = { workspace = true }
-nemo-platform = { workspace = true }
 nmp-automodel = { workspace = true }
 nemo-customizer-plugin = { workspace = true }
 nmp-customization-common = { workspace = true }

--- a/plugins/nemo-automodel/src/nemo_automodel_plugin/jobs/jobs.py
+++ b/plugins/nemo-automodel/src/nemo_automodel_plugin/jobs/jobs.py
@@ -12,7 +12,7 @@ schema (automodel-specific).
 from __future__ import annotations
 
 import asyncio
-from typing import ClassVar, cast
+from typing import ClassVar
 
 from nemo_automodel_plugin.config import get_config
 from nemo_automodel_plugin.schema import AutomodelJobInput, AutomodelJobOutput, ValidationError
@@ -23,22 +23,35 @@ from nemo_platform_plugin.jobs.docker import validate_gpu_available_for_docker
 from nemo_platform_plugin.jobs.exceptions import PlatformJobCompilationError
 from nmp.automodel.compile import platform_job_config_compiler
 from nmp.customization_common.contributor.jobs import BaseSubmitJob, require_container_runtime
+from nmp.customization_common.service.platform_client import (
+    AsyncCustomizationPlatformClients,
+    async_customization_platform_clients_from_platform,
+)
 from pydantic import BaseModel
 
 
-class AutomodelJob(BaseSubmitJob):
+class AutomodelJob(BaseSubmitJob[AutomodelJobInput, AutomodelJobOutput]):
     """GPU Automodel fine-tuning job under the customization router."""
 
     name: ClassVar[str] = "automodel.jobs"
     description: ClassVar[str] = "Automodel SFT, retrieval, and knowledge-distillation training jobs."
     job_collection_path: ClassVar[str | None] = "/automodel/jobs"
-    input_spec_schema: ClassVar[type[BaseModel] | None] = AutomodelJobInput
-    spec_schema: ClassVar[type[BaseModel] | None] = AutomodelJobOutput
+    input_spec_schema: ClassVar[type[AutomodelJobInput] | None] = AutomodelJobInput
+    spec_schema: ClassVar[type[AutomodelJobOutput] | None] = AutomodelJobOutput
     runtime_label: ClassVar[str] = "Automodel"
 
     @classmethod
-    async def _transform(cls, job_input: BaseModel, workspace: str, async_sdk: AsyncNeMoPlatform) -> AutomodelJobOutput:
-        return await transform_input_to_output(cast(AutomodelJobInput, job_input), workspace, async_sdk)
+    def _job_input_schema(cls) -> type[AutomodelJobInput]:
+        return AutomodelJobInput
+
+    @classmethod
+    async def _transform(
+        cls,
+        job_input: AutomodelJobInput,
+        workspace: str,
+        platform: AsyncCustomizationPlatformClients,
+    ) -> AutomodelJobOutput:
+        return await transform_input_to_output(job_input, workspace, platform)
 
     @classmethod
     async def compile(
@@ -47,13 +60,12 @@ class AutomodelJob(BaseSubmitJob):
         spec: BaseModel,
         entity_client: object,
         job_name: str | None,
-        async_sdk: object,
+        async_sdk: AsyncNeMoPlatform,
         profile: str | None = None,
         options: dict | None = None,
     ) -> PlatformJobSpec:
         del entity_client, options
-        if not isinstance(async_sdk, AsyncNeMoPlatform):
-            raise TypeError(f"async_sdk must be AsyncNeMoPlatform, got {type(async_sdk).__name__}")
+        platform = async_customization_platform_clients_from_platform(async_sdk)
         canonical = (
             spec if isinstance(spec, AutomodelJobOutput) else AutomodelJobOutput.model_validate(spec.model_dump())
         )
@@ -78,7 +90,7 @@ class AutomodelJob(BaseSubmitJob):
         platform_spec = await platform_job_config_compiler(
             canonical,
             workspace,
-            async_sdk,
+            platform,
             job_name=job_name,
             profile=execution_profile,
         )

--- a/plugins/nemo-automodel/src/nemo_automodel_plugin/transform.py
+++ b/plugins/nemo-automodel/src/nemo_automodel_plugin/transform.py
@@ -5,19 +5,20 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+from typing import Literal
 
 from nmp.customization_common.contributor.transform import generated_output_name
-from nmp.customization_common.service.platform_client import check_dataset_access, fetch_model_entity
+from nmp.customization_common.service.platform_client import (
+    AsyncCustomizationPlatformClients,
+    check_dataset_access,
+    fetch_model_entity,
+)
 
 from nemo_automodel_plugin.schema import (
     AutomodelJobInput,
     AutomodelJobOutput,
     OutputResponse,
 )
-
-if TYPE_CHECKING:
-    from nemo_platform import AsyncNeMoPlatform
 
 
 def _infer_output_type(input_spec: AutomodelJobInput, checkpoint_head_type: str) -> Literal["model", "adapter"]:
@@ -34,13 +35,13 @@ def _infer_output_type(input_spec: AutomodelJobInput, checkpoint_head_type: str)
 async def transform_input_to_output(
     input_spec: AutomodelJobInput,
     workspace: str,
-    sdk: AsyncNeMoPlatform,
+    platform: AsyncCustomizationPlatformClients,
 ) -> AutomodelJobOutput:
     """Enrich submitter input into canonical AutomodelJobOutput."""
-    model_entity = await fetch_model_entity(input_spec.model, workspace, sdk)
-    await check_dataset_access(sdk, input_spec.dataset.training, workspace)
+    model_entity = await fetch_model_entity(input_spec.model, workspace, platform)
+    await check_dataset_access(platform, input_spec.dataset.training, workspace)
     if input_spec.dataset.validation:
-        await check_dataset_access(sdk, input_spec.dataset.validation, workspace)
+        await check_dataset_access(platform, input_spec.dataset.validation, workspace)
 
     checkpoint_head_type = "unknown"
     if model_entity.spec:

--- a/plugins/nemo-automodel/tests/test_jobs.py
+++ b/plugins/nemo-automodel/tests/test_jobs.py
@@ -15,6 +15,7 @@ import asyncio
 from typing import Any
 from unittest.mock import patch
 
+import httpx
 import pytest
 from nemo_automodel_plugin.jobs.jobs import AutomodelJob
 from nemo_automodel_plugin.schema import AutomodelJobOutput
@@ -38,15 +39,26 @@ def _make_canonical(**parallelism: Any) -> AutomodelJobOutput:
 
 
 def _compile(canonical: AutomodelJobOutput) -> Any:
-    return asyncio.run(
-        AutomodelJob.compile(
+    async def run_compile() -> Any:
+        async_sdk = AsyncNeMoPlatform(
+            base_url="http://test",
             workspace="default",
-            spec=canonical,
-            entity_client=object(),
-            job_name=None,
-            async_sdk=object.__new__(AsyncNeMoPlatform),
-        ),
-    )
+            http_client=httpx.AsyncClient(
+                transport=httpx.MockTransport(lambda request: httpx.Response(200, request=request))
+            ),
+        )
+        try:
+            return await AutomodelJob.compile(
+                workspace="default",
+                spec=canonical,
+                entity_client=object(),
+                job_name=None,
+                async_sdk=async_sdk,
+            )
+        finally:
+            await async_sdk.close()
+
+    return asyncio.run(run_compile())
 
 
 class TestCompileValidationErrors:

--- a/plugins/nemo-customizer/src/nemo_customizer/sdk/resources.py
+++ b/plugins/nemo-customizer/src/nemo_customizer/sdk/resources.py
@@ -75,17 +75,17 @@ def _mount_contributor_sdk_resources(
     return resources
 
 
-def _missing_resource_attribute(owner: object, name: str) -> AttributeError:
-    return AttributeError(f"'{type(owner).__name__}' object has no attribute {name!r}")
+def _missing_resource_attribute(owner_type_name: str, name: str) -> AttributeError:
+    return AttributeError(f"'{owner_type_name}' object has no attribute {name!r}")
 
 
 def _require_resource_attribute(
-    owner: object,
+    owner_type_name: str,
     name: str,
     resource: ResourceT | None,
 ) -> ResourceT:
     if resource is None:
-        raise _missing_resource_attribute(owner, name)
+        raise _missing_resource_attribute(owner_type_name, name)
     return resource
 
 
@@ -116,15 +116,15 @@ class Customization:
 
     @property
     def automodel(self) -> CustomizationBackendResource:
-        return _require_resource_attribute(self, "automodel", self._automodel)
+        return _require_resource_attribute(type(self).__name__, "automodel", self._automodel)
 
     @property
     def rl(self) -> CustomizationBackendResource:
-        return _require_resource_attribute(self, "rl", self._rl)
+        return _require_resource_attribute(type(self).__name__, "rl", self._rl)
 
     @property
     def unsloth(self) -> CustomizationBackendResource:
-        return _require_resource_attribute(self, "unsloth", self._unsloth)
+        return _require_resource_attribute(type(self).__name__, "unsloth", self._unsloth)
 
     def plugin_status(self) -> dict[str, object]:
         """Return customization router health, including the registered contributors."""
@@ -162,15 +162,15 @@ class AsyncCustomization:
 
     @property
     def automodel(self) -> AsyncCustomizationBackendResource:
-        return _require_resource_attribute(self, "automodel", self._automodel)
+        return _require_resource_attribute(type(self).__name__, "automodel", self._automodel)
 
     @property
     def rl(self) -> AsyncCustomizationBackendResource:
-        return _require_resource_attribute(self, "rl", self._rl)
+        return _require_resource_attribute(type(self).__name__, "rl", self._rl)
 
     @property
     def unsloth(self) -> AsyncCustomizationBackendResource:
-        return _require_resource_attribute(self, "unsloth", self._unsloth)
+        return _require_resource_attribute(type(self).__name__, "unsloth", self._unsloth)
 
     async def plugin_status(self) -> dict[str, object]:
         """Return customization router health, including the registered contributors."""

--- a/plugins/nemo-customizer/tests/test_sdk.py
+++ b/plugins/nemo-customizer/tests/test_sdk.py
@@ -121,7 +121,7 @@ def test_customization_composes_contributor_resources_on_typed_nemo_client() -> 
     assert customization.automodel.jobs is not None
 
 
-def test_customization_accepts_legacy_nemo_platform_owner() -> None:
+def test_customization_accepts_generated_nemo_platform_owner() -> None:
     transport, requests = _recording_customization_transport()
     platform = NeMoPlatform(
         base_url="http://localhost:8000",
@@ -238,7 +238,7 @@ async def test_async_plugin_status_hits_versioned_hub_healthz() -> None:
     assert status["status"] == "ok"
 
 
-async def test_async_customization_accepts_legacy_nemo_platform_owner() -> None:
+async def test_async_customization_accepts_generated_nemo_platform_owner() -> None:
     transport, requests = _recording_customization_transport()
     platform = AsyncNeMoPlatform(
         base_url="http://localhost:8000",

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/jobs/bridge.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/jobs/bridge.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from nemo_data_designer_plugin.jobs.run import run_step_config
 from nemo_data_designer_plugin.jobs.spec import DataDesignerStepConfig
 from nemo_platform import NeMoPlatform
+from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.client.client import NemoClient
 from nemo_platform_plugin.job_context import JobContext, StoragePaths
 from nemo_platform_plugin.job_results import PlatformJobResults
 from nemo_platform_plugin.jobs.constants import (
@@ -49,7 +51,7 @@ def _get_ctx(sdk: NeMoPlatform) -> JobContext:
     results = PlatformJobResults(
         workspace=workspace,
         job_name=job_name,
-        sdk=sdk,
+        client=client_from_platform(sdk, NemoClient),
     )
     return JobContext(
         workspace=workspace,

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/jobs/retrieval_bridge.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/jobs/retrieval_bridge.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from typing import Any
 
 from nemo_platform import NeMoPlatform
+from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.client.client import NemoClient
 from nemo_platform_plugin.job_context import JobContext, StoragePaths
 from nemo_platform_plugin.job_results import PlatformJobResults
 from nemo_platform_plugin.jobs.constants import (
@@ -40,7 +42,7 @@ def _get_ctx(sdk: NeMoPlatform) -> JobContext:
         ephemeral=Path(os.environ[EPHEMERAL_TASK_STORAGE_PATH_ENVVAR]),
         persistent=Path(persistent_env) if persistent_env else None,
     )
-    results = PlatformJobResults(workspace=workspace, job_name=job_name, sdk=sdk)
+    results = PlatformJobResults(workspace=workspace, job_name=job_name, client=client_from_platform(sdk, NemoClient))
     return JobContext(workspace=workspace, job_id=job_name, storage=storage, results=results)
 
 

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/testing/utils.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/testing/utils.py
@@ -30,6 +30,7 @@ from nemo_data_designer_plugin.sdk.resources import DataDesignerResource
 from nemo_data_designer_plugin.service import DataDesignerService
 from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
 from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.client.client import NemoClient
 from nemo_platform_plugin.commands import add_function_commands, add_job_commands
 from nemo_platform_plugin.files.client import FilesClient
 from nemo_platform_plugin.files.types import CreateFilesetRequest
@@ -435,7 +436,11 @@ async def task_context(
             job_ctx = JobContext(
                 workspace="default",
                 storage=StoragePaths(ephemeral=ephemeral, persistent=persistent),
-                results=PlatformJobResults(job_name=job_name, workspace="default", sdk=client_context.sdk),
+                results=PlatformJobResults(
+                    job_name=job_name,
+                    workspace="default",
+                    client=client_from_platform(client_context.sdk, NemoClient),
+                ),
                 job_id=job.id,
             )
             yield CreateJobTestContext(

--- a/plugins/nemo-rl/pyproject.toml
+++ b/plugins/nemo-rl/pyproject.toml
@@ -9,7 +9,6 @@ readme = "README.md"
 requires-python = ">=3.11,<3.14"
 dependencies = [
     "nemo-platform-plugin",
-    "nemo-platform",
     "nmp-rl",
     "nmp-customization-common",
     "pydantic>=2.10.6",
@@ -36,7 +35,6 @@ packages = ["src/nemo_rl_plugin"]
 
 [tool.uv.sources]
 nemo-platform-plugin = { workspace = true }
-nemo-platform = { workspace = true }
 nemo-customizer-plugin = { workspace = true }
 nmp-rl = { workspace = true }
 nmp-customization-common = { workspace = true }

--- a/plugins/nemo-rl/src/nemo_rl_plugin/environment.py
+++ b/plugins/nemo-rl/src/nemo_rl_plugin/environment.py
@@ -11,13 +11,10 @@ checked here instead, so the submitter gets it back from the API call.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-from nemo_platform_plugin.client.adapter import client_from_platform
 from nemo_platform_plugin.client.errors import NotFoundError as ClientNotFoundError
 from nemo_platform_plugin.client.errors import PermissionDeniedError as ClientPermissionDeniedError
-from nemo_platform_plugin.files.client import AsyncFilesClient
 from nmp.customization_common.schemas.file_io import FileSetRef
+from nmp.customization_common.service.platform_client import AsyncCustomizationPlatformClients
 from nmp.rl.tasks.environment.validate import (
     MANIFEST_FILENAME,
     EnvironmentPackageValidationError,
@@ -25,12 +22,9 @@ from nmp.rl.tasks.environment.validate import (
     validate_manifest_against_listing,
 )
 
-if TYPE_CHECKING:
-    from nemo_platform import AsyncNeMoPlatform
-
 
 async def check_environment_package(
-    sdk: "AsyncNeMoPlatform",
+    platform: AsyncCustomizationPlatformClients,
     environment_uri: str,
     default_workspace: str,
 ) -> None:
@@ -43,10 +37,9 @@ async def check_environment_package(
     """
     ref = FileSetRef.model_validate(environment_uri)
     workspace = ref.workspace or default_workspace
-    files = client_from_platform(sdk, AsyncFilesClient)
 
     try:
-        listing = (await files.list_files(workspace=workspace, name=ref.name)).data()
+        listing = (await platform.files.list_files(workspace=workspace, name=ref.name)).data()
     except ClientPermissionDeniedError:
         raise PermissionError(f"Access denied to environment fileset '{workspace}/{ref.name}'") from None
     except ClientNotFoundError:
@@ -62,7 +55,9 @@ async def check_environment_package(
         )
 
     try:
-        raw = await (await files.download_file(workspace=workspace, name=ref.name, path=MANIFEST_FILENAME)).read()
+        raw = await (
+            await platform.files.download_file(workspace=workspace, name=ref.name, path=MANIFEST_FILENAME)
+        ).read()
     except ClientPermissionDeniedError:
         raise PermissionError(f"Access denied to environment fileset '{workspace}/{ref.name}'") from None
 

--- a/plugins/nemo-rl/src/nemo_rl_plugin/jobs/jobs.py
+++ b/plugins/nemo-rl/src/nemo_rl_plugin/jobs/jobs.py
@@ -15,7 +15,7 @@ resolves the execution profile.
 
 from __future__ import annotations
 
-from typing import ClassVar, cast
+from typing import ClassVar
 
 from nemo_platform import AsyncNeMoPlatform
 from nemo_platform_plugin.jobs.api_factory import PlatformJobSpec
@@ -23,24 +23,37 @@ from nemo_platform_plugin.jobs.exceptions import PlatformJobCompilationError
 from nemo_rl_plugin.schema import RlJobInput
 from nemo_rl_plugin.transform import transform_input_to_output
 from nmp.customization_common.contributor.jobs import BaseSubmitJob, require_distributed_runtime
+from nmp.customization_common.service.platform_client import (
+    AsyncCustomizationPlatformClients,
+    async_customization_platform_clients_from_platform,
+)
 from nmp.rl.compile import platform_job_config_compiler
 from nmp.rl.schemas import RlJobOutput
 from pydantic import BaseModel
 
 
-class RlJob(BaseSubmitJob):
+class RlJob(BaseSubmitJob[RlJobInput, RlJobOutput]):
     """NeMo-RL DPO and GRPO training job under the customization router (submit-only)."""
 
     name: ClassVar[str] = "rl.jobs"
     description: ClassVar[str] = "NeMo-RL DPO and GRPO training jobs on the platform Kubernetes GPU cluster (Ray)."
     job_collection_path: ClassVar[str | None] = "/rl/jobs"
-    input_spec_schema: ClassVar[type[BaseModel] | None] = RlJobInput
-    spec_schema: ClassVar[type[BaseModel] | None] = RlJobOutput
+    input_spec_schema: ClassVar[type[RlJobInput] | None] = RlJobInput
+    spec_schema: ClassVar[type[RlJobOutput] | None] = RlJobOutput
     runtime_label: ClassVar[str] = "NeMo-RL"
 
     @classmethod
-    async def _transform(cls, job_input: BaseModel, workspace: str, async_sdk: AsyncNeMoPlatform) -> RlJobOutput:
-        return await transform_input_to_output(cast(RlJobInput, job_input), workspace, async_sdk)
+    def _job_input_schema(cls) -> type[RlJobInput]:
+        return RlJobInput
+
+    @classmethod
+    async def _transform(
+        cls,
+        job_input: RlJobInput,
+        workspace: str,
+        platform: AsyncCustomizationPlatformClients,
+    ) -> RlJobOutput:
+        return await transform_input_to_output(job_input, workspace, platform)
 
     @classmethod
     async def compile(
@@ -49,7 +62,7 @@ class RlJob(BaseSubmitJob):
         spec: BaseModel,
         entity_client: object,
         job_name: str | None,
-        async_sdk: object,
+        async_sdk: AsyncNeMoPlatform,
         profile: str | None = None,
         options: dict | None = None,
     ) -> PlatformJobSpec:
@@ -62,6 +75,7 @@ class RlJob(BaseSubmitJob):
         (single-node ``gpu`` vs multi-node ``gpu_distributed``).
         """
         del entity_client, options
+        platform = async_customization_platform_clients_from_platform(async_sdk)
         require_distributed_runtime(cls.runtime_label)
         canonical = spec if isinstance(spec, RlJobOutput) else RlJobOutput.model_validate(spec.model_dump())
         try:
@@ -75,7 +89,7 @@ class RlJob(BaseSubmitJob):
         return await platform_job_config_compiler(
             workspace=workspace,
             spec=canonical,
-            sdk=cast(AsyncNeMoPlatform, async_sdk),
+            platform=platform,
             job_name=job_name,
             profile=execution_profile,
         )

--- a/plugins/nemo-rl/src/nemo_rl_plugin/transform.py
+++ b/plugins/nemo-rl/src/nemo_rl_plugin/transform.py
@@ -9,11 +9,10 @@ accepted — the container pipeline expects a real fileset to download from.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from nmp.customization_common.contributor.transform import generated_output_name
 from nmp.customization_common.schemas.values import OutputNameType
 from nmp.customization_common.service.platform_client import (
+    AsyncCustomizationPlatformClients,
     check_dataset_access,
     check_environment_access,
     check_gym_dataset_layout,
@@ -24,9 +23,6 @@ from nmp.rl.schemas import GRPOTraining, OutputResponse, RlJobOutput
 
 from nemo_rl_plugin.environment import check_environment_package
 from nemo_rl_plugin.schema import OutputRequest, RlJobInput
-
-if TYPE_CHECKING:
-    from nemo_platform import AsyncNeMoPlatform
 
 
 def _infer_output_type(input_spec: RlJobInput) -> OutputNameType:
@@ -39,7 +35,7 @@ def _infer_output_type(input_spec: RlJobInput) -> OutputNameType:
 async def transform_input_to_output(
     input_spec: RlJobInput,
     workspace: str,
-    sdk: "AsyncNeMoPlatform",
+    platform: AsyncCustomizationPlatformClients,
 ) -> RlJobOutput:
     """Enrich submitter input into a canonical :class:`RlJobOutput`.
 
@@ -49,15 +45,15 @@ async def transform_input_to_output(
     """
     training_type = TrainingType(input_spec.training.type)
 
-    model_entity = await fetch_model_entity(input_spec.model, workspace, sdk)
-    await check_dataset_access(sdk, input_spec.dataset, workspace)
+    model_entity = await fetch_model_entity(input_spec.model, workspace, platform)
+    await check_dataset_access(platform, input_spec.dataset, workspace)
 
     if training_type == TrainingType.GRPO:
         if not input_spec.environment:
             raise ValueError("GRPO jobs require an environment fileset reference.")
-        await check_environment_access(sdk, input_spec.environment, workspace)
-        await check_environment_package(sdk, input_spec.environment, workspace)
-        await check_gym_dataset_layout(sdk, input_spec.dataset, workspace)
+        await check_environment_access(platform, input_spec.environment, workspace)
+        await check_environment_package(platform, input_spec.environment, workspace)
+        await check_gym_dataset_layout(platform, input_spec.dataset, workspace)
 
     model_spec = model_entity.spec
     head_type = getattr(model_spec, "head_type", None) if model_spec else None

--- a/plugins/nemo-rl/tests/test_environment_checks.py
+++ b/plugins/nemo-rl/tests/test_environment_checks.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 from nemo_rl_plugin.environment import check_environment_package
+from nmp.customization_common.service.platform_client import AsyncCustomizationPlatformClients
 
 ADAPTER_MANIFEST = b"""
 format: adapter-wheels-v1
@@ -28,81 +29,78 @@ ADAPTER_FILES = [
 ]
 
 
-def _sdk(paths: list[str], manifest: bytes = ADAPTER_MANIFEST) -> Mock:
+def _platform(paths: list[str], manifest: bytes = ADAPTER_MANIFEST) -> AsyncCustomizationPlatformClients:
     """Stub the Files client down to the two calls the check makes."""
     listing = SimpleNamespace(data=[SimpleNamespace(path=p) for p in paths])
     client = Mock()
     client.list_files = AsyncMock(return_value=SimpleNamespace(data=lambda: listing))
     client.download_file = AsyncMock(return_value=SimpleNamespace(read=AsyncMock(return_value=manifest)))
-    return client
-
-
-@pytest.fixture
-def patch_client(monkeypatch: pytest.MonkeyPatch):
-    def _patch(client: Mock) -> None:
-        monkeypatch.setattr("nemo_rl_plugin.environment.client_from_platform", lambda sdk, cls: client)
-
-    return _patch
+    return AsyncCustomizationPlatformClients(files=client, models=Mock())
 
 
 @pytest.mark.asyncio
-async def test_valid_adapter_wheels_package_passes(patch_client) -> None:
-    patch_client(_sdk(ADAPTER_FILES))
-    await check_environment_package(Mock(), "default/env", "default")
+async def test_valid_adapter_wheels_package_passes() -> None:
+    await check_environment_package(_platform(ADAPTER_FILES), "default/env", "default")
 
 
 @pytest.mark.asyncio
-async def test_missing_manifest_is_rejected(patch_client) -> None:
-    patch_client(_sdk(["configs/verifiers_agent.yaml"]))
+async def test_missing_manifest_is_rejected() -> None:
     with pytest.raises(ValueError, match="nemo-environment.yaml"):
-        await check_environment_package(Mock(), "default/env", "default")
+        await check_environment_package(_platform(["configs/verifiers_agent.yaml"]), "default/env", "default")
 
 
 @pytest.mark.asyncio
-async def test_config_path_not_in_package_is_rejected(patch_client) -> None:
+async def test_config_path_not_in_package_is_rejected() -> None:
     """The manifest naming a file nobody uploaded is the common packaging slip.
 
     Left to the job, Gym starts, finds no config, and starts no servers -- which surfaces
     as rollouts timing out rather than as a missing file.
     """
-    patch_client(_sdk(["nemo-environment.yaml", "wheels/x-1.0-py3-none-any.whl"]))
     with pytest.raises(ValueError, match="config_paths reference files that are not in the package"):
-        await check_environment_package(Mock(), "default/env", "default")
+        await check_environment_package(
+            _platform(["nemo-environment.yaml", "wheels/x-1.0-py3-none-any.whl"]),
+            "default/env",
+            "default",
+        )
 
 
 @pytest.mark.asyncio
-async def test_wheels_format_without_wheels_is_rejected(patch_client) -> None:
-    patch_client(_sdk(["nemo-environment.yaml", "configs/verifiers_agent.yaml"]))
+async def test_wheels_format_without_wheels_is_rejected() -> None:
     with pytest.raises(ValueError, match="wheels/"):
-        await check_environment_package(Mock(), "default/env", "default")
+        await check_environment_package(
+            _platform(["nemo-environment.yaml", "configs/verifiers_agent.yaml"]),
+            "default/env",
+            "default",
+        )
 
 
 @pytest.mark.asyncio
-async def test_unlisted_adapter_agent_is_rejected(patch_client) -> None:
+async def test_unlisted_adapter_agent_is_rejected() -> None:
     """adapter.agent selects code baked into the training image, so it is closed-set."""
     manifest = ADAPTER_MANIFEST.replace(b"agent: verifiers_agent", b"agent: some_other_agent")
-    patch_client(_sdk(ADAPTER_FILES, manifest=manifest))
     with pytest.raises(ValueError, match="not built into the training image"):
-        await check_environment_package(Mock(), "default/env", "default")
+        await check_environment_package(_platform(ADAPTER_FILES, manifest=manifest), "default/env", "default")
 
 
 @pytest.mark.asyncio
-async def test_prompt_jsonl_in_environment_is_rejected(patch_client) -> None:
+async def test_prompt_jsonl_in_environment_is_rejected() -> None:
     """Rows belong to the dataset FileSet; one environment is meant to serve many datasets."""
-    patch_client(_sdk([*ADAPTER_FILES, "training.jsonl"]))
     with pytest.raises(ValueError, match="Prompt JSONL must not live in the environment package"):
-        await check_environment_package(Mock(), "default/env", "default")
+        await check_environment_package(_platform([*ADAPTER_FILES, "training.jsonl"]), "default/env", "default")
 
 
 @pytest.mark.asyncio
-async def test_malformed_manifest_is_rejected(patch_client) -> None:
-    patch_client(_sdk(ADAPTER_FILES, manifest=b"format: no-such-format\nmetadata:\n  name: x\n"))
+async def test_malformed_manifest_is_rejected() -> None:
     with pytest.raises(ValueError, match="not a valid package"):
-        await check_environment_package(Mock(), "default/env", "default")
+        await check_environment_package(
+            _platform(ADAPTER_FILES, manifest=b"format: no-such-format\nmetadata:\n  name: x\n"),
+            "default/env",
+            "default",
+        )
 
 
 @pytest.mark.asyncio
-async def test_native_v1_needs_no_wheels(patch_client) -> None:
+async def test_native_v1_needs_no_wheels() -> None:
     manifest = b"""
 format: native-v1
 config_paths:
@@ -110,5 +108,8 @@ config_paths:
 metadata:
   name: ascii-tree
 """
-    patch_client(_sdk(["nemo-environment.yaml", "resources_servers/ascii_tree/configs/ascii_tree.yaml"], manifest))
-    await check_environment_package(Mock(), "default/env", "default")
+    await check_environment_package(
+        _platform(["nemo-environment.yaml", "resources_servers/ascii_tree/configs/ascii_tree.yaml"], manifest),
+        "default/env",
+        "default",
+    )

--- a/plugins/nemo-unsloth/src/nemo_unsloth_plugin/jobs/jobs.py
+++ b/plugins/nemo-unsloth/src/nemo_unsloth_plugin/jobs/jobs.py
@@ -14,7 +14,7 @@ because the compiler call convention and profile resolution are backend-specific
 from __future__ import annotations
 
 import asyncio
-from typing import ClassVar, cast
+from typing import ClassVar
 
 from nemo_platform import AsyncNeMoPlatform
 from nemo_platform_plugin.jobs.api_factory import PlatformJobSpec
@@ -22,25 +22,35 @@ from nemo_platform_plugin.jobs.docker import validate_gpu_available_for_docker
 from nemo_unsloth_plugin.schema import UnslothJobInput
 from nemo_unsloth_plugin.transform import transform_input_to_output
 from nmp.customization_common.contributor.jobs import BaseSubmitJob, require_container_runtime
+from nmp.customization_common.service.platform_client import AsyncCustomizationPlatformClients
 from nmp.unsloth.compile import platform_job_config_compiler
 from nmp.unsloth.config import config as unsloth_config
 from nmp.unsloth.schemas import UnslothJobOutput
 from pydantic import BaseModel
 
 
-class UnslothJob(BaseSubmitJob):
+class UnslothJob(BaseSubmitJob[UnslothJobInput, UnslothJobOutput]):
     """GPU Unsloth fine-tuning job under the customization router (submit-only)."""
 
     name: ClassVar[str] = "unsloth.jobs"
     description: ClassVar[str] = "Unsloth SFT (LoRA / full / merged) training jobs on the platform GPU cluster."
     job_collection_path: ClassVar[str | None] = "/unsloth/jobs"
-    input_spec_schema: ClassVar[type[BaseModel] | None] = UnslothJobInput
-    spec_schema: ClassVar[type[BaseModel] | None] = UnslothJobOutput
+    input_spec_schema: ClassVar[type[UnslothJobInput] | None] = UnslothJobInput
+    spec_schema: ClassVar[type[UnslothJobOutput] | None] = UnslothJobOutput
     runtime_label: ClassVar[str] = "Unsloth"
 
     @classmethod
-    async def _transform(cls, job_input: BaseModel, workspace: str, async_sdk: AsyncNeMoPlatform) -> UnslothJobOutput:
-        return await transform_input_to_output(cast(UnslothJobInput, job_input), workspace, async_sdk)
+    def _job_input_schema(cls) -> type[UnslothJobInput]:
+        return UnslothJobInput
+
+    @classmethod
+    async def _transform(
+        cls,
+        job_input: UnslothJobInput,
+        workspace: str,
+        platform: AsyncCustomizationPlatformClients,
+    ) -> UnslothJobOutput:
+        return await transform_input_to_output(job_input, workspace, platform)
 
     @classmethod
     async def compile(
@@ -49,7 +59,7 @@ class UnslothJob(BaseSubmitJob):
         spec: BaseModel,
         entity_client: object,
         job_name: str | None,
-        async_sdk: object,
+        async_sdk: AsyncNeMoPlatform,
         profile: str | None = None,
         options: dict | None = None,
     ) -> PlatformJobSpec:
@@ -69,7 +79,7 @@ class UnslothJob(BaseSubmitJob):
         platform_spec = await platform_job_config_compiler(
             workspace=workspace,
             spec=canonical,
-            sdk=cast(AsyncNeMoPlatform, async_sdk),
+            sdk=async_sdk,
             job_name=job_name,
             profile=execution_profile,
         )

--- a/plugins/nemo-unsloth/src/nemo_unsloth_plugin/transform.py
+++ b/plugins/nemo-unsloth/src/nemo_unsloth_plugin/transform.py
@@ -17,29 +17,35 @@ download from.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import Literal
 
+from nemo_platform_plugin.models.types import ModelSpec
 from nmp.customization_common.contributor.transform import generated_output_name
-from nmp.customization_common.service.platform_client import check_dataset_access, fetch_model_entity
+from nmp.customization_common.service.platform_client import (
+    AsyncCustomizationPlatformClients,
+    check_dataset_access,
+    fetch_model_entity,
+)
 from nmp.unsloth.schemas import OutputResponse, UnslothJobOutput
 
 from nemo_unsloth_plugin.schema import OutputRequest, UnslothJobInput
 
-if TYPE_CHECKING:
-    from nemo_platform import AsyncNeMoPlatform
 
-
-def _infer_output_type(output_request: OutputRequest) -> str:
+def _infer_output_type(output_request: OutputRequest) -> Literal["adapter", "model"]:
     """Adapter when saving the LoRA, model otherwise (merged or full)."""
     if output_request.save_method == "lora":
         return "adapter"
     return "model"
 
 
+def _is_encoder_model(model_spec: ModelSpec) -> bool:
+    return model_spec.head_type in {"embedding", "cross_encoder"} or model_spec.is_embedding_model
+
+
 async def transform_input_to_output(
     input_spec: UnslothJobInput,
     workspace: str,
-    sdk: "AsyncNeMoPlatform",
+    platform: AsyncCustomizationPlatformClients,
 ) -> UnslothJobOutput:
     """Enrich submitter input into a canonical :class:`UnslothJobOutput`.
 
@@ -47,7 +53,7 @@ async def transform_input_to_output(
         input_spec: Submitter-facing input shape.
         workspace: The job's workspace; used as the default for any bare
             entity / fileset refs.
-        sdk: Async platform SDK handle for validation.
+        platform: Typed async clients for validating platform references.
 
     Returns:
         Canonical :class:`UnslothJobOutput` with ``output.fileset``
@@ -59,17 +65,13 @@ async def transform_input_to_output(
         PermissionError: When access to the model or dataset is denied.
     """
     # Strict refs: both calls error if the entity / fileset is missing.
-    model_entity = await fetch_model_entity(input_spec.model.name, workspace, sdk)
-    await check_dataset_access(sdk, input_spec.dataset.path, workspace)
+    model_entity = await fetch_model_entity(input_spec.model.name, workspace, platform)
+    await check_dataset_access(platform, input_spec.dataset.path, workspace)
     if input_spec.dataset.validation_path:
-        await check_dataset_access(sdk, input_spec.dataset.validation_path, workspace)
+        await check_dataset_access(platform, input_spec.dataset.validation_path, workspace)
 
     model_spec = model_entity.spec
-    head_type = getattr(model_spec, "head_type", None) if model_spec else None
-    is_encoder = head_type in {"embedding", "cross_encoder"} or bool(
-        model_spec and getattr(model_spec, "is_embedding_model", False),
-    )
-    if is_encoder:
+    if model_spec is not None and _is_encoder_model(model_spec):
         raise ValueError(
             "Encoder-model SFT is not supported by the unsloth backend. Use a causal LM model entity instead.",
         )

--- a/plugins/nemo-unsloth/tests/test_jobs.py
+++ b/plugins/nemo-unsloth/tests/test_jobs.py
@@ -22,13 +22,15 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
-from nemo_platform_plugin.files.client import AsyncFilesClient
+from nemo_platform import AsyncNeMoPlatform
 from nemo_platform_plugin.jobs.exceptions import PlatformJobCompilationError
-from nemo_platform_plugin.models.client import AsyncModelsClient
 from nemo_unsloth_plugin.jobs.jobs import UnslothJob
 from nemo_unsloth_plugin.schema import UnslothJobInput
 from nmp.unsloth.schemas import UnslothJobOutput
+
+BASE_URL = "http://test"
 
 
 def _input_dict(**overrides: Any) -> dict[str, Any]:
@@ -41,72 +43,74 @@ def _input_dict(**overrides: Any) -> dict[str, Any]:
     return base
 
 
-def _stub_async_sdk() -> tuple[SimpleNamespace, SimpleNamespace]:
-    """Async SDK used by ``to_spec`` (validates refs).
-
-    Returns ``(sdk, model_entity)`` so callers can wire the same entity into the
-    ``AsyncModelsClient`` mock dispatched by ``client_from_platform``.
-    """
-    me = SimpleNamespace(
-        name="base",
-        workspace="default",
-        spec=None,
-        fileset="base-fs",
-        trust_remote_code=False,
-    )
-    sdk = SimpleNamespace(
-        models=SimpleNamespace(retrieve=AsyncMock(return_value=me)),
-        files=SimpleNamespace(
-            filesets=SimpleNamespace(retrieve=AsyncMock(return_value=SimpleNamespace())),
-        ),
-    )
-    return sdk, me
+def _model_json() -> dict[str, object]:
+    return {
+        "id": "model-base",
+        "name": "base",
+        "workspace": "default",
+        "created_at": "2020-01-01T00:00:00Z",
+        "updated_at": "2020-01-01T00:00:00Z",
+        "spec": None,
+        "fileset": "default/base-fs",
+        "trust_remote_code": False,
+    }
 
 
-def _mock_files_client() -> AsyncMock:
-    """Build a mock AsyncFilesClient for check_dataset_access."""
-    mock = AsyncMock()
-    mock.get_fileset.return_value = MagicMock()
-    return mock
+def _fileset_json(workspace: str, name: str) -> dict[str, object]:
+    return {
+        "id": f"{workspace}-{name}",
+        "name": name,
+        "workspace": workspace,
+        "description": "",
+        "purpose": "generic",
+        "storage": {"type": "local", "path": "/tmp/files"},
+        "metadata": {},
+        "custom_fields": {},
+        "project": "",
+        "created_at": "2020-01-01T00:00:00Z",
+        "updated_at": "2020-01-01T00:00:00Z",
+    }
 
 
-def _client_from_platform_side_effect(model_entity: SimpleNamespace):
-    """Dispatch ``client_from_platform`` to a files or models mock by client class.
+async def _make_canonical_async(workspace: str = "default", **overrides: Any) -> UnslothJobOutput:
+    spec = UnslothJobInput.model_validate(_input_dict(**overrides))
 
-    ``fetch_model_entity`` now resolves models via ``AsyncModelsClient.get_model``
-    (``.data()`` unwraps the typed response) and ``check_dataset_access`` via
-    ``AsyncFilesClient.get_fileset`` — both through ``client_from_platform``.
-    """
-    files = _mock_files_client()
-    models = AsyncMock()
-    models.get_model.return_value = SimpleNamespace(data=lambda: model_entity)
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        parts = path.split("/")
+        if path.startswith("/apis/models/v2/workspaces/"):
+            return httpx.Response(200, request=request, json=_model_json())
+        if path.startswith("/apis/files/v2/workspaces/"):
+            return httpx.Response(200, request=request, json=_fileset_json(parts[5], parts[7]))
+        return httpx.Response(404, request=request, json={"detail": "unexpected request"})
 
-    def _dispatch(platform: object, client_cls: type, *args: object, **kwargs: object):
-        if client_cls is AsyncModelsClient:
-            return models
-        if client_cls is AsyncFilesClient:
-            return files
-        raise AssertionError(f"unexpected client class: {client_cls!r}")
-
-    return _dispatch
+    http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    async_sdk = AsyncNeMoPlatform(base_url=BASE_URL, workspace="default", http_client=http_client)
+    try:
+        output = await UnslothJob.to_spec(
+            spec,
+            workspace=workspace,
+            entity_client=object(),
+            async_sdk=async_sdk,
+            is_local=False,
+        )
+        assert isinstance(output, UnslothJobOutput)
+        return output
+    finally:
+        await async_sdk.close()
 
 
 def _make_canonical(workspace: str = "default", **overrides: Any) -> UnslothJobOutput:
-    spec = UnslothJobInput.model_validate(_input_dict(**overrides))
-    sdk, model_entity = _stub_async_sdk()
-    with patch(
-        "nmp.customization_common.service.platform_client.client_from_platform",
-        side_effect=_client_from_platform_side_effect(model_entity),
-    ):
-        return asyncio.run(
-            UnslothJob.to_spec(
-                spec,
-                workspace=workspace,
-                entity_client=object(),
-                async_sdk=sdk,
-                is_local=False,
-            ),
-        )
+    return asyncio.run(_make_canonical_async(workspace, **overrides))
+
+
+def _compile_sdk() -> AsyncNeMoPlatform:
+    return AsyncNeMoPlatform(
+        base_url=BASE_URL,
+        http_client=httpx.AsyncClient(
+            transport=httpx.MockTransport(lambda request: httpx.Response(200, request=request))
+        ),
+    )
 
 
 class TestToSpec:
@@ -123,31 +127,35 @@ class TestCompile:
     def test_compile_delegates_to_service_compiler(self) -> None:
         """When the runtime check passes, ``compile`` returns whatever the service builds."""
         canonical = _make_canonical()
+        async_sdk = _compile_sdk()
         fake_spec = SimpleNamespace(
             steps=["model-and-dataset-download", "training", "model-upload", "model-entity-creation"]
         )
 
-        with (
-            patch("nemo_unsloth_plugin.jobs.jobs.require_container_runtime"),
-            patch(
-                "nemo_unsloth_plugin.jobs.jobs.platform_job_config_compiler",
-                new=AsyncMock(return_value=fake_spec),
-            ) as compile_mock,
-            patch(
-                "nemo_unsloth_plugin.jobs.jobs.validate_gpu_available_for_docker",
-                new=MagicMock(),
-            ) as validate_mock,
-        ):
-            result = asyncio.run(
-                UnslothJob.compile(
-                    workspace="default",
-                    spec=canonical,
-                    entity_client=object(),
-                    job_name="my-unsloth-job",
-                    async_sdk=object(),
-                    profile=None,
-                ),
-            )
+        try:
+            with (
+                patch("nemo_unsloth_plugin.jobs.jobs.require_container_runtime"),
+                patch(
+                    "nemo_unsloth_plugin.jobs.jobs.platform_job_config_compiler",
+                    new=AsyncMock(return_value=fake_spec),
+                ) as compile_mock,
+                patch(
+                    "nemo_unsloth_plugin.jobs.jobs.validate_gpu_available_for_docker",
+                    new=MagicMock(),
+                ) as validate_mock,
+            ):
+                result = asyncio.run(
+                    UnslothJob.compile(
+                        workspace="default",
+                        spec=canonical,
+                        entity_client=object(),
+                        job_name="my-unsloth-job",
+                        async_sdk=async_sdk,
+                        profile=None,
+                    ),
+                )
+        finally:
+            asyncio.run(async_sdk.close())
 
         assert result is fake_spec
         compile_mock.assert_awaited_once()
@@ -160,45 +168,55 @@ class TestCompile:
 
     def test_compile_passes_caller_profile_override(self) -> None:
         canonical = _make_canonical()
-        with (
-            patch("nemo_unsloth_plugin.jobs.jobs.require_container_runtime"),
-            patch(
-                "nemo_unsloth_plugin.jobs.jobs.platform_job_config_compiler",
-                new=AsyncMock(return_value=SimpleNamespace(steps=[])),
-            ) as compile_mock,
-            patch("nemo_unsloth_plugin.jobs.jobs.validate_gpu_available_for_docker"),
-        ):
-            asyncio.run(
-                UnslothJob.compile(
-                    workspace="default",
-                    spec=canonical,
-                    entity_client=object(),
-                    job_name=None,
-                    async_sdk=object(),
-                    profile="gpu_distributed",
-                ),
-            )
-
-        assert compile_mock.await_args.kwargs["profile"] == "gpu_distributed"
-
-    def test_compile_rejects_runtime_without_container_support(self) -> None:
-        canonical = _make_canonical()
-        # Force the runtime check to raise so we don't need a real runtime
-        # in CI. The check is what runs first; the rest never executes.
-        with patch(
-            "nemo_unsloth_plugin.jobs.jobs.require_container_runtime",
-            side_effect=PlatformJobCompilationError("no container runtime"),
-        ):
-            with pytest.raises(PlatformJobCompilationError, match="no container runtime"):
+        async_sdk = _compile_sdk()
+        try:
+            with (
+                patch("nemo_unsloth_plugin.jobs.jobs.require_container_runtime"),
+                patch(
+                    "nemo_unsloth_plugin.jobs.jobs.platform_job_config_compiler",
+                    new=AsyncMock(return_value=SimpleNamespace(steps=[])),
+                ) as compile_mock,
+                patch("nemo_unsloth_plugin.jobs.jobs.validate_gpu_available_for_docker"),
+            ):
                 asyncio.run(
                     UnslothJob.compile(
                         workspace="default",
                         spec=canonical,
                         entity_client=object(),
                         job_name=None,
-                        async_sdk=object(),
+                        async_sdk=async_sdk,
+                        profile="gpu_distributed",
                     ),
                 )
+        finally:
+            asyncio.run(async_sdk.close())
+
+        await_args = compile_mock.await_args
+        assert await_args is not None
+        assert await_args.kwargs["profile"] == "gpu_distributed"
+
+    def test_compile_rejects_runtime_without_container_support(self) -> None:
+        canonical = _make_canonical()
+        # Force the runtime check to raise so we don't need a real runtime
+        # in CI. The check is what runs first; the rest never executes.
+        async_sdk = _compile_sdk()
+        with patch(
+            "nemo_unsloth_plugin.jobs.jobs.require_container_runtime",
+            side_effect=PlatformJobCompilationError("no container runtime"),
+        ):
+            try:
+                with pytest.raises(PlatformJobCompilationError, match="no container runtime"):
+                    asyncio.run(
+                        UnslothJob.compile(
+                            workspace="default",
+                            spec=canonical,
+                            entity_client=object(),
+                            job_name=None,
+                            async_sdk=async_sdk,
+                        ),
+                    )
+            finally:
+                asyncio.run(async_sdk.close())
 
 
 class TestNoRun:

--- a/plugins/nemo-unsloth/tests/test_schema.py
+++ b/plugins/nemo-unsloth/tests/test_schema.py
@@ -8,10 +8,11 @@ from __future__ import annotations
 import asyncio
 import json
 from pathlib import Path
-from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from typing import Any
 
+import httpx
 import pytest
+from nemo_platform_plugin.client.client import AsyncNemoClient
 from nemo_platform_plugin.files.client import AsyncFilesClient
 from nemo_platform_plugin.models.client import AsyncModelsClient
 from nemo_unsloth_plugin.schema import (
@@ -25,71 +26,91 @@ from nemo_unsloth_plugin.schema import (
     UnslothJobOutput,
 )
 from nemo_unsloth_plugin.transform import transform_input_to_output
+from nmp.customization_common.service.platform_client import AsyncCustomizationPlatformClients
 from pydantic import ValidationError
 
-
-def _stub_sdk(*, is_embedding: bool = False, head_type: str | None = None) -> tuple[SimpleNamespace, SimpleNamespace]:
-    """Build a minimal async SDK + the model entity the models client returns.
-
-    Returns ``(sdk, model_entity)`` so callers can wire the same entity into the
-    ``AsyncModelsClient`` mock dispatched by ``client_from_platform``.
-    """
-    spec = (
-        SimpleNamespace(is_embedding_model=is_embedding, head_type=head_type or "unknown")
-        if is_embedding or head_type
-        else None
-    )
-    model_entity = SimpleNamespace(
-        name="m",
-        workspace="default",
-        spec=spec,
-        fileset="m",
-        trust_remote_code=False,
-    )
-    sdk = SimpleNamespace(
-        models=SimpleNamespace(retrieve=AsyncMock(return_value=model_entity)),
-        files=SimpleNamespace(
-            filesets=SimpleNamespace(retrieve=AsyncMock(return_value=SimpleNamespace())),
-        ),
-    )
-    return sdk, model_entity
+BASE_URL = "http://test"
 
 
-def _mock_files_client() -> AsyncMock:
-    """Build a mock AsyncFilesClient for check_dataset_access."""
-    mock = AsyncMock()
-    mock.get_fileset.return_value = MagicMock()
-    return mock
+def _model_spec_json(*, is_embedding: bool, head_type: str | None) -> dict[str, object] | None:
+    if not is_embedding and head_type is None:
+        return None
+    return {
+        "context_size": 2048,
+        "head_type": head_type or "unknown",
+        "is_embedding_model": is_embedding,
+        "checkpoint_model_name": "Qwen2.5-0.5B-Instruct",
+        "family": "qwen",
+        "num_layers": 1,
+        "hidden_size": 1,
+        "num_attention_heads": 1,
+        "num_kv_heads": 1,
+        "ffn_hidden_size": 1,
+        "vocab_size": 1,
+        "tied_embeddings": True,
+        "gated_mlp": True,
+        "base_num_parameters": 1,
+        "precision": "bf16",
+    }
 
 
-def _client_from_platform_side_effect(model_entity: SimpleNamespace):
-    """Dispatch ``client_from_platform`` to a files or models mock by client class.
+def _model_json(*, is_embedding: bool = False, head_type: str | None = None) -> dict[str, object]:
+    return {
+        "id": "model-m",
+        "name": "m",
+        "workspace": "default",
+        "created_at": "2020-01-01T00:00:00Z",
+        "updated_at": "2020-01-01T00:00:00Z",
+        "spec": _model_spec_json(is_embedding=is_embedding, head_type=head_type),
+        "fileset": "default/m",
+        "trust_remote_code": False,
+    }
 
-    ``fetch_model_entity`` now resolves models via ``AsyncModelsClient.get_model``
-    (``.data()`` unwraps the typed response) and ``check_dataset_access`` via
-    ``AsyncFilesClient.get_fileset`` — both through ``client_from_platform``.
-    """
-    files = _mock_files_client()
-    models = AsyncMock()
-    models.get_model.return_value = SimpleNamespace(data=lambda: model_entity)
 
-    def _dispatch(platform: object, client_cls: type, *args: object, **kwargs: object):
-        if client_cls is AsyncModelsClient:
-            return models
-        if client_cls is AsyncFilesClient:
-            return files
-        raise AssertionError(f"unexpected client class: {client_cls!r}")
+def _fileset_json(workspace: str, name: str) -> dict[str, object]:
+    return {
+        "id": f"{workspace}-{name}",
+        "name": name,
+        "workspace": workspace,
+        "description": "",
+        "purpose": "generic",
+        "storage": {"type": "local", "path": "/tmp/files"},
+        "metadata": {},
+        "custom_fields": {},
+        "project": "",
+        "created_at": "2020-01-01T00:00:00Z",
+        "updated_at": "2020-01-01T00:00:00Z",
+    }
 
-    return _dispatch
+
+async def _run_transform_async(
+    spec: UnslothJobInput,
+    *,
+    is_embedding: bool = False,
+    head_type: str | None = None,
+) -> UnslothJobOutput:
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        parts = path.split("/")
+        if path.startswith("/apis/models/v2/workspaces/"):
+            return httpx.Response(
+                200, request=request, json=_model_json(is_embedding=is_embedding, head_type=head_type)
+            )
+        if path.startswith("/apis/files/v2/workspaces/"):
+            return httpx.Response(200, request=request, json=_fileset_json(parts[5], parts[7]))
+        return httpx.Response(404, request=request, json={"detail": "unexpected request"})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http_client:
+        client = AsyncNemoClient(base_url=BASE_URL, workspace="default", http_client=http_client)
+        platform = AsyncCustomizationPlatformClients(
+            files=AsyncFilesClient.from_client(client),
+            models=AsyncModelsClient.from_client(client),
+        )
+        return await transform_input_to_output(spec, "default", platform)
 
 
 def _run_transform(spec: UnslothJobInput) -> UnslothJobOutput:
-    sdk, model_entity = _stub_sdk()
-    with patch(
-        "nmp.customization_common.service.platform_client.client_from_platform",
-        side_effect=_client_from_platform_side_effect(model_entity),
-    ):
-        return asyncio.run(transform_input_to_output(spec, "default", sdk))
+    return asyncio.run(_run_transform_async(spec))
 
 
 class TestCanonicalReexport:
@@ -102,7 +123,8 @@ class TestCanonicalReexport:
         assert UnslothJobOutput.__module__ == "nmp.unsloth.schemas"
 
 
-def _minimal_payload() -> dict[str, object]:
+# Raw Pydantic payload under mutation in validation tests.
+def _minimal_payload() -> dict[str, Any]:
     return {
         "model": {"name": "unsloth/Qwen2.5-0.5B-Instruct", "max_seq_length": 2048},
         "dataset": {"path": "/data/sample.jsonl"},
@@ -272,16 +294,9 @@ class TestTransformOutput:
         ids=["legacy-embedding", "cross-encoder"],
     )
     def test_encoder_model_rejected(self, is_embedding: bool, head_type: str | None) -> None:
-        sdk, model_entity = _stub_sdk(is_embedding=is_embedding, head_type=head_type)
         spec = UnslothJobInput.model_validate(_minimal_payload())
-        with (
-            patch(
-                "nmp.customization_common.service.platform_client.client_from_platform",
-                side_effect=_client_from_platform_side_effect(model_entity),
-            ),
-            pytest.raises(ValueError, match="Encoder-model SFT"),
-        ):
-            asyncio.run(transform_input_to_output(spec, "default", sdk))
+        with pytest.raises(ValueError, match="Encoder-model SFT"):
+            asyncio.run(_run_transform_async(spec, is_embedding=is_embedding, head_type=head_type))
 
 
 class TestSubSpecExtras:

--- a/services/automodel/pyproject.toml
+++ b/services/automodel/pyproject.toml
@@ -10,7 +10,6 @@ dependencies = [
     "nmp-common",
     "nmp-customization-common",
     "nemo-platform-plugin",
-    "nemo-platform-sdk",
     "pydantic>=2.10.6",
     "pydantic-settings>=2.6.1",
     "httpx>=0.27.0",
@@ -41,10 +40,8 @@ packages = ["src/nmp"]
 nmp-common = { workspace = true }
 nmp-customization-common = { workspace = true }
 nemo-platform-plugin = { workspace = true }
-nemo-platform-sdk = { workspace = true }
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 pythonpath = ["src"]
 testpaths = ["tests"]
-

--- a/services/automodel/src/nmp/automodel/app/jobs/compiler.py
+++ b/services/automodel/src/nmp/automodel/app/jobs/compiler.py
@@ -5,8 +5,6 @@
 
 import logging
 
-from nemo_platform import AsyncNeMoPlatform
-from nemo_platform_plugin.client.adapter import client_from_platform
 from nemo_platform_plugin.client.errors import NotFoundError
 from nemo_platform_plugin.jobs.api_factory import (
     ContainerSpec,
@@ -18,7 +16,6 @@ from nemo_platform_plugin.jobs.api_factory import (
     ResourcesRequestsSpec,
     ResourcesSpec,
 )
-from nemo_platform_plugin.models.client import AsyncModelsClient
 from nemo_platform_plugin.models.types import ModelDeploymentConfig, ModelEntity
 from nmp.automodel.api.v2.jobs.schemas import (
     CustomizationJobOutput,
@@ -65,7 +62,7 @@ from nmp.customization_common.schemas.model_entity import (
 from nmp.customization_common.schemas.model_entity import (
     PEFTConfig as ModelEntityPEFTConfig,
 )
-from nmp.customization_common.service.platform_client import fetch_model_entity
+from nmp.customization_common.service.platform_client import AsyncCustomizationPlatformClients, fetch_model_entity
 from nmp.customization_common.tasks.file_io_metadata import build_output_fileset_metadata_from_model_entity
 
 logger = logging.getLogger(__name__)
@@ -287,13 +284,12 @@ def _build_model_entity_config(
 async def _resolve_deployment_config_ref(
     config_ref: str,
     workspace: str,
-    sdk: AsyncNeMoPlatform,
+    platform: AsyncCustomizationPlatformClients,
 ) -> ModelDeploymentConfig:
     """Resolve a ``name`` or ``workspace/name`` string to a ModelDeploymentConfig."""
     ref = parse_entity_ref(config_ref, default_workspace=workspace)
-    models = client_from_platform(sdk, AsyncModelsClient)
     try:
-        response = await models.get_deployment_config(name=ref.name, workspace=ref.workspace)
+        response = await platform.models.get_deployment_config(name=ref.name, workspace=ref.workspace)
         return response.data()
     except NotFoundError as e:
         raise PlatformJobCompilationError(
@@ -306,7 +302,7 @@ async def _resolve_deployment_config_ref(
 async def _validate_deployment_config(
     workspace: str,
     transformed_spec: CustomizationJobOutput,
-    sdk: AsyncNeMoPlatform,
+    platform: AsyncCustomizationPlatformClients,
     auth_client: AuthClient,
 ) -> None:
     """Validate deployment_config consistency before training starts.
@@ -336,7 +332,7 @@ async def _validate_deployment_config(
     ft_type = transformed_spec.training.finetuning_type
     is_lora = ft_type == FinetuningType.LORA
     produces_new_model = ft_type in (FinetuningType.ALL_WEIGHTS, FinetuningType.LORA_MERGED)
-    resolved_config = await _resolve_deployment_config_ref(dc, workspace, sdk)
+    resolved_config = await _resolve_deployment_config_ref(dc, workspace, platform)
 
     # LoRA job referencing a config that has lora_enabled=False
     if is_lora and resolved_config.model_spec.lora_enabled is False:
@@ -350,8 +346,7 @@ async def _validate_deployment_config(
     if produces_new_model:
         output_name = transformed_spec.output.name
         try:
-            models = client_from_platform(sdk, AsyncModelsClient)
-            response = await models.get_model(name=output_name, workspace=workspace)
+            response = await platform.models.get_model(name=output_name, workspace=workspace)
             existing_me = response.data()
         except NotFoundError:
             # Output model entity doesn't exist yet, so a string
@@ -380,18 +375,10 @@ async def _validate_deployment_config(
 async def platform_job_config_compiler(
     workspace: str,
     job_spec: CustomizationJobOutput,
-    sdk: AsyncNeMoPlatform,
-    *,
-    job_name: str | None = None,
-    profile: str | None = None,
+    platform: AsyncCustomizationPlatformClients,
 ) -> PlatformJobSpec:
     """Compile canonical job spec into a four-step PlatformJobSpec."""
-    del job_name  # reserved for future scheduling decisions
     transformed_spec = job_spec
-    if profile is not None and transformed_spec.training.execution_profile is None:
-        transformed_spec = transformed_spec.model_copy(
-            update={"training": transformed_spec.training.model_copy(update={"execution_profile": profile})},
-        )
     logger.info("Compiling Automodel job to PlatformJobSpec: %s", transformed_spec.model_dump_json(indent=2))
 
     try:
@@ -405,13 +392,13 @@ async def platform_job_config_compiler(
     task_profile = transformed_spec.training.execution_profile or config.default_training_execution_profile
 
     # Fetch the primary model entity
-    me = await fetch_model_entity(transformed_spec.model, workspace, sdk)
+    me = await fetch_model_entity(transformed_spec.model, workspace, platform)
 
     # For distillation jobs, also fetch the teacher model entity
     teacher_me: ModelEntity | None = None
     if isinstance(transformed_spec.training, DistillationTraining):
         try:
-            teacher_me = await fetch_model_entity(transformed_spec.training.teacher_model, workspace, sdk)
+            teacher_me = await fetch_model_entity(transformed_spec.training.teacher_model, workspace, platform)
         except ValueError as e:
             raise PlatformJobCompilationError(
                 f"Teacher model '{transformed_spec.training.teacher_model}' not found. "
@@ -428,7 +415,7 @@ async def platform_job_config_compiler(
             raise PlatformJobCompilationError(
                 "No auth context available; cannot validate deployment config permissions.",
             )
-        await _validate_deployment_config(workspace, transformed_spec, sdk, auth_client)
+        await _validate_deployment_config(workspace, transformed_spec, platform, auth_client)
 
     file_io_download_config = _build_file_download_config(transformed_spec, me, teacher_me)
     training_recipe = _resolve_training_recipe(me, transformed_spec.training.recipe)

--- a/services/automodel/src/nmp/automodel/compile.py
+++ b/services/automodel/src/nmp/automodel/compile.py
@@ -7,30 +7,33 @@ from __future__ import annotations
 
 from typing import Any
 
-from nemo_platform import AsyncNeMoPlatform
 from nemo_platform_plugin.jobs.api_factory import PlatformJobSpec
 from nmp.automodel.adapter import automodel_spec_to_compiler_output
 from nmp.automodel.api.v2.jobs.schemas import CustomizationJobOutput
 from nmp.automodel.app.jobs.compiler import platform_job_config_compiler as _compile_canonical
+from nmp.customization_common.service.platform_client import AsyncCustomizationPlatformClients
 from pydantic import BaseModel
 
 
 async def platform_job_config_compiler(
     job_spec: CustomizationJobOutput | dict[str, Any] | BaseModel,
     workspace: str,
-    sdk: AsyncNeMoPlatform,
+    platform: AsyncCustomizationPlatformClients,
     job_name: str | None = None,
     profile: str | None = None,
 ) -> PlatformJobSpec:
     """Compile Automodel job spec (plugin or legacy shape) to PlatformJobSpec."""
+    del job_name  # reserved for future scheduling decisions
     if not isinstance(job_spec, CustomizationJobOutput):
         job_spec = automodel_spec_to_compiler_output(job_spec)
+    if profile is not None and job_spec.training.execution_profile is None:
+        job_spec = job_spec.model_copy(
+            update={"training": job_spec.training.model_copy(update={"execution_profile": profile})},
+        )
     return await _compile_canonical(
         workspace,
         job_spec,
-        sdk,
-        job_name=job_name,
-        profile=profile,
+        platform,
     )
 
 

--- a/services/automodel/src/nmp/automodel/tasks/retrieval_mine/__main__.py
+++ b/services/automodel/src/nmp/automodel/tasks/retrieval_mine/__main__.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-from nemo_platform import NeMoPlatform
+from nemo_platform_plugin.client.client import NemoClient
 from nemo_platform_plugin.job_context import JobContext, StoragePaths
 from nemo_platform_plugin.job_results import PlatformJobResults
 from nemo_platform_plugin.jobs.constants import (
@@ -18,11 +18,11 @@ from nemo_platform_plugin.jobs.constants import (
     NEMO_JOB_WORKSPACE_ENVVAR,
     PERSISTENT_JOB_STORAGE_PATH_ENVVAR,
 )
-from nemo_platform_plugin.sdk_provider import get_platform_sdk
 from nmp.automodel.tasks.retrieval_mine.runner import RetrievalMineStepConfig, run_mine, work_dir
+from nmp.common.client_factory import get_nemo_client
 
 
-def _get_ctx(sdk: NeMoPlatform) -> JobContext:
+def _get_ctx(client: NemoClient) -> JobContext:
     workspace = os.environ[NEMO_JOB_WORKSPACE_ENVVAR]
     job_name = os.environ[NEMO_JOB_ID_ENVVAR]
     persistent_env = os.environ.get(PERSISTENT_JOB_STORAGE_PATH_ENVVAR)
@@ -30,15 +30,15 @@ def _get_ctx(sdk: NeMoPlatform) -> JobContext:
         ephemeral=Path(os.environ[EPHEMERAL_TASK_STORAGE_PATH_ENVVAR]),
         persistent=Path(persistent_env) if persistent_env else None,
     )
-    results = PlatformJobResults(workspace=workspace, job_name=job_name, sdk=sdk)
+    results = PlatformJobResults(workspace=workspace, job_name=job_name, client=client)
     return JobContext(workspace=workspace, job_id=job_name, storage=storage, results=results)
 
 
 def main() -> int:
     with open(os.environ[NEMO_JOB_STEP_CONFIG_FILE_PATH_ENVVAR], encoding="utf-8") as handle:
         spec = RetrievalMineStepConfig.model_validate_json(handle.read())
-    sdk = get_platform_sdk(as_service="data-designer")
-    ctx = _get_ctx(sdk)
+    client = get_nemo_client(as_service="data-designer")
+    ctx = _get_ctx(client)
     result = run_mine(
         spec.job_config,
         work_dir(ctx, "stage1_data_prep"),

--- a/services/automodel/tests/test_compiler.py
+++ b/services/automodel/tests/test_compiler.py
@@ -10,7 +10,6 @@ from typing import Any
 from unittest.mock import AsyncMock, Mock
 
 import pytest
-from nemo_platform import AsyncNeMoPlatform
 from nemo_platform_plugin.models.types import ModelEntity
 from nmp.automodel.adapter import automodel_spec_to_compiler_output
 from nmp.automodel.api.v2.jobs.schemas import (
@@ -27,6 +26,7 @@ from nmp.automodel.entities.values import OutputNameType
 from nmp.automodel.images import get_tasks_image, get_training_image
 from nmp.common.entities.utils import get_random_id
 from nmp.common.jobs.exceptions import PlatformJobCompilationError
+from nmp.customization_common.service.platform_client import AsyncCustomizationPlatformClients
 
 
 def _make_mock_model_entity(
@@ -47,8 +47,8 @@ def _make_mock_model_entity(
 
 
 @pytest.fixture
-def mock_sdk():
-    return Mock(spec=AsyncNeMoPlatform)
+def platform_clients() -> AsyncCustomizationPlatformClients:
+    return AsyncCustomizationPlatformClients(files=AsyncMock(), models=AsyncMock())
 
 
 def _output(*, output_type: OutputNameType = OutputNameType.ADAPTER) -> OutputResponse:
@@ -266,7 +266,10 @@ def test_compile_training_step_auto_defaults_keep_explicit_lr() -> None:
 
 
 @pytest.mark.asyncio
-async def test_platform_job_config_compiler_rejects_unmerged_lora_for_encoders(mock_sdk, monkeypatch):
+async def test_platform_job_config_compiler_rejects_unmerged_lora_for_encoders(
+    platform_clients: AsyncCustomizationPlatformClients,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setattr(
         "nmp.automodel.app.jobs.compiler.fetch_model_entity",
         AsyncMock(return_value=_make_mock_model_entity()),
@@ -283,7 +286,7 @@ async def test_platform_job_config_compiler_rejects_unmerged_lora_for_encoders(m
         output=_output(),
     )
     with pytest.raises(PlatformJobCompilationError, match="unmerged LoRA"):
-        await platform_job_config_compiler(job, "default", mock_sdk)
+        await platform_job_config_compiler(job, "default", platform_clients)
 
 
 def test_the_reporting_budget_reaches_the_training_step_config() -> None:
@@ -370,7 +373,10 @@ def test_a_plugin_spec_without_a_schedule_block_still_compiles() -> None:
 
 
 @pytest.mark.asyncio
-async def test_platform_job_config_compiler_sft_lora(mock_sdk, monkeypatch):
+async def test_platform_job_config_compiler_sft_lora(
+    platform_clients: AsyncCustomizationPlatformClients,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setattr(
         "nmp.automodel.app.jobs.compiler.fetch_model_entity",
         AsyncMock(return_value=_make_mock_model_entity()),
@@ -411,7 +417,7 @@ async def test_platform_job_config_compiler_sft_lora(mock_sdk, monkeypatch):
         "output": {"name": "test-out", "type": "adapter", "fileset": "test-out-fs"},
     }
     compiler_spec = automodel_spec_to_compiler_output(plugin_shape)
-    spec = await platform_job_config_compiler(compiler_spec, "default", mock_sdk)
+    spec = await platform_job_config_compiler(compiler_spec, "default", platform_clients)
 
     steps = spec.steps if hasattr(spec, "steps") else spec["steps"]
     assert len(steps) == 4
@@ -448,12 +454,15 @@ async def test_platform_job_config_compiler_sft_lora(mock_sdk, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_platform_job_config_compiler_applies_profile_to_task_steps(mock_sdk, monkeypatch):
+async def test_platform_job_config_compiler_applies_profile_to_task_steps(
+    platform_clients: AsyncCustomizationPlatformClients,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setattr(
         "nmp.automodel.app.jobs.compiler.fetch_model_entity",
         AsyncMock(return_value=_make_mock_model_entity()),
     )
 
-    spec = await platform_job_config_compiler(_make_job_output(), "default", mock_sdk, profile="custom-gpu")
+    spec = await platform_job_config_compiler(_make_job_output(), "default", platform_clients, profile="custom-gpu")
 
     assert [step.executor.profile for step in spec.steps] == ["custom-gpu"] * 4

--- a/services/automodel/tests/test_models_client_migration.py
+++ b/services/automodel/tests/test_models_client_migration.py
@@ -3,20 +3,23 @@
 
 """Deployment-config resolution through the typed Models client, over a mocked httpx transport.
 
-Driving a real ``AsyncNeMoPlatform`` -> ``client_from_platform`` ->
-``AsyncModelsClient`` chain asserts the wire contract (method, path, parsed
-model and error mapping) rather than restating the call the implementation
-happens to make.
+Driving a real ``AsyncNemoClient`` -> ``AsyncModelsClient`` chain asserts the
+wire contract (method, path, parsed model and error mapping) rather than
+restating the call the implementation happens to make.
 """
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock
+
 import httpx
 import pytest
-from nemo_platform import AsyncNeMoPlatform
+from nemo_platform_plugin.client.client import AsyncNemoClient
 from nemo_platform_plugin.jobs.exceptions import PlatformJobCompilationError
+from nemo_platform_plugin.models.client import AsyncModelsClient
 from nemo_platform_plugin.models.types import ModelDeploymentConfig
 from nmp.automodel.app.jobs.compiler import _resolve_deployment_config_ref
+from nmp.customization_common.service.platform_client import AsyncCustomizationPlatformClients
 
 BASE = "http://test:8000"
 
@@ -49,15 +52,16 @@ def _recording_transport(
     return httpx.MockTransport(handler), seen
 
 
-def _sdk(transport: httpx.MockTransport) -> AsyncNeMoPlatform:
-    return AsyncNeMoPlatform(base_url=BASE, workspace="default", http_client=httpx.AsyncClient(transport=transport))
+def _platform(transport: httpx.MockTransport) -> AsyncCustomizationPlatformClients:
+    client = AsyncNemoClient(base_url=BASE, workspace="default", http_client=httpx.AsyncClient(transport=transport))
+    return AsyncCustomizationPlatformClients(files=AsyncMock(), models=AsyncModelsClient.from_client(client))
 
 
 @pytest.mark.asyncio
 async def test_resolve_deployment_config_hits_the_deployment_config_endpoint() -> None:
     transport, seen = _recording_transport()
 
-    result = await _resolve_deployment_config_ref("other/config", "default", _sdk(transport))
+    result = await _resolve_deployment_config_ref("other/config", "default", _platform(transport))
 
     assert isinstance(result, ModelDeploymentConfig)
     assert (result.workspace, result.name) == ("other", "config")
@@ -71,7 +75,7 @@ async def test_resolve_deployment_config_hits_the_deployment_config_endpoint() -
 async def test_resolve_deployment_config_defaults_to_the_job_workspace() -> None:
     transport, seen = _recording_transport(payload=_config_json(workspace="default"))
 
-    await _resolve_deployment_config_ref("config", "default", _sdk(transport))
+    await _resolve_deployment_config_ref("config", "default", _platform(transport))
 
     assert str(seen[0].url) == f"{BASE}/apis/models/v2/workspaces/default/deployment-configs/config"
 
@@ -81,4 +85,4 @@ async def test_resolve_deployment_config_maps_404_to_compilation_error() -> None
     transport, _ = _recording_transport(404, {"detail": "missing"})
 
     with pytest.raises(PlatformJobCompilationError, match="does not exist in workspace 'other'"):
-        await _resolve_deployment_config_ref("other/config", "default", _sdk(transport))
+        await _resolve_deployment_config_ref("other/config", "default", _platform(transport))

--- a/services/rl/pyproject.toml
+++ b/services/rl/pyproject.toml
@@ -11,7 +11,6 @@ dependencies = [
     "nmp-common",
     "nmp-customization-common",
     "nemo-platform-plugin",
-    "nemo-platform-sdk",
     "pydantic>=2.10.6",
     "pydantic-settings>=2.6.1",
     "httpx>=0.27.0",
@@ -62,7 +61,6 @@ allow-direct-references = true
 nmp-common = { workspace = true }
 nmp-customization-common = { workspace = true }
 nemo-platform-plugin = { workspace = true }
-nemo-platform-sdk = { workspace = true }
 
 [dependency-groups]
 dev = [

--- a/services/rl/src/nmp/rl/app/jobs/compiler.py
+++ b/services/rl/src/nmp/rl/app/jobs/compiler.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 
 import logging
 
-from nemo_platform import AsyncNeMoPlatform
 from nemo_platform_plugin.integrations import IntegrationsSpec
 from nemo_platform_plugin.jobs.api_factory import (
     ContainerSpec,
@@ -49,7 +48,7 @@ from nmp.customization_common.schemas.file_io import (
     UploadItem,
 )
 from nmp.customization_common.schemas.model_entity import ModelEntityTaskConfig, PEFTConfig
-from nmp.customization_common.service.platform_client import fetch_model_entity
+from nmp.customization_common.service.platform_client import AsyncCustomizationPlatformClients, fetch_model_entity
 from nmp.customization_common.tasks.file_io_metadata import build_output_fileset_metadata_from_model_entity
 from nmp.rl.app.constants import (
     BASE_LOG_DIR_ENVVAR,
@@ -511,7 +510,7 @@ def _build_training_step(
 async def platform_job_config_compiler(
     workspace: str,
     job_spec: RlJobOutput,
-    sdk: AsyncNeMoPlatform,
+    platform: AsyncCustomizationPlatformClients,
     *,
     job_name: str | None = None,
     profile: str | None = None,
@@ -537,7 +536,7 @@ async def platform_job_config_compiler(
 
     job_spec.validate_for_training()
 
-    me = await fetch_model_entity(job_spec.model, workspace, sdk)
+    me = await fetch_model_entity(job_spec.model, workspace, platform)
     trust_remote_code = me.trust_remote_code or False
 
     cpu_resources = _get_cpu_resources()

--- a/services/rl/src/nmp/rl/compile.py
+++ b/services/rl/src/nmp/rl/compile.py
@@ -10,8 +10,8 @@ to turn a validated :class:`~nmp.rl.schemas.RlJobOutput` into a 4-step
 
 from __future__ import annotations
 
-from nemo_platform import AsyncNeMoPlatform
 from nemo_platform_plugin.jobs.api_factory import PlatformJobSpec
+from nmp.customization_common.service.platform_client import AsyncCustomizationPlatformClients
 from nmp.rl.app.jobs.compiler import platform_job_config_compiler as _compile_canonical
 from nmp.rl.schemas import RlJobOutput
 
@@ -20,12 +20,12 @@ async def platform_job_config_compiler(
     *,
     workspace: str,
     spec: RlJobOutput,
-    sdk: AsyncNeMoPlatform,
+    platform: AsyncCustomizationPlatformClients,
     job_name: str | None = None,
     profile: str | None = None,
 ) -> PlatformJobSpec:
     """Compile a canonical NeMo-RL job spec to a ``PlatformJobSpec``. Container submit only."""
-    return await _compile_canonical(workspace, spec, sdk, job_name=job_name, profile=profile)
+    return await _compile_canonical(workspace, spec, platform, job_name=job_name, profile=profile)
 
 
 __all__ = ["platform_job_config_compiler"]

--- a/services/rl/tests/test_compiler.py
+++ b/services/rl/tests/test_compiler.py
@@ -8,15 +8,15 @@ from __future__ import annotations
 
 from datetime import datetime
 from typing import Any
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock
 
 import pytest
-from nemo_platform import AsyncNeMoPlatform
 from nemo_platform_plugin.integrations import IntegrationsSpec, MlflowIntegration, WandbIntegration
 from nemo_platform_plugin.jobs.exceptions import PlatformJobCompilationError
 from nemo_platform_plugin.models.types import ModelEntity
 from nmp.common.entities.utils import get_random_id
 from nmp.customization_common.schemas.values import OutputNameType
+from nmp.customization_common.service.platform_client import AsyncCustomizationPlatformClients
 from nmp.rl.app.jobs.compiler import (
     _build_download_config,
     _build_training_step,
@@ -93,8 +93,8 @@ def _steps(spec: Any) -> list[Any]:
 
 
 @pytest.fixture
-def mock_sdk() -> Mock:
-    return Mock(spec=AsyncNeMoPlatform)
+def platform_clients() -> AsyncCustomizationPlatformClients:
+    return AsyncCustomizationPlatformClients(files=AsyncMock(), models=AsyncMock())
 
 
 # --------------------------------------------------------------------------- #
@@ -285,12 +285,15 @@ def test_explicit_profile_overrides_default() -> None:
 
 
 @pytest.mark.asyncio
-async def test_compiler_emits_four_steps(monkeypatch: pytest.MonkeyPatch, mock_sdk: Mock) -> None:
+async def test_compiler_emits_four_steps(
+    monkeypatch: pytest.MonkeyPatch,
+    platform_clients: AsyncCustomizationPlatformClients,
+) -> None:
     monkeypatch.setattr(
         "nmp.rl.app.jobs.compiler.fetch_model_entity",
         AsyncMock(return_value=_make_model_entity()),
     )
-    spec = await platform_job_config_compiler("default", _make_job_output(), mock_sdk)
+    spec = await platform_job_config_compiler("default", _make_job_output(), platform_clients)
 
     steps = _steps(spec)
     names = [s["name"] for s in steps]
@@ -320,13 +323,16 @@ async def test_compiler_emits_four_steps(monkeypatch: pytest.MonkeyPatch, mock_s
 
 
 @pytest.mark.asyncio
-async def test_compiler_rejects_model_without_fileset(monkeypatch: pytest.MonkeyPatch, mock_sdk: Mock) -> None:
+async def test_compiler_rejects_model_without_fileset(
+    monkeypatch: pytest.MonkeyPatch,
+    platform_clients: AsyncCustomizationPlatformClients,
+) -> None:
     monkeypatch.setattr(
         "nmp.rl.app.jobs.compiler.fetch_model_entity",
         AsyncMock(return_value=_make_model_entity(fileset=None)),
     )
     with pytest.raises(PlatformJobCompilationError, match="has no fileset"):
-        await platform_job_config_compiler("default", _make_job_output(), mock_sdk)
+        await platform_job_config_compiler("default", _make_job_output(), platform_clients)
 
 
 def test_grpo_download_includes_environment() -> None:

--- a/services/unsloth/tests/test_model_entity.py
+++ b/services/unsloth/tests/test_model_entity.py
@@ -18,7 +18,7 @@ import json
 import types
 from datetime import datetime
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from nemo_platform_plugin.files.client import FilesClient
@@ -53,16 +53,14 @@ def _make_job_ctx(workspace: str = "default"):
     )
 
 
-def _make_runner(sdk):
+def _make_runner(models: ModelsClient, files: FilesClient):
     from nmp.customization_common.tasks.model_entity.run import ModelEntityRunner
 
-    return ModelEntityRunner(sdk=sdk, job_ctx=_make_job_ctx())
+    return ModelEntityRunner(models=models, files=files, job_ctx=_make_job_ctx())
 
 
-def _make_sdk() -> MagicMock:
-    sdk = MagicMock()
-    sdk.with_options.return_value = sdk
-    return sdk
+def _make_clients() -> tuple[MagicMock, MagicMock]:
+    return MagicMock(), MagicMock()
 
 
 def _response(data: object) -> MagicMock:
@@ -75,21 +73,6 @@ def _page(items: list[object]) -> MagicMock:
     response = MagicMock()
     response.items.return_value = items
     return response
-
-
-def _configure_clients(mock_client_from_platform: MagicMock) -> tuple[MagicMock, MagicMock]:
-    models = MagicMock()
-    files = MagicMock()
-
-    def make_client(_sdk: object, client_type: type) -> MagicMock:
-        if client_type is ModelsClient:
-            return models
-        if client_type is FilesClient:
-            return files
-        raise AssertionError(f"Unexpected client type: {client_type}")
-
-    mock_client_from_platform.side_effect = make_client
-    return models, files
 
 
 def _raise_runner_conflict() -> None:
@@ -160,18 +143,16 @@ class TestSanitizeName:
 
 
 class TestCreateFullEntity:
-    @patch("nmp.customization_common.tasks.model_entity.run.client_from_platform")
-    def test_creates_model_entity_for_full_sft(self, mock_cfp) -> None:
+    def test_creates_model_entity_for_full_sft(self) -> None:
         from nmp.customization_common.schemas.file_io import FileSetRef
         from nmp.customization_common.schemas.model_entity import ModelEntityTaskConfig
 
-        sdk = _make_sdk()
-        models, files = _configure_clients(mock_cfp)
+        models, files = _make_clients()
         models.get_model.return_value = _response(_model_entity(name="base-model"))
         new_me = _model_entity(name="trained-model")
         models.create_model.return_value = _response(new_me)
 
-        runner = _make_runner(sdk)
+        runner = _make_runner(models, files)
         config = ModelEntityTaskConfig(
             name="trained-model",
             workspace="default",
@@ -196,19 +177,17 @@ class TestCreateFullEntity:
         assert deploy_target is new_me
         assert result is not None
 
-    @patch("nmp.customization_common.tasks.model_entity.run.client_from_platform")
-    def test_conflict_falls_back_to_update(self, mock_cfp) -> None:
+    def test_conflict_falls_back_to_update(self) -> None:
         from nmp.customization_common.schemas.file_io import FileSetRef
         from nmp.customization_common.schemas.model_entity import ModelEntityTaskConfig
 
-        sdk = _make_sdk()
-        models, _files = _configure_clients(mock_cfp)
+        models, files = _make_clients()
         models.get_model.return_value = _response(_model_entity(name="base-model"))
         models.create_model.side_effect = lambda **_: _raise_runner_conflict()
         updated_me = _model_entity(name="trained-model")
         models.update_model.return_value = _response(updated_me)
 
-        runner = _make_runner(sdk)
+        runner = _make_runner(models, files)
         config = ModelEntityTaskConfig(
             name="trained-model",
             workspace="default",
@@ -229,15 +208,13 @@ class TestCreateFullEntity:
         assert body.base_model is None
         assert body.trust_remote_code is False
 
-    @patch("nmp.customization_common.tasks.model_entity.run.client_from_platform")
-    def test_missing_fileset_raises_creation_error(self, mock_cfp) -> None:
+    def test_missing_fileset_raises_creation_error(self) -> None:
         from nmp.customization_common.schemas.file_io import FileSetRef
         from nmp.customization_common.schemas.model_entity import ModelEntityCreationError, ModelEntityTaskConfig
 
-        sdk = _make_sdk()
-        models, files = _configure_clients(mock_cfp)
+        models, files = _make_clients()
         files.get_fileset.side_effect = RuntimeError("fileset missing")
-        runner = _make_runner(sdk)
+        runner = _make_runner(models, files)
         config = ModelEntityTaskConfig(
             name="x",
             workspace="default",
@@ -258,19 +235,17 @@ class TestCreateFullEntity:
 
 
 class TestCreateAdapter:
-    @patch("nmp.customization_common.tasks.model_entity.run.client_from_platform")
-    def test_creates_adapter_for_lora(self, mock_cfp) -> None:
+    def test_creates_adapter_for_lora(self) -> None:
         from nmp.customization_common.schemas.file_io import FileSetRef
         from nmp.customization_common.schemas.model_entity import ModelEntityTaskConfig, PEFTConfig
         from nmp.unsloth.entities.values import FinetuningType
 
-        sdk = _make_sdk()
-        models, _files = _configure_clients(mock_cfp)
+        models, files = _make_clients()
         base_me = _model_entity(name="base-model")
         models.get_model.return_value = _response(base_me)
         models.create_model_adapter.return_value = _response(_model_entity(name="adapter-x"))
 
-        runner = _make_runner(sdk)
+        runner = _make_runner(models, files)
         config = ModelEntityTaskConfig(
             name="adapter-x",
             workspace="default",
@@ -295,19 +270,17 @@ class TestCreateAdapter:
         assert body.enabled is True
         assert deploy_target is base_me
 
-    @patch("nmp.customization_common.tasks.model_entity.run.client_from_platform")
-    def test_adapter_conflict_falls_back_to_update(self, mock_cfp) -> None:
+    def test_adapter_conflict_falls_back_to_update(self) -> None:
         from nmp.customization_common.schemas.file_io import FileSetRef
         from nmp.customization_common.schemas.model_entity import ModelEntityTaskConfig, PEFTConfig
         from nmp.unsloth.entities.values import FinetuningType
 
-        sdk = _make_sdk()
-        models, _files = _configure_clients(mock_cfp)
+        models, files = _make_clients()
         models.get_model.return_value = _response(_model_entity(name="base-model"))
         models.create_model_adapter.side_effect = lambda **_: _raise_runner_conflict()
         models.update_model_adapter.return_value = _response(_model_entity(name="adapter-x"))
 
-        runner = _make_runner(sdk)
+        runner = _make_runner(models, files)
         config = ModelEntityTaskConfig(
             name="adapter-x",
             workspace="default",
@@ -335,14 +308,12 @@ class TestCreateAdapter:
 
 
 class TestLaunchModel:
-    @patch("nmp.customization_common.tasks.model_entity.run.client_from_platform")
-    def test_no_deployment_config_returns_early(self, mock_cfp) -> None:
+    def test_no_deployment_config_returns_early(self) -> None:
         from nmp.customization_common.schemas.file_io import FileSetRef
         from nmp.customization_common.schemas.model_entity import ModelEntityTaskConfig
 
-        sdk = _make_sdk()
-        models, _files = _configure_clients(mock_cfp)
-        runner = _make_runner(sdk)
+        models, files = _make_clients()
+        runner = _make_runner(models, files)
         me = _model_entity(name="x")
         config = ModelEntityTaskConfig(
             name="x",
@@ -357,13 +328,11 @@ class TestLaunchModel:
         models.create_deployment.assert_not_called()
         models.create_deployment_config.assert_not_called()
 
-    @patch("nmp.customization_common.tasks.model_entity.run.client_from_platform")
-    def test_inline_params_creates_config_then_deployment(self, mock_cfp) -> None:
+    def test_inline_params_creates_config_then_deployment(self) -> None:
         from nmp.customization_common.schemas.file_io import FileSetRef
         from nmp.customization_common.schemas.model_entity import DeploymentParameters, ModelEntityTaskConfig
 
-        sdk = _make_sdk()
-        models, _files = _configure_clients(mock_cfp)
+        models, files = _make_clients()
         deployment_config = types.SimpleNamespace(workspace="other", name="sft-cfg-x")
         deployment = types.SimpleNamespace(workspace="other", name="sft-deploy-x")
         deployment_status = types.SimpleNamespace(
@@ -375,7 +344,7 @@ class TestLaunchModel:
         models.create_deployment.return_value = _response(deployment)
         models.get_deployment.return_value = _response(deployment_status)
 
-        runner = _make_runner(sdk)
+        runner = _make_runner(models, files)
         me = _model_entity(
             workspace="other",
             name="x",
@@ -411,13 +380,11 @@ class TestLaunchModel:
         assert deployment_body.config == "sft-cfg-x"
         models.get_deployment.assert_called_once_with(workspace="other", name="sft-deploy-x")
 
-    @patch("nmp.customization_common.tasks.model_entity.run.client_from_platform")
-    def test_inline_config_conflict_updates_before_deployment(self, mock_cfp) -> None:
+    def test_inline_config_conflict_updates_before_deployment(self) -> None:
         from nmp.customization_common.schemas.file_io import FileSetRef
         from nmp.customization_common.schemas.model_entity import DeploymentParameters, ModelEntityTaskConfig
 
-        sdk = _make_sdk()
-        models, _files = _configure_clients(mock_cfp)
+        models, files = _make_clients()
         models.create_deployment_config.side_effect = lambda **_: _raise_runner_conflict()
         updated_config = types.SimpleNamespace(workspace="default", name="sft-cfg-x")
         deployment = types.SimpleNamespace(workspace="default", name="sft-deploy-x")
@@ -431,7 +398,7 @@ class TestLaunchModel:
             )
         )
 
-        runner = _make_runner(sdk)
+        runner = _make_runner(models, files)
         me = _model_entity(
             name="x",
             spec=types.SimpleNamespace(family="llama", base_num_parameters=1_000_000_000),
@@ -455,13 +422,11 @@ class TestLaunchModel:
         assert body.executor_config.gpu == 2
         models.create_deployment.assert_called_once()
 
-    @patch("nmp.customization_common.tasks.model_entity.run.client_from_platform")
-    def test_string_ref_resolves_existing_config(self, mock_cfp) -> None:
+    def test_string_ref_resolves_existing_config(self) -> None:
         from nmp.customization_common.schemas.file_io import FileSetRef
         from nmp.customization_common.schemas.model_entity import ModelEntityTaskConfig
 
-        sdk = _make_sdk()
-        models, _files = _configure_clients(mock_cfp)
+        models, files = _make_clients()
         deployment_config = types.SimpleNamespace(workspace="shared", name="existing-cfg")
         deployment = types.SimpleNamespace(workspace="shared", name="sft-deploy-x")
         models.get_deployment_config.return_value = _response(deployment_config)
@@ -474,7 +439,7 @@ class TestLaunchModel:
             )
         )
 
-        runner = _make_runner(sdk)
+        runner = _make_runner(models, files)
         me = _model_entity(name="x", spec=types.SimpleNamespace(family="llama", base_num_parameters=1))
         config = ModelEntityTaskConfig(
             name="x",
@@ -492,8 +457,7 @@ class TestLaunchModel:
         assert deployment_call.kwargs["workspace"] == "shared"
         assert deployment_call.kwargs["body"].config == "existing-cfg"
 
-    @patch("nmp.customization_common.tasks.model_entity.run.client_from_platform")
-    def test_lora_with_active_deployment_skips(self, mock_cfp) -> None:
+    def test_lora_with_active_deployment_skips(self) -> None:
         from nmp.customization_common.schemas.file_io import FileSetRef
         from nmp.customization_common.schemas.model_entity import (
             DeploymentParameters,
@@ -502,14 +466,13 @@ class TestLaunchModel:
         )
         from nmp.unsloth.entities.values import FinetuningType
 
-        sdk = _make_sdk()
-        models, _files = _configure_clients(mock_cfp)
+        models, files = _make_clients()
         existing_config = types.SimpleNamespace(workspace="other", name="cfg-1")
         active_deployment = types.SimpleNamespace(status=ModelDeploymentStatus.READY)
         models.list_deployment_configs.return_value = _page([existing_config])
         models.list_deployments.return_value = _page([active_deployment])
 
-        runner = _make_runner(sdk)
+        runner = _make_runner(models, files)
         me = _model_entity(workspace="other", name="base")
         config = ModelEntityTaskConfig(
             name="adapter",
@@ -534,10 +497,8 @@ class TestLaunchModel:
         models.create_deployment_config.assert_not_called()
         models.create_deployment.assert_not_called()
 
-    @patch("nmp.customization_common.tasks.model_entity.run.client_from_platform")
     def test_lora_with_lora_enabled_false_warns_and_skips(
         self,
-        mock_cfp,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         from nmp.customization_common.schemas.file_io import FileSetRef
@@ -548,11 +509,10 @@ class TestLaunchModel:
         )
         from nmp.unsloth.entities.values import FinetuningType
 
-        sdk = _make_sdk()
-        models, _files = _configure_clients(mock_cfp)
+        models, files = _make_clients()
         models.list_deployment_configs.return_value = _page([])
 
-        runner = _make_runner(sdk)
+        runner = _make_runner(models, files)
         me = _model_entity(name="base")
         config = ModelEntityTaskConfig(
             name="adapter",

--- a/uv.lock
+++ b/uv.lock
@@ -4326,7 +4326,6 @@ name = "nemo-automodel-plugin"
 version = "0.0.0"
 source = { editable = "plugins/nemo-automodel" }
 dependencies = [
-    { name = "nemo-platform", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-platform-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nmp-automodel", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nmp-customization-common", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -4347,7 +4346,6 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "nemo-platform", editable = "packages/nemo_platform" },
     { name = "nemo-platform-plugin", editable = "packages/nemo_platform_plugin" },
     { name = "nmp-automodel", editable = "services/automodel" },
     { name = "nmp-customization-common", editable = "packages/nmp_customization_common" },
@@ -5112,7 +5110,6 @@ automodel-service = [
     { name = "httpx", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "jsonschema", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-platform-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nemo-platform-sdk", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nmp-common", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nmp-customization-common", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "pydantic", extra = ["email"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -5520,9 +5517,9 @@ nmp-common = [
     { name = "structlog", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nmp-customization-common = [
+    { name = "filesets", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "httpx", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-platform-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nemo-platform-sdk", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nmp-common", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "pydantic", extra = ["email"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "pydantic-settings", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -5606,7 +5603,6 @@ plugins = [
 rl-service = [
     { name = "httpx", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-platform-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nemo-platform-sdk", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nmp-common", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nmp-customization-common", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "packaging", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -5901,6 +5897,7 @@ requires-dist = [
     { name = "filesets", marker = "extra == 'all'", editable = "packages/filesets" },
     { name = "filesets", marker = "extra == 'core-service'", editable = "packages/filesets" },
     { name = "filesets", marker = "extra == 'files-service'", editable = "packages/filesets" },
+    { name = "filesets", marker = "extra == 'nmp-customization-common'", editable = "packages/filesets" },
     { name = "filesets", marker = "extra == 'services'", editable = "packages/filesets" },
     { name = "fsspec", marker = "extra == 'all'", specifier = ">=2024.10.0" },
     { name = "fsspec", marker = "extra == 'guardrails-service'", specifier = ">=2024.10.0" },
@@ -6096,15 +6093,12 @@ requires-dist = [
     { name = "nemo-platform-plugin", marker = "extra == 'unsloth-service'", editable = "packages/nemo_platform_plugin" },
     { name = "nemo-platform-sdk", editable = "sdk/python/nemo-platform" },
     { name = "nemo-platform-sdk", marker = "extra == 'all'", editable = "sdk/python/nemo-platform" },
-    { name = "nemo-platform-sdk", marker = "extra == 'automodel-service'", editable = "sdk/python/nemo-platform" },
     { name = "nemo-platform-sdk", marker = "extra == 'core-service'", editable = "sdk/python/nemo-platform" },
     { name = "nemo-platform-sdk", marker = "extra == 'entities-service'", editable = "sdk/python/nemo-platform" },
     { name = "nemo-platform-sdk", marker = "extra == 'nemo-deployments-plugin'", editable = "sdk/python/nemo-platform" },
     { name = "nemo-platform-sdk", marker = "extra == 'nemo-platform-plugin'", editable = "sdk/python/nemo-platform" },
     { name = "nemo-platform-sdk", marker = "extra == 'nmp-common'", editable = "sdk/python/nemo-platform" },
-    { name = "nemo-platform-sdk", marker = "extra == 'nmp-customization-common'", editable = "sdk/python/nemo-platform" },
     { name = "nemo-platform-sdk", marker = "extra == 'plugins'", editable = "sdk/python/nemo-platform" },
-    { name = "nemo-platform-sdk", marker = "extra == 'rl-service'", editable = "sdk/python/nemo-platform" },
     { name = "nemo-platform-sdk", marker = "extra == 'services'", editable = "sdk/python/nemo-platform" },
     { name = "nemo-platform-sdk", marker = "extra == 'unsloth-service'", editable = "sdk/python/nemo-platform" },
     { name = "nemo-relay", marker = "extra == 'all'", specifier = ">=0.7,<0.8" },
@@ -6913,7 +6907,6 @@ name = "nemo-rl-plugin"
 version = "0.1.0"
 source = { editable = "plugins/nemo-rl" }
 dependencies = [
-    { name = "nemo-platform", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-platform-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nmp-customization-common", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nmp-rl", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -6934,7 +6927,6 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "nemo-platform", editable = "packages/nemo_platform" },
     { name = "nemo-platform-plugin", editable = "packages/nemo_platform_plugin" },
     { name = "nmp-customization-common", editable = "packages/nmp_customization_common" },
     { name = "nmp-rl", editable = "services/rl" },
@@ -7780,7 +7772,6 @@ dependencies = [
     { name = "httpx", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "jsonschema", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-platform-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nemo-platform-sdk", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nmp-common", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nmp-customization-common", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "pydantic", extra = ["email"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -7804,7 +7795,6 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "jsonschema", specifier = ">=4.23.0" },
     { name = "nemo-platform-plugin", editable = "packages/nemo_platform_plugin" },
-    { name = "nemo-platform-sdk", editable = "sdk/python/nemo-platform" },
     { name = "nmp-common", editable = "packages/nmp_common" },
     { name = "nmp-customization-common", editable = "packages/nmp_customization_common" },
     { name = "peft", marker = "extra == 'training'", specifier = ">=0.20.0" },
@@ -7933,9 +7923,9 @@ name = "nmp-customization-common"
 version = "0.0.0"
 source = { editable = "packages/nmp_customization_common" }
 dependencies = [
+    { name = "filesets", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "httpx", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-platform-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nemo-platform-sdk", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nmp-common", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "pydantic", extra = ["email"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "pydantic-settings", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -7952,9 +7942,9 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "filesets", editable = "packages/filesets" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "nemo-platform-plugin", editable = "packages/nemo_platform_plugin" },
-    { name = "nemo-platform-sdk", editable = "sdk/python/nemo-platform" },
     { name = "nmp-common", editable = "packages/nmp_common" },
     { name = "pydantic", specifier = ">=2.10.6" },
     { name = "pydantic-settings", specifier = ">=2.6.1" },
@@ -8578,7 +8568,6 @@ source = { editable = "services/rl" }
 dependencies = [
     { name = "httpx", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-platform-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nemo-platform-sdk", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nmp-common", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nmp-customization-common", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "packaging", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -8608,7 +8597,6 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "mlflow-skinny", marker = "extra == 'integrations'", specifier = ">=3.15.0,<3.16.0" },
     { name = "nemo-platform-plugin", editable = "packages/nemo_platform_plugin" },
-    { name = "nemo-platform-sdk", editable = "sdk/python/nemo-platform" },
     { name = "nmp-common", editable = "packages/nmp_common" },
     { name = "nmp-customization-common", editable = "packages/nmp_customization_common" },
     { name = "packaging", specifier = ">=24.0" },


### PR DESCRIPTION
## TL;DR
This branch moves customization plugin and service paths onto `nemo_platform_plugin` typed clients instead of reaching through generated Stainless SDK resources. It also tightens shared HTTP transport ownership and keeps the file I/O task on a single sync typed-client path for uploads/downloads.

## Details
The refactor centralizes adaptation from generated `NeMoPlatform` / `AsyncNeMoPlatform` instances into typed sync and async clients, preserving workspace, base URL, headers, retry settings, timeout behavior, URL resolution, and shared httpx transports without transferring transport ownership.

Customization common now works with typed `FilesClient`, `JobsClient`, and `ModelsClient` instances for file I/O, model entity creation, service-side reference validation, and progress reporting. File transfers use the sync `FilesetFileSystem` with the typed files client, removing the mixed sync/async client path while keeping retry and progress reporting behavior at the task layer.

Automodel, RL, Unsloth, Customizer, Data Designer, Anonymizer, and related agent test plumbing are updated to use the typed-client flow. Submit-job scaffolding now carries concrete input/output schemas through transform and compile paths, and service compilers receive a typed async customization client bundle for platform lookups.

Package metadata is adjusted to remove obsolete direct generated SDK dependencies from migrated customization packages/services and to add the direct `filesets` dependency used by file I/O.

## Reviewer Notes
- Runtime entry points that still receive generated SDK instances now adapt them at the boundary with `client_from_platform(...)`; deeper customization code operates on typed clients or the typed async customization client bundle.
- Derived/adapted typed clients intentionally do not close parent SDK/client transports.
- `PlatformJobResults` construction changed from `sdk=` to `client=`, and in-repo call sites have been updated accordingly.
