### PR TITLE
refactor(data-designer): migrate off stainless clients

### DIFF
--- a/packages/data_designer_nemo/src/data_designer_nemo/nemotron_personas.py
+++ b/packages/data_designer_nemo/src/data_designer_nemo/nemotron_personas.py
@@ -6,12 +6,11 @@ from dataclasses import dataclass
 from typing import Literal
 
 from data_designer.config.utils.constants import NEMOTRON_PERSONAS_DATASET_SIZES
-from nemo_platform import NeMoPlatform
-from nemo_platform_plugin.client.adapter import client_from_platform
 from nemo_platform_plugin.client.errors import ConflictError
 from nemo_platform_plugin.files.client import FilesClient
 from nemo_platform_plugin.files.storage_config import NGCStorageConfig
-from nemo_platform_plugin.files.types import CreateFilesetRequest
+from nemo_platform_plugin.files.types import CreateFilesetRequest, FilesetPurpose
+from nemo_platform_plugin.schema import SecretRef
 
 logger = logging.getLogger(__name__)
 
@@ -67,7 +66,7 @@ def get_locale_fileset_file_ref(locale: str) -> str:
 
 def sync_nemotron_personas_fileset(
     *,
-    sdk: NeMoPlatform,
+    files: FilesClient,
     locale: str,
     api_key_secret: str,
 ) -> NemotronPersonasFilesetSyncResult:
@@ -75,7 +74,7 @@ def sync_nemotron_personas_fileset(
     Sync the NGC-backed fileset for a single Nemotron personas locale.
 
     Args:
-        sdk: NeMoPlatform client.
+        files: Files typed client.
         locale: Locale identifier (e.g. 'en_US').
         api_key_secret: Fully qualified secret reference for the NGC API key.
 
@@ -85,7 +84,7 @@ def sync_nemotron_personas_fileset(
     logger.info("Syncing Nemotron personas fileset", extra={"locale": locale})
 
     try:
-        _create_fileset(sdk, locale, api_key_secret)
+        _create_fileset(files, locale, api_key_secret)
         logger.info("Successfully created Nemotron personas fileset", extra={"locale": locale})
         return _CREATED
     except ConflictError:
@@ -93,14 +92,13 @@ def sync_nemotron_personas_fileset(
         return _EXISTS
 
 
-def _create_fileset(sdk: NeMoPlatform, locale: str, api_key_secret: str) -> None:
-    files = client_from_platform(sdk, FilesClient)
+def _create_fileset(files: FilesClient, locale: str, api_key_secret: str) -> None:
     files.create_fileset(
         workspace=WORKSPACE,
         body=CreateFilesetRequest(
             name=get_resource_name_for_locale(locale),
             description=f"Nemotron Personas dataset for locale: {locale!r}",
-            purpose="dataset",
+            purpose=FilesetPurpose.DATASET,
             storage=_get_storage_config_for_locale(locale, api_key_secret),
             cache=True,
         ),
@@ -111,7 +109,7 @@ def _get_storage_config_for_locale(locale: str, api_key_secret: str) -> NGCStora
     resource_name = get_resource_name_for_locale(locale)
 
     return NGCStorageConfig(
-        api_key_secret=api_key_secret,
+        api_key_secret=SecretRef(api_key_secret),
         org=NGC_ORG,
         team=NGC_TEAM,
         target=resource_name,

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/data_designer/client.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/data_designer/client.py
@@ -6,8 +6,8 @@
 Wraps the endpoint functions from ``data_designer.endpoints`` as direct
 methods using the ``method()`` descriptor, following the files/models pattern.
 
-The Data Designer plugin exposes a streaming preview endpoint and a
-job-submission collection (``/jobs/create``).  The high-level SDK resource
+The Data Designer plugin exposes streaming preview endpoints and
+job-submission collections (``/jobs/create`` and retrieval job groups). The high-level SDK resource
 (``DataDesignerResource``) adds frame-collection and job-polling convenience
 on top of these raw HTTP calls; callers that need that convenience should
 continue using the plugin's resource layer, which will construct these
@@ -21,12 +21,17 @@ from nemo_platform_plugin.data_designer import endpoints
 
 class _DataDesignerMethods:
     preview = method(endpoints.preview)
+    retrieval_preview = method(endpoints.retrieval_preview)
     create_job = method(endpoints.create_job)
     list_jobs = method(endpoints.list_jobs)
     get_job = method(endpoints.get_job)
     delete_job = method(endpoints.delete_job)
+    cancel_job = method(endpoints.cancel_job)
     get_job_status = method(endpoints.get_job_status)
     get_job_logs = method(endpoints.get_job_logs)
+    list_job_results = method(endpoints.list_job_results)
+    get_job_result = method(endpoints.get_job_result)
+    download_job_result = method(endpoints.download_job_result)
 
 
 class DataDesignerClient(_DataDesignerMethods, NemoClient):

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/data_designer/endpoints.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/data_designer/endpoints.py
@@ -4,9 +4,9 @@
 """Typed endpoint definitions for the Data Designer service.
 
 The Data Designer plugin exposes:
-- ``POST /preview`` — streaming NDJSON preview of a config
-- ``/jobs/create`` collection — standard job CRUD (create, list, get, delete,
-  status, logs) rebased from the generic ``/jobs`` collection
+- ``POST /preview`` and ``POST /retrieval-preview`` streaming NDJSON functions
+- four job collections under ``/jobs/{job_collection}``: ``create``,
+  ``retrieval-generate``, ``retrieval-prepare``, and ``retrieval-run``
 
 The service prefix is ``/apis/data-designer/v2/workspaces/{workspace}``.
 """
@@ -16,16 +16,25 @@ from __future__ import annotations
 from abc import abstractmethod
 
 from nemo_platform_plugin.client.endpoint import delete, get, post
-from nemo_platform_plugin.client.types import Paginated, Stream
+from nemo_platform_plugin.client.types import BinaryContent, Paginated, Stream
 from nemo_platform_plugin.data_designer.types import (
+    DataDesignerJobCollection,
     DataDesignerJobLogsQueryParams,
     DataDesignerJobRequest,
     DataDesignerJobResponse,
     ListDataDesignerJobsQueryParams,
     PreviewFrameData,
     PreviewRequest,
+    RetrievalPreviewRequest,
 )
-from nemo_platform_plugin.jobs.schemas import PlatformJobLogPage, PlatformJobStatusResponse
+from nemo_platform_plugin.jobs.schemas import (
+    PlatformJobListResultResponse,
+    PlatformJobLogPage,
+    PlatformJobResultResponse,
+    PlatformJobStatusResponse,
+)
+
+_DATA_DESIGNER = "/apis/data-designer/v2/workspaces/{workspace}"
 
 # ---------------------------------------------------------------------------
 # Preview (streaming NDJSON)
@@ -37,40 +46,91 @@ from nemo_platform_plugin.jobs.schemas import PlatformJobLogPage, PlatformJobSta
 def preview(*, workspace: str | None = None, body: PreviewRequest) -> Stream[PreviewFrameData]: ...
 
 
-# ---------------------------------------------------------------------------
-# Job CRUD (collection: /jobs/create)
-# ---------------------------------------------------------------------------
-
-
-@post("/apis/data-designer/v2/workspaces/{workspace}/jobs/create")
+@post("/apis/data-designer/v2/workspaces/{workspace}/retrieval-preview")
 @abstractmethod
-def create_job(*, workspace: str | None = None, body: DataDesignerJobRequest) -> DataDesignerJobResponse: ...
+def retrieval_preview(*, workspace: str | None = None, body: RetrievalPreviewRequest) -> Stream[PreviewFrameData]: ...
 
 
-@get("/apis/data-designer/v2/workspaces/{workspace}/jobs/create")
+# ---------------------------------------------------------------------------
+# Job CRUD (collections: /jobs/{job_collection})
+# ---------------------------------------------------------------------------
+
+
+@post(_DATA_DESIGNER + "/jobs/{job_collection}")
+@abstractmethod
+def create_job(
+    *,
+    workspace: str | None = None,
+    job_collection: DataDesignerJobCollection = "create",
+    body: DataDesignerJobRequest,
+) -> DataDesignerJobResponse: ...
+
+
+@get(_DATA_DESIGNER + "/jobs/{job_collection}")
 @abstractmethod
 def list_jobs(
-    *, workspace: str | None = None, query_params: ListDataDesignerJobsQueryParams | None = None
+    *,
+    workspace: str | None = None,
+    job_collection: DataDesignerJobCollection = "create",
+    query_params: ListDataDesignerJobsQueryParams | None = None,
 ) -> Paginated[DataDesignerJobResponse]: ...
 
 
-@get("/apis/data-designer/v2/workspaces/{workspace}/jobs/create/{name}")
+@get(_DATA_DESIGNER + "/jobs/{job_collection}/{name}")
 @abstractmethod
-def get_job(*, workspace: str | None = None, name: str) -> DataDesignerJobResponse: ...
+def get_job(
+    *, workspace: str | None = None, job_collection: DataDesignerJobCollection = "create", name: str
+) -> DataDesignerJobResponse: ...
 
 
-@delete("/apis/data-designer/v2/workspaces/{workspace}/jobs/create/{name}")
+@delete(_DATA_DESIGNER + "/jobs/{job_collection}/{name}")
 @abstractmethod
-def delete_job(*, workspace: str | None = None, name: str) -> None: ...
+def delete_job(
+    *, workspace: str | None = None, job_collection: DataDesignerJobCollection = "create", name: str
+) -> None: ...
 
 
-@get("/apis/data-designer/v2/workspaces/{workspace}/jobs/create/{name}/status")
+@post(_DATA_DESIGNER + "/jobs/{job_collection}/{name}/cancel")
 @abstractmethod
-def get_job_status(*, workspace: str | None = None, name: str) -> PlatformJobStatusResponse: ...
+def cancel_job(
+    *, workspace: str | None = None, job_collection: DataDesignerJobCollection = "create", name: str
+) -> DataDesignerJobResponse: ...
 
 
-@get("/apis/data-designer/v2/workspaces/{workspace}/jobs/create/{name}/logs")
+@get(_DATA_DESIGNER + "/jobs/{job_collection}/{name}/status")
+@abstractmethod
+def get_job_status(
+    *, workspace: str | None = None, job_collection: DataDesignerJobCollection = "create", name: str
+) -> PlatformJobStatusResponse: ...
+
+
+@get(_DATA_DESIGNER + "/jobs/{job_collection}/{name}/logs")
 @abstractmethod
 def get_job_logs(
-    *, workspace: str | None = None, name: str, query_params: DataDesignerJobLogsQueryParams | None = None
+    *,
+    workspace: str | None = None,
+    job_collection: DataDesignerJobCollection = "create",
+    name: str,
+    query_params: DataDesignerJobLogsQueryParams | None = None,
 ) -> PlatformJobLogPage: ...
+
+
+@get(_DATA_DESIGNER + "/jobs/{job_collection}/{name}/results")
+@abstractmethod
+def list_job_results(
+    *, workspace: str | None = None, job_collection: DataDesignerJobCollection = "create", name: str
+) -> PlatformJobListResultResponse: ...
+
+
+@get(_DATA_DESIGNER + "/jobs/{job_collection}/{job}/results/{name}")
+@abstractmethod
+def get_job_result(
+    *, workspace: str | None = None, job_collection: DataDesignerJobCollection = "create", job: str, name: str
+) -> PlatformJobResultResponse: ...
+
+
+@get(_DATA_DESIGNER + "/jobs/{job_collection}/{job}/results/{name}/download")
+@abstractmethod
+def download_job_result(
+    *, workspace: str | None = None, job_collection: DataDesignerJobCollection = "create", job: str, name: str
+) -> BinaryContent: ...

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/data_designer/types.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/data_designer/types.py
@@ -11,11 +11,14 @@ exposes a streaming preview function and a job-submission collection
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, NotRequired, TypedDict
+from typing import Literal, NotRequired, TypedDict
 
 from nemo_platform_plugin.jobs.schemas import PlatformJobStatus
 from nemo_platform_plugin.schema import Page
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, JsonValue
+
+JsonMap = dict[str, JsonValue]
+DataDesignerJobCollection = Literal["create", "retrieval-generate", "retrieval-prepare", "retrieval-run"]
 
 # ---------------------------------------------------------------------------
 # Preview types
@@ -32,8 +35,15 @@ class PreviewRequest(BaseModel):
     ``.to_dict()`` (or ``model_dump(mode="json")``) to produce this dict.
     """
 
-    config: dict[str, Any]
+    config: JsonMap
     num_records: int | None = None
+
+
+class RetrievalPreviewRequest(BaseModel):
+    """Request body for the retrieval-preview endpoint."""
+
+    generate: JsonMap
+    num_records: int = Field(default=1, ge=1)
 
 
 class PreviewFrameData(BaseModel):
@@ -65,9 +75,11 @@ class DataDesignerJobRequest(BaseModel):
     name: str | None = None
     description: str | None = None
     project: str | None = None
-    spec: dict[str, Any] = Field(default_factory=dict)
-    ownership: dict[str, Any] | None = None
-    custom_fields: dict[str, Any] | None = None
+    spec: JsonMap = Field(default_factory=dict)
+    profile: str | None = None
+    options: JsonMap | None = None
+    ownership: JsonMap | None = None
+    custom_fields: JsonMap | None = None
     output_location: str | None = None
 
 
@@ -85,12 +97,12 @@ class DataDesignerJobResponse(BaseModel):
     workspace: str | None = None
     created_at: datetime | None = None
     updated_at: datetime | None = None
-    spec: dict[str, Any] = Field(default_factory=dict)
+    spec: JsonMap = Field(default_factory=dict)
     status: PlatformJobStatus | None = None
-    status_details: dict[str, Any] | None = None
-    error_details: dict[str, Any] | None = None
-    ownership: dict[str, Any] | None = None
-    custom_fields: dict[str, Any] | None = None
+    status_details: JsonMap | None = None
+    error_details: JsonMap | None = None
+    ownership: JsonMap | None = None
+    custom_fields: JsonMap | None = None
 
 
 DataDesignerJobPage = Page[DataDesignerJobResponse]

--- a/packages/nemo_platform_plugin/tests/data_designer/test_client.py
+++ b/packages/nemo_platform_plugin/tests/data_designer/test_client.py
@@ -1,0 +1,284 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for DataDesignerClient / AsyncDataDesignerClient with mocked httpx transports."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+
+import httpx
+import pytest
+from nemo_platform_plugin.client.errors import (
+    ConflictError,
+    InternalServerError,
+    NotFoundError,
+    UnprocessableEntityError,
+)
+from nemo_platform_plugin.data_designer.client import AsyncDataDesignerClient, DataDesignerClient
+from nemo_platform_plugin.data_designer.types import DataDesignerJobRequest, JsonMap, PreviewRequest
+from pydantic import JsonValue
+
+BASE = "http://test:8000"
+
+_JOB_JSON: JsonMap = {
+    "id": "job-id",
+    "name": "job-a",
+    "workspace": "default",
+    "spec": {"config": {"columns": []}, "num_records": 5},
+    "status": "created",
+    "status_details": {},
+    "error_details": None,
+}
+
+_STATUS_JSON: JsonMap = {
+    "id": "job-id",
+    "name": "job-a",
+    "status": "completed",
+    "status_details": {},
+    "error_details": None,
+    "steps": [],
+    "created_at": "2026-01-01T00:00:00Z",
+    "updated_at": "2026-01-01T00:00:00Z",
+}
+
+_RESULT_JSON: JsonMap = {
+    "name": "artifacts",
+    "job": "job-a",
+    "workspace": "default",
+    "artifact_url": "fileset://default/job-a#artifacts",
+    "artifact_storage_type": "fileset",
+}
+
+
+ResponseHandler = Callable[[httpx.Request], httpx.Response]
+
+
+def _json_handler(status_code: int, payload: JsonValue) -> ResponseHandler:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status_code, request=request, json=payload)
+
+    return handler
+
+
+def _bytes_handler(status_code: int, content: bytes) -> ResponseHandler:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status_code, request=request, content=content)
+
+    return handler
+
+
+def _sequence_handler(handlers: list[ResponseHandler]) -> ResponseHandler:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return handlers.pop(0)(request)
+
+    return handler
+
+
+def _sync_http(handler: ResponseHandler) -> tuple[httpx.Client, list[httpx.Request]]:
+    requests: list[httpx.Request] = []
+
+    def capture(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return handler(request)
+
+    return httpx.Client(transport=httpx.MockTransport(capture)), requests
+
+
+def _async_http(handler: ResponseHandler) -> tuple[httpx.AsyncClient, list[httpx.Request]]:
+    requests: list[httpx.Request] = []
+
+    async def capture(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return handler(request)
+
+    return httpx.AsyncClient(transport=httpx.MockTransport(capture)), requests
+
+
+def test_create_job_serializes_body_and_unwraps_response() -> None:
+    http_client, requests = _sync_http(_json_handler(201, _JOB_JSON))
+    client = DataDesignerClient(base_url=BASE, workspace="default", http_client=http_client)
+    body = DataDesignerJobRequest(
+        name="job-a",
+        spec={"config": {"columns": []}, "num_records": 5},
+        profile="gpu-large",
+        options={"priority": "high"},
+    )
+
+    job = client.create_job(body=body).data()
+
+    assert job.name == "job-a"
+    request = requests[0]
+    assert request.method == "POST"
+    assert request.url.path == "/apis/data-designer/v2/workspaces/default/jobs/create"
+    assert json.loads(request.content) == {
+        "name": "job-a",
+        "spec": {"config": {"columns": []}, "num_records": 5},
+        "profile": "gpu-large",
+        "options": {"priority": "high"},
+    }
+
+
+def test_create_retrieval_job_resolves_collection_path() -> None:
+    http_client, requests = _sync_http(_json_handler(201, {**_JOB_JSON, "name": "retrieval-job"}))
+    client = DataDesignerClient(base_url=BASE, workspace="default", http_client=http_client)
+
+    client.create_job(job_collection="retrieval-generate", body=DataDesignerJobRequest(spec={"corpus": "system/c"}))
+
+    assert requests[0].url.path == "/apis/data-designer/v2/workspaces/default/jobs/retrieval-generate"
+
+
+def test_list_jobs_paginated_items() -> None:
+    http_client, _ = _sync_http(
+        _json_handler(
+            200,
+            {
+                "data": [_JOB_JSON],
+                "pagination": {
+                    "page": 1,
+                    "page_size": 10,
+                    "current_page_size": 1,
+                    "total_pages": 1,
+                    "total_results": 1,
+                },
+            },
+        )
+    )
+    client = DataDesignerClient(base_url=BASE, workspace="default", http_client=http_client)
+
+    jobs = list(client.list_jobs().items())
+
+    assert [job.name for job in jobs] == ["job-a"]
+
+
+def test_get_job_status_unwraps_response() -> None:
+    http_client, _ = _sync_http(_json_handler(200, _STATUS_JSON))
+    client = DataDesignerClient(base_url=BASE, workspace="default", http_client=http_client)
+
+    status = client.get_job_status(name="job-a").data()
+
+    assert status.name == "job-a"
+    assert status.status == "completed"
+
+
+def test_get_job_logs_unwraps_log_page() -> None:
+    http_client, _ = _sync_http(
+        _json_handler(
+            200,
+            {
+                "data": [
+                    {
+                        "timestamp": "2026-01-01T00:00:00Z",
+                        "job": "job-a",
+                        "job_step": "step",
+                        "job_task": "task",
+                        "message": '{"message":"hello","levelname":"INFO","name":"data_designer"}',
+                    }
+                ],
+                "total": 1,
+                "next_page": None,
+                "prev_page": None,
+            },
+        )
+    )
+    client = DataDesignerClient(base_url=BASE, workspace="default", http_client=http_client)
+
+    logs = client.get_job_logs(name="job-a").data()
+
+    assert logs.data[0].job == "job-a"
+    assert logs.next_page is None
+
+
+def test_list_and_get_job_results_unwrap_models() -> None:
+    http_client, requests = _sync_http(
+        _sequence_handler([_json_handler(200, {"data": [_RESULT_JSON]}), _json_handler(200, _RESULT_JSON)])
+    )
+    client = DataDesignerClient(base_url=BASE, workspace="default", http_client=http_client)
+
+    results = client.list_job_results(name="job-a").data()
+    result = client.get_job_result(job="job-a", name="artifacts").data()
+
+    assert requests[0].url.path == "/apis/data-designer/v2/workspaces/default/jobs/create/job-a/results"
+    assert requests[1].url.path == "/apis/data-designer/v2/workspaces/default/jobs/create/job-a/results/artifacts"
+    assert results.data[0].name == "artifacts"
+    assert result.artifact_url == "fileset://default/job-a#artifacts"
+
+
+def test_download_job_result_reads_bytes() -> None:
+    http_client, requests = _sync_http(_bytes_handler(200, b"artifact-bytes"))
+    client = DataDesignerClient(base_url=BASE, workspace="default", http_client=http_client)
+
+    data = client.download_job_result(job="job-a", name="artifacts").read()
+
+    assert (
+        requests[0].url.path == "/apis/data-designer/v2/workspaces/default/jobs/create/job-a/results/artifacts/download"
+    )
+    assert data == b"artifact-bytes"
+
+
+def test_preview_stream_parses_ndjson_frames() -> None:
+    http_client, requests = _sync_http(_bytes_handler(200, b'{"kind":"heartbeat"}\n{"kind":"done"}\n'))
+    client = DataDesignerClient(base_url=BASE, workspace="default", http_client=http_client)
+
+    response = client.preview(body=PreviewRequest(config={"columns": []}, num_records=1))
+    with response.stream() as stream:
+        frames = list(stream)
+
+    assert requests[0].url.path == "/apis/data-designer/v2/workspaces/default/preview"
+    assert [frame.kind for frame in frames] == ["heartbeat", "done"]
+
+
+def test_not_found_maps_to_typed_error() -> None:
+    http_client, _ = _sync_http(_json_handler(404, {"detail": "not found"}))
+    client = DataDesignerClient(base_url=BASE, workspace="default", http_client=http_client)
+
+    with pytest.raises(NotFoundError, match="not found"):
+        client.get_job(name="missing")
+
+
+def test_validation_error_maps_to_typed_error() -> None:
+    http_client, _ = _sync_http(_json_handler(422, {"detail": "invalid config"}))
+    client = DataDesignerClient(base_url=BASE, workspace="default", http_client=http_client)
+
+    with pytest.raises(UnprocessableEntityError, match="invalid config"):
+        client.create_job(body=DataDesignerJobRequest(spec={}))
+
+
+@pytest.mark.parametrize(
+    ("status_code", "error_cls", "detail"),
+    [
+        (409, ConflictError, "job already exists"),
+        (500, InternalServerError, "server exploded"),
+    ],
+)
+def test_additional_http_errors_map_to_typed_errors(status_code: int, error_cls: type[Exception], detail: str) -> None:
+    http_client, _ = _sync_http(_json_handler(status_code, {"detail": detail}))
+    client = DataDesignerClient(base_url=BASE, workspace="default", http_client=http_client)
+
+    with pytest.raises(error_cls, match=detail):
+        client.create_job(body=DataDesignerJobRequest(spec={}))
+
+
+@pytest.mark.asyncio
+async def test_async_get_job_unwraps_response() -> None:
+    http_client, requests = _async_http(_json_handler(200, _JOB_JSON))
+    client = AsyncDataDesignerClient(base_url=BASE, workspace="default", http_client=http_client)
+
+    response = await client.get_job(name="job-a")
+
+    assert requests[0].url.path == "/apis/data-designer/v2/workspaces/default/jobs/create/job-a"
+    assert response.data().name == "job-a"
+
+
+@pytest.mark.asyncio
+async def test_async_download_job_result_reads_bytes() -> None:
+    http_client, requests = _async_http(_bytes_handler(200, b"artifact-bytes"))
+    client = AsyncDataDesignerClient(base_url=BASE, workspace="default", http_client=http_client)
+
+    data = await (await client.download_job_result(job="job-a", name="artifacts")).read()
+
+    assert (
+        requests[0].url.path == "/apis/data-designer/v2/workspaces/default/jobs/create/job-a/results/artifacts/download"
+    )
+    assert data == b"artifact-bytes"

--- a/packages/nemo_platform_plugin/tests/data_designer/test_endpoints.py
+++ b/packages/nemo_platform_plugin/tests/data_designer/test_endpoints.py
@@ -1,0 +1,206 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for Data Designer service endpoint definitions."""
+
+from __future__ import annotations
+
+import json
+from typing import get_origin
+
+from nemo_platform_plugin.client.types import BinaryContent, Paginated, PreparedRequest, Stream
+from nemo_platform_plugin.data_designer import endpoints
+from nemo_platform_plugin.data_designer.types import (
+    DataDesignerJobRequest,
+    DataDesignerJobResponse,
+    PreviewFrameData,
+    PreviewRequest,
+    RetrievalPreviewRequest,
+)
+from nemo_platform_plugin.jobs.schemas import (
+    PlatformJobListResultResponse,
+    PlatformJobLogPage,
+    PlatformJobResultResponse,
+    PlatformJobStatusResponse,
+)
+
+
+def _job_request() -> DataDesignerJobRequest:
+    return DataDesignerJobRequest(
+        name="job-a",
+        spec={"config": {"columns": []}, "num_records": 10},
+        profile="gpu-large",
+        options={"priority": "high"},
+        custom_fields={"purpose": "test"},
+    )
+
+
+def _json_content(prepared: PreparedRequest) -> object:
+    assert isinstance(prepared.content, bytes)
+    return json.loads(prepared.content)
+
+
+def test_preview_endpoint_shape() -> None:
+    body = PreviewRequest(config={"columns": []}, num_records=3)
+
+    prepared = endpoints.preview(workspace="default", body=body)
+
+    assert isinstance(prepared, PreparedRequest)
+    assert prepared.method == "POST"
+    assert prepared.path_template == "/apis/data-designer/v2/workspaces/{workspace}/preview"
+    assert prepared.path_params == {"workspace": "default"}
+    assert prepared.content == body.model_dump_json(exclude_unset=True).encode()
+    assert prepared.content_type == "application/json"
+    assert get_origin(prepared.response_type) is Stream
+
+
+def test_retrieval_preview_endpoint_shape() -> None:
+    body = RetrievalPreviewRequest(generate={"corpus": "system/corpus", "provider": "default/llm"}, num_records=2)
+
+    prepared = endpoints.retrieval_preview(workspace="default", body=body)
+
+    assert prepared.method == "POST"
+    assert prepared.path_template == "/apis/data-designer/v2/workspaces/{workspace}/retrieval-preview"
+    assert prepared.path_params == {"workspace": "default"}
+    assert prepared.content == body.model_dump_json(exclude_unset=True).encode()
+    assert get_origin(prepared.response_type) is Stream
+
+
+def test_retrieval_preview_num_records_defaults_to_service_contract() -> None:
+    body = RetrievalPreviewRequest(generate={"corpus": "system/corpus", "provider": "default/llm"})
+
+    prepared = endpoints.retrieval_preview(workspace="default", body=body)
+
+    assert _json_content(prepared) == {
+        "generate": {"corpus": "system/corpus", "provider": "default/llm"},
+    }
+
+
+def test_create_job_defaults_to_create_collection() -> None:
+    body = _job_request()
+
+    prepared = endpoints.create_job(workspace="default", body=body)
+
+    assert prepared.method == "POST"
+    assert prepared.path_template == "/apis/data-designer/v2/workspaces/{workspace}/jobs/{job_collection}"
+    assert prepared.path_params == {"workspace": "default", "job_collection": "create"}
+    assert _json_content(prepared) == {
+        "name": "job-a",
+        "spec": {"config": {"columns": []}, "num_records": 10},
+        "profile": "gpu-large",
+        "options": {"priority": "high"},
+        "custom_fields": {"purpose": "test"},
+    }
+    assert prepared.response_type is DataDesignerJobResponse
+
+
+def test_create_job_supports_retrieval_collection() -> None:
+    prepared = endpoints.create_job(
+        workspace="default",
+        job_collection="retrieval-generate",
+        body=DataDesignerJobRequest(spec={"corpus": "system/corpus"}),
+    )
+
+    assert prepared.path_params == {"workspace": "default", "job_collection": "retrieval-generate"}
+
+
+def test_list_jobs_endpoint_shape() -> None:
+    prepared = endpoints.list_jobs(
+        workspace="default",
+        job_collection="retrieval-prepare",
+        query_params={"page": 2, "page_size": 25, "sort": "-created_at"},
+    )
+
+    assert prepared.method == "GET"
+    assert prepared.path_params == {"workspace": "default", "job_collection": "retrieval-prepare"}
+    assert prepared.query_params == {"page": 2, "page_size": 25, "sort": "-created_at"}
+    assert get_origin(prepared.response_type) is Paginated
+
+
+def test_get_job_endpoint_shape() -> None:
+    prepared = endpoints.get_job(workspace="default", job_collection="retrieval-run", name="job-a")
+
+    assert prepared.method == "GET"
+    assert prepared.path_template.endswith("/jobs/{job_collection}/{name}")
+    assert prepared.path_params == {"workspace": "default", "job_collection": "retrieval-run", "name": "job-a"}
+    assert prepared.response_type is DataDesignerJobResponse
+
+
+def test_delete_job_endpoint_shape() -> None:
+    prepared = endpoints.delete_job(workspace="default", name="job-a")
+
+    assert prepared.method == "DELETE"
+    assert prepared.path_params == {"workspace": "default", "job_collection": "create", "name": "job-a"}
+    assert prepared.response_type is None
+
+
+def test_cancel_job_endpoint_shape() -> None:
+    prepared = endpoints.cancel_job(workspace="default", job_collection="retrieval-run", name="job-a")
+
+    assert prepared.method == "POST"
+    assert prepared.path_template.endswith("/jobs/{job_collection}/{name}/cancel")
+    assert prepared.response_type is DataDesignerJobResponse
+
+
+def test_get_job_status_endpoint_shape() -> None:
+    prepared = endpoints.get_job_status(workspace="default", name="job-a")
+
+    assert prepared.method == "GET"
+    assert prepared.path_template.endswith("/jobs/{job_collection}/{name}/status")
+    assert prepared.response_type is PlatformJobStatusResponse
+
+
+def test_get_job_logs_endpoint_shape() -> None:
+    prepared = endpoints.get_job_logs(
+        workspace="default",
+        name="job-a",
+        query_params={"limit": 100, "page_cursor": "abc", "tail": 20},
+    )
+
+    assert prepared.method == "GET"
+    assert prepared.path_template.endswith("/jobs/{job_collection}/{name}/logs")
+    assert prepared.query_params == {"limit": 100, "page_cursor": "abc", "tail": 20}
+    assert prepared.response_type is PlatformJobLogPage
+
+
+def test_list_job_results_endpoint_shape() -> None:
+    prepared = endpoints.list_job_results(workspace="default", name="job-a")
+
+    assert prepared.method == "GET"
+    assert prepared.path_template.endswith("/jobs/{job_collection}/{name}/results")
+    assert prepared.response_type is PlatformJobListResultResponse
+
+
+def test_get_job_result_endpoint_shape() -> None:
+    prepared = endpoints.get_job_result(workspace="default", job="job-a", name="artifacts")
+
+    assert prepared.method == "GET"
+    assert prepared.path_template.endswith("/jobs/{job_collection}/{job}/results/{name}")
+    assert prepared.path_params == {
+        "workspace": "default",
+        "job_collection": "create",
+        "job": "job-a",
+        "name": "artifacts",
+    }
+    assert prepared.response_type is PlatformJobResultResponse
+
+
+def test_download_job_result_endpoint_shape() -> None:
+    prepared = endpoints.download_job_result(workspace="default", job="job-a", name="artifacts")
+
+    assert prepared.method == "GET"
+    assert prepared.path_template.endswith("/jobs/{job_collection}/{job}/results/{name}/download")
+    assert prepared.content is None
+    assert prepared.response_type is BinaryContent
+
+
+def test_workspace_can_be_omitted_for_client_default_resolution() -> None:
+    prepared = endpoints.get_job(name="job-a")
+
+    assert prepared.path_params == {"job_collection": "create", "name": "job-a"}
+
+
+def test_preview_frame_type_is_importable_for_stream_validation() -> None:
+    frame = PreviewFrameData(kind="heartbeat")
+
+    assert frame.kind == "heartbeat"

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/cli/personas.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/cli/personas.py
@@ -17,9 +17,9 @@ from data_designer_nemo.nemotron_personas import (
     get_resource_name_for_locale,
     sync_nemotron_personas_fileset,
 )
-from nemo_platform import NeMoPlatform
-from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.client.client import NemoClient
 from nemo_platform_plugin.client.errors import ConflictError
+from nemo_platform_plugin.files.client import FilesClient
 from nemo_platform_plugin.secrets.client import SecretsClient
 from nemo_platform_plugin.secrets.types import PlatformSecretCreateRequest
 from pydantic import SecretStr
@@ -85,11 +85,12 @@ def make_fileset_command(
     api_key = _get_api_key_from_env(api_key_env_var)
 
     print_header("Nemotron Personas Fileset")
-    sdk = NeMoPlatform()
+    client = NemoClient.from_config()
+    files = FilesClient.from_client(client)
 
     if api_key is not None:
         try:
-            secrets = client_from_platform(sdk, SecretsClient)
+            secrets = SecretsClient.from_client(client)
             secrets.create_secret(
                 workspace=secret_workspace,
                 body=PlatformSecretCreateRequest(name=secret_name, value=SecretStr(api_key)),
@@ -107,7 +108,7 @@ def make_fileset_command(
     fileset_name = get_resource_name_for_locale(locale)
     fileset_ref = f"{WORKSPACE}/{fileset_name}"
     try:
-        result = sync_nemotron_personas_fileset(sdk=sdk, locale=locale, api_key_secret=api_key_secret)
+        result = sync_nemotron_personas_fileset(files=files, locale=locale, api_key_secret=api_key_secret)
     except Exception as exc:
         print_error(f"Failed to create fileset {fileset_ref!r}: {exc}")
         raise typer.Exit(code=1) from exc

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/sdk/job_resources.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/sdk/job_resources.py
@@ -9,17 +9,19 @@ import tarfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Awaitable, Callable, TypeVar
+from typing import Awaitable, Callable, TypeVar, overload
 
-import httpx
 from data_designer.config.analysis.dataset_profiler import DatasetProfilerResults
 from data_designer.config.utils.visualization import WithRecordSamplerMixin
 from data_designer.logging import RandomEmoji
-from nemo_data_designer_plugin.sdk import http
-from nemo_data_designer_plugin.sdk.errors import DataDesignerJobError, extract_http_error_info
+from nemo_data_designer_plugin.sdk.errors import DataDesignerJobError
 from nemo_data_designer_plugin.sdk.job_results import DataDesignerJobResults
 from nemo_data_designer_plugin.sdk.logging import with_logging
 from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
+from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.client.errors import NemoHTTPError, NotFoundError
+from nemo_platform_plugin.data_designer.client import AsyncDataDesignerClient, DataDesignerClient
+from nemo_platform_plugin.data_designer.types import DataDesignerJobCollection, DataDesignerJobLogsQueryParams
 from nemo_platform_plugin.jobs.archive import safe_extract_tar
 from nemo_platform_plugin.jobs.schemas import PlatformJobStatus
 from typing_extensions import Self
@@ -47,26 +49,17 @@ async def _async_pause(seconds: float) -> None:
     await asyncio.sleep(seconds)
 
 
-def _job_url(
-    platform: http.PlatformClient,
-    workspace: str | None,
-    path: str,
-    *,
-    collection: str = "create",
-) -> str:
-    return http.url(platform, workspace, f"/jobs/{collection}{path}")
-
-
-def _raise_for_status(resp: httpx.Response) -> None:
-    try:
-        resp.raise_for_status()
-    except httpx.HTTPStatusError as exc:
-        status_code, detail = extract_http_error_info(exc)
-        raise DataDesignerJobError(detail, status_code=status_code) from exc
+def _get_job_error(exc: NemoHTTPError) -> DataDesignerJobError:
+    return DataDesignerJobError(exc.detail, status_code=exc.status_code)
 
 
 def _safe_extract_tar(tar: tarfile.TarFile, output_path: Path) -> None:
     safe_extract_tar(tar, output_path, error_cls=DataDesignerJobError)
+
+
+def _extract_artifact_bytes(artifact_bytes: bytes, output_path: Path) -> None:
+    with tarfile.open(fileobj=io.BytesIO(artifact_bytes), mode="r:*") as tar:
+        _safe_extract_tar(tar, output_path)
 
 
 @dataclass
@@ -107,16 +100,44 @@ class _WaitLogCollector:
 
 @with_logging
 class DataDesignerJobResource(WithRecordSamplerMixin):
+    @overload
+    def __init__(
+        self,
+        *,
+        job_name: str,
+        client: DataDesignerClient,
+        workspace: str | None,
+        job_collection: DataDesignerJobCollection = "create",
+    ) -> None: ...
+
+    @overload
     def __init__(
         self,
         *,
         job_name: str,
         platform: NeMoPlatform,
         workspace: str | None,
-        job_collection: str = "create",
+        job_collection: DataDesignerJobCollection = "create",
+    ) -> None: ...
+
+    def __init__(
+        self,
+        *,
+        job_name: str,
+        client: DataDesignerClient | None = None,
+        platform: NeMoPlatform | None = None,
+        workspace: str | None,
+        job_collection: DataDesignerJobCollection = "create",
     ):
+        if client is None:
+            if platform is None:
+                raise TypeError("DataDesignerJobResource requires either client= or platform=")
+            client = client_from_platform(platform, DataDesignerClient)
+        elif platform is not None:
+            raise TypeError("Pass only one of client= or platform=")
+
         self._job_name = job_name
-        self._platform = platform
+        self._client = client
         self._workspace = workspace
         self._job_collection = job_collection
         self._consecutive_poll_errors = 0
@@ -136,12 +157,13 @@ class DataDesignerJobResource(WithRecordSamplerMixin):
         Returns:
             The job dict with up-to-date details.
         """
-        resp = self._platform._client.get(
-            _job_url(self._platform, self._workspace, f"/{self._job_name}", collection=self._job_collection),
-            headers=http.headers(self._platform),
-        )
-        _raise_for_status(resp)
-        return resp.json()
+        try:
+            job = self._client.get_job(
+                workspace=self._workspace, job_collection=self._job_collection, name=self._job_name
+            ).data()
+        except NemoHTTPError as exc:
+            raise _get_job_error(exc) from exc
+        return job.model_dump(mode="json")
 
     def get_job_status(self) -> PlatformJobStatus | None:
         """Get the current status of the job.
@@ -149,12 +171,13 @@ class DataDesignerJobResource(WithRecordSamplerMixin):
         Returns:
             The current job status.
         """
-        resp = self._platform._client.get(
-            _job_url(self._platform, self._workspace, f"/{self._job_name}/status", collection=self._job_collection),
-            headers=http.headers(self._platform),
-        )
-        _raise_for_status(resp)
-        return resp.json().get("status")
+        try:
+            status = self._client.get_job_status(
+                workspace=self._workspace, job_collection=self._job_collection, name=self._job_name
+            ).data()
+        except NemoHTTPError as exc:
+            raise _get_job_error(exc) from exc
+        return status.status
 
     def check_if_complete(self, *, raise_if_not_complete: bool = False) -> bool:
         """Check if the job is in a completed state.
@@ -206,19 +229,21 @@ class DataDesignerJobResource(WithRecordSamplerMixin):
         logs = []
         page_cursor = None
         while True:
-            params = {"page_cursor": page_cursor} if page_cursor else None
-            resp = self._platform._client.get(
-                _job_url(self._platform, self._workspace, f"/{self._job_name}/logs", collection=self._job_collection),
-                headers=http.headers(self._platform),
-                params=params,
-            )
-            _raise_for_status(resp)
-            response = resp.json()
-            for log in response.get("data", []):
-                deserialized = _try_parse_log_message(log.get("message", ""))
+            query_params: DataDesignerJobLogsQueryParams | None = {"page_cursor": page_cursor} if page_cursor else None
+            try:
+                page = self._client.get_job_logs(
+                    workspace=self._workspace,
+                    job_collection=self._job_collection,
+                    name=self._job_name,
+                    query_params=query_params,
+                ).data()
+            except NemoHTTPError as exc:
+                raise _get_job_error(exc) from exc
+            for log in page.data:
+                deserialized = _try_parse_log_message(log.message)
                 if deserialized is not None:
                     logs.append(deserialized)
-            page_cursor = response.get("next_page")
+            page_cursor = page.next_page
             if page_cursor is None:
                 break
         return logs
@@ -236,31 +261,25 @@ class DataDesignerJobResource(WithRecordSamplerMixin):
         output_path = Path(path or self._job_name)
         logger.info(f"🏺 Downloading artifacts from Job {self._job_name!r}")
 
-        resp = self._platform._client.get(
-            _job_url(
-                self._platform,
-                self._workspace,
-                f"/{self._job_name}/results/artifacts/download",
-                collection=self._job_collection,
-            ),
-            headers=http.headers(self._platform),
-        )
-        _raise_for_status(resp)
-        with tarfile.open(fileobj=io.BytesIO(resp.content), mode="r:*") as tar:
-            _safe_extract_tar(tar, output_path)
+        try:
+            artifact_bytes = self._client.download_job_result(
+                workspace=self._workspace,
+                job_collection=self._job_collection,
+                job=self._job_name,
+                name=ARTIFACTS_RESULT_NAME,
+            ).read()
+        except NemoHTTPError as exc:
+            raise _get_job_error(exc) from exc
+        _extract_artifact_bytes(artifact_bytes, output_path)
 
         try:
-            analysis_resp = self._platform._client.get(
-                _job_url(
-                    self._platform,
-                    self._workspace,
-                    f"/{self._job_name}/results/analysis/download",
-                    collection=self._job_collection,
-                ),
-                headers=http.headers(self._platform),
-            )
-            _raise_for_status(analysis_resp)
-            analysis = DatasetProfilerResults.model_validate(analysis_resp.json())
+            analysis_bytes = self._client.download_job_result(
+                workspace=self._workspace,
+                job_collection=self._job_collection,
+                job=self._job_name,
+                name=ANALYSIS_RESULT_NAME,
+            ).read()
+            analysis = DatasetProfilerResults.model_validate_json(analysis_bytes)
         except Exception as e:
             msg = f"Unable to fetch analysis: {e}"
             logger.warning(msg)
@@ -281,17 +300,13 @@ class DataDesignerJobResource(WithRecordSamplerMixin):
         """
         self._check_if_result_available(ANALYSIS_RESULT_NAME)
         try:
-            resp = self._platform._client.get(
-                _job_url(
-                    self._platform,
-                    self._workspace,
-                    f"/{self._job_name}/results/analysis/download",
-                    collection=self._job_collection,
-                ),
-                headers=http.headers(self._platform),
-            )
-            _raise_for_status(resp)
-            return DatasetProfilerResults.model_validate(resp.json())
+            analysis_bytes = self._client.download_job_result(
+                workspace=self._workspace,
+                job_collection=self._job_collection,
+                job=self._job_name,
+                name=ANALYSIS_RESULT_NAME,
+            ).read()
+            return DatasetProfilerResults.model_validate_json(analysis_bytes)
         except Exception as e:
             raise DataDesignerJobError(f"🛑 Error loading analysis: {e}") from e
 
@@ -301,16 +316,12 @@ class DataDesignerJobResource(WithRecordSamplerMixin):
             return
         if status == "active" or status in TERMINAL_INCOMPLETE_STATUSES:
             try:
-                resp = self._platform._client.get(
-                    _job_url(
-                        self._platform,
-                        self._workspace,
-                        f"/{self._job_name}/results/{result_name}",
-                        collection=self._job_collection,
-                    ),
-                    headers=http.headers(self._platform),
-                )
-                _raise_for_status(resp)
+                self._client.get_job_result(
+                    workspace=self._workspace,
+                    job_collection=self._job_collection,
+                    job=self._job_name,
+                    name=result_name,
+                ).data()
                 if status == "active":
                     logger.info(
                         f"{RandomEmoji.cooking()} Your dataset is still cooking. "
@@ -318,10 +329,10 @@ class DataDesignerJobResource(WithRecordSamplerMixin):
                     )
                 else:
                     logger.warning(f"Job ended with status {status!r}. Fetching completed {result_name} result.")
-            except DataDesignerJobError as e:
-                if e.status_code == 404:
-                    raise DataDesignerJobError(f"{result_name!r} result is not available.") from e
-                raise DataDesignerJobError(f"🛑 Error loading dataset: {e}") from e
+            except NotFoundError as e:
+                raise DataDesignerJobError(f"{result_name!r} result is not available.") from e
+            except NemoHTTPError as e:
+                raise DataDesignerJobError(f"🛑 Error loading dataset: {e.detail}", status_code=e.status_code) from e
         else:
             raise DataDesignerJobError(f"Current job status is {status!r}, results are not available.")
 
@@ -351,16 +362,44 @@ class DataDesignerJobResource(WithRecordSamplerMixin):
 
 @with_logging
 class AsyncDataDesignerJobResource(WithRecordSamplerMixin):
+    @overload
+    def __init__(
+        self,
+        *,
+        job_name: str,
+        client: AsyncDataDesignerClient,
+        workspace: str | None,
+        job_collection: DataDesignerJobCollection = "create",
+    ) -> None: ...
+
+    @overload
     def __init__(
         self,
         *,
         job_name: str,
         platform: AsyncNeMoPlatform,
         workspace: str | None,
-        job_collection: str = "create",
+        job_collection: DataDesignerJobCollection = "create",
+    ) -> None: ...
+
+    def __init__(
+        self,
+        *,
+        job_name: str,
+        client: AsyncDataDesignerClient | None = None,
+        platform: AsyncNeMoPlatform | None = None,
+        workspace: str | None,
+        job_collection: DataDesignerJobCollection = "create",
     ):
+        if client is None:
+            if platform is None:
+                raise TypeError("AsyncDataDesignerJobResource requires either client= or platform=")
+            client = client_from_platform(platform, AsyncDataDesignerClient)
+        elif platform is not None:
+            raise TypeError("Pass only one of client= or platform=")
+
         self._job_name = job_name
-        self._platform = platform
+        self._client = client
         self._workspace = workspace
         self._job_collection = job_collection
         self._consecutive_poll_errors = 0
@@ -380,12 +419,13 @@ class AsyncDataDesignerJobResource(WithRecordSamplerMixin):
         Returns:
             The job dict with up-to-date details.
         """
-        resp = await self._platform._client.get(
-            _job_url(self._platform, self._workspace, f"/{self._job_name}", collection=self._job_collection),
-            headers=http.headers(self._platform),
-        )
-        _raise_for_status(resp)
-        return resp.json()
+        try:
+            response = await self._client.get_job(
+                workspace=self._workspace, job_collection=self._job_collection, name=self._job_name
+            )
+        except NemoHTTPError as exc:
+            raise _get_job_error(exc) from exc
+        return response.data().model_dump(mode="json")
 
     async def get_job_status(self) -> PlatformJobStatus | None:
         """Get the current status of the job.
@@ -393,12 +433,13 @@ class AsyncDataDesignerJobResource(WithRecordSamplerMixin):
         Returns:
             The current job status.
         """
-        resp = await self._platform._client.get(
-            _job_url(self._platform, self._workspace, f"/{self._job_name}/status", collection=self._job_collection),
-            headers=http.headers(self._platform),
-        )
-        _raise_for_status(resp)
-        return resp.json().get("status")
+        try:
+            response = await self._client.get_job_status(
+                workspace=self._workspace, job_collection=self._job_collection, name=self._job_name
+            )
+        except NemoHTTPError as exc:
+            raise _get_job_error(exc) from exc
+        return response.data().status
 
     async def check_if_complete(self, *, raise_if_not_complete: bool = False) -> bool:
         """Check if the job is in a completed state.
@@ -450,19 +491,22 @@ class AsyncDataDesignerJobResource(WithRecordSamplerMixin):
         logs = []
         page_cursor = None
         while True:
-            params = {"page_cursor": page_cursor} if page_cursor else None
-            resp = await self._platform._client.get(
-                _job_url(self._platform, self._workspace, f"/{self._job_name}/logs", collection=self._job_collection),
-                headers=http.headers(self._platform),
-                params=params,
-            )
-            _raise_for_status(resp)
-            response = resp.json()
-            for log in response.get("data", []):
-                deserialized = _try_parse_log_message(log.get("message", ""))
+            query_params: DataDesignerJobLogsQueryParams | None = {"page_cursor": page_cursor} if page_cursor else None
+            try:
+                response = await self._client.get_job_logs(
+                    workspace=self._workspace,
+                    job_collection=self._job_collection,
+                    name=self._job_name,
+                    query_params=query_params,
+                )
+            except NemoHTTPError as exc:
+                raise _get_job_error(exc) from exc
+            page = response.data()
+            for log in page.data:
+                deserialized = _try_parse_log_message(log.message)
                 if deserialized is not None:
                     logs.append(deserialized)
-            page_cursor = response.get("next_page")
+            page_cursor = page.next_page
             if page_cursor is None:
                 break
         return logs
@@ -480,31 +524,27 @@ class AsyncDataDesignerJobResource(WithRecordSamplerMixin):
         output_path = Path(path or self._job_name)
         logger.info(f"🏺 Downloading artifacts from Job {self._job_name!r}")
 
-        resp = await self._platform._client.get(
-            _job_url(
-                self._platform,
-                self._workspace,
-                f"/{self._job_name}/results/artifacts/download",
-                collection=self._job_collection,
-            ),
-            headers=http.headers(self._platform),
-        )
-        _raise_for_status(resp)
-        with tarfile.open(fileobj=io.BytesIO(resp.content), mode="r:*") as tar:
-            _safe_extract_tar(tar, output_path)
+        try:
+            artifact_response = await self._client.download_job_result(
+                workspace=self._workspace,
+                job_collection=self._job_collection,
+                job=self._job_name,
+                name=ARTIFACTS_RESULT_NAME,
+            )
+            artifact_bytes = await artifact_response.read()
+        except NemoHTTPError as exc:
+            raise _get_job_error(exc) from exc
+        await asyncio.to_thread(_extract_artifact_bytes, artifact_bytes, output_path)
 
         try:
-            analysis_resp = await self._platform._client.get(
-                _job_url(
-                    self._platform,
-                    self._workspace,
-                    f"/{self._job_name}/results/analysis/download",
-                    collection=self._job_collection,
-                ),
-                headers=http.headers(self._platform),
+            analysis_response = await self._client.download_job_result(
+                workspace=self._workspace,
+                job_collection=self._job_collection,
+                job=self._job_name,
+                name=ANALYSIS_RESULT_NAME,
             )
-            _raise_for_status(analysis_resp)
-            analysis = DatasetProfilerResults.model_validate(analysis_resp.json())
+            analysis_bytes = await analysis_response.read()
+            analysis = DatasetProfilerResults.model_validate_json(analysis_bytes)
         except Exception as e:
             msg = f"Unable to fetch analysis: {e}"
             logger.warning(msg)
@@ -525,17 +565,14 @@ class AsyncDataDesignerJobResource(WithRecordSamplerMixin):
         """
         await self._check_if_result_available(ANALYSIS_RESULT_NAME)
         try:
-            resp = await self._platform._client.get(
-                _job_url(
-                    self._platform,
-                    self._workspace,
-                    f"/{self._job_name}/results/analysis/download",
-                    collection=self._job_collection,
-                ),
-                headers=http.headers(self._platform),
+            response = await self._client.download_job_result(
+                workspace=self._workspace,
+                job_collection=self._job_collection,
+                job=self._job_name,
+                name=ANALYSIS_RESULT_NAME,
             )
-            _raise_for_status(resp)
-            return DatasetProfilerResults.model_validate(resp.json())
+            analysis_bytes = await response.read()
+            return DatasetProfilerResults.model_validate_json(analysis_bytes)
         except Exception as e:
             raise DataDesignerJobError(f"🛑 Error loading analysis: {e}") from e
 
@@ -545,16 +582,13 @@ class AsyncDataDesignerJobResource(WithRecordSamplerMixin):
             return
         if status == "active" or status in TERMINAL_INCOMPLETE_STATUSES:
             try:
-                resp = await self._platform._client.get(
-                    _job_url(
-                        self._platform,
-                        self._workspace,
-                        f"/{self._job_name}/results/{result_name}",
-                        collection=self._job_collection,
-                    ),
-                    headers=http.headers(self._platform),
+                response = await self._client.get_job_result(
+                    workspace=self._workspace,
+                    job_collection=self._job_collection,
+                    job=self._job_name,
+                    name=result_name,
                 )
-                _raise_for_status(resp)
+                response.data()
                 if status == "active":
                     logger.info(
                         f"{RandomEmoji.cooking()} Your dataset is still cooking. "
@@ -562,10 +596,10 @@ class AsyncDataDesignerJobResource(WithRecordSamplerMixin):
                     )
                 else:
                     logger.warning(f"Job ended with status {status!r}. Fetching completed {result_name} result.")
-            except DataDesignerJobError as e:
-                if e.status_code == 404:
-                    raise DataDesignerJobError(f"{result_name!r} result is not available.") from e
-                raise DataDesignerJobError(f"🛑 Error loading dataset: {e}") from e
+            except NotFoundError as e:
+                raise DataDesignerJobError(f"{result_name!r} result is not available.") from e
+            except NemoHTTPError as e:
+                raise DataDesignerJobError(f"🛑 Error loading dataset: {e.detail}", status_code=e.status_code) from e
         else:
             raise DataDesignerJobError(f"Current job status is {status!r}, results are not available.")
 

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/sdk/resources.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/sdk/resources.py
@@ -16,7 +16,6 @@ from data_designer.config.dataset_metadata import DatasetMetadata
 from data_designer.config.preview_results import PreviewResults
 from data_designer.config.utils.info import InterfaceInfo
 from data_designer.logging import RandomEmoji
-from models.resources import AsyncModelsResource, ModelsResource
 from nemo_data_designer_plugin.functions._types import (
     AnalysisFrame,
     DatasetFrame,
@@ -32,7 +31,6 @@ from nemo_data_designer_plugin.jobs.retrieval_spec import (
     RetrievalRunJobConfig,
 )
 from nemo_data_designer_plugin.jobs.spec import DataDesignerJobConfig
-from nemo_data_designer_plugin.sdk import http
 from nemo_data_designer_plugin.sdk.errors import (
     DataDesignerClientError,
     DataDesignerConfigValidationError,
@@ -47,8 +45,13 @@ from nemo_data_designer_plugin.sdk.validation import (
     validate_config_sync,
 )
 from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
-from nemo_platform.types.inference import ModelProvider as NMPModelProvider
+from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.client.errors import NemoHTTPError
+from nemo_platform_plugin.data_designer.client import AsyncDataDesignerClient, DataDesignerClient
+from nemo_platform_plugin.data_designer.types import DataDesignerJobCollection, DataDesignerJobRequest, PreviewRequest
 from nemo_platform_plugin.functions.frames import Done, Error, Heartbeat
+from nemo_platform_plugin.models.client import AsyncModelsClient, ModelsClient
+from nemo_platform_plugin.models.types import ModelProvider as NMPModelProvider
 from nemo_platform_plugin.sdk import NemoPluginSDKResources
 from pydantic import BaseModel, TypeAdapter
 
@@ -208,24 +211,20 @@ class _PreviewFrameCollector:
 
 
 class _BaseDataDesignerResource(Generic[PlatformResourceClientT]):
-    """Shared HTTP helpers for the sync and async plugin SDK resources."""
+    """Shared platform handle for sync and async plugin SDK resources."""
 
     def __init__(self, platform: PlatformResourceClientT) -> None:
         self._platform = platform
-
-    def _headers(self) -> dict[str, str]:
-        return http.headers(self._platform)
-
-    def _url(self, path: str, workspace: str | None) -> str:
-        return http.url(self._platform, workspace, path)
-
-    def _client(self):
-        return self._platform._client
 
 
 @with_logging
 class DataDesignerResource(_BaseDataDesignerResource[NeMoPlatform]):
     """High-level sync client for the Data Designer plugin service."""
+
+    def __init__(self, platform: NeMoPlatform) -> None:
+        super().__init__(platform)
+        self._data_designer_client = client_from_platform(platform, DataDesignerClient)
+        self._models_client = client_from_platform(platform, ModelsClient)
 
     def preview(
         self,
@@ -269,22 +268,12 @@ class DataDesignerResource(_BaseDataDesignerResource[NeMoPlatform]):
         request: PreviewSpec,
         workspace: str | None,
     ) -> Iterator[PreviewFrame]:
-        with self._client().stream(
-            "POST",
-            self._url("/preview", workspace),
-            headers=self._headers(),
-            json=request.model_dump(mode="json", exclude_none=True),
-        ) as resp:
-            try:
-                resp.raise_for_status()
-            except httpx.HTTPStatusError:
-                resp.read()
-                raise
-            for line in resp.iter_lines():
-                if line:
-                    frame = _decode_preview_frame(line)
-                    if frame is not None:
-                        yield frame
+        body = PreviewRequest.model_validate(request.model_dump(mode="json", exclude_none=True))
+        with self._data_designer_client.preview(workspace=workspace, body=body).stream() as frames:
+            for frame in frames:
+                preview_frame = _parse_preview_frame(frame)
+                if preview_frame is not None:
+                    yield preview_frame
 
     def create(
         self,
@@ -325,9 +314,11 @@ class DataDesignerResource(_BaseDataDesignerResource[NeMoPlatform]):
         Raises:
             ValueError: If the job ID provided is empty.
         """
-        resp = self._client().get(self._url(f"/jobs/create/{job_name}", workspace), headers=self._headers())
-        resp.raise_for_status()
-        return DataDesignerJobResource(job_name=job_name, platform=self._platform, workspace=workspace)
+        try:
+            self._data_designer_client.get_job(workspace=workspace, name=job_name).data()
+        except Exception as e:
+            raise _get_error(e) from e
+        return DataDesignerJobResource(job_name=job_name, client=self._data_designer_client, workspace=workspace)
 
     def get_default_model_configs(self) -> list[dd.ModelConfig]:
         """Default model configs are not supported in the NeMo Platform Data Designer service."""
@@ -340,8 +331,8 @@ class DataDesignerResource(_BaseDataDesignerResource[NeMoPlatform]):
         Returns:
             A list of ModelProvider objects available for inference.
         """
-        nmp_providers = self._platform.inference.providers.list(workspace="-")
-        return [_nmp_provider_to_ndd_provider(self._platform.models, provider) for provider in nmp_providers]
+        nmp_providers = self._models_client.list_providers(workspace="-")
+        return [_nmp_provider_to_ndd_provider(self._models_client, provider) for provider in nmp_providers.items()]
 
     def get_info(self) -> InterfaceInfo:
         return InterfaceInfo(model_providers=self.get_default_model_providers())
@@ -407,24 +398,19 @@ class DataDesignerResource(_BaseDataDesignerResource[NeMoPlatform]):
 
     def _submit_named_job(
         self,
-        job_name: str,
+        job_name: DataDesignerJobCollection,
         spec: BaseModel,
         *,
         workspace: str | None,
         wait_until_done: bool,
     ) -> DataDesignerJobResource:
         try:
-            resp = self._client().post(
-                self._url(f"/jobs/{job_name}", workspace),
-                headers=self._headers(),
-                json={"spec": spec.model_dump(mode="json")},
-            )
-            resp.raise_for_status()
-            job = resp.json()
-            logger.info(f"  |-- job name: {job['name']}")
+            body = DataDesignerJobRequest.model_validate({"spec": spec.model_dump(mode="json")})
+            job = self._data_designer_client.create_job(workspace=workspace, job_collection=job_name, body=body).data()
+            logger.info(f"  |-- job name: {job.name}")
             job_client = DataDesignerJobResource(
-                job_name=job["name"],
-                platform=self._platform,
+                job_name=job.name,
+                client=self._data_designer_client,
                 workspace=workspace,
                 job_collection=job_name,
             )
@@ -438,6 +424,11 @@ class DataDesignerResource(_BaseDataDesignerResource[NeMoPlatform]):
 @with_logging
 class AsyncDataDesignerResource(_BaseDataDesignerResource[AsyncNeMoPlatform]):
     """High-level async client for the Data Designer plugin service."""
+
+    def __init__(self, platform: AsyncNeMoPlatform) -> None:
+        super().__init__(platform)
+        self._data_designer_client = client_from_platform(platform, AsyncDataDesignerClient)
+        self._models_client = client_from_platform(platform, AsyncModelsClient)
 
     async def preview(
         self,
@@ -481,22 +472,13 @@ class AsyncDataDesignerResource(_BaseDataDesignerResource[AsyncNeMoPlatform]):
         request: PreviewSpec,
         workspace: str | None,
     ) -> AsyncIterator[PreviewFrame]:
-        async with self._client().stream(
-            "POST",
-            self._url("/preview", workspace),
-            headers=self._headers(),
-            json=request.model_dump(mode="json", exclude_none=True),
-        ) as resp:
-            try:
-                resp.raise_for_status()
-            except httpx.HTTPStatusError:
-                await resp.aread()
-                raise
-            async for line in resp.aiter_lines():
-                if line:
-                    frame = _decode_preview_frame(line)
-                    if frame is not None:
-                        yield frame
+        body = PreviewRequest.model_validate(request.model_dump(mode="json", exclude_none=True))
+        response = await self._data_designer_client.preview(workspace=workspace, body=body)
+        async with response.stream() as frames:
+            async for frame in frames:
+                preview_frame = _parse_preview_frame(frame)
+                if preview_frame is not None:
+                    yield preview_frame
 
     async def create(
         self,
@@ -537,9 +519,12 @@ class AsyncDataDesignerResource(_BaseDataDesignerResource[AsyncNeMoPlatform]):
         Raises:
             ValueError: If the job ID provided is empty.
         """
-        resp = await self._client().get(self._url(f"/jobs/create/{job_name}", workspace), headers=self._headers())
-        resp.raise_for_status()
-        return AsyncDataDesignerJobResource(job_name=job_name, platform=self._platform, workspace=workspace)
+        try:
+            response = await self._data_designer_client.get_job(workspace=workspace, name=job_name)
+            response.data()
+        except Exception as e:
+            raise _get_error(e) from e
+        return AsyncDataDesignerJobResource(job_name=job_name, client=self._data_designer_client, workspace=workspace)
 
     async def get_default_model_configs(self) -> list[dd.ModelConfig]:
         """Default model configs are not supported in the NeMo Platform Data Designer service."""
@@ -552,8 +537,10 @@ class AsyncDataDesignerResource(_BaseDataDesignerResource[AsyncNeMoPlatform]):
         Returns:
             A list of ModelProvider objects available for inference.
         """
-        nmp_providers = await self._platform.inference.providers.list(workspace="-")
-        return [_nmp_provider_to_ndd_provider(self._platform.models, provider) async for provider in nmp_providers]
+        nmp_providers = await self._models_client.list_providers(workspace="-")
+        return [
+            _nmp_provider_to_ndd_provider(self._models_client, provider) async for provider in nmp_providers.items()
+        ]
 
     async def get_info(self) -> InterfaceInfo:
         return InterfaceInfo(model_providers=await self.get_default_model_providers())
@@ -605,24 +592,22 @@ class AsyncDataDesignerResource(_BaseDataDesignerResource[AsyncNeMoPlatform]):
 
     async def _submit_named_job(
         self,
-        job_name: str,
+        job_name: DataDesignerJobCollection,
         spec: BaseModel,
         *,
         workspace: str | None,
         wait_until_done: bool,
     ) -> AsyncDataDesignerJobResource:
         try:
-            resp = await self._client().post(
-                self._url(f"/jobs/{job_name}", workspace),
-                headers=self._headers(),
-                json={"spec": spec.model_dump(mode="json")},
+            body = DataDesignerJobRequest.model_validate({"spec": spec.model_dump(mode="json")})
+            response = await self._data_designer_client.create_job(
+                workspace=workspace, job_collection=job_name, body=body
             )
-            resp.raise_for_status()
-            job = resp.json()
-            logger.info(f"  |-- job name: {job['name']}")
+            job = response.data()
+            logger.info(f"  |-- job name: {job.name}")
             job_client = AsyncDataDesignerJobResource(
-                job_name=job["name"],
-                platform=self._platform,
+                job_name=job.name,
+                client=self._data_designer_client,
                 workspace=workspace,
                 job_collection=job_name,
             )
@@ -634,6 +619,12 @@ class AsyncDataDesignerResource(_BaseDataDesignerResource[AsyncNeMoPlatform]):
 
 
 def _get_error(e: BaseException) -> DataDesignerClientError:
+    if isinstance(e, NemoHTTPError):
+        status_code = e.status_code
+        detail = e.detail
+        if status_code == 422:
+            return DataDesignerConfigValidationError(f"‼️ Config validation failed!\n{detail}", status_code=status_code)
+        return DataDesignerClientError(f"‼️ Something went wrong!\n{detail}", status_code=status_code)
     if isinstance(e, httpx.HTTPStatusError):
         status_code, detail = extract_http_error_info(e)
         if status_code == 422:
@@ -643,7 +634,7 @@ def _get_error(e: BaseException) -> DataDesignerClientError:
 
 
 def _nmp_provider_to_ndd_provider(
-    models: ModelsResource | AsyncModelsResource,
+    models: ModelsClient | AsyncModelsClient,
     nmp_provider: NMPModelProvider,
 ) -> dd.ModelProvider:
     return dd.ModelProvider(

--- a/plugins/nemo-data-designer/tests/integration/test_personas_cli.py
+++ b/plugins/nemo-data-designer/tests/integration/test_personas_cli.py
@@ -10,6 +10,7 @@ from data_designer_nemo.nemotron_personas import WORKSPACE, get_resource_name_fo
 from nemo_data_designer_plugin.cli import personas as personas_module
 from nemo_platform import NeMoPlatform
 from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.client.client import NemoClient
 from nemo_platform_plugin.files.client import FilesClient
 from nemo_platform_plugin.files.storage_config import NGCStorageConfig
 from nemo_platform_plugin.secrets.client import SecretsClient
@@ -55,7 +56,8 @@ def sdk(monkeypatch: pytest.MonkeyPatch, mock_ngc_client: dict[str, Mock]) -> Ge
 
 @pytest.fixture
 def cli_sdk(monkeypatch: pytest.MonkeyPatch, sdk: NeMoPlatform) -> NeMoPlatform:
-    monkeypatch.setattr(personas_module, "NeMoPlatform", lambda: sdk)
+    client = client_from_platform(sdk, NemoClient)
+    monkeypatch.setattr(personas_module.NemoClient, "from_config", staticmethod(lambda: client))
     return sdk
 
 
@@ -197,12 +199,11 @@ def test_make_fileset_create_secret_internal_error_surfaces_clearly(
     def _boom(*args: object, **kwargs: object) -> None:
         raise RuntimeError("secrets backend exploded")
 
-    # The CLI creates secrets via ``client_from_platform(sdk, SecretsClient).create_secret``.
-    # ``create_secret`` is a descriptor whose ``__get__`` rejects class-level access, so it
-    # can't be patched on the class; intercept at the ``client_from_platform`` boundary instead.
+    # ``create_secret`` is a descriptor whose ``__get__`` rejects class-level access,
+    # so patch the typed-client constructor boundary.
     mock_secrets = Mock()
     mock_secrets.create_secret.side_effect = _boom
-    with patch.object(personas_module, "client_from_platform", return_value=mock_secrets):
+    with patch.object(personas_module.SecretsClient, "from_client", return_value=mock_secrets):
         result = u.invoke_cli(
             [
                 "personas",
@@ -266,7 +267,7 @@ def test_make_fileset_create_fileset_internal_error_surfaces_clearly(cli_sdk: Ne
     mock_files = Mock()
     mock_files.create_fileset.side_effect = RuntimeError(error_message)
 
-    with patch("data_designer_nemo.nemotron_personas.client_from_platform", return_value=mock_files):
+    with patch.object(personas_module.FilesClient, "from_client", return_value=mock_files):
         result = u.invoke_cli(
             [
                 "personas",

--- a/plugins/nemo-data-designer/tests/unit/test_sdk_resources.py
+++ b/plugins/nemo-data-designer/tests/unit/test_sdk_resources.py
@@ -39,12 +39,15 @@ from nemo_data_designer_plugin.sdk.errors import (
     DataDesignerConfigValidationError,
     DataDesignerPreviewError,
 )
+from nemo_data_designer_plugin.sdk.job_resources import AsyncDataDesignerJobResource, DataDesignerJobResource
 from nemo_data_designer_plugin.sdk.resources import (
     AsyncDataDesignerResource,
     DataDesignerResource,
     _decode_preview_frame,
 )
 from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
+from nemo_platform_plugin.data_designer.client import AsyncDataDesignerClient, DataDesignerClient
+from nemo_platform_plugin.data_designer.types import DataDesignerJobResponse
 from nemo_platform_plugin.functions.frames import Done, Error, Heartbeat
 from pydantic import BaseModel
 
@@ -67,6 +70,20 @@ def resource(platform: NeMoPlatform) -> DataDesignerResource:
 @pytest.fixture
 def async_resource(async_platform: AsyncNeMoPlatform) -> AsyncDataDesignerResource:
     return AsyncDataDesignerResource(async_platform)
+
+
+def test_job_resource_accepts_legacy_platform_constructor(platform: NeMoPlatform) -> None:
+    job = DataDesignerJobResource(job_name="dd-job", platform=platform, workspace="default")
+
+    assert job.name == "dd-job"
+    assert isinstance(job._client, DataDesignerClient)
+
+
+def test_async_job_resource_accepts_legacy_platform_constructor(async_platform: AsyncNeMoPlatform) -> None:
+    job = AsyncDataDesignerJobResource(job_name="dd-job", platform=async_platform, workspace="default")
+
+    assert job.name == "dd-job"
+    assert isinstance(job._client, AsyncDataDesignerClient)
 
 
 @pytest.fixture
@@ -260,14 +277,15 @@ async def test_http_error_translates_5xx_to_generic_client_error(
 def test_create_posts_to_named_create_job(
     resource: DataDesignerResource, config_builder: dd.DataDesignerConfigBuilder
 ) -> None:
-    mock_resp = MagicMock()
-    mock_resp.json.return_value = {"name": "dd-job-1"}
-    mock_client = MagicMock()
-    mock_client.post.return_value = mock_resp
-    with patch.object(resource, "_client", return_value=mock_client):
+    mock_response = MagicMock()
+    mock_response.data.return_value = DataDesignerJobResponse(name="dd-job-1")
+    mock_create_job = MagicMock(return_value=mock_response)
+    with patch.object(resource._data_designer_client, "create_job", mock_create_job):
         job = resource.create(config_builder, num_records=10, workspace="ws")
-    url = mock_client.post.call_args.args[0]
-    assert url.endswith("/jobs/create")
+    kwargs = mock_create_job.call_args.kwargs
+    assert kwargs["workspace"] == "ws"
+    assert kwargs["job_collection"] == "create"
+    assert kwargs["body"].spec["num_records"] == 10
     assert job._job_name == "dd-job-1"
     assert job._job_collection == "create"
 
@@ -276,13 +294,14 @@ def test_create_posts_to_named_create_job(
 async def test_async_create_posts_to_named_create_job(
     async_resource: AsyncDataDesignerResource, config_builder: dd.DataDesignerConfigBuilder
 ) -> None:
-    mock_resp = MagicMock()
-    mock_resp.json.return_value = {"name": "dd-job-2"}
-    mock_client = MagicMock()
-    mock_client.post = AsyncMock(return_value=mock_resp)
-    with patch.object(async_resource, "_client", return_value=mock_client):
+    mock_response = MagicMock()
+    mock_response.data.return_value = DataDesignerJobResponse(name="dd-job-2")
+    mock_create_job = AsyncMock(return_value=mock_response)
+    with patch.object(async_resource._data_designer_client, "create_job", mock_create_job):
         job = await async_resource.create(config_builder, num_records=10, workspace="ws")
-    url = mock_client.post.call_args.args[0]
-    assert url.endswith("/jobs/create")
+    kwargs = mock_create_job.call_args.kwargs
+    assert kwargs["workspace"] == "ws"
+    assert kwargs["job_collection"] == "create"
+    assert kwargs["body"].spec["num_records"] == 10
     assert job._job_name == "dd-job-2"
     assert job._job_collection == "create"


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
Migrate the Data Designer plugin resource layer and personas helper away from direct Stainless/root SDK calls and onto source-owned typed clients. The public behavior is intended to stay the same while request construction, response typing, and tests move into `nemo_platform_plugin`.

## Changes
- Extend `nemo_platform_plugin.data_designer` typed client coverage for retrieval preview, file/job collections, job status/log/results/artifact routes, and artifact downloads.
- Route Data Designer SDK resources, artifact downloads, and the personas CLI helper through the typed clients instead of Stainless/root SDK transport.
- Preserve artifact tar safety checks and use `asyncio.to_thread` for async stdlib tar extraction.
- Add plugin client/endpoint tests plus updated SDK and personas CLI coverage.
- Add the migration plan under `plans/` for traceability.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: this is an internal client transport migration with no intended user-visible behavior change; the migration plan is included for developer traceability.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `flox -q activate -- uv run pre-commit run -a` — passed after rebasing onto `origin/main`.
- `flox -q activate -- uv run pytest packages/nemo_platform_plugin/tests/data_designer plugins/nemo-data-designer/tests/unit/test_sdk_resources.py plugins/nemo-data-designer/tests/integration/test_personas_cli.py -q` — passed, 57 tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added streaming retrieval previews for Data Designer workflows.
  * Added support for cancelling jobs and viewing, retrieving, and downloading job results.
  * Expanded job support with configurable job collections, profiles, and options.
  * Improved typed handling of job requests and responses.
  * Updated persona fileset synchronization to use dataset filesets and secure API key references.

* **Documentation**
  * Added migration guidance for the Data Designer client architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->