### PR TITLE
refactor(agents): migrate off Stainless-shaped SDK calls

### DIFF
--- a/e2e/test_nemo_agents.py
+++ b/e2e/test_nemo_agents.py
@@ -15,6 +15,7 @@ import httpx
 import pytest
 from nemo_platform import NeMoPlatform
 from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.client.errors import NemoHTTPError
 from nemo_platform_plugin.workspaces.client import WorkspacesClient
 from nemo_platform_plugin.workspaces.types import CreateWorkspaceRequest
 from nmp.testing import MockProviderResponse, add_mock_provider
@@ -106,8 +107,21 @@ def _pagination(page: Any) -> dict[str, Any]:
     return pagination
 
 
-def _assert_http_status(exc_info: pytest.ExceptionInfo[httpx.HTTPStatusError], status_code: int) -> None:
-    assert exc_info.value.response.status_code == status_code
+HTTPStatusException = httpx.HTTPStatusError | NemoHTTPError
+
+
+def _http_status(exc: HTTPStatusException) -> int:
+    return exc.status_code if isinstance(exc, NemoHTTPError) else exc.response.status_code
+
+
+def _http_error_text(exc: HTTPStatusException) -> str:
+    if isinstance(exc, NemoHTTPError):
+        return str(exc.body) if exc.body is not None else str(exc)
+    return exc.response.text
+
+
+def _assert_http_status(exc_info: pytest.ExceptionInfo[HTTPStatusException], status_code: int) -> None:
+    assert _http_status(exc_info.value) == status_code
 
 
 def _assert_deployment_status(status: str) -> None:
@@ -131,22 +145,22 @@ def _get_agents_page(
 def _delete_agent_if_exists(sdk: NeMoPlatform, *, workspace: str, name: str) -> None:
     try:
         sdk.agents.delete(name, workspace=workspace)
-    except httpx.HTTPStatusError as exc:
-        if exc.response.status_code != 404:
+    except (httpx.HTTPStatusError, NemoHTTPError) as exc:
+        if _http_status(exc) != 404:
             raise
 
 
 def _delete_deployment_if_exists(sdk: NeMoPlatform, *, workspace: str, name: str) -> None:
     try:
         sdk.agents.deployments.delete(name, workspace=workspace)
-    except httpx.HTTPStatusError as exc:
-        if exc.response.status_code == 404:
+    except (httpx.HTTPStatusError, NemoHTTPError) as exc:
+        if _http_status(exc) == 404:
             return
-        if exc.response.status_code in {409, 500}:
+        if _http_status(exc) in {409, 500}:
             try:
                 sdk.agents.deployments.get(name, workspace=workspace)
-            except httpx.HTTPStatusError as get_exc:
-                if get_exc.response.status_code == 404:
+            except (httpx.HTTPStatusError, NemoHTTPError) as get_exc:
+                if _http_status(get_exc) == 404:
                     return
         raise
 
@@ -158,8 +172,8 @@ def _get_deployment_log_text(sdk: NeMoPlatform, *, workspace: str, name: str) ->
             params={"tail": 50},
         )
         response.raise_for_status()
-    except httpx.HTTPStatusError as exc:
-        return exc.response.text
+    except (httpx.HTTPStatusError, NemoHTTPError) as exc:
+        return _http_error_text(exc)
 
     payload = response.json()
     lines = _page_data(payload)
@@ -180,8 +194,8 @@ def _wait_for_deployment_deleted(
         try:
             deployment = sdk.agents.deployments.get(name, workspace=workspace)
             last_status = deployment.get("status")
-        except httpx.HTTPStatusError as exc:
-            if exc.response.status_code == 404:
+        except (httpx.HTTPStatusError, NemoHTTPError) as exc:
+            if _http_status(exc) == 404:
                 return
             raise
 
@@ -245,7 +259,7 @@ def test_agent_create_list_get_delete_lifecycle(sdk: NeMoPlatform, workspace: st
     finally:
         _delete_agent_if_exists(sdk, workspace=workspace, name=name)
 
-    with pytest.raises(httpx.HTTPStatusError) as exc_info:
+    with pytest.raises((httpx.HTTPStatusError, NemoHTTPError)) as exc_info:
         sdk.agents.get(name, workspace=workspace)
     _assert_http_status(exc_info, 404)
 
@@ -255,7 +269,7 @@ def test_agent_duplicate_create_returns_conflict(sdk: NeMoPlatform, workspace: s
     sdk.agents.create(workspace=workspace, name=name, config=_agent_config(name))
 
     try:
-        with pytest.raises(httpx.HTTPStatusError) as exc_info:
+        with pytest.raises((httpx.HTTPStatusError, NemoHTTPError)) as exc_info:
             sdk.agents.create(workspace=workspace, name=name, config=_agent_config(f"{name}-again"))
         _assert_http_status(exc_info, 409)
     finally:
@@ -265,11 +279,11 @@ def test_agent_duplicate_create_returns_conflict(sdk: NeMoPlatform, workspace: s
 def test_agent_missing_get_and_delete_return_not_found(sdk: NeMoPlatform, workspace: str) -> None:
     missing_name = _unique_name("missing")
 
-    with pytest.raises(httpx.HTTPStatusError) as get_exc_info:
+    with pytest.raises((httpx.HTTPStatusError, NemoHTTPError)) as get_exc_info:
         sdk.agents.get(missing_name, workspace=workspace)
     _assert_http_status(get_exc_info, 404)
 
-    with pytest.raises(httpx.HTTPStatusError) as delete_exc_info:
+    with pytest.raises((httpx.HTTPStatusError, NemoHTTPError)) as delete_exc_info:
         sdk.agents.delete(missing_name, workspace=workspace)
     _assert_http_status(delete_exc_info, 404)
 
@@ -327,7 +341,7 @@ def test_agents_are_isolated_by_workspace(sdk: NeMoPlatform, workspace: str) -> 
             config=_agent_config(f"{agent_name}-primary"),
         )
 
-        with pytest.raises(httpx.HTTPStatusError) as exc_info:
+        with pytest.raises((httpx.HTTPStatusError, NemoHTTPError)) as exc_info:
             sdk.agents.get(agent_name, workspace=other_workspace)
         _assert_http_status(exc_info, 404)
 
@@ -374,14 +388,14 @@ def test_agents_sdk_resource_methods_are_available(sdk: NeMoPlatform, workspace:
 
 
 def test_agents_sdk_missing_get_raises_not_found(sdk: NeMoPlatform, workspace: str) -> None:
-    with pytest.raises(httpx.HTTPStatusError) as exc_info:
+    with pytest.raises((httpx.HTTPStatusError, NemoHTTPError)) as exc_info:
         sdk.agents.get(_unique_name("sdk-missing"), workspace=workspace)
     _assert_http_status(exc_info, 404)
 
 
 @pytest.mark.container_only
 def test_agent_deployment_missing_agent_returns_not_found(sdk: NeMoPlatform, workspace: str) -> None:
-    with pytest.raises(httpx.HTTPStatusError) as exc_info:
+    with pytest.raises((httpx.HTTPStatusError, NemoHTTPError)) as exc_info:
         sdk.agents.deployments.create(
             workspace=workspace,
             agent=_unique_name("missing-agent"),
@@ -422,7 +436,7 @@ def test_agent_deployment_create_list_get_delete_lifecycle(sdk: NeMoPlatform, wo
         _wait_for_deployment_deleted(sdk, workspace=workspace, name=deployment_name)
         _delete_agent_if_exists(sdk, workspace=workspace, name=agent_name)
 
-    with pytest.raises(httpx.HTTPStatusError) as exc_info:
+    with pytest.raises((httpx.HTTPStatusError, NemoHTTPError)) as exc_info:
         sdk.agents.deployments.get(deployment_name, workspace=workspace)
     _assert_http_status(exc_info, 404)
 
@@ -441,7 +455,7 @@ def test_agent_delete_is_blocked_while_deployment_is_active(sdk: NeMoPlatform, w
         )
         _assert_deployment_status(deployment["status"])
 
-        with pytest.raises(httpx.HTTPStatusError) as exc_info:
+        with pytest.raises((httpx.HTTPStatusError, NemoHTTPError)) as exc_info:
             sdk.agents.delete(agent_name, workspace=workspace)
         _assert_http_status(exc_info, 409)
 
@@ -455,7 +469,7 @@ def test_agent_delete_is_blocked_while_deployment_is_active(sdk: NeMoPlatform, w
 
 @pytest.mark.container_only
 def test_agent_gateway_missing_deployment_returns_not_found(sdk: NeMoPlatform, workspace: str) -> None:
-    with pytest.raises(httpx.HTTPStatusError) as exc_info:
+    with pytest.raises((httpx.HTTPStatusError, NemoHTTPError)) as exc_info:
         sdk.agents.invoke(
             workspace=workspace,
             deployment=_unique_name("missing-deployment"),

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/agents/client.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/agents/client.py
@@ -7,6 +7,8 @@ Wraps the endpoint functions from ``agents.endpoints`` as direct methods
 using the ``method()`` descriptor, following the files/models pattern.
 """
 
+from __future__ import annotations
+
 from functools import cached_property
 
 from nemo_platform_plugin.agents import endpoints
@@ -24,15 +26,58 @@ class _AgentsMethods:
     list_deployments = method(endpoints.list_deployments)
     create_deployment = method(endpoints.create_deployment)
     delete_deployment = method(endpoints.delete_deployment)
+    get_deployment_logs = method(endpoints.get_deployment_logs)
+    stream_deployment_logs = method(endpoints.stream_deployment_logs)
+    create_session = method(endpoints.create_session)
+    list_sessions = method(endpoints.list_sessions)
+    get_session = method(endpoints.get_session)
+    close_session = method(endpoints.close_session)
+    delete_session = method(endpoints.delete_session)
+    create_environment_spec = method(endpoints.create_environment_spec)
+    list_environment_specs = method(endpoints.list_environment_specs)
+    get_environment_spec = method(endpoints.get_environment_spec)
+    delete_environment_spec = method(endpoints.delete_environment_spec)
+    create_environment = method(endpoints.create_environment)
+    list_environments = method(endpoints.list_environments)
+    get_environment = method(endpoints.get_environment)
+    delete_environment = method(endpoints.delete_environment)
+    create_compute_spec = method(endpoints.create_compute_spec)
+    list_compute_specs = method(endpoints.list_compute_specs)
+    get_compute_spec = method(endpoints.get_compute_spec)
+    delete_compute_spec = method(endpoints.delete_compute_spec)
     invoke_agent = method(endpoints.invoke_agent)
     invoke_deployment = method(endpoints.invoke_deployment)
     create_execute_job = method(endpoints.create_execute_job)
     get_execute_job = method(endpoints.get_execute_job)
     list_execute_job_results = method(endpoints.list_execute_job_results)
+    create_agent_job = method(endpoints.create_agent_job)
+    list_agent_jobs = method(endpoints.list_agent_jobs)
+    get_agent_job = method(endpoints.get_agent_job)
+    delete_agent_job = method(endpoints.delete_agent_job)
+    cancel_agent_job = method(endpoints.cancel_agent_job)
+    list_agent_job_logs = method(endpoints.list_agent_job_logs)
+    list_agent_job_results = method(endpoints.list_agent_job_results)
+    get_agent_job_status = method(endpoints.get_agent_job_status)
+    get_agent_job_result = method(endpoints.get_agent_job_result)
+    download_agent_job_result = method(endpoints.download_agent_job_result)
+
+
+def _execute_job_request(
+    *,
+    spec: JsonObject,
+    name: str | None,
+    description: str | None,
+) -> CreateExecuteJobRequest:
+    payload: dict[str, JsonObject | str] = {"spec": spec}
+    if name is not None:
+        payload["name"] = name
+    if description is not None:
+        payload["description"] = description
+    return CreateExecuteJobRequest.model_validate(payload)
 
 
 class _ExecuteJobsCompat:
-    def __init__(self, client: "AgentsClient") -> None:
+    def __init__(self, client: AgentsClient) -> None:
         self._client = client
 
     def create(
@@ -45,7 +90,7 @@ class _ExecuteJobsCompat:
     ) -> JsonObject:
         return self._client.create_execute_job(
             workspace=workspace,
-            body=CreateExecuteJobRequest(spec=spec, name=name, description=description),
+            body=_execute_job_request(spec=spec, name=name, description=description),
         ).data()
 
     def get(self, name: str, *, workspace: str | None = None) -> JsonObject:
@@ -56,7 +101,7 @@ class _ExecuteJobsCompat:
 
 
 class _AsyncExecuteJobsCompat:
-    def __init__(self, client: "AsyncAgentsClient") -> None:
+    def __init__(self, client: AsyncAgentsClient) -> None:
         self._client = client
 
     async def create(
@@ -69,7 +114,7 @@ class _AsyncExecuteJobsCompat:
     ) -> JsonObject:
         response = await self._client.create_execute_job(
             workspace=workspace,
-            body=CreateExecuteJobRequest(spec=spec, name=name, description=description),
+            body=_execute_job_request(spec=spec, name=name, description=description),
         )
         return response.data()
 
@@ -81,7 +126,7 @@ class _AsyncExecuteJobsCompat:
 
 
 class _JobsCompat:
-    def __init__(self, client: "AgentsClient") -> None:
+    def __init__(self, client: AgentsClient) -> None:
         self._client = client
 
     @cached_property
@@ -90,7 +135,7 @@ class _JobsCompat:
 
 
 class _AsyncJobsCompat:
-    def __init__(self, client: "AsyncAgentsClient") -> None:
+    def __init__(self, client: AsyncAgentsClient) -> None:
         self._client = client
 
     @cached_property
@@ -101,7 +146,7 @@ class _AsyncJobsCompat:
 class AgentsClient(_AgentsMethods, NemoClient):
     """Sync client for the Agents service API."""
 
-    @cached_property
+    @property
     def jobs(self) -> _JobsCompat:
         return _JobsCompat(self)
 
@@ -109,6 +154,6 @@ class AgentsClient(_AgentsMethods, NemoClient):
 class AsyncAgentsClient(_AgentsMethods, AsyncNemoClient):
     """Async client for the Agents service API."""
 
-    @cached_property
+    @property
     def jobs(self) -> _AsyncJobsCompat:
         return _AsyncJobsCompat(self)

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/agents/endpoints.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/agents/endpoints.py
@@ -1,34 +1,59 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Typed endpoint definitions for the Agents service.
-
-Single source of truth for the HTTP contract. Replaces the Stainless-generated
-agent resource from ``nemo_agents_plugin.sdk``.
-"""
+"""Typed endpoint definitions for the Agents service."""
 
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import Any
 
 from nemo_platform_plugin.agents.types import (
     Agent,
+    AgentComputeSpec,
     AgentDeployment,
+    AgentEnvironment,
+    AgentEnvironmentSpec,
+    AgentJob,
+    AgentJobCollection,
+    AgentJobLog,
+    AgentJobLogsQueryParams,
+    AgentJobRequest,
+    AgentJobResult,
+    AgentJobResultListResponse,
+    AgentJobStatusResponse,
+    AgentSession,
     CreateAgentDeploymentRequest,
     CreateAgentRequest,
+    CreateComputeSpecRequest,
+    CreateEnvironmentRequest,
+    CreateEnvironmentSpecRequest,
     CreateExecuteJobRequest,
+    CreateSessionRequest,
+    DeploymentLogsQueryParams,
+    DeploymentLogsResponse,
     InvokeAgentRequest,
+    JsonMap,
     JsonObject,
+    ListAgentJobResultsQueryParams,
+    ListAgentJobsQueryParams,
     ListAgentsQueryParams,
     ListDeploymentsQueryParams,
+    ListEnvironmentResourcesQueryParams,
+    ListSessionsQueryParams,
+    LogLine,
 )
 from nemo_platform_plugin.client.endpoint import delete, get, post
-from nemo_platform_plugin.client.types import Paginated, PreparedRequest
+from nemo_platform_plugin.client.types import BinaryContent, CursorPagination, Paginated, PreparedRequest, Stream
 
-_AGENTS = "/apis/agents/v2/workspaces/{workspace}/agents"
-_DEPLOYMENTS = "/apis/agents/v2/workspaces/{workspace}/deployments"
-_EXECUTE_JOBS = "/apis/agents/v2/workspaces/{workspace}/jobs/execute"
+_PREFIX = "/apis/agents/v2/workspaces/{workspace}"
+_AGENTS = f"{_PREFIX}/agents"
+_DEPLOYMENTS = f"{_PREFIX}/deployments"
+_SESSIONS = f"{_PREFIX}/sessions"
+_ENVIRONMENT_SPECS = f"{_PREFIX}/environment-specs"
+_ENVIRONMENTS = f"{_PREFIX}/environments"
+_COMPUTE_SPECS = f"{_PREFIX}/compute-specs"
+_EXECUTE_JOBS = f"{_PREFIX}/jobs/execute"
+_JOBS = f"{_PREFIX}/jobs/{{collection}}"
 
 
 # ---------------------------------------------------------------------------
@@ -64,7 +89,7 @@ def delete_agent(*, workspace: str | None = None, name: str) -> None: ...
 
 
 # ---------------------------------------------------------------------------
-# Agent deployment CRUD
+# Agent deployment CRUD + logs
 # ---------------------------------------------------------------------------
 
 
@@ -90,19 +115,136 @@ def create_deployment(*, workspace: str | None = None, body: CreateAgentDeployme
 def delete_deployment(*, workspace: str | None = None, name: str) -> None: ...
 
 
+@get(f"{_DEPLOYMENTS}/{{name}}/logs")
+@abstractmethod
+def get_deployment_logs(
+    *, workspace: str | None = None, name: str, query_params: DeploymentLogsQueryParams | None = None
+) -> DeploymentLogsResponse: ...
+
+
+@get(f"{_DEPLOYMENTS}/{{name}}/logs/stream")
+@abstractmethod
+def stream_deployment_logs(*, workspace: str | None = None, name: str) -> Stream[LogLine]: ...
+
+
 # ---------------------------------------------------------------------------
-# Agent invocation (gateway proxy to OpenAI-compatible endpoint)
+# Agent sessions
+# ---------------------------------------------------------------------------
+
+
+@post(_SESSIONS)
+@abstractmethod
+def create_session(*, workspace: str | None = None, body: CreateSessionRequest) -> AgentSession: ...
+
+
+@get(_SESSIONS)
+@abstractmethod
+def list_sessions(
+    *, workspace: str | None = None, query_params: ListSessionsQueryParams | None = None
+) -> Paginated[AgentSession]: ...
+
+
+@get(f"{_SESSIONS}/{{name}}")
+@abstractmethod
+def get_session(*, workspace: str | None = None, name: str) -> AgentSession: ...
+
+
+@post(f"{_SESSIONS}/{{name}}/close")
+@abstractmethod
+def close_session(*, workspace: str | None = None, name: str) -> AgentSession: ...
+
+
+@delete(f"{_SESSIONS}/{{name}}")
+@abstractmethod
+def delete_session(*, workspace: str | None = None, name: str) -> None: ...
+
+
+# ---------------------------------------------------------------------------
+# Environment, environment-spec, and compute-spec CRUD
+# ---------------------------------------------------------------------------
+
+
+@post(_ENVIRONMENT_SPECS)
+@abstractmethod
+def create_environment_spec(
+    *, workspace: str | None = None, body: CreateEnvironmentSpecRequest
+) -> AgentEnvironmentSpec: ...
+
+
+@get(_ENVIRONMENT_SPECS)
+@abstractmethod
+def list_environment_specs(
+    *, workspace: str | None = None, query_params: ListEnvironmentResourcesQueryParams | None = None
+) -> Paginated[AgentEnvironmentSpec]: ...
+
+
+@get(f"{_ENVIRONMENT_SPECS}/{{name}}")
+@abstractmethod
+def get_environment_spec(*, workspace: str | None = None, name: str) -> AgentEnvironmentSpec: ...
+
+
+@delete(f"{_ENVIRONMENT_SPECS}/{{name}}")
+@abstractmethod
+def delete_environment_spec(*, workspace: str | None = None, name: str) -> None: ...
+
+
+@post(_ENVIRONMENTS)
+@abstractmethod
+def create_environment(*, workspace: str | None = None, body: CreateEnvironmentRequest) -> AgentEnvironment: ...
+
+
+@get(_ENVIRONMENTS)
+@abstractmethod
+def list_environments(
+    *, workspace: str | None = None, query_params: ListEnvironmentResourcesQueryParams | None = None
+) -> Paginated[AgentEnvironment]: ...
+
+
+@get(f"{_ENVIRONMENTS}/{{name}}")
+@abstractmethod
+def get_environment(*, workspace: str | None = None, name: str) -> AgentEnvironment: ...
+
+
+@delete(f"{_ENVIRONMENTS}/{{name}}")
+@abstractmethod
+def delete_environment(*, workspace: str | None = None, name: str) -> None: ...
+
+
+@post(_COMPUTE_SPECS)
+@abstractmethod
+def create_compute_spec(*, workspace: str | None = None, body: CreateComputeSpecRequest) -> AgentComputeSpec: ...
+
+
+@get(_COMPUTE_SPECS)
+@abstractmethod
+def list_compute_specs(
+    *, workspace: str | None = None, query_params: ListEnvironmentResourcesQueryParams | None = None
+) -> Paginated[AgentComputeSpec]: ...
+
+
+@get(f"{_COMPUTE_SPECS}/{{name}}")
+@abstractmethod
+def get_compute_spec(*, workspace: str | None = None, name: str) -> AgentComputeSpec: ...
+
+
+@delete(f"{_COMPUTE_SPECS}/{{name}}")
+@abstractmethod
+def delete_compute_spec(*, workspace: str | None = None, name: str) -> None: ...
+
+
+# ---------------------------------------------------------------------------
+# Gateway invocation
 # ---------------------------------------------------------------------------
 
 
 @post(f"{_AGENTS}/{{name}}/-/v1/chat/completions")
 @abstractmethod
-def invoke_agent(*, workspace: str | None = None, name: str, body: InvokeAgentRequest) -> dict[str, Any]: ...
+def invoke_agent(*, workspace: str | None = None, name: str, body: InvokeAgentRequest) -> JsonMap: ...
 
 
 @post(f"{_DEPLOYMENTS}/{{name}}/-/v1/chat/completions")
 @abstractmethod
-def invoke_deployment(*, workspace: str | None = None, name: str, body: InvokeAgentRequest) -> dict[str, Any]: ...
+def invoke_deployment(*, workspace: str | None = None, name: str, body: InvokeAgentRequest) -> JsonMap: ...
 
 
 # ---------------------------------------------------------------------------
@@ -123,3 +265,83 @@ def get_execute_job(*, workspace: str | None = None, name: str) -> JsonObject: .
 @get(f"{_EXECUTE_JOBS}/{{name}}/results")
 @abstractmethod
 def list_execute_job_results(*, workspace: str | None = None, name: str) -> JsonObject: ...
+
+
+# ---------------------------------------------------------------------------
+# Agents job collections
+# ---------------------------------------------------------------------------
+
+
+@post(_JOBS)
+@abstractmethod
+def create_agent_job(
+    *, workspace: str | None = None, collection: AgentJobCollection, body: AgentJobRequest
+) -> AgentJob: ...
+
+
+@get(_JOBS)
+@abstractmethod
+def list_agent_jobs(
+    *,
+    workspace: str | None = None,
+    collection: AgentJobCollection,
+    query_params: ListAgentJobsQueryParams | None = None,
+) -> Paginated[AgentJob]: ...
+
+
+@get(f"{_JOBS}/{{name}}")
+@abstractmethod
+def get_agent_job(*, workspace: str | None = None, collection: AgentJobCollection, name: str) -> AgentJob: ...
+
+
+@delete(f"{_JOBS}/{{name}}")
+@abstractmethod
+def delete_agent_job(*, workspace: str | None = None, collection: AgentJobCollection, name: str) -> None: ...
+
+
+@post(f"{_JOBS}/{{name}}/cancel")
+@abstractmethod
+def cancel_agent_job(*, workspace: str | None = None, collection: AgentJobCollection, name: str) -> AgentJob: ...
+
+
+@get(f"{_JOBS}/{{name}}/logs")
+@abstractmethod
+def list_agent_job_logs(
+    *,
+    workspace: str | None = None,
+    collection: AgentJobCollection,
+    name: str,
+    query_params: AgentJobLogsQueryParams | None = None,
+) -> Paginated[AgentJobLog, CursorPagination]: ...
+
+
+@get(f"{_JOBS}/{{name}}/results")
+@abstractmethod
+def list_agent_job_results(
+    *,
+    workspace: str | None = None,
+    collection: AgentJobCollection,
+    name: str,
+    query_params: ListAgentJobResultsQueryParams | None = None,
+) -> AgentJobResultListResponse: ...
+
+
+@get(f"{_JOBS}/{{name}}/status")
+@abstractmethod
+def get_agent_job_status(
+    *, workspace: str | None = None, collection: AgentJobCollection, name: str
+) -> AgentJobStatusResponse: ...
+
+
+@get(f"{_JOBS}/{{job}}/results/{{name}}")
+@abstractmethod
+def get_agent_job_result(
+    *, workspace: str | None = None, collection: AgentJobCollection, job: str, name: str
+) -> AgentJobResult: ...
+
+
+@get(f"{_JOBS}/{{job}}/results/{{name}}/download")
+@abstractmethod
+def download_agent_job_result(
+    *, workspace: str | None = None, collection: AgentJobCollection, job: str, name: str
+) -> BinaryContent: ...

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/agents/types.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/agents/types.py
@@ -1,82 +1,358 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Shared request/response types for the Agents service.
-
-Single source of truth for the HTTP contract. Replaces the Stainless-generated
-agent resource from ``nemo_agents_plugin.sdk``.
-"""
+"""Shared request/response types for the Agents service HTTP contract."""
 
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, NotRequired, TypedDict
+from typing import Any, Literal, NotRequired, TypeAlias, TypedDict
 
+from nemo_platform_plugin.jobs.schemas import (
+    PlatformJobListResultResponse,
+    PlatformJobLog,
+    PlatformJobResultResponse,
+    PlatformJobStatus,
+    PlatformJobStatusResponse,
+)
 from nemo_platform_plugin.schema import Page
-from pydantic import BaseModel, ConfigDict, Field, JsonValue
+from pydantic import BaseModel, ConfigDict, Field
 
-# ---------------------------------------------------------------------------
-# Response types
-# ---------------------------------------------------------------------------
+JsonMap: TypeAlias = dict[str, Any]
+JsonObject: TypeAlias = JsonMap
+StringMap: TypeAlias = dict[str, str]
 
+DeploymentStatus: TypeAlias = Literal["pending", "starting", "running", "failed", "deleting"]
+DeploymentMode: TypeAlias = Literal["subprocess", "docker", "k8s"]
+EndpointProtocol: TypeAlias = Literal["http", "https", "grpc", "tcp"]
+SessionLifecycleStatus: TypeAlias = Literal["active", "expired", "lost", "closed"]
+AgentJobCollection: TypeAlias = Literal[
+    "analyze",
+    "evaluate",
+    "evaluate-suite",
+    "execute",
+    "optimize",
+    "optimize-skills",
+    "package",
+]
 
-class Agent(BaseModel):
-    """An agent definition — stores agent config and metadata."""
-
-    model_config = ConfigDict(extra="allow")
-
-    name: str = ""
-    workspace: str = ""
-    project: str | None = None
-    description: str = ""
-    config: dict[str, Any] = Field(default_factory=dict)
-    config_format: str = "nat-workflow-v1"
-    id: str | None = None
-    created_at: datetime | None = None
-    created_by: str | None = None
-    updated_at: datetime | None = None
-    updated_by: str | None = None
-
-
-AgentPage = Page[Agent]
+NAT_WORKFLOW_CONFIG_FORMAT = "nat-workflow-v1"
+NEMO_AGENTS_SPEC_CONFIG_FORMAT = "nemo-agents-spec-v1"
 
 
-class AgentDeployment(BaseModel):
-    """A running (or pending) deployment of an Agent."""
+class EntityMetadata(BaseModel):
+    """Common entity metadata emitted by NeMo Platform entity-backed routes."""
 
     model_config = ConfigDict(extra="allow")
 
-    name: str = ""
-    workspace: str = ""
-    project: str | None = None
-    agent: str = ""
-    config: dict[str, Any] = Field(default_factory=dict)
-    status: str = "pending"
-    deployment_mode: str = "subprocess"
-    endpoint: str = ""
-    id: str | None = None
-    created_at: datetime | None = None
-    updated_at: datetime | None = None
+    name: str = Field(default="", description="Entity name within the workspace.")
+    workspace: str = Field(default="", description="Workspace identifier.")
+    project: str | None = Field(default=None, description="Project associated with this entity.")
+    id: str | None = Field(default=None, description="Entity UUID.")
+    entity_id: str | None = Field(default=None, description="Compatibility alias for the entity UUID.")
+    parent: str | None = Field(default=None, description="Parent entity ID for nested entities.")
+    created_at: datetime | None = Field(default=None, description="Timestamp of entity creation.")
+    created_by: str | None = Field(default=None, description="Principal id for entity creator.")
+    updated_at: datetime | None = Field(default=None, description="Timestamp of last entity update.")
+    updated_by: str | None = Field(default=None, description="Principal id for last entity update.")
+    db_version: int | None = Field(default=None, description="Database version for optimistic locking.")
 
 
-DeploymentPage = Page[AgentDeployment]
+class AuthContext(BaseModel):
+    """Wire/data mirror of the creator auth context captured on delegated resources."""
+
+    principal_id: str = Field(..., description="The principal's unique identifier.")
+    principal_email: str | None = Field(default=None, description="The principal's email address.")
+    principal_groups: list[str] = Field(default_factory=list, description="Groups the principal belongs to.")
+    principal_on_behalf_of: str | None = Field(
+        default=None,
+        description="If acting on behalf of another principal, their principal ID.",
+    )
+    principal_on_behalf_of_groups: list[str] | None = Field(
+        default=None,
+        description="Groups the on-behalf-of principal belongs to.",
+    )
+    principal_on_behalf_of_email: str | None = Field(
+        default=None,
+        description="The on-behalf-of principal's email address.",
+    )
 
 
-# ---------------------------------------------------------------------------
-# Request types
-# ---------------------------------------------------------------------------
+class Endpoint(BaseModel):
+    """A routable network endpoint for a deployment.
+
+    Mirrors ``nemo_deployments_plugin.types.Endpoint`` so container-mode
+    deployments can carry the address the deployments-plugin ``Deployment``
+    projected without the agents plugin depending on that plugin at the
+    entity-schema layer.
+    """
+
+    name: str
+    url: str
+    protocol: EndpointProtocol = "http"
+
+
+class ComputeResources(BaseModel):
+    """Kubernetes-style resource requests/limits.
+
+    Mirrors ``nemo_deployments_plugin.entities.ResourceRequirements`` so the
+    agents entity schema does not depend on the deployments plugin. Compiled
+    into the execute container's resources for container deployment modes.
+    """
+
+    limits: StringMap = Field(
+        default_factory=dict,
+        description="k8s resource limits (e.g. cpu, memory, nvidia.com/gpu).",
+    )
+    requests: StringMap = Field(default_factory=dict, description="k8s resource requests.")
+
+
+class ComputeSpecInline(BaseModel):
+    """Inline compute spec - the resources an invocation runs with."""
+
+    description: str = Field(default="", description="Human-readable description.")
+    resources: ComputeResources = Field(
+        default_factory=ComputeResources,
+        description="k8s-style resource requests/limits for the execute container.",
+    )
+
+
+class ModelProviderOverride(BaseModel):
+    """Exceptional external model-provider override.
+
+    Null in the normal case: model selection is on the Agent and the provider
+    URL is the Inference Gateway (auto-injected). Set ONLY to point the agent at
+    a non-IGW external provider endpoint.
+    """
+
+    base_url: str = Field(description="External model-provider endpoint.")
+    api_key: str | None = Field(
+        default=None,
+        description="Secrets-service ref for the provider API key (only needed for external providers).",
+    )
+    provider: str | None = Field(
+        default=None,
+        description='Provider selector (e.g. "openai", "anthropic").',
+    )
+
+
+class McpFulfillment(BaseModel):
+    """EnvironmentSpec-side fulfillment for one MCP server the Agent declares.
+
+    The Agent DECLARES an MCP dependency by name; the EnvironmentSpec PROVIDES
+    the url + env + secrets for that same name. Matched by server-name key at
+    compile time; ``secrets`` are merged into the server's ``env``.
+    """
+
+    url: str = Field(description="Endpoint the environment provides for this MCP server.")
+    env: StringMap = Field(default_factory=dict, description="Non-secret env for the MCP server.")
+    secrets: StringMap = Field(
+        default_factory=dict,
+        description="ENV_NAME -> Secrets-service ref, merged into the MCP server env at compile.",
+    )
+
+
+class EnvironmentSpecInline(BaseModel):
+    """Inline environment spec - the dependencies and configuration an agent reaches.
+
+    This is the fulfillment half of a request/fulfill split: the Agent declares
+    the dependencies it needs; the EnvironmentSpec provides concrete endpoints
+    and secret references. It compiles into the agent.yaml / FabricConfig and
+    the injected process environment.
+    """
+
+    description: str = Field(default="", description="Human-readable description.")
+    env: StringMap = Field(default_factory=dict, description="Plaintext, non-secret env vars.")
+    secrets: StringMap = Field(default_factory=dict, description="ENV_VAR_NAME -> Secrets-service/plugin ref.")
+    model_provider_override: ModelProviderOverride | None = Field(
+        default=None,
+        description="Set only to point at a non-IGW external model provider.",
+    )
+    provider: str = Field(default="local", description="local | docker | opensandbox | k8s.")
+    workspace_path: str | None = Field(default=None, description="Workspace path visible to the harness.")
+    artifacts_path: str | None = Field(default=None, description="Provider-specific artifact output location.")
+    control_location: str | None = Field(default=None, description="external_control | in_env_control.")
+    ownership: str | None = Field(default=None, description="caller_owned | fabric_owned.")
+    connection: JsonMap = Field(
+        default_factory=dict,
+        description="Provider connection metadata (server url, cred ref, namespace).",
+    )
+    metadata: JsonMap = Field(default_factory=dict, description="Consumer-provided passthrough metadata.")
+    settings: JsonMap = Field(default_factory=dict, description="Provider-specific settings.")
+    mcp: dict[str, McpFulfillment] = Field(
+        default_factory=dict,
+        description="server-name -> fulfillment (url/env/secrets) for an Agent-declared MCP dependency.",
+    )
+
+
+class AgentEnvironmentInline(BaseModel):
+    """Inline AgentEnvironment - a composition of environment + compute specs.
+
+    Each part is a ``ref | inline | None`` union: a ``"workspace/name"`` string
+    references a stored spec entity, an object provides the spec inline, and
+    ``None`` omits it. (A ``sandbox_spec`` is out of scope for now and omitted.)
+    """
+
+    description: str = Field(default="", description="Human-readable description.")
+    environment_spec: str | EnvironmentSpecInline | None = Field(
+        default=None,
+        description='"workspace/name" ref to an AgentEnvironmentSpec, an inline spec, or None.',
+    )
+    compute_spec: str | ComputeSpecInline | None = Field(
+        default=None,
+        description='"workspace/name" ref to an AgentComputeSpec, an inline spec, or None.',
+    )
+
+
+class AgentInline(BaseModel):
+    """Inline agent definition without entity identity."""
+
+    description: str = Field(default="", description="Human-readable description of the agent.")
+    config: JsonMap = Field(
+        default_factory=dict,
+        description="Agent config dict interpreted according to config_format.",
+    )
+    config_format: str = Field(
+        default=NAT_WORKFLOW_CONFIG_FORMAT,
+        description="Agent config schema tag.",
+    )
+
+
+class Agent(EntityMetadata, AgentInline):
+    """An agent definition stored in the Agents service."""
+
+
+class AgentComputeSpec(EntityMetadata, ComputeSpecInline):
+    """A reusable compute spec entity."""
+
+
+class AgentEnvironmentSpec(EntityMetadata, EnvironmentSpecInline):
+    """A reusable environment spec entity."""
+
+
+class AgentEnvironment(EntityMetadata, AgentEnvironmentInline):
+    """A reusable composition of environment and compute specs."""
+
+
+class AgentDeployment(EntityMetadata):
+    """A running, pending, failed, or deleting deployment of an Agent."""
+
+    agent: str = Field(default="", description="Name of the Agent entity this deployment is for.")
+    config: JsonMap = Field(
+        default_factory=dict,
+        description="Resolved agent config used by the deployment.",
+    )
+    environment: str | AgentEnvironmentInline | None = Field(
+        default=None,
+        description='"workspace/name" ref to an AgentEnvironment, an inline environment, or None.',
+    )
+    compute: ComputeSpecInline | None = Field(
+        default=None,
+        description="Resolved compute snapshot from the referenced environment.",
+    )
+    secrets: StringMap = Field(default_factory=dict, description="Resolved secret env references.")
+    status: DeploymentStatus = Field(default="pending", description="Deployment lifecycle status.")
+    deployment_mode: DeploymentMode = Field(default="subprocess", description="Runtime backend.")
+    endpoint: str = Field(default="", description="Subprocess loopback endpoint.")
+    endpoints: list[Endpoint] = Field(default_factory=list, description="Routable endpoints for container modes.")
+    image: str = Field(default="", description="Container image for docker/k8s modes.")
+    use_image_entrypoint: bool = Field(
+        default=False,
+        description="Container modes only: preserve the image ENTRYPOINT/CMD.",
+    )
+    plugin_deployment: str = Field(default="", description="Linked nemo-deployments Deployment entity name.")
+    port: int = Field(default=0, description="Port the agent process is listening on.")
+    pid: int = Field(default=0, description="OS process ID of the agent subprocess.")
+    error: str = Field(default="", description="Error message if status is failed.")
+    auth_context: AuthContext | None = Field(default=None, description="Creator auth context for delegated access.")
+
+
+class AgentSession(EntityMetadata):
+    """A durable logical conversation associated with an AgentDeployment."""
+
+    deployment_id: str = Field(
+        min_length=1,
+        description="Immutable ID of the AgentDeployment this session belongs to.",
+    )
+    status: SessionLifecycleStatus = Field(default="active", description="Session lifecycle status.")
+    first_active_at: datetime | None = Field(default=None, description="UTC timestamp of first accepted invocation.")
+    last_active_at: datetime | None = Field(
+        default=None,
+        description="UTC timestamp of latest accepted or completed invocation.",
+    )
+    expires_at: datetime | None = Field(default=None, description="UTC rolling idle deadline.")
 
 
 class CreateAgentRequest(BaseModel):
-    name: str
-    description: str = ""
-    config: dict[str, Any] = Field(default_factory=dict)
-    config_format: str = "nat-workflow-v1"
+    """Request body for ``POST /v2/workspaces/{workspace}/agents``."""
+
+    name: str = Field(description="Unique agent name within the workspace.")
+    description: str = Field(default="", description="Human-readable description.")
+    config: JsonMap = Field(description="Agent config dict interpreted according to config_format.")
+    config_format: str = Field(default=NAT_WORKFLOW_CONFIG_FORMAT, description="Config format identifier.")
 
 
-class CreateAgentDeploymentRequest(BaseModel):
-    agent: str
-    config: dict[str, Any] = Field(default_factory=dict)
+class CreateDeploymentRequest(BaseModel):
+    """Request body for ``POST /v2/workspaces/{workspace}/deployments``."""
+
+    agent: str = Field(description="Name of the Agent to deploy.")
+    name: str | None = Field(
+        default=None,
+        description="Optional deployment name.  Auto-generated from agent name + random suffix if omitted.",
+    )
+    deployment_mode: DeploymentMode = Field(
+        default="subprocess",
+        description="Runtime backend: subprocess (default), docker, or k8s.",
+    )
+    image: str = Field(
+        default="",
+        description="Container image for docker/k8s modes. Ignored for subprocess.",
+    )
+    use_image_entrypoint: bool = Field(
+        default=False,
+        description=(
+            "For docker/k8s modes, leave the container command and args empty so the image's "
+            "ENTRYPOINT/CMD starts the agent server."
+        ),
+    )
+    environment: str | AgentEnvironmentInline | None = Field(
+        default=None,
+        description=(
+            'Optional AgentEnvironment: a "workspace/name" ref, an inline environment, or None. '
+            "Resolved and snapshotted onto the deployment at create time."
+        ),
+    )
+
+
+CreateAgentDeploymentRequest: TypeAlias = CreateDeploymentRequest
+
+
+class CreateSessionRequest(BaseModel):
+    """Request body for ``POST /v2/workspaces/{workspace}/sessions``."""
+
+    deployment_id: str = Field(min_length=1, description="ID of the AgentDeployment to create a session for.")
+    name: str | None = Field(
+        default=None,
+        description="Optional session name. Auto-generated from deployment name + random suffix if omitted.",
+    )
+
+
+class CreateEnvironmentRequest(AgentEnvironmentInline):
+    """Request body for ``POST /v2/workspaces/{workspace}/environments``."""
+
+    name: str = Field(description="Unique environment name within the workspace.")
+
+
+class CreateEnvironmentSpecRequest(EnvironmentSpecInline):
+    """Request body for ``POST /v2/workspaces/{workspace}/environment-specs``."""
+
+    name: str = Field(description="Unique environment-spec name within the workspace.")
+
+
+class CreateComputeSpecRequest(ComputeSpecInline):
+    """Request body for ``POST /v2/workspaces/{workspace}/compute-specs``."""
+
+    name: str = Field(description="Unique compute-spec name within the workspace.")
 
 
 class InvokeAgentRequest(BaseModel):
@@ -84,24 +360,79 @@ class InvokeAgentRequest(BaseModel):
 
     model_config = ConfigDict(extra="allow")
 
-    messages: list[dict[str, Any]] = Field(default_factory=list)
+    messages: list[JsonMap] = Field(default_factory=list)
     stream: bool = False
 
 
-JsonObject = dict[str, JsonValue]
+class LogLine(BaseModel):
+    """One deployment log line shaped like ``PlatformJobLog`` for UI reuse."""
+
+    timestamp: str = Field(description="ISO-8601 timestamp parsed from the line; empty when absent.")
+    job: str = Field(default="", description="Empty - kept for jobs-log shape compatibility.")
+    job_step: str = Field(default="", description="Empty - kept for jobs-log shape compatibility.")
+    job_task: str = Field(default="", description="Empty - kept for jobs-log shape compatibility.")
+    message: str = Field(description="The raw log line minus any parsed timestamp prefix.")
 
 
-class CreateExecuteJobRequest(BaseModel):
-    """Request body for the agents.execute job collection."""
+class DeploymentLogsResponse(BaseModel):
+    """Response body for ``GET /deployments/{name}/logs``."""
 
-    spec: JsonObject = Field(description="ExecuteAgentJobConfig payload owned by the Agents plugin.")
+    data: list[LogLine]
+    total_lines: int = Field(description="Number of lines actually returned.")
+    next_offset: int = Field(description="Byte offset just past the returned tail.")
+
+
+class AgentJobRequest(BaseModel):
+    """Request body for creating one Agents job collection item."""
+
     name: str | None = None
     description: str | None = None
+    project: str | None = None
+    spec: JsonMap
+    profile: str | None = None
+    options: JsonMap | None = None
+    ownership: JsonMap | None = None
+    custom_fields: JsonMap | None = None
+    output_location: str | None = None
 
 
-# ---------------------------------------------------------------------------
-# Query parameter types
-# ---------------------------------------------------------------------------
+class CreateExecuteJobRequest(AgentJobRequest):
+    """Compatibility request body for the agents.execute job collection."""
+
+    spec: JsonObject = Field(description="ExecuteAgentJobConfig payload owned by the Agents plugin.")
+
+
+class AgentJob(BaseModel):
+    """Agents job response with collection-specific spec kept as JSON."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: str | None = None
+    name: str = ""
+    description: str | None = None
+    project: str | None = None
+    workspace: str | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+    spec: JsonMap = Field(default_factory=dict)
+    status: PlatformJobStatus | None = None
+    status_details: JsonMap | None = None
+    error_details: JsonMap | None = None
+    ownership: JsonMap | None = None
+    custom_fields: JsonMap | None = None
+
+
+AgentPage = Page[Agent]
+DeploymentPage = Page[AgentDeployment]
+SessionPage = Page[AgentSession]
+EnvironmentPage = Page[AgentEnvironment]
+EnvironmentSpecPage = Page[AgentEnvironmentSpec]
+ComputeSpecPage = Page[AgentComputeSpec]
+AgentJobPage = Page[AgentJob]
+AgentJobResultListResponse = PlatformJobListResultResponse
+AgentJobResult = PlatformJobResultResponse
+AgentJobStatusResponse = PlatformJobStatusResponse
+AgentJobLog = PlatformJobLog
 
 
 class ListAgentsQueryParams(TypedDict, total=False):
@@ -116,3 +447,44 @@ class ListDeploymentsQueryParams(TypedDict, total=False):
     page_size: NotRequired[int]
     sort: NotRequired[str]
     filter: NotRequired[str]
+
+
+ListSessionsQueryParams = TypedDict(
+    "ListSessionsQueryParams",
+    {
+        "page": NotRequired[int],
+        "page_size": NotRequired[int],
+        "sort": NotRequired[str],
+        "filter": NotRequired[str | JsonMap],
+        "filter[deployment_id]": NotRequired[str],
+    },
+    total=False,
+)
+
+
+class ListEnvironmentResourcesQueryParams(TypedDict, total=False):
+    page: NotRequired[int]
+    page_size: NotRequired[int]
+    sort: NotRequired[str]
+    filter: NotRequired[str | JsonMap]
+
+
+class DeploymentLogsQueryParams(TypedDict, total=False):
+    tail: NotRequired[int]
+
+
+class ListAgentJobsQueryParams(TypedDict, total=False):
+    page: NotRequired[int]
+    page_size: NotRequired[int]
+    sort: NotRequired[str]
+    filter: NotRequired[str | JsonMap]
+
+
+class AgentJobLogsQueryParams(TypedDict, total=False):
+    limit: NotRequired[int]
+    page_cursor: NotRequired[str]
+    tail: NotRequired[int]
+
+
+class ListAgentJobResultsQueryParams(TypedDict, total=False):
+    sort: NotRequired[str]

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/client/client.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/client/client.py
@@ -526,6 +526,13 @@ class BaseNemoClient(Generic[HttpClientT]):
         """Shorthand for ``with_options(headers=...)``."""
         return self.with_options(headers=headers)
 
+    def with_workspace(self, workspace: str) -> Self:
+        """Return a copy of this client with *workspace* as the default workspace."""
+        clone = copy.copy(self)
+        clone._owns_http = False
+        clone._workspace = workspace
+        return clone
+
     def with_retry(self, retry: RetryPolicy) -> Self:
         """Shorthand for ``with_options(retry=...)``."""
         return self.with_options(retry=retry)

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/jobs/file_manager.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/jobs/file_manager.py
@@ -205,6 +205,10 @@ class FilesetFileManager(BaseFilesetFileManager):
             local_dir = Path(local_dir)
 
         full_remote_path = self._fileset_path(remote_path)
+        if not remote_path or remote_path.endswith("/"):
+            self._fs.get(full_remote_path, str(local_dir), recursive=True)
+            return TmpDirPath(path=local_dir, tmp_dir=local_dir)
+
         info = self._fs.info(full_remote_path)
 
         if info["type"] == "directory":
@@ -267,6 +271,10 @@ class AsyncFilesetFileManager(BaseFilesetFileManager):
             local_dir = Path(local_dir)
 
         full_remote_path = self._fileset_path(remote_path)
+        if not remote_path or remote_path.endswith("/"):
+            await self._fs._get(full_remote_path, str(local_dir), recursive=True)
+            return TmpDirPath(path=local_dir, tmp_dir=local_dir)
+
         info = await self._fs._info(full_remote_path)
 
         if info["type"] == "directory":

--- a/packages/nemo_platform_plugin/tests/agents/test_client.py
+++ b/packages/nemo_platform_plugin/tests/agents/test_client.py
@@ -1,0 +1,313 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""AgentsClient transport tests via mocked httpx transport."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+from nemo_platform_plugin.agents.client import AgentsClient, AsyncAgentsClient
+from nemo_platform_plugin.agents.types import (
+    AgentJobRequest,
+    CreateAgentRequest,
+    CreateDeploymentRequest,
+    CreateSessionRequest,
+    InvokeAgentRequest,
+)
+from nemo_platform_plugin.client.errors import BadRequestError, ConflictError, NotFoundError, UnprocessableEntityError
+from nemo_platform_plugin.jobs.schemas import FileStorageType
+from pydantic import JsonValue
+
+BASE = "http://test:8000"
+
+
+def _page(item: dict[str, JsonValue]) -> dict[str, JsonValue]:
+    return {
+        "data": [item],
+        "pagination": {
+            "page": 1,
+            "page_size": 1,
+            "current_page_size": 1,
+            "total_pages": 1,
+            "total_results": 1,
+        },
+    }
+
+
+def _read_json(request: httpx.Request) -> dict[str, JsonValue]:
+    body = json.loads(request.content)
+    assert isinstance(body, dict)
+    return body
+
+
+def test_create_agent_serializes_body_and_unwraps() -> None:
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        assert request.method == "POST"
+        assert request.url == f"{BASE}/apis/agents/v2/workspaces/default/agents"
+        assert _read_json(request) == {"name": "calc", "config": {"workflow": {}}}
+        return httpx.Response(201, json={"name": "calc", "workspace": "default", "config": {"workflow": {}}})
+
+    http_client = httpx.Client(transport=httpx.MockTransport(handler))
+    client = AgentsClient(base_url=BASE, workspace="default", http_client=http_client)
+
+    agent = client.create_agent(body=CreateAgentRequest(name="calc", config={"workflow": {}})).data()
+
+    assert agent.name == "calc"
+    assert agent.config == {"workflow": {}}
+    assert len(seen) == 1
+
+
+def test_create_agent_exist_ok_replays_get_on_conflict() -> None:
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        if request.method == "POST":
+            return httpx.Response(409, json={"detail": "already exists"})
+        assert request.method == "GET"
+        assert request.url == f"{BASE}/apis/agents/v2/workspaces/default/agents/calc"
+        return httpx.Response(200, json={"name": "calc", "workspace": "default", "config": {"workflow": {}}})
+
+    http_client = httpx.Client(transport=httpx.MockTransport(handler))
+    client = AgentsClient(base_url=BASE, workspace="default", http_client=http_client)
+
+    agent = client.create_agent(body=CreateAgentRequest(name="calc", config={"workflow": {}}), exist_ok=True).data()
+
+    assert agent.name == "calc"
+    assert [request.method for request in seen] == ["POST", "GET"]
+
+
+def test_list_agents_paginates() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url == f"{BASE}/apis/agents/v2/workspaces/default/agents?page_size=1"
+        return httpx.Response(200, json=_page({"name": "calc", "workspace": "default", "config": {}}))
+
+    http_client = httpx.Client(transport=httpx.MockTransport(handler))
+    client = AgentsClient(base_url=BASE, workspace="default", http_client=http_client)
+
+    names = [agent.name for agent in client.list_agents(query_params={"page_size": 1}).items()]
+
+    assert names == ["calc"]
+
+
+def test_deployment_session_and_invoke_routes() -> None:
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        if request.url.path.endswith("/deployments"):
+            assert _read_json(request) == {"agent": "calc", "name": "calc-prod"}
+            return httpx.Response(201, json={"name": "calc-prod", "workspace": "default", "agent": "calc"})
+        if request.url.path.endswith("/sessions"):
+            assert _read_json(request) == {"deployment_id": "dep-id"}
+            return httpx.Response(
+                201,
+                json={"name": "session-one", "workspace": "default", "deployment_id": "dep-id"},
+            )
+        assert request.url.path.endswith("/deployments/calc-prod/-/v1/chat/completions")
+        assert request.headers["X-Nemo-Session-Id"] == "session-one"
+        return httpx.Response(200, json={"id": "completion-id"})
+
+    http_client = httpx.Client(transport=httpx.MockTransport(handler))
+    client = AgentsClient(base_url=BASE, workspace="default", http_client=http_client)
+
+    deployment = client.create_deployment(body=CreateDeploymentRequest(agent="calc", name="calc-prod")).data()
+    session = client.create_session(body=CreateSessionRequest(deployment_id="dep-id")).data()
+    completion = client.with_headers({"X-Nemo-Session-Id": session.name}).invoke_deployment(
+        name=deployment.name,
+        body=InvokeAgentRequest(messages=[{"role": "user", "content": "hello"}]),
+    )
+
+    assert completion.data() == {"id": "completion-id"}
+    assert [request.method for request in seen] == ["POST", "POST", "POST"]
+
+
+def test_stream_deployment_logs_parses_sse() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url == f"{BASE}/apis/agents/v2/workspaces/default/deployments/calc-prod/logs/stream"
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=b'id: 7\ndata: {"timestamp":"2026-01-01T00:00:00","message":"ready"}\n\n',
+        )
+
+    http_client = httpx.Client(transport=httpx.MockTransport(handler))
+    client = AgentsClient(base_url=BASE, workspace="default", http_client=http_client)
+
+    with client.stream_deployment_logs(name="calc-prod").stream() as lines:
+        parsed = list(lines)
+
+    assert len(parsed) == 1
+    assert parsed[0].message == "ready"
+
+
+def test_download_agent_job_result_reads_bytes() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url == f"{BASE}/apis/agents/v2/workspaces/default/jobs/execute/job-1/results/result/download"
+        return httpx.Response(200, content=b'{"ok": true}\n')
+
+    http_client = httpx.Client(transport=httpx.MockTransport(handler))
+    client = AgentsClient(base_url=BASE, workspace="default", http_client=http_client)
+
+    result = client.download_agent_job_result(collection="execute", job="job-1", name="result").read()
+
+    assert result == b'{"ok": true}\n'
+
+
+def test_agent_job_methods() -> None:
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        if request.method == "POST":
+            assert request.url == f"{BASE}/apis/agents/v2/workspaces/default/jobs/execute"
+            assert _read_json(request) == {"spec": {"agent": "calc", "input": "2+2"}}
+            return httpx.Response(
+                201,
+                json={"name": "job-1", "workspace": "default", "spec": {"agent": "calc"}, "status": "created"},
+            )
+        if request.url.path.endswith("/results"):
+            return httpx.Response(
+                200,
+                json={
+                    "data": [
+                        {
+                            "name": "result",
+                            "job": "job-1",
+                            "workspace": "default",
+                            "artifact_url": "fileset://result",
+                            "artifact_storage_type": FileStorageType.FILESET.value,
+                        }
+                    ]
+                },
+            )
+        return httpx.Response(
+            200,
+            json={
+                "id": "job-1",
+                "name": "job-1",
+                "status": "created",
+                "status_details": {},
+                "error_details": None,
+                "steps": [],
+                "created_at": "2026-01-01T00:00:00Z",
+                "updated_at": "2026-01-01T00:00:00Z",
+            },
+        )
+
+    http_client = httpx.Client(transport=httpx.MockTransport(handler))
+    client = AgentsClient(base_url=BASE, workspace="default", http_client=http_client)
+
+    job = client.create_agent_job(
+        collection="execute",
+        body=AgentJobRequest(spec={"agent": "calc", "input": "2+2"}),
+    ).data()
+    results = client.list_agent_job_results(collection="execute", name=job.name).data()
+    status = client.get_agent_job_status(collection="execute", name=job.name).data()
+
+    assert job.name == "job-1"
+    assert results.data[0].name == "result"
+    assert status.name == "job-1"
+    assert [request.method for request in seen] == ["POST", "GET", "GET"]
+
+
+def test_execute_job_compat_methods_return_json_maps() -> None:
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        if request.method == "POST":
+            assert request.url == f"{BASE}/apis/agents/v2/workspaces/default/jobs/execute"
+            assert _read_json(request) == {"name": "job-1", "spec": {"agent": "calc", "input": "2+2"}}
+            return httpx.Response(
+                201,
+                json={"name": "job-1", "workspace": "default", "spec": {"agent": "calc"}, "status": "created"},
+            )
+        if request.url.path.endswith("/results"):
+            return httpx.Response(200, json={"data": [{"name": "result"}]})
+        return httpx.Response(200, json={"name": "job-1", "workspace": "default", "spec": {"agent": "calc"}})
+
+    http_client = httpx.Client(transport=httpx.MockTransport(handler))
+    client = AgentsClient(base_url=BASE, workspace="default", http_client=http_client)
+
+    job = client.jobs.execute.create(name="job-1", spec={"agent": "calc", "input": "2+2"})
+    retrieved = client.jobs.execute.get("job-1")
+    results = client.jobs.execute.list_results("job-1")
+
+    assert job["name"] == "job-1"
+    assert retrieved["name"] == "job-1"
+    assert results["data"] == [{"name": "result"}]
+    assert [request.method for request in seen] == ["POST", "GET", "GET"]
+
+
+def test_execute_job_compat_uses_cloned_client_after_preclone_access() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url == f"{BASE}/apis/agents/v2/workspaces/cloned/jobs/execute/job-1"
+        assert request.headers["X-Clone"] == "yes"
+        return httpx.Response(200, json={"name": "job-1", "workspace": "cloned", "spec": {}})
+
+    http_client = httpx.Client(transport=httpx.MockTransport(handler))
+    client = AgentsClient(base_url=BASE, workspace="default", http_client=http_client)
+    _ = client.jobs
+
+    cloned = client.with_workspace("cloned").with_headers({"X-Clone": "yes"})
+    retrieved = cloned.jobs.execute.get("job-1")
+
+    assert retrieved["workspace"] == "cloned"
+
+
+@pytest.mark.asyncio
+async def test_async_execute_job_compat_uses_cloned_client_after_preclone_access() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url == f"{BASE}/apis/agents/v2/workspaces/cloned/jobs/execute/job-1"
+        return httpx.Response(200, json={"name": "job-1", "workspace": "cloned", "spec": {}})
+
+    http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    client = AsyncAgentsClient(base_url=BASE, workspace="default", http_client=http_client)
+    _ = client.jobs
+
+    cloned = client.with_workspace("cloned")
+    retrieved = await cloned.jobs.execute.get("job-1")
+
+    assert retrieved["workspace"] == "cloned"
+    await http_client.aclose()
+
+
+@pytest.mark.parametrize(
+    ("status_code", "error_type"),
+    [(400, BadRequestError), (404, NotFoundError), (409, ConflictError), (422, UnprocessableEntityError)],
+)
+def test_typed_http_errors(status_code: int, error_type: type[Exception]) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status_code, json={"detail": f"bad {request.url.path}"})
+
+    http_client = httpx.Client(transport=httpx.MockTransport(handler))
+    client = AgentsClient(base_url=BASE, workspace="default", http_client=http_client)
+
+    with pytest.raises(error_type):
+        client.get_agent(name="missing").data()
+
+
+@pytest.mark.asyncio
+async def test_async_create_session() -> None:
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        assert request.url == f"{BASE}/apis/agents/v2/workspaces/default/sessions"
+        return httpx.Response(201, json={"name": "session-one", "deployment_id": "dep-id"})
+
+    http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    client = AsyncAgentsClient(base_url=BASE, workspace="default", http_client=http_client)
+
+    session = (await client.create_session(body=CreateSessionRequest(deployment_id="dep-id"))).data()
+
+    assert session.name == "session-one"
+    assert len(seen) == 1
+    await http_client.aclose()

--- a/packages/nemo_platform_plugin/tests/agents/test_endpoints.py
+++ b/packages/nemo_platform_plugin/tests/agents/test_endpoints.py
@@ -1,0 +1,234 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for Agents service endpoint definitions."""
+
+from __future__ import annotations
+
+import json
+from typing import get_args, get_origin
+
+import pytest
+from nemo_platform_plugin.agents import endpoints
+from nemo_platform_plugin.agents.types import (
+    Agent,
+    AgentComputeSpec,
+    AgentDeployment,
+    AgentEnvironment,
+    AgentEnvironmentSpec,
+    AgentJob,
+    AgentJobCollection,
+    AgentJobLog,
+    AgentJobRequest,
+    AgentJobResultListResponse,
+    AgentJobStatusResponse,
+    AgentSession,
+    CreateAgentRequest,
+    CreateComputeSpecRequest,
+    CreateDeploymentRequest,
+    CreateEnvironmentRequest,
+    CreateEnvironmentSpecRequest,
+    CreateExecuteJobRequest,
+    CreateSessionRequest,
+    DeploymentLogsResponse,
+    InvokeAgentRequest,
+    JsonObject,
+    LogLine,
+)
+from nemo_platform_plugin.client.types import BinaryContent, CursorPagination, Paginated, PreparedRequest, Stream
+from pydantic import JsonValue
+
+_PREFIX = "/apis/agents/v2/workspaces/{workspace}"
+_COLLECTIONS: tuple[AgentJobCollection, ...] = (
+    "analyze",
+    "evaluate",
+    "evaluate-suite",
+    "execute",
+    "optimize",
+    "optimize-skills",
+    "package",
+)
+
+
+def _json_body(prepared: PreparedRequest) -> dict[str, JsonValue]:
+    assert isinstance(prepared.content, bytes)
+    body = json.loads(prepared.content)
+    assert isinstance(body, dict)
+    return body
+
+
+def test_create_agent() -> None:
+    body = CreateAgentRequest(name="calc", config={"workflow": {}})
+    prepared = endpoints.create_agent(workspace="default", body=body)
+
+    assert isinstance(prepared, PreparedRequest)
+    assert prepared.method == "POST"
+    assert prepared.path_template == f"{_PREFIX}/agents"
+    assert prepared.path_params == {"workspace": "default"}
+    assert prepared.content_type == "application/json"
+    assert prepared.response_type is Agent
+    assert _json_body(prepared) == {"name": "calc", "config": {"workflow": {}}}
+    assert prepared.on_conflict_get is not None
+    assert prepared.on_conflict_get.path_params == {"workspace": "default", "name": "calc"}
+
+
+def test_list_and_get_agents() -> None:
+    list_prepared = endpoints.list_agents(workspace="default", query_params={"page": 2, "sort": "-created_at"})
+    get_prepared = endpoints.get_agent(workspace="default", name="calc")
+
+    assert get_origin(list_prepared.response_type) is Paginated
+    assert list_prepared.query_params == {"page": 2, "sort": "-created_at"}
+    assert get_prepared.path_params == {"workspace": "default", "name": "calc"}
+    assert get_prepared.response_type is Agent
+
+
+def test_deployment_crud_and_logs() -> None:
+    body = CreateDeploymentRequest(agent="calc", name="calc-prod", deployment_mode="k8s", image="repo/calc:1")
+    create_prepared = endpoints.create_deployment(workspace="default", body=body)
+    list_prepared = endpoints.list_deployments(workspace="default")
+    get_prepared = endpoints.get_deployment(workspace="default", name="calc-prod")
+    logs_prepared = endpoints.get_deployment_logs(workspace="default", name="calc-prod", query_params={"tail": 100})
+    stream_prepared = endpoints.stream_deployment_logs(workspace="default", name="calc-prod")
+
+    assert create_prepared.path_template == f"{_PREFIX}/deployments"
+    assert _json_body(create_prepared) == {
+        "agent": "calc",
+        "name": "calc-prod",
+        "deployment_mode": "k8s",
+        "image": "repo/calc:1",
+    }
+    assert get_origin(list_prepared.response_type) is Paginated
+    assert get_prepared.response_type is AgentDeployment
+    assert logs_prepared.query_params == {"tail": 100}
+    assert logs_prepared.response_type is DeploymentLogsResponse
+    assert get_origin(stream_prepared.response_type) is Stream
+    assert get_args(stream_prepared.response_type) == (LogLine,)
+
+
+def test_sessions() -> None:
+    create_prepared = endpoints.create_session(
+        workspace="default",
+        body=CreateSessionRequest(deployment_id="dep-id", name="chat-one"),
+    )
+    list_prepared = endpoints.list_sessions(workspace="default", query_params={"filter": {"deployment_id": "dep-id"}})
+    close_prepared = endpoints.close_session(workspace="default", name="chat-one")
+
+    assert create_prepared.path_template == f"{_PREFIX}/sessions"
+    assert create_prepared.response_type is AgentSession
+    assert _json_body(create_prepared) == {"deployment_id": "dep-id", "name": "chat-one"}
+    assert get_origin(list_prepared.response_type) is Paginated
+    assert list_prepared.query_params == {"filter": {"deployment_id": "dep-id"}}
+    assert close_prepared.method == "POST"
+    assert close_prepared.path_template == f"{_PREFIX}/sessions/{{name}}/close"
+
+
+def test_environment_resources() -> None:
+    env_spec_create = endpoints.create_environment_spec(
+        workspace="default",
+        body=CreateEnvironmentSpecRequest(name="env-spec", env={"LOG_LEVEL": "debug"}),
+    )
+    env_create = endpoints.create_environment(
+        workspace="default",
+        body=CreateEnvironmentRequest(name="env", environment_spec="default/env-spec"),
+    )
+    compute_create = endpoints.create_compute_spec(
+        workspace="default",
+        body=CreateComputeSpecRequest(name="small"),
+    )
+
+    assert env_spec_create.path_template == f"{_PREFIX}/environment-specs"
+    assert env_spec_create.response_type is AgentEnvironmentSpec
+    assert get_origin(endpoints.list_environment_specs(workspace="default").response_type) is Paginated
+    assert endpoints.get_environment_spec(workspace="default", name="env-spec").response_type is AgentEnvironmentSpec
+    assert endpoints.delete_environment_spec(workspace="default", name="env-spec").response_type is None
+    assert env_create.response_type is AgentEnvironment
+    assert get_origin(endpoints.list_environments(workspace="default").response_type) is Paginated
+    assert endpoints.get_environment(workspace="default", name="env").response_type is AgentEnvironment
+    assert endpoints.delete_environment(workspace="default", name="env").response_type is None
+    assert compute_create.response_type is AgentComputeSpec
+    assert get_origin(endpoints.list_compute_specs(workspace="default").response_type) is Paginated
+    assert endpoints.get_compute_spec(workspace="default", name="small").response_type is AgentComputeSpec
+    assert endpoints.delete_compute_spec(workspace="default", name="small").response_type is None
+
+
+def test_gateway_invocation() -> None:
+    body = InvokeAgentRequest(messages=[{"role": "user", "content": "hello"}], stream=False)
+    agent_prepared = endpoints.invoke_agent(workspace="default", name="calc", body=body)
+    deployment_prepared = endpoints.invoke_deployment(workspace="default", name="calc-prod", body=body)
+
+    assert agent_prepared.path_template == f"{_PREFIX}/agents/{{name}}/-/v1/chat/completions"
+    assert deployment_prepared.path_template == f"{_PREFIX}/deployments/{{name}}/-/v1/chat/completions"
+    assert _json_body(agent_prepared) == {"messages": [{"role": "user", "content": "hello"}], "stream": False}
+
+
+def test_execute_job_compat_endpoints() -> None:
+    create_prepared = endpoints.create_execute_job(
+        workspace="default",
+        body=CreateExecuteJobRequest(name="job-1", spec={"agent": "calc", "input": "2+2"}),
+    )
+    get_prepared = endpoints.get_execute_job(workspace="default", name="job-1")
+    results_prepared = endpoints.list_execute_job_results(workspace="default", name="job-1")
+
+    assert create_prepared.path_template == f"{_PREFIX}/jobs/execute"
+    assert create_prepared.response_type == JsonObject
+    assert _json_body(create_prepared) == {"name": "job-1", "spec": {"agent": "calc", "input": "2+2"}}
+    assert get_prepared.path_template == f"{_PREFIX}/jobs/execute/{{name}}"
+    assert get_prepared.response_type == JsonObject
+    assert results_prepared.path_template == f"{_PREFIX}/jobs/execute/{{name}}/results"
+    assert results_prepared.response_type == JsonObject
+
+
+@pytest.mark.parametrize("collection", _COLLECTIONS)
+def test_agent_job_collection_crud(collection: AgentJobCollection) -> None:
+    create_prepared = endpoints.create_agent_job(
+        workspace="default",
+        collection=collection,
+        body=AgentJobRequest(spec={"agent": "calc", "input": "2+2"}),
+    )
+    list_prepared = endpoints.list_agent_jobs(
+        workspace="default",
+        collection=collection,
+        query_params={"page": 2, "filter": {"status": "completed"}},
+    )
+    get_prepared = endpoints.get_agent_job(workspace="default", collection=collection, name="job-1")
+    cancel_prepared = endpoints.cancel_agent_job(workspace="default", collection=collection, name="job-1")
+
+    assert create_prepared.path_template == f"{_PREFIX}/jobs/{{collection}}"
+    assert create_prepared.path_params == {"workspace": "default", "collection": collection}
+    assert create_prepared.response_type is AgentJob
+    assert get_origin(list_prepared.response_type) is Paginated
+    assert list_prepared.query_params == {"page": 2, "filter": {"status": "completed"}}
+    assert get_prepared.response_type is AgentJob
+    assert cancel_prepared.path_template == f"{_PREFIX}/jobs/{{collection}}/{{name}}/cancel"
+    assert cancel_prepared.response_type is AgentJob
+    assert endpoints.delete_agent_job(workspace="default", collection=collection, name="job-1").response_type is None
+
+
+def test_agent_job_logs_results_status_and_download() -> None:
+    logs_prepared = endpoints.list_agent_job_logs(
+        workspace="default",
+        collection="execute",
+        name="job-1",
+        query_params={"limit": 50, "page_cursor": "abc", "tail": 500},
+    )
+    results_prepared = endpoints.list_agent_job_results(workspace="default", collection="execute", name="job-1")
+    status_prepared = endpoints.get_agent_job_status(workspace="default", collection="execute", name="job-1")
+    result_prepared = endpoints.get_agent_job_result(
+        workspace="default",
+        collection="execute",
+        job="job-1",
+        name="result",
+    )
+    download_prepared = endpoints.download_agent_job_result(
+        workspace="default",
+        collection="execute",
+        job="job-1",
+        name="result",
+    )
+
+    assert get_args(logs_prepared.response_type) == (AgentJobLog, CursorPagination)
+    assert logs_prepared.query_params == {"limit": 50, "page_cursor": "abc", "tail": 500}
+    assert results_prepared.response_type is AgentJobResultListResponse
+    assert status_prepared.response_type is AgentJobStatusResponse
+    assert result_prepared.path_template == f"{_PREFIX}/jobs/{{collection}}/{{job}}/results/{{name}}"
+    assert download_prepared.response_type is BinaryContent

--- a/packages/nemo_platform_plugin/tests/client/test_client.py
+++ b/packages/nemo_platform_plugin/tests/client/test_client.py
@@ -566,6 +566,29 @@ def test_from_client_close_does_not_close_parent_transport() -> None:
     assert parent._http.is_closed
 
 
+def test_with_workspace_returns_clone_sharing_transport() -> None:
+    mock_http = MagicMock(spec=httpx.Client)
+    client = NemoClient(base_url=BASE, workspace="team-a", http_client=mock_http)
+
+    clone = client.with_workspace("default")
+
+    assert clone is not client
+    assert clone.workspace == "default"
+    assert client.workspace == "team-a"
+    assert clone._http is mock_http
+
+
+def test_with_workspace_close_does_not_close_parent_transport() -> None:
+    parent = NemoClient(base_url=BASE)
+    child = parent.with_workspace("team-a")
+
+    child.close()
+
+    assert not parent._http.is_closed
+    parent.close()
+    assert parent._http.is_closed
+
+
 def test_from_client_carries_the_timeout() -> None:
     """The clone shares the transport, so it must carry the override too."""
     upload_timeout = httpx.Timeout(30.0, write=10 * 60, read=5 * 60)
@@ -608,6 +631,18 @@ async def test_aclose_skips_external_transport_async() -> None:
 async def test_from_client_aclose_does_not_close_parent_transport_async() -> None:
     parent = AsyncNemoClient(base_url=BASE)
     child = AsyncNemoClient.from_client(parent)
+
+    await child.aclose()
+
+    assert not parent._http.is_closed
+    await parent.aclose()
+    assert parent._http.is_closed
+
+
+@pytest.mark.asyncio
+async def test_with_workspace_aclose_does_not_close_parent_transport_async() -> None:
+    parent = AsyncNemoClient(base_url=BASE)
+    child = parent.with_workspace("team-a")
 
     await child.aclose()
 

--- a/packages/nemo_platform_plugin/tests/jobs/test_file_manager.py
+++ b/packages/nemo_platform_plugin/tests/jobs/test_file_manager.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+import pytest
+from filesets import AsyncFilesetFileSystem, FilesetFileSystem
+from nemo_platform_plugin.jobs.file_manager import AsyncFilesetFileManager, FilesetFileManager
+
+
+class _FakeFilesetFileSystem:
+    def __init__(self) -> None:
+        self.downloads: list[tuple[str, str, bool]] = []
+
+    def info(self, path: str) -> object:
+        raise AssertionError(f"info should not be called for trailing-slash refs: {path}")
+
+    def get(self, rpath: str, lpath: str, recursive: bool = True) -> None:
+        self.downloads.append((rpath, lpath, recursive))
+        local_path = Path(lpath)
+        local_path.mkdir(parents=True, exist_ok=True)
+        (local_path / "context.txt").write_text("downloaded")
+
+
+class _FakeAsyncFilesetFileSystem:
+    def __init__(self) -> None:
+        self.downloads: list[tuple[str, str, bool]] = []
+
+    async def _info(self, path: str) -> object:
+        raise AssertionError(f"_info should not be called for trailing-slash refs: {path}")
+
+    async def _get(self, rpath: str, lpath: str, recursive: bool = True) -> None:
+        self.downloads.append((rpath, lpath, recursive))
+        local_path = Path(lpath)
+        local_path.mkdir(parents=True, exist_ok=True)
+        (local_path / "context.txt").write_text("downloaded")
+
+
+def test_fileset_manager_downloads_trailing_slash_ref_without_info(tmp_path: Path) -> None:
+    fs = _FakeFilesetFileSystem()
+    manager = FilesetFileManager(
+        workspace="default",
+        fileset_name="inputs",
+        filesystem=cast(FilesetFileSystem, fs),
+        ensure_fileset_exists=False,
+    )
+
+    result = manager.download_from_url("default/inputs#project/", local_dir=tmp_path)
+
+    assert fs.downloads == [("default/inputs#project/", str(tmp_path), True)]
+    assert result.path == tmp_path
+    assert result.tmp_dir == tmp_path
+    assert (tmp_path / "context.txt").read_text() == "downloaded"
+
+
+@pytest.mark.asyncio
+async def test_async_fileset_manager_downloads_trailing_slash_ref_without_info(tmp_path: Path) -> None:
+    fs = _FakeAsyncFilesetFileSystem()
+    manager = AsyncFilesetFileManager(
+        workspace="default",
+        fileset_name="inputs",
+        filesystem=cast(AsyncFilesetFileSystem, fs),
+        ensure_fileset_exists=False,
+    )
+
+    result = await manager.download_from_url("default/inputs#project/", local_dir=tmp_path)
+
+    assert fs.downloads == [("default/inputs#project/", str(tmp_path), True)]
+    assert result.path == tmp_path
+    assert result.tmp_dir == tmp_path
+    assert (tmp_path / "context.txt").read_text() == "downloaded"

--- a/plugins/nemo-agents/src/nemo_agents_plugin/cli.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/cli.py
@@ -50,9 +50,7 @@ from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from pkgutil import resolve_name
-from types import SimpleNamespace
-from typing import Any, ClassVar, Literal, Optional, cast
-from urllib.parse import urlencode
+from typing import Any, ClassVar, Literal, Optional, TypeVar, cast
 
 import click
 import httpx
@@ -95,10 +93,34 @@ from nemo_platform_ext.cli.core.api import is_tty
 from nemo_platform_ext.cli.core.formatters import Column, format_output
 from nemo_platform_ext.cli.core.help_formatter import NmpGroup
 from nemo_platform_ext.ui.prompts import is_interactive
+from nemo_platform_plugin.agents.client import AgentsClient
+from nemo_platform_plugin.agents.types import (
+    AgentDeployment as ClientAgentDeployment,
+)
+from nemo_platform_plugin.agents.types import (
+    CreateAgentRequest,
+    CreateComputeSpecRequest,
+    CreateDeploymentRequest,
+    CreateEnvironmentRequest,
+    CreateEnvironmentSpecRequest,
+    CreateSessionRequest,
+    ListSessionsQueryParams,
+)
 from nemo_platform_plugin.cli import NemoCLI
 from nemo_platform_plugin.cli_errors import print_http_request_error, print_http_status_error
 from nemo_platform_plugin.cli_progress import request_progress
+from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.client.errors import (
+    NemoClientError,
+    NemoHTTPError,
+    NemoTransportError,
+)
+from nemo_platform_plugin.client.errors import (
+    NotFoundError as PluginNotFoundError,
+)
+from nemo_platform_plugin.client.response import NemoPaginatedResponse, NemoResponse
 from nemo_platform_plugin.discovery import AGENT_CLI_GROUP, discover_entry_points
+from nemo_platform_plugin.files.client import FilesClient
 from nemo_platform_plugin.job import NemoJob
 from pydantic import ValidationError
 from typer.main import get_command as _typer_get_command
@@ -108,6 +130,7 @@ logger = logging.getLogger(__name__)
 _DEFAULT_WORKSPACE = "default"
 _LIST_OUTPUT_FORMAT = Literal["table", "json", "yaml", "csv", "markdown", "raw"]
 _DEPLOYMENT_RESOLUTION_PAGE_SIZE = 100
+_T = TypeVar("_T")
 
 _AGENT_LIST_COLUMNS = [
     Column("name"),
@@ -1048,20 +1071,23 @@ def _register_platform_commands(app: typer.Typer) -> None:
     ) -> None:
         """List persisted sessions, newest first."""
         base_url = _resolve_base_url(base_url)
-        path = f"/apis/agents/v2/workspaces/{workspace}/sessions"
+        client = _agents_client(base_url, workspace)
+        query_params: ListSessionsQueryParams | None = None
         if agent_deployment is not None:
             if not agent_deployment.strip():
                 typer.echo("Error: --agent-deployment must not be empty.", err=True)
                 raise typer.Exit(code=2)
-            deployment = _api_request(
-                "GET",
-                base_url,
-                f"/apis/agents/v2/workspaces/{workspace}/deployments/{agent_deployment}",
+            deployment = _run_sdk(
+                "GET agent API",
+                lambda: _json_from_response(client.get_deployment(workspace=workspace, name=agent_deployment)),
             )
             deployment_id = _require_deployment_id(deployment, agent_deployment)
-            path += f"?{urlencode({'filter[deployment_id]': deployment_id})}"
+            query_params = {"filter[deployment_id]": deployment_id}
 
-        resp = _api_request("GET", base_url, path)
+        resp = _run_sdk(
+            "GET agent API",
+            lambda: _json_from_page(client.list_sessions(workspace=workspace, query_params=query_params)),
+        )
         _print_list_response(
             ctx,
             resp,
@@ -1078,7 +1104,11 @@ def _register_platform_commands(app: typer.Typer) -> None:
     ) -> None:
         """Get a persisted session by name."""
         base_url = _resolve_base_url(base_url)
-        resp = _api_request("GET", base_url, f"/apis/agents/v2/workspaces/{workspace}/sessions/{name}")
+        client = _agents_client(base_url, workspace)
+        resp = _run_sdk(
+            "GET agent API",
+            lambda: _json_from_response(client.get_session(workspace=workspace, name=name)),
+        )
         typer.echo(json.dumps(resp, indent=2))
 
     @sessions_app.command(name="close")
@@ -1092,7 +1122,11 @@ def _register_platform_commands(app: typer.Typer) -> None:
         base_url = _resolve_base_url(base_url)
         if not yes:
             typer.confirm(f"Close session '{name}'? It cannot be resumed after it is closed.", abort=True)
-        _api_request("POST", base_url, f"/apis/agents/v2/workspaces/{workspace}/sessions/{name}/close")
+        client = _agents_client(base_url, workspace)
+        _run_sdk(
+            "POST agent API",
+            lambda: _json_from_response(client.close_session(workspace=workspace, name=name)),
+        )
         typer.echo(f"Session '{name}' closed.")
 
     @app.command(rich_help_panel="Agent Resources (requires running cluster)")
@@ -1142,7 +1176,13 @@ def _register_platform_commands(app: typer.Typer) -> None:
             "config": config_dict,
             "config_format": config_format,
         }
-        resp = _api_request("POST", base_url, f"/apis/agents/v2/workspaces/{workspace}/agents", json_body=payload)
+        client = _agents_client(base_url, workspace)
+        resp = _run_sdk(
+            "POST agent API",
+            lambda: _json_from_response(
+                client.create_agent(workspace=workspace, body=CreateAgentRequest.model_validate(payload))
+            ),
+        )
         if config_format == NEMO_AGENTS_SPEC_CONFIG_FORMAT:
             try:
                 _upload_ethos_fileset(
@@ -1162,8 +1202,8 @@ def _register_platform_commands(app: typer.Typer) -> None:
                         workspace=workspace,
                         base_url=base_url,
                     )
-                # ``typer.Exit`` subclasses ``Exception``, so this also covers the
-                # exit raised by ``_api_request`` on an HTTP error.
+                # ``typer.Exit`` subclasses ``Exception``, so this also covers
+                # the exit raised by ``_run_sdk`` on an HTTP error.
                 except Exception:
                     logger.exception(
                         "Failed to roll back agent %r after fileset upload failure",
@@ -1200,7 +1240,11 @@ def _register_platform_commands(app: typer.Typer) -> None:
     ) -> None:
         """List agents on the platform."""
         base_url = _resolve_base_url(base_url)
-        resp = _api_request("GET", base_url, f"/apis/agents/v2/workspaces/{workspace}/agents")
+        client = _agents_client(base_url, workspace)
+        resp = _run_sdk(
+            "GET agent API",
+            lambda: _json_from_page(client.list_agents(workspace=workspace)),
+        )
         _print_list_response(
             ctx,
             resp,
@@ -1217,7 +1261,11 @@ def _register_platform_commands(app: typer.Typer) -> None:
     ) -> None:
         """Get an agent by name."""
         base_url = _resolve_base_url(base_url)
-        resp = _api_request("GET", base_url, f"/apis/agents/v2/workspaces/{workspace}/agents/{name}")
+        client = _agents_client(base_url, workspace)
+        resp = _run_sdk(
+            "GET agent API",
+            lambda: _json_from_response(client.get_agent(workspace=workspace, name=name)),
+        )
         typer.echo(json.dumps(resp, indent=2))
 
     @app.command(rich_help_panel="Agent Resources (requires running cluster)")
@@ -1319,7 +1367,7 @@ def _register_platform_commands(app: typer.Typer) -> None:
         if environment is not None and not environment.strip():
             typer.echo("--environment must not be empty.", err=True)
             raise typer.Exit(code=2)
-        payload: dict = {"agent": agent, "deployment_mode": mode}
+        payload: dict[str, Any] = {"agent": agent, "deployment_mode": mode}
         if name:
             payload["name"] = name
         if image:
@@ -1328,7 +1376,13 @@ def _register_platform_commands(app: typer.Typer) -> None:
             payload["use_image_entrypoint"] = True
         if environment is not None:
             payload["environment"] = environment
-        resp = _api_request("POST", base_url, f"/apis/agents/v2/workspaces/{workspace}/deployments", json_body=payload)
+        client = _agents_client(base_url, workspace)
+        resp = _run_sdk(
+            "POST agent API",
+            lambda: _json_from_response(
+                client.create_deployment(workspace=workspace, body=CreateDeploymentRequest.model_validate(payload))
+            ),
+        )
         if not wait:
             typer.echo(json.dumps(resp, indent=2))
             return
@@ -1345,7 +1399,7 @@ def _register_platform_commands(app: typer.Typer) -> None:
             )
             return
 
-        success = _wait_for_deployment(base_url, workspace, deployment_name, timeout=timeout)
+        success = _wait_for_deployment(client, workspace, deployment_name, timeout=timeout)
         raise typer.Exit(code=0 if success else 1)
 
     @app.command(rich_help_panel="Agent Resources (requires running cluster)")
@@ -1407,10 +1461,12 @@ def _register_platform_commands(app: typer.Typer) -> None:
 
         if agent and not name:
             base_url = _resolve_base_url(base_url)
+            client = _agents_client(base_url, workspace)
             candidates = [
                 d
-                for d in _unwrap_list(
-                    _api_request("GET", base_url, f"/apis/agents/v2/workspaces/{workspace}/deployments")
+                for d in _run_sdk(
+                    "GET agent API",
+                    lambda: _list_deployment_maps(client, workspace),
                 )
                 if d.get("agent") == agent and d.get("status") not in ("deleting",)
             ]
@@ -1455,18 +1511,31 @@ def _register_platform_commands(app: typer.Typer) -> None:
     ) -> None:
         """Stop and remove a deployment (or all deployments for an agent)."""
         base_url = _resolve_base_url(base_url)
+        client = _agents_client(base_url, workspace)
         if name:
             if not yes:
                 typer.confirm(f"Undeploy '{name}'?", abort=True)
-            _api_request("DELETE", base_url, f"/apis/agents/v2/workspaces/{workspace}/deployments/{name}")
+            _run_sdk(
+                "DELETE agent API",
+                lambda: client.delete_deployment(workspace=workspace, name=name).data(),
+            )
             typer.echo(f"Deployment '{name}' marked for deletion.")
         elif agent:
-            deps = _unwrap_list(_api_request("GET", base_url, f"/apis/agents/v2/workspaces/{workspace}/deployments"))
-            removed = [d for d in deps if d.get("agent") == agent]
+            deps = _run_sdk(
+                "GET agent API",
+                lambda: list(client.list_deployments(workspace=workspace).items()),
+            )
+            removed = [deployment for deployment in deps if deployment.agent == agent]
             if not yes:
                 typer.confirm(f"Undeploy {len(removed)} deployment(s) for agent '{agent}'?", abort=True)
-            for d in removed:
-                _api_request("DELETE", base_url, f"/apis/agents/v2/workspaces/{workspace}/deployments/{d['name']}")
+            for deployment in removed:
+                _run_sdk(
+                    "DELETE agent API",
+                    lambda deployment_name=deployment.name: client.delete_deployment(
+                        workspace=workspace,
+                        name=deployment_name,
+                    ).data(),
+                )
             typer.echo(f"Marked {len(removed)} deployment(s) for agent '{agent}' for deletion.")
         else:
             typer.echo("Error: provide a deployment name or --agent.", err=True)
@@ -1499,7 +1568,11 @@ def _register_platform_commands(app: typer.Typer) -> None:
     ) -> None:
         """List deployments."""
         base_url = _resolve_base_url(base_url)
-        resp = _api_request("GET", base_url, f"/apis/agents/v2/workspaces/{workspace}/deployments")
+        client = _agents_client(base_url, workspace)
+        resp = _run_sdk(
+            "GET agent API",
+            lambda: _json_from_page(client.list_deployments(workspace=workspace)),
+        )
         _print_list_response(
             ctx,
             resp,
@@ -1516,7 +1589,11 @@ def _register_platform_commands(app: typer.Typer) -> None:
     ) -> None:
         """Get a deployment by name."""
         base_url = _resolve_base_url(base_url)
-        resp = _api_request("GET", base_url, f"/apis/agents/v2/workspaces/{workspace}/deployments/{name}")
+        client = _agents_client(base_url, workspace)
+        resp = _run_sdk(
+            "GET agent API",
+            lambda: _json_from_response(client.get_deployment(workspace=workspace, name=name)),
+        )
         typer.echo(json.dumps(resp, indent=2))
 
     @deps_app.command(name="delete")
@@ -1530,7 +1607,11 @@ def _register_platform_commands(app: typer.Typer) -> None:
         base_url = _resolve_base_url(base_url)
         if not yes:
             typer.confirm(f"Delete deployment '{name}'?", abort=True)
-        _api_request("DELETE", base_url, f"/apis/agents/v2/workspaces/{workspace}/deployments/{name}")
+        client = _agents_client(base_url, workspace)
+        _run_sdk(
+            "DELETE agent API",
+            lambda: client.delete_deployment(workspace=workspace, name=name).data(),
+        )
         typer.echo(f"Deployment '{name}' marked for deletion.")
 
     @deps_app.command(name="wait")
@@ -1561,20 +1642,24 @@ def _register_platform_commands(app: typer.Typer) -> None:
             raise typer.Exit(code=1)
 
         if agent and not name:
+            client = _agents_client(base_url, workspace)
             active = [
                 d
-                for d in _unwrap_list(
-                    _api_request("GET", base_url, f"/apis/agents/v2/workspaces/{workspace}/deployments")
+                for d in _run_sdk(
+                    "GET agent API",
+                    lambda: _list_deployment_maps(client, workspace),
                 )
                 if d.get("agent") == agent and d.get("status") not in ("failed", "deleting")
             ]
             if not active:
                 typer.echo(f"Error: no active deployment found for agent '{agent}'.", err=True)
                 raise typer.Exit(code=1)
+            active.sort(key=_deployment_created_at_key)
             name = active[-1]["name"]
 
         assert name  # guaranteed by the checks above
-        success = _wait_for_deployment(base_url, workspace, name, timeout=timeout, interval=interval)
+        client = _agents_client(base_url, workspace)
+        success = _wait_for_deployment(client, workspace, name, timeout=timeout, interval=interval)
         raise typer.Exit(code=0 if success else 1)
 
 
@@ -1653,10 +1738,15 @@ def _register_environment_commands(app: typer.Typer) -> None:
         """Create an environment spec from a file or inline JSON."""
         base_url = _resolve_base_url(base_url)
         body = _spec_body_from_inputs(name=name, spec_file=spec_file, spec_json=spec)
-        sdk = _agents_sdk(base_url, workspace)
+        client = _agents_client(base_url, workspace)
         resp = _run_sdk(
             "POST agent API",
-            lambda: sdk.environment_specs.create(name=body.pop("name"), workspace=workspace, spec=body),
+            lambda: _json_from_response(
+                client.create_environment_spec(
+                    workspace=workspace,
+                    body=CreateEnvironmentSpecRequest.model_validate(body),
+                )
+            ),
         )
         typer.echo(json.dumps(resp, indent=2))
 
@@ -1683,7 +1773,11 @@ def _register_environment_commands(app: typer.Typer) -> None:
     ) -> None:
         """List environment specs."""
         base_url = _resolve_base_url(base_url)
-        resp = _api_request("GET", base_url, f"/apis/agents/v2/workspaces/{workspace}/environment-specs")
+        client = _agents_client(base_url, workspace)
+        resp = _run_sdk(
+            "GET agent API",
+            lambda: _json_from_page(client.list_environment_specs(workspace=workspace)),
+        )
         _print_list_response(
             ctx,
             resp,
@@ -1700,7 +1794,11 @@ def _register_environment_commands(app: typer.Typer) -> None:
     ) -> None:
         """Get an environment spec by name."""
         base_url = _resolve_base_url(base_url)
-        resp = _api_request("GET", base_url, f"/apis/agents/v2/workspaces/{workspace}/environment-specs/{name}")
+        client = _agents_client(base_url, workspace)
+        resp = _run_sdk(
+            "GET agent API",
+            lambda: _json_from_response(client.get_environment_spec(workspace=workspace, name=name)),
+        )
         typer.echo(json.dumps(resp, indent=2))
 
     @espec_app.command(name="delete")
@@ -1714,7 +1812,11 @@ def _register_environment_commands(app: typer.Typer) -> None:
         base_url = _resolve_base_url(base_url)
         if not yes:
             typer.confirm(f"Delete environment-spec '{name}'?", abort=True)
-        _api_request("DELETE", base_url, f"/apis/agents/v2/workspaces/{workspace}/environment-specs/{name}")
+        client = _agents_client(base_url, workspace)
+        _run_sdk(
+            "DELETE agent API",
+            lambda: client.delete_environment_spec(workspace=workspace, name=name).data(),
+        )
         typer.echo(f"Environment-spec '{name}' deleted.")
 
     # -- environments --------------------------------------------------------
@@ -1751,10 +1853,15 @@ def _register_environment_commands(app: typer.Typer) -> None:
             body["environment_spec"] = environment_spec
         if compute_spec is not None:
             body["compute_spec"] = compute_spec
-        sdk = _agents_sdk(base_url, workspace)
+        client = _agents_client(base_url, workspace)
         resp = _run_sdk(
             "POST agent API",
-            lambda: sdk.environments.create(name=body.pop("name"), workspace=workspace, spec=body),
+            lambda: _json_from_response(
+                client.create_environment(
+                    workspace=workspace,
+                    body=CreateEnvironmentRequest.model_validate(body),
+                )
+            ),
         )
         typer.echo(json.dumps(resp, indent=2))
 
@@ -1781,7 +1888,11 @@ def _register_environment_commands(app: typer.Typer) -> None:
     ) -> None:
         """List environments."""
         base_url = _resolve_base_url(base_url)
-        resp = _api_request("GET", base_url, f"/apis/agents/v2/workspaces/{workspace}/environments")
+        client = _agents_client(base_url, workspace)
+        resp = _run_sdk(
+            "GET agent API",
+            lambda: _json_from_page(client.list_environments(workspace=workspace)),
+        )
         _print_list_response(
             ctx,
             resp,
@@ -1798,7 +1909,11 @@ def _register_environment_commands(app: typer.Typer) -> None:
     ) -> None:
         """Get an environment by name."""
         base_url = _resolve_base_url(base_url)
-        resp = _api_request("GET", base_url, f"/apis/agents/v2/workspaces/{workspace}/environments/{name}")
+        client = _agents_client(base_url, workspace)
+        resp = _run_sdk(
+            "GET agent API",
+            lambda: _json_from_response(client.get_environment(workspace=workspace, name=name)),
+        )
         typer.echo(json.dumps(resp, indent=2))
 
     @env_app.command(name="delete")
@@ -1812,7 +1927,11 @@ def _register_environment_commands(app: typer.Typer) -> None:
         base_url = _resolve_base_url(base_url)
         if not yes:
             typer.confirm(f"Delete environment '{name}'?", abort=True)
-        _api_request("DELETE", base_url, f"/apis/agents/v2/workspaces/{workspace}/environments/{name}")
+        client = _agents_client(base_url, workspace)
+        _run_sdk(
+            "DELETE agent API",
+            lambda: client.delete_environment(workspace=workspace, name=name).data(),
+        )
         typer.echo(f"Environment '{name}' deleted.")
 
     # -- compute-specs -------------------------------------------------------
@@ -1832,10 +1951,15 @@ def _register_environment_commands(app: typer.Typer) -> None:
         """Create a compute spec from a file or inline JSON."""
         base_url = _resolve_base_url(base_url)
         body = _spec_body_from_inputs(name=name, spec_file=spec_file, spec_json=spec)
-        sdk = _agents_sdk(base_url, workspace)
+        client = _agents_client(base_url, workspace)
         resp = _run_sdk(
             "POST agent API",
-            lambda: sdk.compute_specs.create(name=body.pop("name"), workspace=workspace, spec=body),
+            lambda: _json_from_response(
+                client.create_compute_spec(
+                    workspace=workspace,
+                    body=CreateComputeSpecRequest.model_validate(body),
+                )
+            ),
         )
         typer.echo(json.dumps(resp, indent=2))
 
@@ -1862,7 +1986,11 @@ def _register_environment_commands(app: typer.Typer) -> None:
     ) -> None:
         """List compute specs."""
         base_url = _resolve_base_url(base_url)
-        resp = _api_request("GET", base_url, f"/apis/agents/v2/workspaces/{workspace}/compute-specs")
+        client = _agents_client(base_url, workspace)
+        resp = _run_sdk(
+            "GET agent API",
+            lambda: _json_from_page(client.list_compute_specs(workspace=workspace)),
+        )
         _print_list_response(
             ctx,
             resp,
@@ -1879,7 +2007,11 @@ def _register_environment_commands(app: typer.Typer) -> None:
     ) -> None:
         """Get a compute spec by name."""
         base_url = _resolve_base_url(base_url)
-        resp = _api_request("GET", base_url, f"/apis/agents/v2/workspaces/{workspace}/compute-specs/{name}")
+        client = _agents_client(base_url, workspace)
+        resp = _run_sdk(
+            "GET agent API",
+            lambda: _json_from_response(client.get_compute_spec(workspace=workspace, name=name)),
+        )
         typer.echo(json.dumps(resp, indent=2))
 
     @cspec_app.command(name="delete")
@@ -1893,7 +2025,11 @@ def _register_environment_commands(app: typer.Typer) -> None:
         base_url = _resolve_base_url(base_url)
         if not yes:
             typer.confirm(f"Delete compute-spec '{name}'?", abort=True)
-        _api_request("DELETE", base_url, f"/apis/agents/v2/workspaces/{workspace}/compute-specs/{name}")
+        client = _agents_client(base_url, workspace)
+        _run_sdk(
+            "DELETE agent API",
+            lambda: client.delete_compute_spec(workspace=workspace, name=name).data(),
+        )
         typer.echo(f"Compute-spec '{name}' deleted.")
 
 
@@ -1916,7 +2052,7 @@ def _deployment_address(dep: dict[str, Any]) -> str:
 
 
 def _wait_for_deployment(
-    base_url: str,
+    client: AgentsClient,
     workspace: str,
     name: str,
     *,
@@ -1936,14 +2072,16 @@ def _wait_for_deployment(
         ``True`` if the deployment reached ``running``, ``False`` if it
         reached ``failed`` or the timeout expired.
     """
-    path = f"/apis/agents/v2/workspaces/{workspace}/deployments/{name}"
     start = time.monotonic()
     last_status = ""
 
     typer.echo(f"Waiting for deployment '{name}' (timeout={timeout}s)...")
 
     while time.monotonic() - start < timeout:
-        dep = _api_request("GET", base_url, path)
+        dep = _run_sdk(
+            "GET agent API",
+            lambda: _json_from_response(client.get_deployment(workspace=workspace, name=name)),
+        )
         status = dep.get("status", "")
         elapsed = int(time.monotonic() - start)
 
@@ -2354,10 +2492,10 @@ def _create_session_for_deployment(
     session_name: str | None,
 ) -> tuple[AgentDeployment, AgentSession, str]:
     """Validate a Fabric deployment and create its persisted Platform session."""
-    deployment_response = _api_request(
-        "GET",
-        base_url,
-        f"/apis/agents/v2/workspaces/{workspace}/deployments/{deployment_name}",
+    client = _agents_client(base_url, workspace)
+    deployment_response = _run_sdk(
+        "GET agent API",
+        lambda: _json_from_response(client.get_deployment(workspace=workspace, name=deployment_name)),
     )
     deployment_id = _require_deployment_id(deployment_response, deployment_name)
     try:
@@ -2384,11 +2522,11 @@ def _create_session_for_deployment(
     payload = {"deployment_id": deployment_id}
     if session_name is not None:
         payload["name"] = session_name
-    response = _api_request(
-        "POST",
-        base_url,
-        f"/apis/agents/v2/workspaces/{workspace}/sessions",
-        json_body=payload,
+    response = _run_sdk(
+        "POST agent API",
+        lambda: _json_from_response(
+            client.create_session(workspace=workspace, body=CreateSessionRequest.model_validate(payload))
+        ),
     )
     try:
         session_id = response["id"]
@@ -2409,10 +2547,10 @@ def _resolve_existing_session(
     session_name: str,
 ) -> tuple[AgentDeployment, AgentSession, str]:
     """Resolve a resumable persisted session and its bound deployment."""
-    response = _api_request(
-        "GET",
-        base_url,
-        f"/apis/agents/v2/workspaces/{workspace}/sessions/{session_name}",
+    client = _agents_client(base_url, workspace)
+    response = _run_sdk(
+        "GET agent API",
+        lambda: _json_from_response(client.get_session(workspace=workspace, name=session_name)),
     )
     try:
         session_id = response["id"]
@@ -2433,7 +2571,7 @@ def _resolve_existing_session(
         raise typer.Exit(code=1)
 
     deployment = _resolve_deployment_by_id(
-        base_url=base_url,
+        client=client,
         workspace=workspace,
         deployment_id=resolved_session.deployment_id,
         session_name=session_name,
@@ -2443,7 +2581,7 @@ def _resolve_existing_session(
 
 def _resolve_deployment_by_id(
     *,
-    base_url: str,
+    client: AgentsClient,
     workspace: str,
     deployment_id: str,
     session_name: str,
@@ -2451,11 +2589,14 @@ def _resolve_deployment_by_id(
     """Find a session's bound deployment through the paginated list API."""
     page = 1
     while True:
-        query = urlencode({"page": page, "page_size": _DEPLOYMENT_RESOLUTION_PAGE_SIZE})
-        response = _api_request(
-            "GET",
-            base_url,
-            f"/apis/agents/v2/workspaces/{workspace}/deployments?{query}",
+        response = _run_sdk(
+            "GET agent API",
+            lambda: _json_from_page(
+                client.list_deployments(
+                    workspace=workspace,
+                    query_params={"page": page, "page_size": _DEPLOYMENT_RESOLUTION_PAGE_SIZE},
+                )
+            ),
         )
         for candidate in _unwrap_list(response):
             if candidate.get("id") != deployment_id:
@@ -2491,6 +2632,15 @@ def _unwrap_list(resp: Any) -> list[dict[str, Any]]:
     return [d for d in items if isinstance(d, dict)]
 
 
+def _list_deployment_maps(client: AgentsClient, workspace: str) -> list[dict[str, Any]]:
+    """Return every deployment page in the serialized mapping shape used by CLI filters."""
+    return [_deployment_map(deployment) for deployment in client.list_deployments(workspace=workspace).items()]
+
+
+def _deployment_map(deployment: ClientAgentDeployment) -> dict[str, Any]:
+    return deployment.model_dump(mode="json")
+
+
 def _print_list_response(
     ctx: typer.Context,
     response: Any,
@@ -2508,6 +2658,32 @@ def _print_list_response(
         no_truncate=_resolve_no_truncate(ctx, no_truncate),
         timestamp_format=_resolve_timestamp_format(ctx),
     )
+
+
+def _agents_client(base_url: str, workspace: str) -> AgentsClient:
+    return AgentsClient(
+        base_url=base_url,
+        workspace=workspace,
+        default_headers=_resolve_context_headers() or None,
+        timeout=30,
+        http_client=httpx.Client(timeout=30),
+    )
+
+
+def _json_from_response(response: NemoResponse[Any]) -> Any:
+    response.data()
+    return _json_from_http_response(response.http_response)
+
+
+def _json_from_page(response: NemoPaginatedResponse[Any, Any]) -> Any:
+    response.page()
+    return _json_from_http_response(response.http_response)
+
+
+def _json_from_http_response(response: httpx.Response) -> Any:
+    if response.status_code == 204 or not response.content:
+        return None
+    return response.json()
 
 
 def _resolve_list_output_format(ctx: typer.Context, output_format: _LIST_OUTPUT_FORMAT | None) -> str:
@@ -2549,29 +2725,6 @@ def _resolve_timestamp_format(ctx: typer.Context) -> str | None:
     return None
 
 
-def _api_request(method: str, base_url: str, path: str, *, json_body: dict[str, Any] | None = None) -> Any:
-    url = base_url.rstrip("/") + path
-    request_kwargs: dict[str, Any] = {}
-    if json_body is not None:
-        request_kwargs["json"] = json_body
-    headers = _resolve_context_headers()
-    if headers:
-        request_kwargs["headers"] = headers
-    try:
-        with httpx.Client(timeout=30) as client:
-            resp = client.request(method, url, **request_kwargs)
-            resp.raise_for_status()
-            if resp.status_code == 204 or not resp.content:
-                return None
-            return resp.json()
-    except httpx.HTTPStatusError as exc:
-        print_http_status_error(exc, action=f"{method} agent API")
-        raise typer.Exit(code=1)
-    except httpx.RequestError as exc:
-        print_http_request_error(exc, action=f"{method} agent API")
-        raise typer.Exit(code=1)
-
-
 def _platform_sdk(base_url: str) -> Any:
     """Return an auth-aware platform SDK client for fileset upload/delete."""
     headers = _resolve_context_headers()
@@ -2580,39 +2733,43 @@ def _platform_sdk(base_url: str) -> Any:
     return NeMoPlatform(base_url=base_url)
 
 
-def _agents_sdk(base_url: str, workspace: str) -> Any:
-    """Return the agents-plugin SDK resource bound to *base_url* / *workspace*.
-
-    The CLI reuses the plugin SDK (:class:`~nemo_agents_plugin.sdk.AgentsResource`)
-    so request paths and payload shapes are defined once. The SDK reads
-    ``base_url``, ``workspace``, and ``default_headers`` off the object it is
-    handed — mirroring the auth-header threading ``_api_request`` does.
-    """
-    from nemo_agents_plugin.sdk import AgentsResource
-
-    platform = SimpleNamespace(
-        base_url=base_url,
-        workspace=workspace,
-        default_headers=_resolve_context_headers() or None,
-    )
-    return AgentsResource(platform)
-
-
-def _run_sdk(action: str, call: Callable[[], Any]) -> Any:
+def _run_sdk(action: str, call: Callable[[], _T]) -> _T:
     """Invoke an SDK *call*, translating HTTP errors to CLI-friendly output.
 
-    The plugin SDK raises raw ``httpx`` errors; the CLI wants the same rich
-    messages ``_api_request`` prints. This keeps error UX identical whether a
-    command talks to the API directly or through the SDK.
+    Typed client errors and the gateway helpers' raw ``httpx`` errors are
+    translated to the same Rich messages.
     """
     try:
         return call()
+    except NemoHTTPError as exc:
+        print_http_status_error(
+            httpx.HTTPStatusError(str(exc), request=_client_error_request(exc), response=exc.http_response),
+            action=action,
+        )
+        raise typer.Exit(code=1)
+    except NemoTransportError as exc:
+        print_http_request_error(exc.error, action=action)
+        raise typer.Exit(code=1)
+    except ValidationError as exc:
+        typer.echo(f"Error: {action} validation failed: {exc}", err=True)
+        raise typer.Exit(code=2) from exc
+    except NemoClientError as exc:
+        typer.echo(f"Error: {action} failed: {exc}", err=True)
+        raise typer.Exit(code=1)
     except httpx.HTTPStatusError as exc:
         print_http_status_error(exc, action=action)
         raise typer.Exit(code=1)
     except httpx.RequestError as exc:
         print_http_request_error(exc, action=action)
         raise typer.Exit(code=1)
+
+
+def _client_error_request(exc: NemoHTTPError) -> httpx.Request:
+    try:
+        return exc.http_response.request
+    except RuntimeError:
+        url = str(exc.http_response.url) if exc.http_response.url else "http://nemo-platform"
+        return httpx.Request("GET", url)
 
 
 def _collect_text_agent_artifacts(
@@ -2682,14 +2839,13 @@ def _clear_existing_ethos_artifacts(
     workspace: str,
 ) -> None:
     """Remove the previous executable snapshot while preserving durable Ethos."""
-    from nemo_platform import NotFoundError as PlatformNotFoundError
-    from nemo_platform_plugin.client.errors import NotFoundError as PluginNotFoundError
 
     preserved = {ETHOS_FILENAME}
+    files_client = client_from_platform(sdk, FilesClient)
 
     try:
-        existing = sdk.files.list(fileset=fileset, workspace=workspace).data
-    except (FileNotFoundError, PlatformNotFoundError, PluginNotFoundError):
+        existing = files_client.list_files(name=fileset, workspace=workspace).data().data
+    except (FileNotFoundError, PluginNotFoundError):
         return
 
     for artifact in existing:
@@ -2697,8 +2853,8 @@ def _clear_existing_ethos_artifacts(
         if remote_path in preserved:
             continue
         try:
-            sdk.files.delete(remote_path=remote_path, fileset=fileset, workspace=workspace)
-        except (FileNotFoundError, PlatformNotFoundError, PluginNotFoundError):
+            files_client.delete_file(name=fileset, path=remote_path, workspace=workspace)
+        except (FileNotFoundError, PluginNotFoundError):
             # Another client may have removed the same stale file after the list.
             continue
 
@@ -2780,7 +2936,11 @@ def _delete_agent_entity(*, agent_name: str, workspace: str, base_url: str) -> N
     Deleting the fileset here would destroy that durable contract, so the
     executable artifacts it also carries are left behind instead.
     """
-    _api_request("DELETE", base_url, f"/apis/agents/v2/workspaces/{workspace}/agents/{agent_name}")
+    client = _agents_client(base_url, workspace)
+    _run_sdk(
+        "DELETE agent API",
+        lambda: client.delete_agent(workspace=workspace, name=agent_name).data(),
+    )
 
 
 def _load_yaml(path: Path) -> dict:

--- a/plugins/nemo-agents/src/nemo_agents_plugin/entities.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/entities.py
@@ -13,14 +13,45 @@ from __future__ import annotations
 from datetime import datetime
 from enum import StrEnum
 from pathlib import Path
-from typing import Any, Literal, Self
+from typing import Any, Self
 
+from nemo_platform_plugin.agents.types import (
+    NAT_WORKFLOW_CONFIG_FORMAT as NAT_WORKFLOW_CONFIG_FORMAT,
+)
+from nemo_platform_plugin.agents.types import (
+    NEMO_AGENTS_SPEC_CONFIG_FORMAT as NEMO_AGENTS_SPEC_CONFIG_FORMAT,
+)
+from nemo_platform_plugin.agents.types import (
+    AgentEnvironmentInline as AgentEnvironmentInline,
+)
+from nemo_platform_plugin.agents.types import (
+    ComputeResources as ComputeResources,
+)
+from nemo_platform_plugin.agents.types import (
+    ComputeSpecInline as ComputeSpecInline,
+)
+from nemo_platform_plugin.agents.types import (
+    DeploymentMode as DeploymentMode,
+)
+from nemo_platform_plugin.agents.types import (
+    DeploymentStatus as DeploymentStatus,
+)
+from nemo_platform_plugin.agents.types import (
+    Endpoint as Endpoint,
+)
+from nemo_platform_plugin.agents.types import (
+    EnvironmentSpecInline as EnvironmentSpecInline,
+)
+from nemo_platform_plugin.agents.types import (
+    McpFulfillment as McpFulfillment,
+)
+from nemo_platform_plugin.agents.types import (
+    ModelProviderOverride as ModelProviderOverride,
+)
 from nemo_platform_plugin.auth import AuthContext
 from nemo_platform_plugin.entity import NemoEntity
 from nemo_platform_plugin.refs import FilesetRef
 from pydantic import BaseModel, Field, PrivateAttr, computed_field
-
-DeploymentStatus = Literal["pending", "starting", "running", "failed", "deleting"]
 
 
 class SessionStatus(StrEnum):
@@ -53,8 +84,6 @@ class SessionStatus(StrEnum):
 # agent as a local ``nat serve`` process reachable on a loopback ``endpoint``.
 # ``docker``/``k8s`` run the agent as a durable container deployment via the
 # deployments plugin; their routable address is projected onto ``endpoints``.
-DeploymentMode = Literal["subprocess", "docker", "k8s"]
-
 # Modes that compile to the nemo-deployments plugin (not local subprocess).
 CONTAINER_DEPLOYMENT_MODES: frozenset[str] = frozenset({"docker", "k8s"})
 
@@ -62,20 +91,6 @@ CONTAINER_DEPLOYMENT_MODES: frozenset[str] = frozenset({"docker", "k8s"})
 def is_container_deployment_mode(mode: str) -> bool:
     """Return True when *mode* uses the deployments-plugin runner backend."""
     return mode in CONTAINER_DEPLOYMENT_MODES
-
-
-class Endpoint(BaseModel):
-    """A routable network endpoint for a deployment.
-
-    Mirrors ``nemo_deployments_plugin.types.Endpoint`` so container-mode
-    deployments can carry the address the deployments-plugin ``Deployment``
-    projected without the agents plugin depending on that plugin at the
-    entity-schema layer.
-    """
-
-    name: str
-    url: str
-    protocol: Literal["http", "https", "grpc", "tcp"] = "http"
 
 
 # ---------------------------------------------------------------------------
@@ -90,150 +105,16 @@ class Endpoint(BaseModel):
 # authored once and reused across many Environments.
 #
 # The specs are also first-class entities (``agent_environment_spec``,
-# ``agent_compute_spec``, ``agent_environment``) with their own CRUD APIs. The
-# inline BaseModels below are the shared shape: an entity embeds the inline
-# fields, and an AgentEnvironment field accepts either a ``"workspace/name"``
-# ref string or the inline model.
+# ``agent_compute_spec``, ``agent_environment``) with their own CRUD APIs. Most
+# inline BaseModels come from ``nemo_platform_plugin.agents.types`` so the
+# entity and typed-client contracts share one shape. ``AgentInline`` stays local
+# because persisted agent configs are mutable framework payloads where
+# ``dict[str, Any]`` preserves useful static ergonomics for nested config access.
 #
 # Environment values compile into two targets at deploy time: the on-disk
 # agent.yaml / FabricConfig (env vars, MCP, model provider) and, for container
 # modes, the deployments-plugin Container.resources (compute). See
 # :mod:`nemo_agents_plugin.environment_resolution` for the merge + snapshot.
-
-
-class ComputeResources(BaseModel):
-    """Kubernetes-style resource requests/limits.
-
-    Mirrors ``nemo_deployments_plugin.entities.ResourceRequirements`` so the
-    agents entity schema does not depend on the deployments plugin. Compiled
-    into the execute container's resources for container deployment modes.
-    """
-
-    limits: dict[str, str] = Field(
-        default_factory=dict,
-        description="k8s resource limits (e.g. cpu, memory, nvidia.com/gpu).",
-    )
-    requests: dict[str, str] = Field(
-        default_factory=dict,
-        description="k8s resource requests.",
-    )
-
-
-class ComputeSpecInline(BaseModel):
-    """Inline compute spec - the resources an invocation runs with."""
-
-    description: str = Field(default="", description="Human-readable description.")
-    resources: ComputeResources = Field(
-        default_factory=ComputeResources,
-        description="k8s-style resource requests/limits for the execute container.",
-    )
-
-
-class ModelProviderOverride(BaseModel):
-    """Exceptional external model-provider override.
-
-    Null in the normal case: model selection is on the Agent and the provider
-    URL is the Inference Gateway (auto-injected). Set ONLY to point the agent at
-    a non-IGW external provider endpoint.
-    """
-
-    base_url: str = Field(description="External model-provider endpoint.")
-    api_key: str | None = Field(
-        default=None,
-        description="Secrets-service ref for the provider API key (only needed for external providers).",
-    )
-    provider: str | None = Field(
-        default=None,
-        description='Provider selector (e.g. "openai", "anthropic").',
-    )
-
-
-class McpFulfillment(BaseModel):
-    """EnvironmentSpec-side fulfillment for one MCP server the Agent declares.
-
-    The Agent DECLARES an MCP dependency by name; the EnvironmentSpec PROVIDES
-    the url + env + secrets for that same name. Matched by server-name key at
-    compile time; ``secrets`` are merged into the server's ``env``.
-    """
-
-    url: str = Field(description="Endpoint the environment provides for this MCP server.")
-    env: dict[str, str] = Field(default_factory=dict, description="Non-secret env for the MCP server.")
-    secrets: dict[str, str] = Field(
-        default_factory=dict,
-        description="ENV_NAME -> Secrets-service ref, merged into the MCP server env at compile.",
-    )
-
-
-class EnvironmentSpecInline(BaseModel):
-    """Inline environment spec - the dependencies and configuration an agent reaches.
-
-    This is the fulfillment half of a request/fulfill split: the Agent declares
-    the dependencies it needs; the EnvironmentSpec provides concrete endpoints
-    and secret references. It compiles into the agent.yaml / FabricConfig and
-    the injected process environment.
-    """
-
-    description: str = Field(default="", description="Human-readable description.")
-
-    # Env vars -> injected into the runtime process env (not authored on disk).
-    env: dict[str, str] = Field(default_factory=dict, description="Plaintext, non-secret env vars.")
-
-    # Secrets -> Secrets-service refs, injected as secret-backed env vars.
-    secrets: dict[str, str] = Field(
-        default_factory=dict,
-        description="ENV_VAR_NAME -> Secrets-service/plugin ref.",
-    )
-
-    # External model-provider override (exceptional; null in the normal IGW case).
-    model_provider_override: ModelProviderOverride | None = Field(
-        default=None,
-        description="Set only to point at a non-IGW external model provider.",
-    )
-
-    # Fabric environment mirror -> compiles into FabricConfig.environment.
-    # NOTE: ``workspace_path`` (the harness workspace path) is deliberately named
-    # to avoid colliding with the NeMo entity ``workspace`` (tenant) field that
-    # AgentEnvironmentSpec inherits from EntityBase. ``artifacts_path`` carries a
-    # matching ``_path`` suffix for symmetry.
-    provider: str = Field(default="local", description="local | docker | opensandbox | k8s.")
-    workspace_path: str | None = Field(default=None, description="Workspace path visible to the harness.")
-    artifacts_path: str | None = Field(default=None, description="Provider-specific artifact output location.")
-    control_location: str | None = Field(
-        default=None,
-        description="external_control | in_env_control.",
-    )
-    ownership: str | None = Field(default=None, description="caller_owned | fabric_owned.")
-    connection: dict[str, Any] = Field(
-        default_factory=dict,
-        description="Provider connection metadata (server url, cred ref, namespace).",
-    )
-    metadata: dict[str, Any] = Field(default_factory=dict, description="Consumer-provided passthrough metadata.")
-    settings: dict[str, Any] = Field(default_factory=dict, description="Provider-specific settings.")
-
-    # MCP fulfillment -> merged into FabricConfig.mcp.servers.<name> by server-name key.
-    mcp: dict[str, McpFulfillment] = Field(
-        default_factory=dict,
-        description="server-name -> fulfillment (url/env/secrets) for an Agent-declared MCP dependency.",
-    )
-
-
-class AgentEnvironmentInline(BaseModel):
-    """Inline AgentEnvironment - a composition of environment + compute specs.
-
-    Each part is a ``ref | inline | None`` union: a ``"workspace/name"`` string
-    references a stored spec entity, an object provides the spec inline, and
-    ``None`` omits it. (A ``sandbox_spec`` is out of scope for now and omitted.)
-    """
-
-    description: str = Field(default="", description="Human-readable description.")
-    environment_spec: str | EnvironmentSpecInline | None = Field(
-        default=None,
-        description='"workspace/name" ref to an AgentEnvironmentSpec, an inline spec, or None.',
-    )
-    compute_spec: str | ComputeSpecInline | None = Field(
-        default=None,
-        description='"workspace/name" ref to an AgentComputeSpec, an inline spec, or None.',
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -273,43 +154,6 @@ This file is parsed into Agent.config when using the nemo-agents-spec-v1 format.
 
 ETHOS_LOCAL_ROOT = "agents"
 """Local directory holding agent build artifacts."""
-
-NAT_WORKFLOW_CONFIG_FORMAT = "nat-workflow-v1"
-"""Canonical format tag for the legacy NAT workflow config format."""
-
-NEMO_AGENTS_SPEC_CONFIG_FORMAT = "nemo-agents-spec-v1"
-"""Canonical format tag for the Platform-owned agent.yaml spec format."""
-
-
-class AgentInline(BaseModel):
-    """Inline Agent - an agent definition without entity identity.
-
-    The shared shape behind the :class:`Agent` entity: the entity embeds these
-    fields and adds name/workspace, and a field that accepts an agent can take
-    either a ``"workspace/name"`` ref string or this model. Lets a caller
-    execute an agent it composes at request time — models chosen per request,
-    settings scoped to one run — without first persisting an Agent.
-
-    Deliberately as permissive as the entity: consumers impose their own
-    requirements rather than this model narrowing them for everyone. The
-    ``agents.execute`` job, for example, accepts only ``nemo-agents-spec-v1``
-    and rejects a config that is not a valid agent spec.
-    """
-
-    description: str = Field(default="", description="Human-readable description of the agent.")
-    config: dict[str, Any] = Field(
-        default_factory=dict,
-        description="Agent config dict interpreted according to config_format.",
-    )
-    config_format: str = Field(
-        default=NAT_WORKFLOW_CONFIG_FORMAT,
-        description=(
-            "platform-internal schema version tag for the agent config dict. "
-            "`nat-workflow-v1` is the default legacy NAT workflow format; "
-            "`nemo-agents-spec-v1` identifies the Platform-owned agent.yaml spec format."
-        ),
-    )
-
 
 # Container deployments deliver the Ethos fileset through a ConfigMap (k8s) or a
 # single env var (docker), both of which cap out around 1MiB. Bound the tree at
@@ -377,6 +221,36 @@ class AgentEnvironment(NemoEntity, AgentEnvironmentInline, entity_type="agent_en
     The single thing an AgentDeployment references. Each part is a
     ``ref | inline | None`` union so specs can be authored once and reused.
     """
+
+
+class AgentInline(BaseModel):
+    """Inline Agent - an agent definition without entity identity.
+
+    The shared shape behind the :class:`Agent` entity: the entity embeds these
+    fields and adds name/workspace, and a field that accepts an agent can take
+    either a ``"workspace/name"`` ref string or this model. Lets a caller
+    execute an agent it composes at request time — models chosen per request,
+    settings scoped to one run — without first persisting an Agent.
+
+    Deliberately as permissive as the entity: consumers impose their own
+    requirements rather than this model narrowing them for everyone. The
+    ``agents.execute`` job, for example, accepts only ``nemo-agents-spec-v1``
+    and rejects a config that is not a valid agent spec.
+    """
+
+    description: str = Field(default="", description="Human-readable description of the agent.")
+    config: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Agent config dict interpreted according to config_format.",
+    )
+    config_format: str = Field(
+        default=NAT_WORKFLOW_CONFIG_FORMAT,
+        description=(
+            "platform-internal schema version tag for the agent config dict. "
+            "`nat-workflow-v1` is the default legacy NAT workflow format; "
+            "`nemo-agents-spec-v1` identifies the Platform-owned agent.yaml spec format."
+        ),
+    )
 
 
 # TODO: first-class environment, sandbox, and harness specs are planned for the

--- a/plugins/nemo-agents/src/nemo_agents_plugin/jobs/evaluate_agent.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/jobs/evaluate_agent.py
@@ -29,6 +29,7 @@ import tempfile
 from pathlib import Path
 from typing import ClassVar, Iterator
 
+from filesets import FilesetFileSystem
 from nemo_agents_plugin.refs import AgentRef, AgentTarget, classify_agent_target
 from nemo_agents_plugin.utils import (
     get_base_url,
@@ -37,9 +38,12 @@ from nemo_agents_plugin.utils import (
     temp_injected_config,
 )
 from nemo_platform import NeMoPlatform
+from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.files.client import FilesClient
 from nemo_platform_plugin.job import NemoJob
 from nemo_platform_plugin.job_context import JobContext
 from nemo_platform_plugin.jobs.api_factory import PlatformJobSpec
+from nemo_platform_plugin.jobs.file_manager import FilesetFileManager
 from nemo_platform_plugin.refs import (
     EndpointURL,
     FilesetRef,
@@ -367,7 +371,14 @@ class EvaluateAgentJob(NemoJob):
         ) as tmp:
             tmp_path = Path(tmp)
             logger.info("Downloading fileset %s/%s into %s for eval config.", ws, name, tmp_path)
-            sdk.files.download(local_path=str(tmp_path), fileset=name, workspace=ws)
+            files_client = client_from_platform(sdk, FilesClient)
+            manager = FilesetFileManager(
+                workspace=ws,
+                fileset_name=name,
+                filesystem=FilesetFileSystem(client=files_client),
+                ensure_fileset_exists=False,
+            )
+            manager.download_from_url(f"{ws}/{name}", local_dir=tmp_path)
             # ``cfg.eval_config`` is caller-controlled — resolve and confirm
             # it stays inside the downloaded fileset before yielding it, so
             # an absolute path or ``..`` segment can't make ``nat eval`` read
@@ -401,7 +412,7 @@ class EvaluateAgentJob(NemoJob):
         - :class:`FilesetRef` → a fresh tempdir under
           ``ctx.storage.ephemeral``; on successful exit the tempdir is
           uploaded to the named fileset (auto-created if missing) via
-          ``sdk.files.upload`` before being cleaned up.
+          the typed Files client before being cleaned up.
 
         The tempdir is removed regardless of whether the upload
         succeeds; failures during upload propagate so the caller sees
@@ -486,18 +497,21 @@ class EvaluateAgentJob(NemoJob):
 
         *sdk* is the platform SDK handle injected into :meth:`run` by
         the :class:`~nemo_platform_plugin.scheduler.NemoJobScheduler` (signature-based
-        DI). The upload goes through :meth:`sdk.files.upload`.
+        DI). The upload goes through the typed Files client that shares the
+        SDK's transport.
         """
-        # Trailing slash uploads contents, not the dir itself.
-        result = sdk.files.upload(
-            local_path=str(local_dir) + "/",
-            fileset=fileset,
+        files_client = client_from_platform(sdk, FilesClient)
+        manager = FilesetFileManager(
             workspace=workspace,
-            fileset_auto_create=True,
+            fileset_name=fileset,
+            filesystem=FilesetFileSystem(client=files_client),
+            ensure_fileset_exists=True,
         )
+        manager.validate_storage()
+        manager.upload(local_path=local_dir, remote_path="")
         logger.info(
             "Uploaded eval outputs from %s to fileset %s/%s.",
             local_dir,
             workspace,
-            result.name,
+            fileset,
         )

--- a/plugins/nemo-agents/src/nemo_agents_plugin/jobs/execute.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/jobs/execute.py
@@ -53,12 +53,14 @@ from nemo_agents_plugin.telemetry.intake_export import (
     supports_intake_atif_export,
 )
 from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
+from nemo_platform_plugin.client.adapter import client_from_platform
 from nemo_platform_plugin.client.constants import (
     WORKLOAD_IDENTITY_TOKEN_FILE_ENVVAR,
     is_workload_identity_token_file_set,
 )
 from nemo_platform_plugin.client.oidc_factory import resolve_workload_exchange_provider
 from nemo_platform_plugin.entity_client import NemoEntityNotFoundError
+from nemo_platform_plugin.files.client import AsyncFilesClient, FilesClient
 from nemo_platform_plugin.job import NemoJob
 from nemo_platform_plugin.job_context import JobContext
 from nemo_platform_plugin.job_results import ResultRef
@@ -328,8 +330,9 @@ class ExecuteAgentJob(NemoJob):
 
         workdir = None
         if request.workdir is not None:
-            sdk = cast(AsyncNeMoPlatform, async_sdk)
-            workdir = await validate_agent_workdir(request.workdir, sdk.files, default_workspace=workspace)
+            async_sdk_handle = cast(AsyncNeMoPlatform, async_sdk)
+            files_client = client_from_platform(async_sdk_handle, AsyncFilesClient)
+            workdir = await validate_agent_workdir(request.workdir, files_client, default_workspace=workspace)
 
         extension = request.extension or _make_noop_extension_config()
         validate_execute_agent_extension_config(extension.kind, extension.config)
@@ -429,7 +432,8 @@ class ExecuteAgentJob(NemoJob):
             if sdk is None:
                 raise RuntimeError("sdk is required to stage workdir inputs.")
             logger.info("Staging workdir inputs for agent %s.", agent_ref)
-            materialize_agent_workdir(step_config.workdir, sdk.files, fabric_dirs.workspace)
+            files_client = client_from_platform(sdk, FilesClient)
+            materialize_agent_workdir(step_config.workdir, files_client, fabric_dirs.workspace)
 
         input_workdir_ref = ctx.results.save(INPUT_WORKDIR_RESULT_NAME, fabric_dirs.workspace)
 

--- a/plugins/nemo-agents/src/nemo_agents_plugin/jobs/fileset_io.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/jobs/fileset_io.py
@@ -23,8 +23,12 @@ import tempfile
 from pathlib import Path
 from typing import Iterator
 
+from filesets import FilesetFileSystem
 from nemo_platform import NeMoPlatform
+from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.files.client import FilesClient
 from nemo_platform_plugin.job_context import JobContext
+from nemo_platform_plugin.jobs.file_manager import FilesetFileManager
 from nemo_platform_plugin.refs import (
     FilesetRef,
     LocalDir,
@@ -41,6 +45,21 @@ def split_fileset_ref(ref: str, default_workspace: str) -> tuple[str, str]:
     """Split a ``workspace/name`` (or bare ``name``) fileset ref into ``(ws, name)``."""
     parsed = parse_entity_ref(ref, default_workspace=default_workspace)
     return parsed.workspace, parsed.name
+
+
+def _fileset_manager(
+    files_client: FilesClient,
+    *,
+    workspace: str,
+    fileset: str,
+    ensure_fileset_exists: bool,
+) -> FilesetFileManager:
+    return FilesetFileManager(
+        workspace=workspace,
+        fileset_name=fileset,
+        filesystem=FilesetFileSystem(client=files_client),
+        ensure_fileset_exists=ensure_fileset_exists,
+    )
 
 
 @contextlib.contextmanager
@@ -78,7 +97,9 @@ def resolve_staged_config(
     with tempfile.TemporaryDirectory(prefix=f".{kind}-{name}-", dir=str(ctx.storage.ephemeral)) as tmp:
         tmp_path = Path(tmp)
         logger.info("Downloading fileset %s/%s into %s for %s.", ws, name, tmp_path, kind)
-        sdk.files.download(local_path=str(tmp_path), fileset=name, workspace=ws)
+        files_client = client_from_platform(sdk, FilesClient)
+        manager = _fileset_manager(files_client, workspace=ws, fileset=name, ensure_fileset_exists=False)
+        manager.download_from_url(f"{ws}/{name}", local_dir=tmp_path)
         # ``config_rel_path`` is caller-controlled — confirm it stays inside the
         # downloaded fileset so an absolute path or ``..`` segment can't make the
         # subprocess read arbitrary files from the task host.
@@ -154,11 +175,8 @@ def resolve_output(
 
 def upload_to_fileset(local_dir: Path, *, fileset: str, workspace: str, sdk: NeMoPlatform) -> None:
     """Upload *local_dir*'s contents recursively to the named fileset (auto-created)."""
-    # Trailing slash uploads contents, not the dir itself.
-    result = sdk.files.upload(
-        local_path=str(local_dir) + "/",
-        fileset=fileset,
-        workspace=workspace,
-        fileset_auto_create=True,
-    )
-    logger.info("Uploaded outputs from %s to fileset %s/%s.", local_dir, workspace, result.name)
+    files_client = client_from_platform(sdk, FilesClient)
+    manager = _fileset_manager(files_client, workspace=workspace, fileset=fileset, ensure_fileset_exists=True)
+    manager.validate_storage()
+    manager.upload(local_path=local_dir, remote_path="")
+    logger.info("Uploaded outputs from %s to fileset %s/%s.", local_dir, workspace, fileset)

--- a/plugins/nemo-agents/src/nemo_agents_plugin/jobs/package_agent.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/jobs/package_agent.py
@@ -38,6 +38,7 @@ from nemo_platform import AsyncNeMoPlatform
 from nemo_platform_plugin.client.adapter import client_from_platform
 from nemo_platform_plugin.entities.client import AsyncEntitiesClient
 from nemo_platform_plugin.entity_client import NemoEntitiesClient, NemoEntityNotFoundError
+from nemo_platform_plugin.files.client import AsyncFilesClient
 from nemo_platform_plugin.job import NemoJob
 from nemo_platform_plugin.job_context import JobContext
 from nemo_platform_plugin.job_results import ResultRef
@@ -440,5 +441,5 @@ class PackageAgentJob(NemoJob):
             agent_name=cfg.agent,
             agent_config=cfg.agent_config,
             base_dir=build_dir,
-            sdk=async_sdk.files if async_sdk is not None else None,
+            files_client=client_from_platform(async_sdk, AsyncFilesClient) if async_sdk is not None else None,
         )

--- a/plugins/nemo-agents/src/nemo_agents_plugin/runner/deployments_backend.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/runner/deployments_backend.py
@@ -68,6 +68,7 @@ from nemo_platform_plugin.config import LOOPBACK_ADDRESSES
 from nemo_platform_plugin.entities.base import parse_qualified_name
 from nemo_platform_plugin.entities.client import AsyncEntitiesClient
 from nemo_platform_plugin.entity_client import NemoEntitiesClient, NemoEntityNotFoundError
+from nemo_platform_plugin.files.client import AsyncFilesClient
 from nemo_platform_plugin.sdk_provider import get_async_platform_sdk
 
 logger = logging.getLogger(__name__)
@@ -702,7 +703,7 @@ class DeploymentsRunnerBackend(RunnerBackend):
                     agent_name=agent,
                     rewritten_agent_config=config,
                     agent_yaml_path=agent_yaml_path,
-                    sdk=sdk.files,
+                    files_client=client_from_platform(sdk, AsyncFilesClient),
                 )
             except FabricArtifactStagingError as exc:
                 logger.error("Refusing to deploy Fabric agent %r: %s", name, exc)

--- a/plugins/nemo-agents/src/nemo_agents_plugin/runner/fabric_artifact_staging.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/runner/fabric_artifact_staging.py
@@ -12,7 +12,7 @@ import shutil
 import tempfile
 from collections.abc import Collection
 from pathlib import Path, PurePosixPath
-from typing import Any, Protocol
+from typing import Any
 
 import yaml
 from nemo_agents_plugin.entities import (
@@ -23,8 +23,8 @@ from nemo_agents_plugin.entities import (
     ethos_fileset_name,
 )
 from nemo_deployments_plugin.entities import ConfigFile
-from nemo_platform import NotFoundError as PlatformNotFoundError
 from nemo_platform_plugin.client.errors import NotFoundError as PluginClientNotFoundError
+from nemo_platform_plugin.files.client import AsyncFilesClient
 
 logger = logging.getLogger(__name__)
 _CONTRACT_FILENAMES = {ETHOS_FILENAME, AGENT_SPEC_FILENAME}
@@ -34,14 +34,73 @@ class FabricArtifactStagingError(ValueError):
     """Raised when Fabric deployment artifact staging cannot satisfy the agent config."""
 
 
-class _FilesDownloader(Protocol):
-    async def download(
-        self,
-        *,
-        local_path: str,
-        fileset: str | None = None,
-        workspace: str | None = None,
-    ) -> None: ...
+class FabricEthosFilesetNotFound(FileNotFoundError):
+    """Raised when the optional Ethos fileset is genuinely absent."""
+
+
+async def _download_fileset(
+    files_client: AsyncFilesClient,
+    *,
+    workspace: str,
+    fileset_name: str,
+    local_path: Path,
+) -> None:
+    try:
+        listing = (await files_client.list_files(workspace=workspace, name=fileset_name)).data()
+    except PluginClientNotFoundError as exc:
+        raise FabricEthosFilesetNotFound(f"Ethos fileset {workspace}/{fileset_name} was not found") from exc
+
+    for file_info in listing.data:
+        relative_path = _fileset_relative_path(file_info.path)
+        response = await files_client.download_file(
+            workspace=workspace,
+            name=fileset_name,
+            path=relative_path.as_posix(),
+        )
+        content = await response.read()
+        await asyncio.to_thread(_write_downloaded_file, local_path / Path(*relative_path.parts), content)
+
+
+def _fileset_relative_path(path: str) -> PurePosixPath:
+    relative_path = PurePosixPath(path.lstrip("/"))
+    if not relative_path.parts or relative_path.is_absolute() or ".." in relative_path.parts:
+        raise FabricArtifactStagingError(f"Invalid path in Ethos fileset: {path!r}")
+    return relative_path
+
+
+def _write_downloaded_file(path: Path, content: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+
+
+def _copy_downloaded_tree(download_root: Path, base_dir: Path, preserved: set[str]) -> None:
+    resolved_base = base_dir.resolve()
+    copies: list[tuple[Path, Path]] = []
+    for source in sorted(download_root.rglob("*")):
+        rel = source.relative_to(download_root)
+        rel_posix = PurePosixPath(rel.as_posix())
+        if rel_posix.parts[0] in preserved:
+            raise FabricArtifactStagingError(
+                f"Ethos fileset path {rel_posix.as_posix()!r} targets preserved runtime directory "
+                f"{rel_posix.parts[0]!r}"
+            )
+        if source.is_symlink():
+            raise FabricArtifactStagingError(
+                f"Staged Ethos path {rel_posix.as_posix()!r} escapes the agent base directory {base_dir}"
+            )
+        if not source.is_file():
+            continue
+
+        destination = base_dir / rel
+        if not destination.resolve(strict=False).is_relative_to(resolved_base):
+            raise FabricArtifactStagingError(
+                f"Staged Ethos path {rel_posix.as_posix()!r} escapes the agent base directory {base_dir}"
+            )
+        copies.append((source, destination))
+
+    for source, destination in copies:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(source, destination)
 
 
 async def stage_fabric_ethos_dir(
@@ -50,7 +109,7 @@ async def stage_fabric_ethos_dir(
     agent_name: str,
     agent_config: dict[str, Any],
     base_dir: Path,
-    sdk: _FilesDownloader | None,
+    files_client: AsyncFilesClient | None = None,
 ) -> None:
     """Download the Ethos fileset into *base_dir* for subprocess deployments.
 
@@ -76,11 +135,19 @@ async def stage_fabric_ethos_dir(
     preserved = _runtime_dir_names(agent_config)
     await asyncio.to_thread(_clear_staged_tree, base_dir, preserved)
 
-    if agent_name and sdk is not None:
+    if agent_name and files_client is not None:
         fileset_name = ethos_fileset_name(agent_name)
         try:
-            await sdk.download(local_path=str(base_dir), fileset=fileset_name, workspace=workspace)
-        except (FileNotFoundError, PlatformNotFoundError, PluginClientNotFoundError) as exc:
+            with tempfile.TemporaryDirectory(prefix=f".fabric-ethos-{agent_name}-") as tmp:
+                tmp_path = Path(tmp)
+                await _download_fileset(
+                    files_client,
+                    workspace=workspace,
+                    fileset_name=fileset_name,
+                    local_path=tmp_path,
+                )
+                await asyncio.to_thread(_copy_downloaded_tree, tmp_path, base_dir, preserved)
+        except FabricEthosFilesetNotFound as exc:
             logger.info(
                 "Ethos fileset %s/%s unavailable (%s); using inline agent.yaml only",
                 workspace,
@@ -180,7 +247,7 @@ async def stage_fabric_ethos_config_files(
     agent_name: str,
     rewritten_agent_config: dict[str, Any],
     agent_yaml_path: str,
-    sdk: _FilesDownloader,
+    files_client: AsyncFilesClient | None = None,
 ) -> list[ConfigFile]:
     """Download the Ethos fileset and return container ``config_files`` entries.
 
@@ -192,12 +259,14 @@ async def stage_fabric_ethos_config_files(
     config_yaml = yaml.safe_dump(rewritten_agent_config, sort_keys=False)
     if not agent_name:
         return [ConfigFile(path=agent_yaml_path, content=config_yaml)]
+    if files_client is None:
+        raise FabricArtifactStagingError("Fabric Ethos staging requires an AsyncFilesClient.")
 
     fileset_name = ethos_fileset_name(agent_name)
     try:
         with tempfile.TemporaryDirectory(prefix=f".fabric-ethos-{agent_name}-") as tmp:
             tmp_path = Path(tmp)
-            await sdk.download(local_path=str(tmp_path), fileset=fileset_name, workspace=workspace)
+            await _download_fileset(files_client, workspace=workspace, fileset_name=fileset_name, local_path=tmp_path)
             config_files = _collect_staged_config_files(
                 root=tmp_path,
                 agent_yaml_path=agent_yaml_path,
@@ -209,7 +278,7 @@ async def stage_fabric_ethos_config_files(
             validate_referenced_skill_paths(rewritten_agent_config, delivered)
             _validate_staged_size(config_files, fileset_name)
             return config_files
-    except (FileNotFoundError, PlatformNotFoundError, PluginClientNotFoundError) as exc:
+    except FabricEthosFilesetNotFound as exc:
         logger.info(
             "Ethos fileset %s/%s unavailable (%s); using inline agent.yaml only",
             workspace,

--- a/plugins/nemo-agents/src/nemo_agents_plugin/runner/in_memory.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/runner/in_memory.py
@@ -47,6 +47,8 @@ from nemo_agents_plugin.fabric.gateway_credentials import platform_gateway_crede
 from nemo_agents_plugin.runner.backend import DeploymentInfo, LocalLog, LogLocation, NotYetAvailable, RunnerBackend
 from nemo_agents_plugin.runner.fabric_artifact_staging import stage_fabric_ethos_dir
 from nemo_platform_plugin.auth import AuthContext
+from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.files.client import AsyncFilesClient
 from nemo_platform_plugin.sdk_provider import get_async_platform_sdk
 
 # Match characters not safe for filesystem paths.  Deployment names are
@@ -438,7 +440,7 @@ class InMemoryRunnerBackend(RunnerBackend):
             agent_name=agent,
             agent_config=config,
             base_dir=base_dir,
-            sdk=sdk.files if sdk else None,
+            files_client=client_from_platform(sdk, AsyncFilesClient) if sdk else None,
         )
 
     def _spawn(

--- a/plugins/nemo-agents/src/nemo_agents_plugin/schema.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/schema.py
@@ -20,80 +20,35 @@ Naming conventions:
 
 from __future__ import annotations
 
-from typing import Any
-
 from nemo_agents_plugin.entities import (
-    NAT_WORKFLOW_CONFIG_FORMAT,
     Agent,
     AgentComputeSpec,
     AgentDeployment,
     AgentEnvironment,
-    AgentEnvironmentInline,
     AgentEnvironmentSpec,
     AgentSession,
-    ComputeSpecInline,
-    DeploymentMode,
     DeploymentStatus,
-    EnvironmentSpecInline,
+)
+from nemo_platform_plugin.agents.types import (
+    CreateAgentRequest as CreateAgentRequest,
+)
+from nemo_platform_plugin.agents.types import (
+    CreateComputeSpecRequest as CreateComputeSpecRequest,
+)
+from nemo_platform_plugin.agents.types import (
+    CreateDeploymentRequest as CreateDeploymentRequest,
+)
+from nemo_platform_plugin.agents.types import (
+    CreateEnvironmentRequest as CreateEnvironmentRequest,
+)
+from nemo_platform_plugin.agents.types import (
+    CreateEnvironmentSpecRequest as CreateEnvironmentSpecRequest,
+)
+from nemo_platform_plugin.agents.types import (
+    CreateSessionRequest as CreateSessionRequest,
 )
 from nemo_platform_plugin.schema import NemoFilter, NemoListResponse
-from pydantic import BaseModel, Field
-
-# ---------------------------------------------------------------------------
-# Request bodies — plain BaseModel, named by convention
-# ---------------------------------------------------------------------------
-
-
-class CreateAgentRequest(BaseModel):
-    """Request body for ``POST /v2/workspaces/{workspace}/agents``."""
-
-    name: str = Field(description="Unique agent name within the workspace.")
-    description: str = Field(default="", description="Human-readable description.")
-    config: dict[str, Any] = Field(description="Agent config dict interpreted according to config_format.")
-    config_format: str = Field(default=NAT_WORKFLOW_CONFIG_FORMAT, description="Config format identifier.")
-
-
-class CreateDeploymentRequest(BaseModel):
-    """Request body for ``POST /v2/workspaces/{workspace}/deployments``."""
-
-    agent: str = Field(description="Name of the Agent to deploy.")
-    name: str | None = Field(
-        default=None,
-        description="Optional deployment name.  Auto-generated from agent name + random suffix if omitted.",
-    )
-    deployment_mode: DeploymentMode = Field(
-        default="subprocess",
-        description="Runtime backend: subprocess (default), docker, or k8s.",
-    )
-    image: str = Field(
-        default="",
-        description="Container image for docker/k8s modes. Ignored for subprocess.",
-    )
-    use_image_entrypoint: bool = Field(
-        default=False,
-        description=(
-            "For docker/k8s modes, leave the container command and args empty so the image's "
-            "ENTRYPOINT/CMD starts the agent server."
-        ),
-    )
-    environment: str | AgentEnvironmentInline | None = Field(
-        default=None,
-        description=(
-            'Optional AgentEnvironment: a "workspace/name" ref, an inline environment, or None. '
-            "Resolved and snapshotted onto the deployment at create time."
-        ),
-    )
-
-
-class CreateSessionRequest(BaseModel):
-    """Request body for ``POST /v2/workspaces/{workspace}/sessions``."""
-
-    deployment_id: str = Field(min_length=1, description="ID of the AgentDeployment to create a session for.")
-    name: str | None = Field(
-        default=None,
-        description="Optional session name. Auto-generated from deployment name + random suffix if omitted.",
-    )
-
+from pydantic import Field
 
 # ---------------------------------------------------------------------------
 # Filters — extend NemoFilter so extra fields are rejected (extra="forbid")
@@ -129,24 +84,6 @@ class SessionFilter(NemoFilter):
         default=None,
         description="Filter to sessions for this deployment ID.",
     )
-
-
-class CreateEnvironmentRequest(AgentEnvironmentInline):
-    """Request body for ``POST /v2/workspaces/{workspace}/environments``."""
-
-    name: str = Field(description="Unique environment name within the workspace.")
-
-
-class CreateEnvironmentSpecRequest(EnvironmentSpecInline):
-    """Request body for ``POST /v2/workspaces/{workspace}/environment-specs``."""
-
-    name: str = Field(description="Unique environment-spec name within the workspace.")
-
-
-class CreateComputeSpecRequest(ComputeSpecInline):
-    """Request body for ``POST /v2/workspaces/{workspace}/compute-specs``."""
-
-    name: str = Field(description="Unique compute-spec name within the workspace.")
 
 
 class EnvironmentFilter(NemoFilter):

--- a/plugins/nemo-agents/src/nemo_agents_plugin/sdk.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/sdk.py
@@ -62,67 +62,102 @@ remain sync-only.
 from __future__ import annotations
 
 import re
-from typing import Any, List, Mapping
+from collections.abc import Mapping
+from typing import TypeVar
 
-import httpx
 from nemo_agents_plugin.entities import (
     AgentEnvironmentInline,
     ComputeSpecInline,
     EnvironmentSpecInline,
 )
 from nemo_agents_plugin.session_protocol import SESSION_ID_HEADER
+from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
+from nemo_platform_plugin.agents.client import AgentsClient, AsyncAgentsClient
+from nemo_platform_plugin.agents.types import (
+    AgentJobRequest,
+    CreateAgentRequest,
+    CreateComputeSpecRequest,
+    CreateDeploymentRequest,
+    CreateEnvironmentRequest,
+    CreateEnvironmentSpecRequest,
+    InvokeAgentRequest,
+    JsonMap,
+)
+from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.client.response import NemoPaginatedResponse, NemoResponse
 from nemo_platform_plugin.sdk import NemoPluginSDKResources
-from pydantic import BaseModel
+from pydantic import BaseModel, TypeAdapter
 
-_DEFAULT_WORKSPACE = "default"
-_DEFAULT_TIMEOUT = 30
 _DEFAULT_MODEL_PLACEHOLDER = re.compile(r"\$(?:\{NEMO_DEFAULT_MODEL\}|NEMO_DEFAULT_MODEL(?![A-Za-z0-9_]))")
+_DEFAULT_WORKSPACE = "default"
+_JSON_MAP_ADAPTER = TypeAdapter(JsonMap)
+_ModelT = TypeVar("_ModelT", bound=BaseModel)
 
 
-def _resolve_workspace(platform: Any, workspace: str | None) -> str:
-    return workspace or getattr(platform, "workspace", None) or _DEFAULT_WORKSPACE
+def _json_map(value: object) -> JsonMap:
+    return _JSON_MAP_ADAPTER.validate_python(value)
 
 
-def _spec_to_dict(spec: BaseModel | dict[str, Any] | None) -> dict[str, Any]:
-    """Normalize a typed ``*Inline`` model (or a loose dict) to a request body.
+def _json_map_from_response(response: NemoResponse[_ModelT]) -> JsonMap:
+    response.data()
+    body: object = response.http_response.json()
+    return _json_map(body)
 
-    Accepts one of the shared backend ``*Inline`` models, a plain dict, or
-    ``None``. Pydantic models are dumped with ``exclude_unset=True`` so only the
-    fields the caller actually set are sent — matching the ``**spec`` behavior
-    where unspecified fields simply were not in the payload.
-    """
+
+def _json_map_from_page(response: NemoPaginatedResponse[_ModelT]) -> JsonMap:
+    response.page()
+    body: object = response.http_response.json()
+    return _json_map(body)
+
+
+def _spec_to_dict(spec: BaseModel | Mapping[str, object] | None) -> JsonMap:
+    """Normalize a typed ``*Inline`` model or a loose mapping to a request body."""
     if spec is None:
         return {}
     if isinstance(spec, BaseModel):
-        return spec.model_dump(exclude_unset=True, mode="json")
-    return dict(spec)
+        return _json_map(spec.model_dump(exclude_unset=True, mode="json"))
+    return _json_map(dict(spec))
 
 
-def _contains_default_model_placeholder(value: Any) -> bool:
+def _contains_default_model_placeholder(value: object) -> bool:
     """Return True when *value* still contains an unresolved default-model placeholder."""
     if isinstance(value, str):
         protected = value.replace("$$", "\0DOLLAR\0")
         return _DEFAULT_MODEL_PLACEHOLDER.search(protected) is not None
     if isinstance(value, dict):
-        return any(_contains_default_model_placeholder(v) for v in value.values())
+        return any(_contains_default_model_placeholder(item) for item in value.values())
     if isinstance(value, list):
-        return any(_contains_default_model_placeholder(v) for v in value)
+        return any(_contains_default_model_placeholder(item) for item in value)
     return False
+
+
+def _agents_client_from_platform(platform: NeMoPlatform) -> AgentsClient:
+    client = client_from_platform(platform, AgentsClient)
+    if client.workspace is None:
+        return client.with_workspace(_DEFAULT_WORKSPACE)
+    return client
+
+
+def _async_agents_client_from_platform(platform: AsyncNeMoPlatform) -> AsyncAgentsClient:
+    async_client = client_from_platform(platform, AsyncAgentsClient)
+    if async_client.workspace is None:
+        return async_client.with_workspace(_DEFAULT_WORKSPACE)
+    return async_client
 
 
 class AgentsResource:
     """SDK namespace for ``nemo.agents.*``."""
 
-    def __init__(self, platform: Any) -> None:
+    def __init__(self, platform: NeMoPlatform) -> None:
         """
         Args:
-            platform: The ``NeMo`` hub object (or any object with a
-                ``base_url`` attribute).  Provides the base URL for all API calls.
-                An optional ``default_headers`` attribute (a ``dict[str, str]``)
-                is attached to every request — this is how the CLI threads its
-                resolved auth token through the SDK.
+            platform: The generated ``NeMoPlatform`` client. The Agents resource
+                adapts it to the typed ``AgentsClient`` while sharing the same
+                base URL, default workspace, auth headers, timeout, retry policy,
+                and underlying HTTP transport.
         """
         self._platform = platform
+        self._client = _agents_client_from_platform(platform)
         self._deployments: _DeploymentResource | None = None
         self._environments: _EnvironmentResource | None = None
         self._environment_specs: _EnvironmentSpecResource | None = None
@@ -137,11 +172,11 @@ class AgentsResource:
         self,
         *,
         name: str,
-        config: dict[str, Any],
+        config: Mapping[str, object],
         description: str = "",
         config_format: str = "nat-workflow-v1",
         workspace: str | None = None,
-    ) -> dict[str, Any]:
+    ) -> JsonMap:
         """Create a new agent.
 
         Args:
@@ -158,70 +193,73 @@ class AgentsResource:
         """
         from nemo_agents_plugin.utils import inject_default_model
 
-        resolved_config = inject_default_model(config)
+        resolved_config = _json_map(inject_default_model(dict(config)))
         if _contains_default_model_placeholder(resolved_config):
             raise ValueError(
                 "Agent config references ${NEMO_DEFAULT_MODEL}, but no default model is selected. "
                 "Run `nemo setup`, set NEMO_DEFAULT_MODEL, or replace the placeholder with an explicit "
                 "VirtualModel name."
             )
-        payload = {
-            "name": name,
-            "config": resolved_config,
-            "description": description,
-            "config_format": config_format,
-        }
-        return self._post(f"/v2/workspaces/{self._workspace(workspace)}/agents", payload)
+        response = self._client.create_agent(
+            workspace=workspace,
+            body=CreateAgentRequest(
+                name=name,
+                config=resolved_config,
+                description=description,
+                config_format=config_format,
+            ),
+        )
+        return _json_map_from_response(response)
 
-    def list(self, workspace: str | None = None) -> List[dict[str, Any]]:
+    def list(self, workspace: str | None = None) -> JsonMap:
         """List agents in *workspace*."""
-        return self._get(f"/v2/workspaces/{self._workspace(workspace)}/agents")
+        return _json_map_from_page(self._client.list_agents(workspace=workspace))
 
-    def get(self, name: str, workspace: str | None = None) -> dict[str, Any]:
+    def get(self, name: str, workspace: str | None = None) -> JsonMap:
         """Get an agent by name."""
-        return self._get(f"/v2/workspaces/{self._workspace(workspace)}/agents/{name}")
+        return _json_map_from_response(self._client.get_agent(workspace=workspace, name=name))
 
     def delete(self, name: str, workspace: str | None = None) -> None:
         """Delete an agent by name."""
-        self._delete(f"/v2/workspaces/{self._workspace(workspace)}/agents/{name}")
+        self._client.delete_agent(workspace=workspace, name=name).data()
 
     # ------------------------------------------------------------------
     # Deployment sub-resource
     # ------------------------------------------------------------------
 
     @property
-    def deployments(self) -> _DeploymentResource:
+    def deployments(self) -> "_DeploymentResource":
         """Sub-resource for deployment lifecycle operations."""
         if self._deployments is None:
-            self._deployments = _DeploymentResource(self)
+            self._deployments = _DeploymentResource(self._client)
         return self._deployments
 
     @property
-    def environments(self) -> _EnvironmentResource:
+    def environments(self) -> "_EnvironmentResource":
         """Sub-resource for AgentEnvironment CRUD (``nemo.agents.environments``)."""
         if self._environments is None:
-            self._environments = _EnvironmentResource(self)
+            self._environments = _EnvironmentResource(self._client)
         return self._environments
 
     @property
-    def environment_specs(self) -> _EnvironmentSpecResource:
+    def environment_specs(self) -> "_EnvironmentSpecResource":
         """Sub-resource for AgentEnvironmentSpec CRUD (``nemo.agents.environment_specs``)."""
         if self._environment_specs is None:
-            self._environment_specs = _EnvironmentSpecResource(self)
+            self._environment_specs = _EnvironmentSpecResource(self._client)
         return self._environment_specs
 
     @property
-    def compute_specs(self) -> _ComputeSpecResource:
+    def compute_specs(self) -> "_ComputeSpecResource":
         """Sub-resource for AgentComputeSpec CRUD (``nemo.agents.compute_specs``)."""
         if self._compute_specs is None:
-            self._compute_specs = _ComputeSpecResource(self)
+            self._compute_specs = _ComputeSpecResource(self._client)
         return self._compute_specs
 
     @property
     def jobs(self) -> "_JobsResource":
         """Sub-resource for agents job collections."""
         if self._jobs is None:
-            self._jobs = _JobsResource(self._platform)
+            self._jobs = _JobsResource(self._client)
         return self._jobs
 
     # ------------------------------------------------------------------
@@ -237,7 +275,7 @@ class AgentsResource:
         session_id: str | None = None,
         workspace: str | None = None,
         timeout: int = 300,
-    ) -> dict[str, Any]:
+    ) -> JsonMap:
         """Send a single request to an agent via the gateway.
 
         Args:
@@ -252,22 +290,21 @@ class AgentsResource:
         Returns:
             The agent's response as a dict.
         """
-        resolved_workspace = self._workspace(workspace)
-        if agent:
-            path = f"/v2/workspaces/{resolved_workspace}/agents/{agent}/-/v1/chat/completions"
-        elif deployment:
-            path = f"/v2/workspaces/{resolved_workspace}/deployments/{deployment}/-/v1/chat/completions"
-        else:
-            raise ValueError("Provide either agent= or deployment=.")
+        if agent is not None and deployment is not None:
+            raise ValueError("Provide either agent= or deployment=, not both.")
         if session_id == "":
             raise ValueError("session_id must not be empty.")
 
-        payload = {
-            "messages": [{"role": "user", "content": input}],
-            "stream": False,
-        }
-        headers = {SESSION_ID_HEADER: session_id} if session_id is not None else None
-        return self._post(path, payload, timeout=timeout, headers=headers)
+        body = InvokeAgentRequest(messages=[{"role": "user", "content": input}], stream=False)
+        client = self._client.with_options(
+            headers={SESSION_ID_HEADER: session_id} if session_id is not None else None,
+            timeout=timeout,
+        )
+        if agent is not None:
+            return client.invoke_agent(workspace=workspace, name=agent, body=body).data()
+        if deployment is not None:
+            return client.invoke_deployment(workspace=workspace, name=deployment, body=body).data()
+        raise ValueError("Provide either agent= or deployment=.")
 
     def evaluate(
         self,
@@ -276,7 +313,7 @@ class AgentsResource:
         agent: str | None = None,
         endpoint: str | None = None,
         workspace: str | None = None,
-    ) -> dict[str, Any]:
+    ) -> JsonMap:
         """Trigger an evaluation run.
 
         .. note::
@@ -288,63 +325,19 @@ class AgentsResource:
 
         Raises:
             NotImplementedError: Always — platform-managed evaluation is not
-                yet available.  Use ``nemo agents evaluate`` CLI instead.
+                yet available. Use ``nemo agents evaluate`` CLI instead.
         """
         raise NotImplementedError(
             "Platform-managed evaluation is not yet implemented. "
             "Use the CLI: nemo agents evaluate --eval-config <path> [--agent <name>]"
         )
 
-    # ------------------------------------------------------------------
-    # HTTP helpers
-    # ------------------------------------------------------------------
-
-    def _base_url(self) -> str:
-        base = getattr(self._platform, "base_url", "http://localhost:8000")
-        return str(base).rstrip("/")
-
-    def _workspace(self, workspace: str | None) -> str:
-        return _resolve_workspace(self._platform, workspace)
-
-    def _agents_url(self, path: str) -> str:
-        return self._base_url() + "/apis/agents" + path
-
-    def _default_headers(self) -> dict[str, str] | None:
-        headers = getattr(self._platform, "default_headers", None)
-        if isinstance(headers, dict) and headers:
-            return {str(key): str(value) for key, value in headers.items()}
-        return None
-
-    def _get(self, path: str) -> Any:
-        with httpx.Client(timeout=_DEFAULT_TIMEOUT) as client:
-            resp = client.get(self._agents_url(path), headers=self._default_headers())
-            resp.raise_for_status()
-            return resp.json()
-
-    def _post(
-        self,
-        path: str,
-        payload: dict[str, Any],
-        timeout: int = _DEFAULT_TIMEOUT,
-        headers: dict[str, str] | None = None,
-    ) -> dict[str, Any]:
-        merged = {**(self._default_headers() or {}), **(headers or {})} or None
-        with httpx.Client(timeout=timeout) as client:
-            resp = client.post(self._agents_url(path), json=payload, headers=merged)
-            resp.raise_for_status()
-            return resp.json()
-
-    def _delete(self, path: str) -> None:
-        with httpx.Client(timeout=_DEFAULT_TIMEOUT) as client:
-            resp = client.delete(self._agents_url(path), headers=self._default_headers())
-            resp.raise_for_status()
-
 
 class _DeploymentResource:
     """Deployment lifecycle operations under ``nemo.agents.deployments``."""
 
-    def __init__(self, parent: AgentsResource) -> None:
-        self._parent = parent
+    def __init__(self, client: AgentsClient) -> None:
+        self._client = client
 
     def create(
         self,
@@ -354,9 +347,9 @@ class _DeploymentResource:
         deployment_mode: str = "subprocess",
         image: str | None = None,
         use_image_entrypoint: bool = False,
-        environment: str | dict[str, Any] | None = None,
+        environment: str | Mapping[str, object] | AgentEnvironmentInline | None = None,
         workspace: str | None = None,
-    ) -> dict[str, Any]:
+    ) -> JsonMap:
         """Create a deployment for *agent*.
 
         Args:
@@ -386,28 +379,36 @@ class _DeploymentResource:
             raise ValueError("image requires deployment_mode='docker' or 'k8s'.")
         if use_image_entrypoint and deployment_mode == "subprocess":
             raise ValueError("use_image_entrypoint requires deployment_mode='docker' or 'k8s'.")
-        payload: dict[str, Any] = {"agent": agent, "deployment_mode": deployment_mode}
-        if name:
+        if isinstance(environment, Mapping):
+            environment_body: str | AgentEnvironmentInline | None = AgentEnvironmentInline.model_validate(environment)
+        else:
+            environment_body = environment
+        payload: dict[str, object] = {"agent": agent, "deployment_mode": deployment_mode}
+        if name is not None:
             payload["name"] = name
-        if image:
+        if image is not None:
             payload["image"] = image
         if use_image_entrypoint:
             payload["use_image_entrypoint"] = True
-        if environment is not None:
-            payload["environment"] = environment
-        return self._parent._post(f"/v2/workspaces/{self._parent._workspace(workspace)}/deployments", payload)
+        if environment_body is not None:
+            payload["environment"] = environment_body
+        response = self._client.create_deployment(
+            workspace=workspace,
+            body=CreateDeploymentRequest.model_validate(payload),
+        )
+        return _json_map_from_response(response)
 
-    def list(self, workspace: str | None = None) -> List[dict[str, Any]]:
+    def list(self, workspace: str | None = None) -> JsonMap:
         """List all deployments in *workspace*."""
-        return self._parent._get(f"/v2/workspaces/{self._parent._workspace(workspace)}/deployments")
+        return _json_map_from_page(self._client.list_deployments(workspace=workspace))
 
-    def get(self, name: str, workspace: str | None = None) -> dict[str, Any]:
+    def get(self, name: str, workspace: str | None = None) -> JsonMap:
         """Get a deployment by name."""
-        return self._parent._get(f"/v2/workspaces/{self._parent._workspace(workspace)}/deployments/{name}")
+        return _json_map_from_response(self._client.get_deployment(workspace=workspace, name=name))
 
     def delete(self, name: str, workspace: str | None = None) -> None:
         """Mark a deployment for deletion."""
-        self._parent._delete(f"/v2/workspaces/{self._parent._workspace(workspace)}/deployments/{name}")
+        self._client.delete_deployment(workspace=workspace, name=name).data()
 
 
 class _EnvironmentSpecResource:
@@ -419,16 +420,16 @@ class _EnvironmentSpecResource:
     at deployment/job create time.
     """
 
-    def __init__(self, parent: AgentsResource) -> None:
-        self._parent = parent
+    def __init__(self, client: AgentsClient) -> None:
+        self._client = client
 
     def create(
         self,
         *,
         name: str,
-        spec: EnvironmentSpecInline | dict[str, Any] | None = None,
+        spec: EnvironmentSpecInline | Mapping[str, object] | None = None,
         workspace: str | None = None,
-    ) -> dict[str, Any]:
+    ) -> JsonMap:
         """Create an environment spec.
 
         Args:
@@ -441,20 +442,24 @@ class _EnvironmentSpecResource:
         Returns:
             The created AgentEnvironmentSpec as a dict.
         """
-        payload: dict[str, Any] = {**_spec_to_dict(spec), "name": name}
-        return self._parent._post(f"/v2/workspaces/{self._parent._workspace(workspace)}/environment-specs", payload)
+        payload = {**_spec_to_dict(spec), "name": name}
+        response = self._client.create_environment_spec(
+            workspace=workspace,
+            body=CreateEnvironmentSpecRequest.model_validate(payload),
+        )
+        return _json_map_from_response(response)
 
-    def list(self, workspace: str | None = None) -> List[dict[str, Any]]:
+    def list(self, workspace: str | None = None) -> JsonMap:
         """List environment specs in *workspace*."""
-        return self._parent._get(f"/v2/workspaces/{self._parent._workspace(workspace)}/environment-specs")
+        return _json_map_from_page(self._client.list_environment_specs(workspace=workspace))
 
-    def get(self, name: str, workspace: str | None = None) -> dict[str, Any]:
+    def get(self, name: str, workspace: str | None = None) -> JsonMap:
         """Get an environment spec by name."""
-        return self._parent._get(f"/v2/workspaces/{self._parent._workspace(workspace)}/environment-specs/{name}")
+        return _json_map_from_response(self._client.get_environment_spec(workspace=workspace, name=name))
 
     def delete(self, name: str, workspace: str | None = None) -> None:
         """Delete an environment spec by name."""
-        self._parent._delete(f"/v2/workspaces/{self._parent._workspace(workspace)}/environment-specs/{name}")
+        self._client.delete_environment_spec(workspace=workspace, name=name).data()
 
 
 class _EnvironmentResource:
@@ -465,19 +470,19 @@ class _EnvironmentResource:
     a deployment or execute job references via its ``environment`` field.
     """
 
-    def __init__(self, parent: AgentsResource) -> None:
-        self._parent = parent
+    def __init__(self, client: AgentsClient) -> None:
+        self._client = client
 
     def create(
         self,
         *,
         name: str,
-        spec: AgentEnvironmentInline | dict[str, Any] | None = None,
-        environment_spec: str | dict[str, Any] | None = None,
-        compute_spec: str | dict[str, Any] | None = None,
+        spec: AgentEnvironmentInline | Mapping[str, object] | None = None,
+        environment_spec: str | Mapping[str, object] | EnvironmentSpecInline | None = None,
+        compute_spec: str | Mapping[str, object] | ComputeSpecInline | None = None,
         description: str | None = None,
         workspace: str | None = None,
-    ) -> dict[str, Any]:
+    ) -> JsonMap:
         """Create an AgentEnvironment.
 
         Args:
@@ -500,26 +505,30 @@ class _EnvironmentResource:
         Returns:
             The created AgentEnvironment as a dict.
         """
-        payload: dict[str, Any] = {**_spec_to_dict(spec), "name": name}
+        payload = {**_spec_to_dict(spec), "name": name}
         if description is not None:
             payload["description"] = description
         if environment_spec is not None:
-            payload["environment_spec"] = environment_spec
+            payload["environment_spec"] = _environment_spec_body(environment_spec)
         if compute_spec is not None:
-            payload["compute_spec"] = compute_spec
-        return self._parent._post(f"/v2/workspaces/{self._parent._workspace(workspace)}/environments", payload)
+            payload["compute_spec"] = _compute_spec_body(compute_spec)
+        response = self._client.create_environment(
+            workspace=workspace,
+            body=CreateEnvironmentRequest.model_validate(payload),
+        )
+        return _json_map_from_response(response)
 
-    def list(self, workspace: str | None = None) -> List[dict[str, Any]]:
+    def list(self, workspace: str | None = None) -> JsonMap:
         """List environments in *workspace*."""
-        return self._parent._get(f"/v2/workspaces/{self._parent._workspace(workspace)}/environments")
+        return _json_map_from_page(self._client.list_environments(workspace=workspace))
 
-    def get(self, name: str, workspace: str | None = None) -> dict[str, Any]:
+    def get(self, name: str, workspace: str | None = None) -> JsonMap:
         """Get an environment by name."""
-        return self._parent._get(f"/v2/workspaces/{self._parent._workspace(workspace)}/environments/{name}")
+        return _json_map_from_response(self._client.get_environment(workspace=workspace, name=name))
 
     def delete(self, name: str, workspace: str | None = None) -> None:
         """Delete an environment by name."""
-        self._parent._delete(f"/v2/workspaces/{self._parent._workspace(workspace)}/environments/{name}")
+        self._client.delete_environment(workspace=workspace, name=name).data()
 
 
 class _ComputeSpecResource:
@@ -529,16 +538,16 @@ class _ComputeSpecResource:
     invocation runs with.
     """
 
-    def __init__(self, parent: AgentsResource) -> None:
-        self._parent = parent
+    def __init__(self, client: AgentsClient) -> None:
+        self._client = client
 
     def create(
         self,
         *,
         name: str,
-        spec: ComputeSpecInline | dict[str, Any] | None = None,
+        spec: ComputeSpecInline | Mapping[str, object] | None = None,
         workspace: str | None = None,
-    ) -> dict[str, Any]:
+    ) -> JsonMap:
         """Create a compute spec.
 
         Args:
@@ -551,144 +560,151 @@ class _ComputeSpecResource:
         Returns:
             The created AgentComputeSpec as a dict.
         """
-        payload: dict[str, Any] = {**_spec_to_dict(spec), "name": name}
-        return self._parent._post(f"/v2/workspaces/{self._parent._workspace(workspace)}/compute-specs", payload)
+        payload = {**_spec_to_dict(spec), "name": name}
+        response = self._client.create_compute_spec(
+            workspace=workspace,
+            body=CreateComputeSpecRequest.model_validate(payload),
+        )
+        return _json_map_from_response(response)
 
-    def list(self, workspace: str | None = None) -> List[dict[str, Any]]:
+    def list(self, workspace: str | None = None) -> JsonMap:
         """List compute specs in *workspace*."""
-        return self._parent._get(f"/v2/workspaces/{self._parent._workspace(workspace)}/compute-specs")
+        return _json_map_from_page(self._client.list_compute_specs(workspace=workspace))
 
-    def get(self, name: str, workspace: str | None = None) -> dict[str, Any]:
+    def get(self, name: str, workspace: str | None = None) -> JsonMap:
         """Get a compute spec by name."""
-        return self._parent._get(f"/v2/workspaces/{self._parent._workspace(workspace)}/compute-specs/{name}")
+        return _json_map_from_response(self._client.get_compute_spec(workspace=workspace, name=name))
 
     def delete(self, name: str, workspace: str | None = None) -> None:
         """Delete a compute spec by name."""
-        self._parent._delete(f"/v2/workspaces/{self._parent._workspace(workspace)}/compute-specs/{name}")
+        self._client.delete_compute_spec(workspace=workspace, name=name).data()
 
 
-# ----------------------------------------------------------------------
-# Job sub-resources
-# ----------------------------------------------------------------------
-#
-# Unlike the resources above, these route through the platform client's own
-# request pipeline (``platform.post`` / ``platform.get``) rather than a bare
-# ``httpx`` client, so the caller's auth headers, base URL, and retry policy
-# are applied. A ``NemoJob`` subclass gets CLI and HTTP routes for free but no
-# SDK surface, so each job collection needs a resource like this one.
+def _environment_spec_body(value: str | Mapping[str, object] | EnvironmentSpecInline) -> str | EnvironmentSpecInline:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, EnvironmentSpecInline):
+        return value
+    return EnvironmentSpecInline.model_validate(value)
 
 
-def _execute_jobs_base(workspace: str) -> str:
-    return f"/apis/agents/v2/workspaces/{workspace}/jobs/execute"
+def _compute_spec_body(value: str | Mapping[str, object] | ComputeSpecInline) -> str | ComputeSpecInline:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, ComputeSpecInline):
+        return value
+    return ComputeSpecInline.model_validate(value)
 
 
 def _execute_job_body(
-    spec: Mapping[str, Any],
+    spec: Mapping[str, object],
     name: str | None,
     description: str | None,
-) -> dict[str, Any]:
+) -> AgentJobRequest:
     """Build the create-job request body.
 
     ``name`` is omitted when not supplied so the Jobs service generates a
     unique one; sending a fixed name makes the second submission collide.
     """
-    body: dict[str, Any] = {"spec": dict(spec)}
+    payload: dict[str, object] = {"spec": _json_map(dict(spec))}
     if name is not None:
-        body["name"] = name
+        payload["name"] = name
     if description is not None:
-        body["description"] = description
-    return body
+        payload["description"] = description
+    return AgentJobRequest.model_validate(payload)
 
 
 class _ExecuteJobsResource:
     """Sync ``client.agents.jobs.execute`` — the ``agents.execute`` job collection."""
 
-    def __init__(self, platform: Any) -> None:
-        self._platform = platform
+    def __init__(self, client: AgentsClient) -> None:
+        self._client = client
 
     def create(
         self,
         *,
-        spec: Mapping[str, Any],
+        spec: Mapping[str, object],
         name: str | None = None,
         description: str | None = None,
         workspace: str | None = None,
-    ) -> dict[str, Any]:
+    ) -> JsonMap:
         """Submit an execute-agent job. *spec* is an ``ExecuteAgentJobConfig``."""
-        return self._platform.post(
-            _execute_jobs_base(_resolve_workspace(self._platform, workspace)),
+        response = self._client.create_agent_job(
+            workspace=workspace,
+            collection="execute",
             body=_execute_job_body(spec, name, description),
-            cast_to=dict[str, Any],
         )
+        return _json_map_from_response(response)
 
-    def get(self, name: str, workspace: str | None = None) -> dict[str, Any]:
+    def get(self, name: str, workspace: str | None = None) -> JsonMap:
         """Get one execute-agent job by name."""
-        base = _execute_jobs_base(_resolve_workspace(self._platform, workspace))
-        return self._platform.get(f"{base}/{name}", cast_to=dict[str, Any])
+        response = self._client.get_agent_job(workspace=workspace, collection="execute", name=name)
+        return _json_map_from_response(response)
 
-    def list_results(self, name: str, workspace: str | None = None) -> dict[str, Any]:
+    def list_results(self, name: str, workspace: str | None = None) -> JsonMap:
         """List the named results a finished execute-agent job saved."""
-        base = _execute_jobs_base(_resolve_workspace(self._platform, workspace))
-        return self._platform.get(f"{base}/{name}/results", cast_to=dict[str, Any])
+        response = self._client.list_agent_job_results(workspace=workspace, collection="execute", name=name)
+        return _json_map_from_response(response)
 
 
 class _AsyncExecuteJobsResource:
     """Async ``client.agents.jobs.execute``."""
 
-    def __init__(self, platform: Any) -> None:
-        self._platform = platform
+    def __init__(self, client: AsyncAgentsClient) -> None:
+        self._client = client
 
     async def create(
         self,
         *,
-        spec: Mapping[str, Any],
+        spec: Mapping[str, object],
         name: str | None = None,
         description: str | None = None,
         workspace: str | None = None,
-    ) -> dict[str, Any]:
+    ) -> JsonMap:
         """Submit an execute-agent job. *spec* is an ``ExecuteAgentJobConfig``."""
-        return await self._platform.post(
-            _execute_jobs_base(_resolve_workspace(self._platform, workspace)),
+        response = await self._client.create_agent_job(
+            workspace=workspace,
+            collection="execute",
             body=_execute_job_body(spec, name, description),
-            cast_to=dict[str, Any],
         )
+        return _json_map_from_response(response)
 
-    async def get(self, name: str, workspace: str | None = None) -> dict[str, Any]:
+    async def get(self, name: str, workspace: str | None = None) -> JsonMap:
         """Get one execute-agent job by name."""
-        base = _execute_jobs_base(_resolve_workspace(self._platform, workspace))
-        return await self._platform.get(f"{base}/{name}", cast_to=dict[str, Any])
+        response = await self._client.get_agent_job(workspace=workspace, collection="execute", name=name)
+        return _json_map_from_response(response)
 
-    async def list_results(self, name: str, workspace: str | None = None) -> dict[str, Any]:
+    async def list_results(self, name: str, workspace: str | None = None) -> JsonMap:
         """List the named results a finished execute-agent job saved."""
-        base = _execute_jobs_base(_resolve_workspace(self._platform, workspace))
-        return await self._platform.get(f"{base}/{name}/results", cast_to=dict[str, Any])
+        response = await self._client.list_agent_job_results(workspace=workspace, collection="execute", name=name)
+        return _json_map_from_response(response)
 
 
 class _JobsResource:
     """Sync ``client.agents.jobs`` namespace."""
 
-    def __init__(self, platform: Any) -> None:
-        self._platform = platform
+    def __init__(self, client: AgentsClient) -> None:
+        self._client = client
         self._execute: _ExecuteJobsResource | None = None
 
     @property
     def execute(self) -> _ExecuteJobsResource:
         if self._execute is None:
-            self._execute = _ExecuteJobsResource(self._platform)
+            self._execute = _ExecuteJobsResource(self._client)
         return self._execute
 
 
 class _AsyncJobsResource:
     """Async ``client.agents.jobs`` namespace."""
 
-    def __init__(self, platform: Any) -> None:
-        self._platform = platform
+    def __init__(self, client: AsyncAgentsClient) -> None:
+        self._client = client
         self._execute: _AsyncExecuteJobsResource | None = None
 
     @property
     def execute(self) -> _AsyncExecuteJobsResource:
         if self._execute is None:
-            self._execute = _AsyncExecuteJobsResource(self._platform)
+            self._execute = _AsyncExecuteJobsResource(self._client)
         return self._execute
 
 
@@ -699,15 +715,16 @@ class AsyncAgentsResource:
     remain sync-only on :class:`AgentsResource`.
     """
 
-    def __init__(self, platform: Any) -> None:
+    def __init__(self, platform: AsyncNeMoPlatform) -> None:
         self._platform = platform
+        self._client = _async_agents_client_from_platform(platform)
         self._jobs: _AsyncJobsResource | None = None
 
     @property
     def jobs(self) -> _AsyncJobsResource:
         """Sub-resource for agents job collections."""
         if self._jobs is None:
-            self._jobs = _AsyncJobsResource(self._platform)
+            self._jobs = _AsyncJobsResource(self._client)
         return self._jobs
 
 

--- a/plugins/nemo-agents/src/nemo_agents_plugin/tasks/execute/workdir.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/tasks/execute/workdir.py
@@ -6,19 +6,14 @@
 from __future__ import annotations
 
 import shutil
+import tempfile
 from pathlib import Path, PurePosixPath
-from typing import Any, Protocol
 
-from filesets import FilesetPathError, build_fileset_ref, parse_fileset_ref
+from filesets import FilesetFileSystem, FilesetPathError, build_fileset_ref, parse_fileset_ref
+from nemo_platform_plugin.files.client import AsyncFilesClient, FilesClient
+from nemo_platform_plugin.files.types import ListFilesQueryParams
+from nemo_platform_plugin.jobs.file_manager import FilesetFileManager, TmpDirPath
 from pydantic import BaseModel, Field, field_validator, model_validator
-
-
-class AsyncFilesClient(Protocol):
-    async def list(self, *, remote_path: str) -> Any: ...
-
-
-class FilesClient(Protocol):
-    def download(self, *, remote_path: str, local_path: str) -> Any: ...
 
 
 class AgentWorkdirArtifactMount(BaseModel):
@@ -89,14 +84,13 @@ async def validate_agent_workdir(
 def materialize_agent_workdir(spec: AgentWorkdir, files_client: FilesClient, target_dir: Path) -> None:
     target_dir.mkdir(parents=True, exist_ok=True)
     if spec.base_workdir is not None:
-        files_client.download(remote_path=spec.base_workdir, local_path=str(target_dir))
+        _download_fileset_ref(files_client, spec.base_workdir, local_dir=target_dir)
 
     for mount in spec.artifact_mounts:
         mount_local_path = target_dir / mount.mount_path
-        mount_local_path.parent.mkdir(parents=True, exist_ok=True)
-        if mount_local_path.is_dir() and not mount_local_path.is_symlink():
-            shutil.rmtree(mount_local_path)
-        files_client.download(remote_path=mount.ref, local_path=str(mount_local_path))
+        with tempfile.TemporaryDirectory(prefix=".nemo-agent-workdir-mount-") as download_dir:
+            downloaded = _download_fileset_ref(files_client, mount.ref, local_dir=Path(download_dir))
+            _replace_mount_path(downloaded.path, mount_local_path)
 
 
 async def _validate_ref(
@@ -113,12 +107,42 @@ async def _validate_ref(
         field=field,
         directory_like=directory_like,
     )
-    response = await files_client.list(remote_path=canonical_ref)
-    if not response.data:
+    ws, fileset, path = parse_fileset_ref(canonical_ref, workspace_fallback=default_workspace)
+    query_params: ListFilesQueryParams = {"path": path} if path else {}
+    response = await files_client.list_files(
+        workspace=ws,
+        name=fileset,
+        query_params=query_params or None,
+    )
+    if not response.data().data:
         if directory_like:
             raise ValueError(f"{field} must point to a non-empty directory or fileset root.")
         raise ValueError(f"{field} must point to an existing fileset artifact.")
     return canonical_ref
+
+
+def _download_fileset_ref(files_client: FilesClient, ref: str, *, local_dir: Path) -> TmpDirPath:
+    ws, fileset, _ = parse_fileset_ref(ref, workspace_fallback="")
+    manager = FilesetFileManager(
+        workspace=ws,
+        fileset_name=fileset,
+        filesystem=FilesetFileSystem(client=files_client),
+        ensure_fileset_exists=False,
+    )
+    return manager.download_from_url(ref, local_dir=local_dir)
+
+
+def _replace_mount_path(source: Path, destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if destination.is_dir() and not destination.is_symlink():
+        shutil.rmtree(destination)
+    elif destination.exists() or destination.is_symlink():
+        destination.unlink()
+
+    if source.is_dir() and not source.is_symlink():
+        shutil.copytree(source, destination)
+    else:
+        shutil.copy2(source, destination)
 
 
 def _canonical_files_ref(ref: str, *, default_workspace: str, field: str, directory_like: bool) -> str:

--- a/plugins/nemo-agents/src/nemo_agents_plugin/telemetry/files_service_exporter.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/telemetry/files_service_exporter.py
@@ -3,10 +3,10 @@
 
 """NeMo Agent Toolkit telemetry exporter that writes traces via the Nemo Files API.
 
-Uses :meth:`nemo_platform.AsyncNeMoPlatform.files.upload_content` (core Files service)
-to store serialized :class:`~nat.data_models.intermediate_step.IntermediateStep` records
-as JSONL under the shared fileset **nemo-telemetry**, scoped by workspace in the API
-URL and by **project** (and optional ``path_prefix`` / ``{agent}``) in object paths.
+Uses the typed Files client to store serialized
+:class:`~nat.data_models.intermediate_step.IntermediateStep` records as JSONL
+under the shared fileset **nemo-agent-telemetry**, scoped by workspace in the
+API URL and by agent name in object paths.
 
 Configuration (under ``general.telemetry.tracing``)::
 
@@ -42,6 +42,9 @@ from nat.observability.processor.intermediate_step_serializer import (  # type: 
 )
 from nemo_agents_plugin.utils import get_base_url
 from nemo_platform import AsyncNeMoPlatform
+from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.files.client import AsyncFilesClient
+from nemo_platform_plugin.files.types import CreateFilesetRequest
 from pydantic import Field
 
 logger = logging.getLogger(__name__)
@@ -86,7 +89,7 @@ class NemoFilesServiceRawExporter(RawExporter[IntermediateStep, str]):
     def __init__(
         self,
         *,
-        sdk: AsyncNeMoPlatform,
+        files_client: AsyncFilesClient,
         workspace: str,
         agent_name: str,
         batch_size: int,
@@ -94,7 +97,7 @@ class NemoFilesServiceRawExporter(RawExporter[IntermediateStep, str]):
         context_state=None,
     ) -> None:
         super().__init__(context_state=context_state)
-        self._sdk = sdk
+        self._files_client = files_client
         self._workspace = workspace
         self._agent_name = agent_name
         self._batch_size = batch_size
@@ -128,12 +131,16 @@ class NemoFilesServiceRawExporter(RawExporter[IntermediateStep, str]):
                 seq,
             )
             try:
-                await self._sdk.files.upload_content(
-                    content=body.encode("utf-8"),
-                    remote_path=remote_path,
-                    fileset=TELEMETRY_FILESET_NAME,
+                await self._files_client.create_fileset(
                     workspace=self._workspace,
-                    fileset_auto_create=True,
+                    body=CreateFilesetRequest(name=TELEMETRY_FILESET_NAME),
+                    exist_ok=True,
+                )
+                await self._files_client.upload_file(
+                    workspace=self._workspace,
+                    name=TELEMETRY_FILESET_NAME,
+                    path=remote_path,
+                    content=body.encode("utf-8"),
                 )
                 logger.debug("flush: upload OK (%s)", remote_path)
             except Exception:
@@ -174,9 +181,9 @@ async def nemo_files_telemetry_exporter(config: NemoFilesTelemetryExporterConfig
     """Build an exporter that uploads telemetry to the Nemo Files service."""
     del builder  # unused; required by NAT registration signature
 
-    sdk = AsyncNeMoPlatform(base_url=get_base_url())
+    async_sdk = AsyncNeMoPlatform(base_url=get_base_url())
     exporter = NemoFilesServiceRawExporter(
-        sdk=sdk,
+        files_client=client_from_platform(async_sdk, AsyncFilesClient),
         workspace=config.workspace,
         agent_name=config.agent_name,
         batch_size=config.batch_size,
@@ -185,4 +192,4 @@ async def nemo_files_telemetry_exporter(config: NemoFilesTelemetryExporterConfig
     try:
         yield exporter
     finally:
-        await sdk.close()
+        await async_sdk.close()

--- a/plugins/nemo-agents/src/nemo_agents_plugin/utils.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/utils.py
@@ -16,8 +16,11 @@ from typing import Any, Iterator
 from urllib.parse import urlsplit
 
 import yaml
-from nemo_platform import NeMoPlatform, NotFoundError
+from nemo_platform import NeMoPlatform
+from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.client.errors import NotFoundError as ClientNotFoundError
 from nemo_platform_plugin.entities import parse_qualified_name
+from nemo_platform_plugin.virtual_models.client import VirtualModelsClient
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +29,7 @@ _ENV_VAR_PATTERN = re.compile(r"\$(?:\{([A-Za-z_][A-Za-z0-9_]*)\}|([A-Za-z_][A-Z
 # LLM ``_type`` values that resolve through the platform Inference Gateway —
 # i.e. their ``model_name`` should correspond to a VirtualModel registered in
 # the workspace.  Other types (e.g. direct cloud SDKs) bypass IGW and are not
-# validatable through ``sdk.inference.virtual_models``.
+# validatable through the platform VirtualModels API.
 _IGW_LLM_TYPES = frozenset({"openai", "nim"})
 
 # Fabric model providers that speak through Platform's OpenAI-compatible IGW
@@ -369,7 +372,7 @@ def validate_llm_models(
     :data:`_IGW_LLM_TYPES`, strips a leading ``{workspace}/`` qualifier from
     ``model_name`` (mirroring IGW's OpenAI proxy — the VM route takes
     workspace as its own path segment, so the bare name is what it expects)
-    then calls ``sdk.inference.virtual_models.retrieve(name, workspace=workspace)``.
+    then calls the typed VirtualModels client.
     Names are deduplicated *after* stripping so the same model declared under
     multiple LLM keys (e.g. agent + judge) costs one network call.
 
@@ -429,11 +432,12 @@ def validate_llm_models(
     if not to_check:
         return
 
+    virtual_models_client = client_from_platform(sdk, VirtualModelsClient)
     missing: list[tuple[str, str]] = []  # (qualified_name, llm_key)
     for (target_ws, target_name), llm_key in to_check.items():
         try:
-            sdk.inference.virtual_models.retrieve(name=target_name, workspace=target_ws)
-        except NotFoundError:
+            virtual_models_client.get_virtual_model(name=target_name, workspace=target_ws)
+        except ClientNotFoundError:
             missing.append((f"{target_ws}/{target_name}", llm_key))
         except Exception as exc:  # pragma: no cover - defensive soft-fail
             # Soft-fail: a transient platform outage or auth blip shouldn't gate

--- a/plugins/nemo-agents/tests/unit/test_cli.py
+++ b/plugins/nemo-agents/tests/unit/test_cli.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import json
 import sys
 from collections.abc import Callable, Sequence
 from contextlib import AbstractContextManager
@@ -18,6 +19,7 @@ from nemo_agents_plugin.cli import (
     MAX_ETHOS_STAGED_BYTES,
     MAX_ETHOS_STAGED_FILES,
     AgentsCLI,
+    _agents_client,
     _collect_text_agent_artifacts,
     _spec_package_warning,
     _upload_ethos_fileset,
@@ -34,21 +36,29 @@ class _ValidatedAgentConfig:
         return self._config
 
 
+class _FakeFilesResponse:
+    def __init__(self, paths: Sequence[str]) -> None:
+        self._body = SimpleNamespace(data=[SimpleNamespace(path=path) for path in paths])
+
+    def data(self) -> SimpleNamespace:
+        return self._body
+
+
 class _FakeEthosFiles:
     def __init__(self, existing_paths: Sequence[str] = (), *, delete_error: Exception | None = None) -> None:
         self.existing_paths = existing_paths
         self.delete_error = delete_error
         self.deleted: list[str] = []
 
-    def list(self, *, fileset: str, workspace: str) -> SimpleNamespace:
-        assert fileset == "fabric-agent-ethos"
+    def list_files(self, *, name: str, workspace: str) -> _FakeFilesResponse:
+        assert name == "fabric-agent-ethos"
         assert workspace == "default"
-        return SimpleNamespace(data=[SimpleNamespace(path=path) for path in self.existing_paths])
+        return _FakeFilesResponse(self.existing_paths)
 
-    def delete(self, *, remote_path: str, fileset: str, workspace: str) -> None:
-        assert fileset == "fabric-agent-ethos"
+    def delete_file(self, *, path: str, name: str, workspace: str) -> None:
+        assert name == "fabric-agent-ethos"
         assert workspace == "default"
-        self.deleted.append(remote_path)
+        self.deleted.append(path)
         if self.delete_error is not None:
             raise self.delete_error
 
@@ -65,6 +75,7 @@ def _upload_ethos_snapshot(agent_root: Path, *, existing_paths: Sequence[str] = 
 
     with (
         patch("nemo_agents_plugin.cli._platform_sdk", return_value=sdk),
+        patch("nemo_agents_plugin.cli.client_from_platform", return_value=files),
         patch("nemo_agents_plugin.jobs.fileset_io.upload_to_fileset", _capture_upload),
     ):
         _upload_ethos_fileset(
@@ -83,13 +94,14 @@ def _install_mock_transport(
     transport = httpx.MockTransport(handler)
     real_client = httpx.Client
 
-    def _factory(*args, **kwargs):
-        if on_create is not None:
-            on_create(kwargs)
-        kwargs["transport"] = transport
-        return real_client(*args, **kwargs)
+    class _Client(real_client):
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            if on_create is not None:
+                on_create(kwargs)
+            kwargs["transport"] = transport
+            super().__init__(*args, **kwargs)
 
-    return patch("nemo_agents_plugin.cli.httpx.Client", _factory)
+    return patch("nemo_agents_plugin.cli.httpx.Client", _Client)
 
 
 def test_no_args_prints_help_successfully() -> None:
@@ -99,6 +111,23 @@ def test_no_args_prints_help_successfully() -> None:
     assert result.exit_code == 0
     assert "Usage:" in result.stdout
     assert "Agent lifecycle management" in result.stdout
+
+
+def test_agents_client_preserves_legacy_cli_timeout() -> None:
+    captured_timeout: list[float | None] = []
+
+    with (
+        patch("nemo_agents_plugin.cli._resolve_context_headers", return_value={}),
+        _install_mock_transport(
+            lambda _request: httpx.Response(200, json={}),
+            on_create=lambda kwargs: captured_timeout.append(kwargs.get("timeout")),
+        ),
+    ):
+        client = _agents_client("http://test", "default")
+
+    assert captured_timeout == [30]
+    assert client._timeout == 30
+    assert client._client.timeout == httpx.Timeout(30)
 
 
 def test_run_starts_nat_server_for_nat_config(tmp_path: Path) -> None:
@@ -456,6 +485,7 @@ def test_create_fabric_uploads_ethos_fileset(tmp_path: Path, monkeypatch: pytest
         _install_mock_transport(handler),
         patch("nemo_agents_plugin.fabric.validation.validate_platform_agent_config", _validate_platform_agent_config),
         patch("nemo_agents_plugin.jobs.fileset_io.upload_to_fileset", fake_upload),
+        patch("nemo_agents_plugin.cli.client_from_platform", return_value=files),
         patch("nemo_agents_plugin.cli._platform_sdk") as mock_sdk,
     ):
         mock_sdk.return_value = SimpleNamespace(base_url="http://test", files=files)
@@ -563,6 +593,7 @@ def test_upload_ethos_fileset_preserves_remote_ethos_over_local(tmp_path: Path) 
 
     with (
         patch("nemo_agents_plugin.cli._platform_sdk", return_value=sdk),
+        patch("nemo_agents_plugin.cli.client_from_platform", return_value=files),
         patch("nemo_agents_plugin.jobs.fileset_io.upload_to_fileset", _capture_upload),
     ):
         _upload_ethos_fileset(
@@ -1143,6 +1174,28 @@ def test_environment_spec_create_from_inline_json() -> None:
     assert body == {"provider": "local", "name": "prod"}
 
 
+def test_environment_spec_create_reports_validation_errors_without_traceback() -> None:
+    called = False
+
+    def handler(_req: httpx.Request) -> httpx.Response:
+        nonlocal called
+        called = True
+        return httpx.Response(201, json={"name": "bad"})
+
+    app = AgentsCLI().get_cli()
+    with _install_mock_transport(handler):
+        result = CliRunner().invoke(
+            app,
+            ["environment-specs", "create", "bad", "--spec", '{"env":{"PORT":1}}', "--base-url", "http://test"],
+        )
+
+    assert result.exit_code == 2
+    assert "Error: POST agent API validation failed:" in result.stderr
+    assert "env.PORT" in result.stderr
+    assert "Traceback" not in result.stderr
+    assert not called
+
+
 def test_environment_spec_create_rejects_both_sources(tmp_path: Path) -> None:
     spec = tmp_path / "spec.json"
     spec.write_text("{}")
@@ -1198,7 +1251,19 @@ def test_compute_spec_create_and_list() -> None:
         if req.method == "POST":
             captured["body"] = req.read()
             return httpx.Response(201, json={"name": "big"})
-        return httpx.Response(200, json={"data": [{"name": "big", "workspace": "default"}], "pagination": {}})
+        return httpx.Response(
+            200,
+            json={
+                "data": [{"name": "big", "workspace": "default"}],
+                "pagination": {
+                    "page": 1,
+                    "page_size": 1,
+                    "current_page_size": 1,
+                    "total_pages": 1,
+                    "total_results": 1,
+                },
+            },
+        )
 
     app = AgentsCLI().get_cli()
     with _install_mock_transport(handler):
@@ -1236,24 +1301,18 @@ def test_environment_delete_confirmation() -> None:
     assert "Environment 'env1' deleted." in result.stdout
 
 
-def test_environment_spec_create_routes_through_sdk() -> None:
-    """The CLI builds the request via the plugin SDK (single source of truth).
-
-    Spy the SDK resource method to prove the CLI delegates to it rather than
-    hand-rolling the request path/body.
-    """
-    from nemo_agents_plugin import sdk as sdk_module
-
+def test_environment_spec_create_routes_through_typed_client() -> None:
+    """The CLI builds the request through the source-owned typed client."""
     captured: dict[str, Any] = {}
 
-    def _spy(self, *, name, workspace=None, spec=None):
-        captured["name"] = name
-        captured["workspace"] = workspace
-        captured["spec"] = spec
-        return {"name": name}
+    def handler(req: httpx.Request) -> httpx.Response:
+        captured["method"] = req.method
+        captured["url"] = str(req.url)
+        captured["body"] = req.read()
+        return httpx.Response(201, request=req, json={"name": "ben"})
 
     app = AgentsCLI().get_cli()
-    with patch.object(sdk_module._EnvironmentSpecResource, "create", _spy):
+    with _install_mock_transport(handler):
         result = CliRunner().invoke(
             app,
             [
@@ -1270,18 +1329,13 @@ def test_environment_spec_create_routes_through_sdk() -> None:
         )
 
     assert result.exit_code == 0, result.stderr
-    assert captured["name"] == "ben"
-    assert captured["workspace"] == "team-a"
-    assert captured["spec"] == {"env": {"LOG_LEVEL": "debug"}}
+    assert captured["method"] == "POST"
+    assert captured["url"].endswith("/apis/agents/v2/workspaces/team-a/environment-specs")
+    assert json.loads(captured["body"]) == {"name": "ben", "env": {"LOG_LEVEL": "debug"}}
 
 
-def test_compute_spec_create_via_sdk_translates_http_error() -> None:
-    """A server error raised inside the SDK is translated to the CLI's rich message.
-
-    The rerouted create commands call the SDK inside ``_run_sdk``; this asserts an
-    httpx.HTTPStatusError from the SDK surfaces as the same ``... agent API`` stderr
-    message + exit 1 the old direct ``_api_request`` path produced.
-    """
+def test_compute_spec_create_via_typed_client_translates_http_error() -> None:
+    """A server error raised inside the typed client uses the CLI's rich message."""
 
     def handler(req: httpx.Request) -> httpx.Response:
         return httpx.Response(500, json={"detail": "boom"})
@@ -1305,13 +1359,8 @@ def test_compute_spec_create_via_sdk_translates_http_error() -> None:
     assert "POST agent API" in result.stderr
 
 
-def test_environment_spec_create_via_sdk_sends_auth_header() -> None:
-    """The CLI threads its resolved auth header through the SDK to the wire.
-
-    Covers the ``_agents_sdk`` seam: the CLI builds an AgentsResource whose
-    ``default_headers`` carry the context auth token, so a create routed through the
-    SDK carries ``Authorization`` on the actual request.
-    """
+def test_environment_spec_create_via_typed_client_sends_auth_header() -> None:
+    """The CLI threads its resolved auth header through the typed client."""
     captured: dict[str, Any] = {}
 
     def handler(req: httpx.Request) -> httpx.Response:

--- a/plugins/nemo-agents/tests/unit/test_cli_context_resolution.py
+++ b/plugins/nemo-agents/tests/unit/test_cli_context_resolution.py
@@ -32,11 +32,25 @@ def _install_mock_transport(handler) -> AbstractContextManager[Any]:
     transport = httpx.MockTransport(handler)
     real_client = httpx.Client
 
-    def _factory(*args, **kwargs):
-        kwargs["transport"] = transport
-        return real_client(*args, **kwargs)
+    class _Client(real_client):
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            kwargs["transport"] = transport
+            super().__init__(*args, **kwargs)
 
-    return patch("nemo_agents_plugin.cli.httpx.Client", _factory)
+    return patch("nemo_agents_plugin.cli.httpx.Client", _Client)
+
+
+def _empty_page() -> dict[str, Any]:
+    return {
+        "data": [],
+        "pagination": {
+            "page": 1,
+            "page_size": 0,
+            "current_page_size": 0,
+            "total_pages": 1,
+            "total_results": 0,
+        },
+    }
 
 
 def _capturing(captured: list[httpx.Request], *, json_body: Any = None):
@@ -44,7 +58,7 @@ def _capturing(captured: list[httpx.Request], *, json_body: Any = None):
 
     def handler(req: httpx.Request) -> httpx.Response:
         captured.append(req)
-        return httpx.Response(200, json=json_body if json_body is not None else {"data": []})
+        return httpx.Response(200, request=req, json=json_body if json_body is not None else _empty_page())
 
     return handler
 

--- a/plugins/nemo-agents/tests/unit/test_cli_delete_undeploy.py
+++ b/plugins/nemo-agents/tests/unit/test_cli_delete_undeploy.py
@@ -35,11 +35,52 @@ def _install_mock_transport(handler):
     transport = httpx.MockTransport(handler)
     real_client = httpx.Client
 
-    def _factory(*args, **kwargs):
-        kwargs["transport"] = transport
-        return real_client(*args, **kwargs)
+    class _Client(real_client):
+        def __init__(self, *args, **kwargs):
+            kwargs["transport"] = transport
+            super().__init__(*args, **kwargs)
 
-    return patch(f"{_PATCH_PREFIX}.httpx.Client", _factory)
+    return patch(f"{_PATCH_PREFIX}.httpx.Client", _Client)
+
+
+def _recording_delete_handler(requests: list[httpx.Request]):
+    def handler(req: httpx.Request) -> httpx.Response:
+        requests.append(req)
+        return httpx.Response(204, request=req)
+
+    return handler
+
+
+def _recording_deployments_handler(requests: list[httpx.Request], deployments: list[dict]):
+    def handler(req: httpx.Request) -> httpx.Response:
+        requests.append(req)
+        if req.method == "GET":
+            return httpx.Response(200, request=req, json=_mock_deployments_response(deployments))
+        return httpx.Response(204, request=req)
+
+    return handler
+
+
+def _recording_deployment_pages_handler(requests: list[httpx.Request], pages: list[list[dict]]):
+    total_results = sum(len(page) for page in pages)
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        requests.append(req)
+        if req.method == "GET":
+            page_number = int(req.url.params.get("page", "1"))
+            return httpx.Response(
+                200,
+                request=req,
+                json=_mock_deployments_response(
+                    pages[page_number - 1],
+                    page=page_number,
+                    total_pages=len(pages),
+                    total_results=total_results,
+                ),
+            )
+        return httpx.Response(204, request=req)
+
+    return handler
 
 
 # ---------------------------------------------------------------------------
@@ -104,96 +145,121 @@ class TestDeleteConfirmation:
 # ---------------------------------------------------------------------------
 
 
-def _mock_deployments_response(deployments: list[dict]) -> dict:
+def _mock_deployments_response(
+    deployments: list[dict],
+    *,
+    page: int = 1,
+    total_pages: int = 1,
+    total_results: int | None = None,
+) -> dict:
     """Build a fake paginated response for GET /deployments."""
-    return {"data": deployments}
+    total = len(deployments) if total_results is None else total_results
+    return {
+        "data": deployments,
+        "pagination": {
+            "page": page,
+            "page_size": len(deployments),
+            "current_page_size": len(deployments),
+            "total_pages": total_pages,
+            "total_results": total,
+        },
+    }
 
 
 class TestUndeployConfirmation:
     def test_undeploy_single_prompts_confirmation(self, app) -> None:
         """Undeploying a single deployment prompts for confirmation."""
-        with patch(f"{_PATCH_PREFIX}._api_request") as mock_request:
+        requests: list[httpx.Request] = []
+        with _install_mock_transport(_recording_delete_handler(requests)):
             result = runner.invoke(app, ["undeploy", "dep-1"], input="y\n")
 
         assert result.exit_code == 0, result.output
-        mock_request.assert_called_once()
-        assert mock_request.call_args.args[0] == "DELETE"
+        assert [request.method for request in requests] == ["DELETE"]
 
     def test_undeploy_single_aborts_on_decline(self, app) -> None:
         """Declining the prompt does not call the API."""
-        with patch(f"{_PATCH_PREFIX}._api_request") as mock_request:
+        requests: list[httpx.Request] = []
+        with _install_mock_transport(_recording_delete_handler(requests)):
             result = runner.invoke(app, ["undeploy", "dep-1"], input="n\n")
 
         assert result.exit_code != 0
-        mock_request.assert_not_called()
+        assert requests == []
 
     def test_undeploy_single_yes_skips_prompt(self, app) -> None:
         """--yes skips the confirmation for single deployment undeploy."""
-        with patch(f"{_PATCH_PREFIX}._api_request") as mock_request:
+        requests: list[httpx.Request] = []
+        with _install_mock_transport(_recording_delete_handler(requests)):
             result = runner.invoke(app, ["undeploy", "dep-1", "--yes"])
 
         assert result.exit_code == 0, result.output
-        mock_request.assert_called_once()
-        assert mock_request.call_args.args[0] == "DELETE"
+        assert [request.method for request in requests] == ["DELETE"]
 
     def test_undeploy_by_agent_prompts_with_count(self, app) -> None:
         """Undeploying by --agent lists deployments, shows count in prompt, and deletes on 'y'."""
-        deps = _mock_deployments_response(
-            [
-                {"name": "dep-1", "agent": "my-agent"},
-                {"name": "dep-2", "agent": "my-agent"},
-            ]
-        )
+        requests: list[httpx.Request] = []
+        deps = [
+            {"name": "dep-1", "agent": "my-agent"},
+            {"name": "dep-2", "agent": "my-agent"},
+        ]
 
-        def _request(method: str, *_args, **_kwargs):
-            if method == "GET":
-                return deps
-            return None
-
-        with patch(f"{_PATCH_PREFIX}._api_request", side_effect=_request) as mock_request:
+        with _install_mock_transport(_recording_deployments_handler(requests, deps)):
             result = runner.invoke(app, ["undeploy", "--agent", "my-agent"], input="y\n")
 
         assert result.exit_code == 0, result.output
-        assert sum(1 for call in mock_request.call_args_list if call.args[0] == "DELETE") == 2
+        assert [request.method for request in requests].count("DELETE") == 2
 
     def test_undeploy_by_agent_aborts_on_decline(self, app) -> None:
         """Declining the prompt after listing does not delete anything."""
-        deps = _mock_deployments_response(
-            [
-                {"name": "dep-1", "agent": "my-agent"},
-                {"name": "dep-2", "agent": "my-agent"},
-            ]
-        )
+        requests: list[httpx.Request] = []
+        deps = [
+            {"name": "dep-1", "agent": "my-agent"},
+            {"name": "dep-2", "agent": "my-agent"},
+        ]
 
-        def _request(method: str, *_args, **_kwargs):
-            if method == "GET":
-                return deps
-            raise AssertionError("should not DELETE after decline")
-
-        with patch(f"{_PATCH_PREFIX}._api_request", side_effect=_request) as mock_request:
+        with _install_mock_transport(_recording_deployments_handler(requests, deps)):
             result = runner.invoke(app, ["undeploy", "--agent", "my-agent"], input="n\n")
 
         assert result.exit_code != 0
-        assert all(call.args[0] != "DELETE" for call in mock_request.call_args_list)
+        assert [request.method for request in requests] == ["GET"]
 
     def test_undeploy_all_flag_works_as_agent_alias(self, app) -> None:
         """--all is an alias for --agent on undeploy."""
-        deps = _mock_deployments_response(
-            [
-                {"name": "dep-1", "agent": "my-agent"},
-            ]
-        )
+        requests: list[httpx.Request] = []
+        deps = [
+            {"name": "dep-1", "agent": "my-agent"},
+        ]
 
-        def _request(method: str, *_args, **_kwargs):
-            if method == "GET":
-                return deps
-            return None
-
-        with patch(f"{_PATCH_PREFIX}._api_request", side_effect=_request) as mock_request:
+        with _install_mock_transport(_recording_deployments_handler(requests, deps)):
             result = runner.invoke(app, ["undeploy", "--all", "my-agent", "--yes"])
 
         assert result.exit_code == 0, result.output
-        assert sum(1 for call in mock_request.call_args_list if call.args[0] == "DELETE") == 1
+        assert [request.method for request in requests].count("DELETE") == 1
+
+    def test_undeploy_by_agent_fetches_all_pages(self, app) -> None:
+        """Bulk undeploy deletes matching deployments beyond the first list page."""
+        requests: list[httpx.Request] = []
+        pages = [
+            [
+                {"name": "dep-1", "agent": "other-agent"},
+            ],
+            [
+                {"name": "dep-2", "agent": "my-agent"},
+                {"name": "dep-3", "agent": "my-agent"},
+            ],
+        ]
+
+        with _install_mock_transport(_recording_deployment_pages_handler(requests, pages)):
+            result = runner.invoke(app, ["undeploy", "--agent", "my-agent", "--yes"])
+
+        assert result.exit_code == 0, result.output
+        get_requests = [request for request in requests if request.method == "GET"]
+        delete_paths = [request.url.path for request in requests if request.method == "DELETE"]
+        assert len(get_requests) == 2
+        assert get_requests[1].url.params["page"] == "2"
+        assert delete_paths == [
+            "/apis/agents/v2/workspaces/default/deployments/dep-2",
+            "/apis/agents/v2/workspaces/default/deployments/dep-3",
+        ]
 
 
 # ---------------------------------------------------------------------------
@@ -204,26 +270,27 @@ class TestUndeployConfirmation:
 class TestDeploymentsDeleteConfirmation:
     def test_deployments_delete_prompts_without_yes(self, app) -> None:
         """deployments delete prompts for confirmation."""
-        with patch(f"{_PATCH_PREFIX}._api_request") as mock_request:
+        requests: list[httpx.Request] = []
+        with _install_mock_transport(_recording_delete_handler(requests)):
             result = runner.invoke(app, ["deployments", "delete", "dep-1"], input="y\n")
 
         assert result.exit_code == 0, result.output
-        mock_request.assert_called_once()
-        assert mock_request.call_args.args[0] == "DELETE"
+        assert [request.method for request in requests] == ["DELETE"]
 
     def test_deployments_delete_aborts_on_decline(self, app) -> None:
         """Declining aborts without calling the API."""
-        with patch(f"{_PATCH_PREFIX}._api_request") as mock_request:
+        requests: list[httpx.Request] = []
+        with _install_mock_transport(_recording_delete_handler(requests)):
             result = runner.invoke(app, ["deployments", "delete", "dep-1"], input="n\n")
 
         assert result.exit_code != 0
-        mock_request.assert_not_called()
+        assert requests == []
 
     def test_deployments_delete_skips_with_yes(self, app) -> None:
         """--yes skips the confirmation prompt."""
-        with patch(f"{_PATCH_PREFIX}._api_request") as mock_request:
+        requests: list[httpx.Request] = []
+        with _install_mock_transport(_recording_delete_handler(requests)):
             result = runner.invoke(app, ["deployments", "delete", "dep-1", "--yes"])
 
         assert result.exit_code == 0, result.output
-        mock_request.assert_called_once()
-        assert mock_request.call_args.args[0] == "DELETE"
+        assert [request.method for request in requests] == ["DELETE"]

--- a/plugins/nemo-agents/tests/unit/test_cli_deploy_logs.py
+++ b/plugins/nemo-agents/tests/unit/test_cli_deploy_logs.py
@@ -32,11 +32,32 @@ def _install_mock_transport(handler) -> AbstractContextManager[Any]:
     transport = httpx.MockTransport(handler)
     real_client = httpx.Client
 
-    def _factory(*args, **kwargs):
-        kwargs["transport"] = transport
-        return real_client(*args, **kwargs)
+    class _Client(real_client):
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            kwargs["transport"] = transport
+            super().__init__(*args, **kwargs)
 
-    return patch("nemo_agents_plugin.cli.httpx.Client", _factory)
+    return patch("nemo_agents_plugin.cli.httpx.Client", _Client)
+
+
+def _page(
+    data: list[dict[str, Any]],
+    *,
+    page: int = 1,
+    total_pages: int = 1,
+    total_results: int | None = None,
+) -> dict[str, Any]:
+    total = len(data) if total_results is None else total_results
+    return {
+        "data": data,
+        "pagination": {
+            "page": page,
+            "page_size": len(data),
+            "current_page_size": len(data),
+            "total_pages": total_pages,
+            "total_results": total,
+        },
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -177,6 +198,68 @@ def test_deploy_no_wait_returns_immediately_with_pending_json() -> None:
     assert gets == []
 
 
+def test_deployments_wait_agent_resolves_latest_active_deployment_across_pages() -> None:
+    """``deployments wait --agent`` fetches all pages and selects newest active deployment."""
+    requests: list[httpx.Request] = []
+    pages = [
+        [
+            {
+                "name": "calc-new",
+                "agent": "calc",
+                "status": "pending",
+                "created_at": "2026-05-18T12:00:00",
+            },
+        ],
+        [
+            {
+                "name": "calc-old",
+                "agent": "calc",
+                "status": "pending",
+                "created_at": "2026-05-17T12:00:00",
+            },
+        ],
+    ]
+    total_results = sum(len(page) for page in pages)
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        requests.append(req)
+        if req.method == "GET" and req.url.path.endswith("/deployments"):
+            page_number = int(req.url.params.get("page", "1"))
+            return httpx.Response(
+                200,
+                json=_page(
+                    pages[page_number - 1],
+                    page=page_number,
+                    total_pages=len(pages),
+                    total_results=total_results,
+                ),
+            )
+        if req.method == "GET" and req.url.path.endswith("/deployments/calc-new"):
+            return httpx.Response(
+                200,
+                json={
+                    "name": "calc-new",
+                    "agent": "calc",
+                    "status": "running",
+                    "created_at": "2026-05-18T12:00:00",
+                },
+            )
+        return httpx.Response(404)
+
+    app = AgentsCLI().get_cli()
+    with _install_mock_transport(handler), patch("nemo_agents_plugin.cli.time.sleep"):
+        result = CliRunner().invoke(
+            app,
+            ["deployments", "wait", "--agent", "calc", "--base-url", "http://test", "--timeout", "10"],
+        )
+
+    assert result.exit_code == 0, result.stdout + (result.stderr or "")
+    list_requests = [request for request in requests if request.url.path.endswith("/deployments")]
+    assert len(list_requests) == 2
+    assert list_requests[1].url.params["page"] == "2"
+    assert requests[-1].url.path.endswith("/deployments/calc-new")
+
+
 # ---------------------------------------------------------------------------
 # logs subcommand — path derivation
 # ---------------------------------------------------------------------------
@@ -306,8 +389,8 @@ def test_logs_resolves_most_recent_deployment_for_agent() -> None:
             # Return them in NON-creation order to confirm the CLI sorts.
             return httpx.Response(
                 200,
-                json={
-                    "data": [
+                json=_page(
+                    [
                         {
                             "name": "calc-2",
                             "agent": "calc",
@@ -327,7 +410,7 @@ def test_logs_resolves_most_recent_deployment_for_agent() -> None:
                             "created_at": "2026-05-18T13:00:00",
                         },
                     ]
-                },
+                ),
             )
         return httpx.Response(404)
 
@@ -337,6 +420,56 @@ def test_logs_resolves_most_recent_deployment_for_agent() -> None:
 
     assert result.exit_code == 0, result.stderr or result.stdout
     assert "calc-2 ok" in result.stdout
+
+
+def test_logs_agent_resolution_fetches_all_deployment_pages() -> None:
+    """``logs --agent`` considers matching deployments beyond the first page."""
+    log_file = _make_log_for(_DEFAULT_WORKSPACE, "calc-2")
+    log_file.write_text("calc-2 from page 2\n")
+    requests: list[httpx.Request] = []
+    pages = [
+        [
+            {
+                "name": "other-1",
+                "agent": "other",
+                "status": "running",
+                "created_at": "2026-05-18T13:00:00",
+            },
+        ],
+        [
+            {
+                "name": "calc-2",
+                "agent": "calc",
+                "status": "running",
+                "created_at": "2026-05-18T12:00:00",
+            },
+        ],
+    ]
+    total_results = sum(len(page) for page in pages)
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        requests.append(req)
+        if req.method == "GET" and req.url.path.endswith("/deployments"):
+            page_number = int(req.url.params.get("page", "1"))
+            return httpx.Response(
+                200,
+                json=_page(
+                    pages[page_number - 1],
+                    page=page_number,
+                    total_pages=len(pages),
+                    total_results=total_results,
+                ),
+            )
+        return httpx.Response(404)
+
+    app = AgentsCLI().get_cli()
+    with _install_mock_transport(handler):
+        result = CliRunner().invoke(app, ["logs", "--agent", "calc", "--base-url", "http://test"])
+
+    assert result.exit_code == 0, result.stderr or result.stdout
+    assert "calc-2 from page 2" in result.stdout
+    assert len(requests) == 2
+    assert requests[1].url.params["page"] == "2"
 
 
 def test_logs_requires_name_or_agent() -> None:

--- a/plugins/nemo-agents/tests/unit/test_cli_list_output.py
+++ b/plugins/nemo-agents/tests/unit/test_cli_list_output.py
@@ -9,6 +9,7 @@ import json
 from typing import Any
 from unittest.mock import patch
 
+import httpx
 import pytest
 from nemo_agents_plugin.cli import AgentsCLI
 from typer.testing import CliRunner
@@ -36,7 +37,13 @@ def _agents_response() -> dict[str, Any]:
                 "created_at": "2026-05-12T19:56:53.332720",
             }
         ],
-        "pagination": {"total": 1},
+        "pagination": {
+            "page": 1,
+            "page_size": 1,
+            "current_page_size": 1,
+            "total_pages": 1,
+            "total_results": 1,
+        },
     }
 
 
@@ -55,13 +62,31 @@ def _deployments_response() -> dict[str, Any]:
                 "created_at": "2026-05-12T20:01:00.123456",
             }
         ],
-        "pagination": {"total": 1},
+        "pagination": {
+            "page": 1,
+            "page_size": 1,
+            "current_page_size": 1,
+            "total_pages": 1,
+            "total_results": 1,
+        },
     }
+
+
+def _install_mock_transport(response: dict[str, Any]):
+    transport = httpx.MockTransport(lambda request: httpx.Response(200, request=request, json=response))
+    real_client = httpx.Client
+
+    class _Client(real_client):
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            kwargs["transport"] = transport
+            super().__init__(*args, **kwargs)
+
+    return patch(f"{_PATCH_PREFIX}.httpx.Client", _Client)
 
 
 class TestListAgentsOutput:
     def test_agents_list_defaults_to_table(self, app) -> None:
-        with patch(f"{_PATCH_PREFIX}._api_request", return_value=_agents_response()):
+        with _install_mock_transport(_agents_response()):
             result = runner.invoke(app, ["list"])
 
         assert result.exit_code == 0, result.output
@@ -74,7 +99,7 @@ class TestListAgentsOutput:
     @pytest.mark.parametrize("flag", ["--format", "-o", "--output-format", "-f"])
     def test_agents_list_supports_json_output(self, app, flag: str) -> None:
         response = _agents_response()
-        with patch(f"{_PATCH_PREFIX}._api_request", return_value=response):
+        with _install_mock_transport(response):
             result = runner.invoke(app, ["list", flag, "json"])
 
         assert result.exit_code == 0, result.output
@@ -84,7 +109,7 @@ class TestListAgentsOutput:
 
 class TestDeploymentsListOutput:
     def test_deployments_list_defaults_to_table(self, app) -> None:
-        with patch(f"{_PATCH_PREFIX}._api_request", return_value=_deployments_response()):
+        with _install_mock_transport(_deployments_response()):
             result = runner.invoke(app, ["deployments", "list"])
 
         assert result.exit_code == 0, result.output
@@ -100,7 +125,7 @@ class TestDeploymentsListOutput:
     @pytest.mark.parametrize("flag", ["--format", "-o", "--output-format", "-f"])
     def test_deployments_list_supports_json_output(self, app, flag: str) -> None:
         response = _deployments_response()
-        with patch(f"{_PATCH_PREFIX}._api_request", return_value=response):
+        with _install_mock_transport(response):
             result = runner.invoke(app, ["deployments", "list", flag, "json"])
 
         assert result.exit_code == 0, result.output

--- a/plugins/nemo-agents/tests/unit/test_cli_session_chat.py
+++ b/plugins/nemo-agents/tests/unit/test_cli_session_chat.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import json
 from datetime import UTC, datetime
 from typing import Any
-from unittest.mock import call, patch
+from unittest.mock import patch
 
 import httpx
 import pytest
@@ -83,6 +83,33 @@ def _deployment_page(
             "total_results": len(deployments),
         },
     }
+
+
+def _install_mock_transport(handler):
+    transport = httpx.MockTransport(handler)
+    real_client = httpx.Client
+
+    class _Client(real_client):
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            kwargs["transport"] = transport
+            super().__init__(*args, **kwargs)
+
+    return patch("nemo_agents_plugin.cli.httpx.Client", _Client)
+
+
+def _scripted_responses(*responses: dict[str, Any]):
+    requests: list[httpx.Request] = []
+    queue = list(responses)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if not queue:
+            raise AssertionError(f"unexpected request: {request.method} {request.url}")
+        response = queue.pop(0)
+        status_code = 201 if request.method == "POST" else 200
+        return httpx.Response(status_code, request=request, json=response)
+
+    return _install_mock_transport(handler), requests
 
 
 def test_session_chat_help_describes_new_and_resumed_sessions() -> None:
@@ -199,12 +226,10 @@ def test_session_chat_requires_an_interactive_terminal() -> None:
 
 def test_session_chat_creates_named_session_and_passes_values_to_transport() -> None:
     app = AgentsCLI().get_cli()
+    transport, requests = _scripted_responses(_deployment_response(), _session_response())
     with (
         patch("nemo_agents_plugin.cli._is_interactive_session_chat", return_value=True),
-        patch(
-            "nemo_agents_plugin.cli._api_request",
-            side_effect=[_deployment_response(), _session_response()],
-        ) as api_request,
+        transport,
         patch("nemo_agents_plugin.cli._run_resolved_session_chat") as run_chat,
     ):
         result = runner.invoke(
@@ -227,19 +252,11 @@ def test_session_chat_creates_named_session_and_passes_values_to_transport() -> 
         "Session 'debug-auth' created. Resume with:\n"
         "  nemo agents chat --session debug-auth --workspace default --base-url http://localhost:8080" in result.stdout
     )
-    assert api_request.call_args_list == [
-        call(
-            "GET",
-            "http://localhost:8080",
-            "/apis/agents/v2/workspaces/default/deployments/fabric-deployment",
-        ),
-        call(
-            "POST",
-            "http://localhost:8080",
-            "/apis/agents/v2/workspaces/default/sessions",
-            json_body={"deployment_id": "deployment-id", "name": "debug-auth"},
-        ),
+    assert [(request.method, request.url.path) for request in requests] == [
+        ("GET", "/apis/agents/v2/workspaces/default/deployments/fabric-deployment"),
+        ("POST", "/apis/agents/v2/workspaces/default/sessions"),
     ]
+    assert json.loads(requests[1].content) == {"deployment_id": "deployment-id", "name": "debug-auth"}
     run_chat.assert_called_once()
     run_kwargs = run_chat.call_args.kwargs
     assert run_kwargs["base_url"] == "http://localhost:8080"
@@ -253,12 +270,10 @@ def test_session_chat_creates_named_session_and_passes_values_to_transport() -> 
 
 def test_session_chat_preserves_api_generated_session_name() -> None:
     generated_name = "fabric-deployment-a1b2c3d4"
+    transport, requests = _scripted_responses(_deployment_response(), _session_response(name=generated_name))
     with (
         patch("nemo_agents_plugin.cli._is_interactive_session_chat", return_value=True),
-        patch(
-            "nemo_agents_plugin.cli._api_request",
-            side_effect=[_deployment_response(), _session_response(name=generated_name)],
-        ) as api_request,
+        transport,
         patch("nemo_agents_plugin.cli._run_resolved_session_chat") as run_chat,
     ):
         result = runner.invoke(
@@ -267,26 +282,18 @@ def test_session_chat_preserves_api_generated_session_name() -> None:
         )
 
     assert result.exit_code == 0, result.stderr
-    assert api_request.call_args_list[1] == call(
-        "POST",
-        "http://localhost:8080",
-        "/apis/agents/v2/workspaces/default/sessions",
-        json_body={"deployment_id": "deployment-id"},
-    )
+    assert requests[1].method == "POST"
+    assert requests[1].url.path == "/apis/agents/v2/workspaces/default/sessions"
+    assert json.loads(requests[1].content) == {"deployment_id": "deployment-id"}
     assert run_chat.call_args.kwargs["session"].name == generated_name
     assert run_chat.call_args.kwargs["session_id"] == "session-id"
 
 
 def test_session_chat_resumes_active_session_and_passes_values_to_transport() -> None:
+    transport, requests = _scripted_responses(_session_response(), _deployment_page(_deployment_response()))
     with (
         patch("nemo_agents_plugin.cli._is_interactive_session_chat", return_value=True),
-        patch(
-            "nemo_agents_plugin.cli._api_request",
-            side_effect=[
-                _session_response(),
-                _deployment_page(_deployment_response()),
-            ],
-        ) as api_request,
+        transport,
         patch("nemo_agents_plugin.cli._run_resolved_session_chat") as run_chat,
     ):
         result = runner.invoke(
@@ -296,18 +303,12 @@ def test_session_chat_resumes_active_session_and_passes_values_to_transport() ->
 
     assert result.exit_code == 0, result.stderr
     assert "Resuming runtime context; prior messages are not redisplayed." in result.stdout
-    assert api_request.call_args_list == [
-        call(
-            "GET",
-            "http://localhost:8080",
-            "/apis/agents/v2/workspaces/default/sessions/debug-auth",
-        ),
-        call(
-            "GET",
-            "http://localhost:8080",
-            "/apis/agents/v2/workspaces/default/deployments?page=1&page_size=100",
-        ),
+    assert [(request.method, request.url.path) for request in requests] == [
+        ("GET", "/apis/agents/v2/workspaces/default/sessions/debug-auth"),
+        ("GET", "/apis/agents/v2/workspaces/default/deployments"),
     ]
+    assert requests[1].url.params["page"] == "1"
+    assert requests[1].url.params["page_size"] == "100"
     run_chat.assert_called_once()
     run_kwargs = run_chat.call_args.kwargs
     assert run_kwargs["base_url"] == "http://localhost:8080"
@@ -321,60 +322,45 @@ def test_session_chat_resumes_active_session_and_passes_values_to_transport() ->
 
 def test_session_chat_pages_until_it_finds_the_session_deployment() -> None:
     target_id = "target-deployment-id"
+    transport, requests = _scripted_responses(
+        _session_response(deployment_id=target_id),
+        _deployment_page(
+            _deployment_response(name="unrelated", deployment_id="unrelated-id"),
+            page=1,
+            total_pages=2,
+        ),
+        _deployment_page(
+            _deployment_response(deployment_id=target_id),
+            page=2,
+            total_pages=2,
+        ),
+    )
     with (
         patch("nemo_agents_plugin.cli._is_interactive_session_chat", return_value=True),
-        patch(
-            "nemo_agents_plugin.cli._api_request",
-            side_effect=[
-                _session_response(deployment_id=target_id),
-                _deployment_page(
-                    _deployment_response(name="unrelated", deployment_id="unrelated-id"),
-                    page=1,
-                    total_pages=2,
-                ),
-                _deployment_page(
-                    _deployment_response(deployment_id=target_id),
-                    page=2,
-                    total_pages=2,
-                ),
-            ],
-        ) as api_request,
+        transport,
         patch("nemo_agents_plugin.cli._run_resolved_session_chat") as run_chat,
     ):
         result = runner.invoke(AgentsCLI().get_cli(), ["chat", "--session", "debug-auth"])
 
     assert result.exit_code == 0, result.stderr
-    assert api_request.call_args_list[-2:] == [
-        call(
-            "GET",
-            "http://localhost:8080",
-            "/apis/agents/v2/workspaces/default/deployments?page=1&page_size=100",
-        ),
-        call(
-            "GET",
-            "http://localhost:8080",
-            "/apis/agents/v2/workspaces/default/deployments?page=2&page_size=100",
-        ),
-    ]
+    assert [request.url.params["page"] for request in requests[-2:]] == ["1", "2"]
     assert run_chat.call_args.kwargs["deployment"].name == "fabric-deployment"
     assert run_chat.call_args.kwargs["session_id"] == "session-id"
 
 
 @pytest.mark.parametrize("status", [SessionStatus.CLOSED, SessionStatus.EXPIRED, SessionStatus.LOST])
 def test_session_chat_rejects_terminal_session_before_deployment_lookup(status: SessionStatus) -> None:
+    transport, requests = _scripted_responses(_session_response(status=status))
     with (
         patch("nemo_agents_plugin.cli._is_interactive_session_chat", return_value=True),
-        patch(
-            "nemo_agents_plugin.cli._api_request",
-            return_value=_session_response(status=status),
-        ) as api_request,
+        transport,
         patch("nemo_agents_plugin.cli._run_resolved_session_chat") as run_chat,
     ):
         result = runner.invoke(AgentsCLI().get_cli(), ["chat", "--session", "debug-auth"])
 
     assert result.exit_code == 1
     assert f"is {status.value} and cannot be resumed" in result.stderr
-    api_request.assert_called_once()
+    assert len(requests) == 1
     run_chat.assert_not_called()
 
 
@@ -400,29 +386,25 @@ def test_session_chat_reports_missing_session() -> None:
 
 
 def test_session_chat_rejects_active_session_past_its_expiration_deadline() -> None:
+    transport, requests = _scripted_responses(_session_response(expires_at=datetime(2000, 1, 1, tzinfo=UTC)))
     with (
         patch("nemo_agents_plugin.cli._is_interactive_session_chat", return_value=True),
-        patch(
-            "nemo_agents_plugin.cli._api_request",
-            return_value=_session_response(expires_at=datetime(2000, 1, 1, tzinfo=UTC)),
-        ) as api_request,
+        transport,
         patch("nemo_agents_plugin.cli._run_resolved_session_chat") as run_chat,
     ):
         result = runner.invoke(AgentsCLI().get_cli(), ["chat", "--session", "debug-auth"])
 
     assert result.exit_code == 1
     assert "is expired and cannot be resumed" in result.stderr
-    api_request.assert_called_once()
+    assert len(requests) == 1
     run_chat.assert_not_called()
 
 
 def test_session_chat_rejects_session_whose_deployment_no_longer_exists() -> None:
+    transport, _requests = _scripted_responses(_session_response(), _deployment_page())
     with (
         patch("nemo_agents_plugin.cli._is_interactive_session_chat", return_value=True),
-        patch(
-            "nemo_agents_plugin.cli._api_request",
-            side_effect=[_session_response(), _deployment_page()],
-        ),
+        transport,
         patch("nemo_agents_plugin.cli._run_resolved_session_chat") as run_chat,
     ):
         result = runner.invoke(AgentsCLI().get_cli(), ["chat", "--session", "debug-auth"])
@@ -434,12 +416,10 @@ def test_session_chat_rejects_session_whose_deployment_no_longer_exists() -> Non
 
 
 def test_session_chat_rejects_invalid_session_lookup_response() -> None:
+    transport, _requests = _scripted_responses({"name": "debug-auth", "deployment_id": "deployment-id"})
     with (
         patch("nemo_agents_plugin.cli._is_interactive_session_chat", return_value=True),
-        patch(
-            "nemo_agents_plugin.cli._api_request",
-            return_value={"name": "debug-auth", "deployment_id": "deployment-id"},
-        ),
+        transport,
         patch("nemo_agents_plugin.cli._run_resolved_session_chat") as run_chat,
     ):
         result = runner.invoke(AgentsCLI().get_cli(), ["chat", "--session", "debug-auth"])
@@ -510,43 +490,37 @@ def test_resolved_session_chat_streams_each_current_turn_with_session_and_auth_h
 
 @pytest.mark.parametrize("exception", [KeyboardInterrupt, EOFError])
 def test_session_chat_interrupt_detaches_without_closing(exception: type[BaseException]) -> None:
+    transport, requests = _scripted_responses(_session_response(), _deployment_page(_deployment_response()))
     with (
         patch("nemo_agents_plugin.cli._is_interactive_session_chat", return_value=True),
-        patch(
-            "nemo_agents_plugin.cli._api_request",
-            side_effect=[_session_response(), _deployment_page(_deployment_response())],
-        ) as api_request,
+        transport,
         patch("nemo_platform_ext.cli.chat_tui.Prompt.ask", side_effect=exception),
     ):
         result = runner.invoke(AgentsCLI().get_cli(), ["chat", "--session", "debug-auth"])
 
     assert result.exit_code == 0, result.stderr
     assert "Session detached" in result.stdout
-    assert api_request.call_args_list == [
-        call("GET", "http://localhost:8080", "/apis/agents/v2/workspaces/default/sessions/debug-auth"),
-        call(
-            "GET",
-            "http://localhost:8080",
-            "/apis/agents/v2/workspaces/default/deployments?page=1&page_size=100",
-        ),
+    assert [(request.method, request.url.path) for request in requests] == [
+        ("GET", "/apis/agents/v2/workspaces/default/sessions/debug-auth"),
+        ("GET", "/apis/agents/v2/workspaces/default/deployments"),
     ]
 
 
 def test_session_chat_interrupt_during_initial_turn_detaches_without_closing() -> None:
-    def interrupt(_: httpx.Request) -> httpx.Response:
-        raise KeyboardInterrupt
+    requests: list[httpx.Request] = []
+    queue = [_session_response(), _deployment_page(_deployment_response())]
 
-    real_client = httpx.Client
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.path.endswith("/-/v1/chat/completions"):
+            raise KeyboardInterrupt
+        if not queue:
+            raise AssertionError(f"unexpected request: {request.method} {request.url}")
+        return httpx.Response(200, request=request, json=queue.pop(0))
+
     with (
         patch("nemo_agents_plugin.cli._is_interactive_session_chat", return_value=True),
-        patch(
-            "nemo_agents_plugin.cli._api_request",
-            side_effect=[_session_response(), _deployment_page(_deployment_response())],
-        ) as api_request,
-        patch(
-            "nemo_agents_plugin.cli.httpx.Client",
-            side_effect=lambda **kwargs: real_client(transport=httpx.MockTransport(interrupt), **kwargs),
-        ),
+        _install_mock_transport(handler),
     ):
         result = runner.invoke(
             AgentsCLI().get_cli(),
@@ -555,16 +529,14 @@ def test_session_chat_interrupt_during_initial_turn_detaches_without_closing() -
 
     assert result.exit_code == 0, result.stderr
     assert "Session detached" in result.stdout
-    assert [request.args[0] for request in api_request.call_args_list] == ["GET", "GET"]
+    assert [request.method for request in requests[:2]] == ["GET", "GET"]
 
 
 def test_session_chat_rejects_non_fabric_deployment_before_session_creation() -> None:
+    transport, requests = _scripted_responses(_deployment_response(config_format=NAT_WORKFLOW_CONFIG_FORMAT))
     with (
         patch("nemo_agents_plugin.cli._is_interactive_session_chat", return_value=True),
-        patch(
-            "nemo_agents_plugin.cli._api_request",
-            return_value=_deployment_response(config_format=NAT_WORKFLOW_CONFIG_FORMAT),
-        ) as api_request,
+        transport,
         patch("nemo_agents_plugin.cli._run_resolved_session_chat") as run_chat,
     ):
         result = runner.invoke(
@@ -574,7 +546,7 @@ def test_session_chat_rejects_non_fabric_deployment_before_session_creation() ->
 
     assert result.exit_code == 1
     assert "is not Fabric-backed" in result.stderr
-    api_request.assert_called_once()
+    assert len(requests) == 1
     run_chat.assert_not_called()
 
 
@@ -589,12 +561,10 @@ def test_session_chat_rejects_unroutable_deployment_before_session_creation(
     status: DeploymentStatus,
     endpoint: str,
 ) -> None:
+    transport, requests = _scripted_responses(_deployment_response(status=status, endpoint=endpoint))
     with (
         patch("nemo_agents_plugin.cli._is_interactive_session_chat", return_value=True),
-        patch(
-            "nemo_agents_plugin.cli._api_request",
-            return_value=_deployment_response(status=status, endpoint=endpoint),
-        ) as api_request,
+        transport,
         patch("nemo_agents_plugin.cli._run_resolved_session_chat") as run_chat,
     ):
         result = runner.invoke(
@@ -604,20 +574,18 @@ def test_session_chat_rejects_unroutable_deployment_before_session_creation(
 
     assert result.exit_code == 1
     assert "is not routable" in result.stderr
-    api_request.assert_called_once()
+    assert len(requests) == 1
     run_chat.assert_not_called()
 
 
 def test_session_chat_rejects_invalid_session_creation_response() -> None:
+    transport, _requests = _scripted_responses(
+        _deployment_response(),
+        {"name": "debug-auth", "deployment_id": "deployment-id"},
+    )
     with (
         patch("nemo_agents_plugin.cli._is_interactive_session_chat", return_value=True),
-        patch(
-            "nemo_agents_plugin.cli._api_request",
-            side_effect=[
-                _deployment_response(),
-                {"name": "debug-auth", "deployment_id": "deployment-id"},
-            ],
-        ),
+        transport,
         patch("nemo_agents_plugin.cli._run_resolved_session_chat") as run_chat,
     ):
         result = runner.invoke(

--- a/plugins/nemo-agents/tests/unit/test_cli_sessions.py
+++ b/plugins/nemo-agents/tests/unit/test_cli_sessions.py
@@ -7,8 +7,9 @@ from __future__ import annotations
 
 import json
 from typing import Any
-from unittest.mock import call, patch
+from unittest.mock import patch
 
+import httpx
 import pytest
 from nemo_agents_plugin.cli import AgentsCLI
 from typer.testing import CliRunner
@@ -37,7 +38,8 @@ def _sessions_response() -> dict[str, Any]:
             }
         ],
         "pagination": {
-            "current_page": 1,
+            "page": 1,
+            "page_size": 1,
             "current_page_size": 1,
             "total_pages": 1,
             "total_results": 1,
@@ -45,6 +47,33 @@ def _sessions_response() -> dict[str, Any]:
         "sort": "-created_at",
         "filter": {},
     }
+
+
+def _install_mock_transport(handler):
+    transport = httpx.MockTransport(handler)
+    real_client = httpx.Client
+
+    class _Client(real_client):
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            kwargs["transport"] = transport
+            super().__init__(*args, **kwargs)
+
+    return patch("nemo_agents_plugin.cli.httpx.Client", _Client)
+
+
+def _scripted_responses(*responses: dict[str, Any]):
+    requests: list[httpx.Request] = []
+    queue = list(responses)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if not queue:
+            raise AssertionError(f"unexpected request: {request.method} {request.url}")
+        response = queue.pop(0)
+        status_code = 201 if request.method == "POST" else 200
+        return httpx.Response(status_code, request=request, json=response)
+
+    return _install_mock_transport(handler), requests
 
 
 def test_sessions_help_exposes_management_scope_without_pagination_or_delete(app) -> None:
@@ -65,15 +94,14 @@ def test_sessions_help_exposes_management_scope_without_pagination_or_delete(app
 
 def test_sessions_list_defaults_to_newest_first_api_table(app) -> None:
     response = _sessions_response()
-    with patch("nemo_agents_plugin.cli._api_request", return_value=response) as api_request:
+    transport, requests = _scripted_responses(response)
+    with transport:
         result = runner.invoke(app, ["sessions", "list", "--base-url", "http://test"])
 
     assert result.exit_code == 0, result.output
-    api_request.assert_called_once_with(
-        "GET",
-        "http://test",
-        "/apis/agents/v2/workspaces/default/sessions",
-    )
+    assert [(request.method, request.url.path) for request in requests] == [
+        ("GET", "/apis/agents/v2/workspaces/default/sessions")
+    ]
     assert "debug-auth" in result.stdout
     assert "active" in result.stdout
     assert "deployment_id" in result.stdout
@@ -85,7 +113,8 @@ def test_sessions_list_defaults_to_newest_first_api_table(app) -> None:
 @pytest.mark.parametrize("output_format", ["json", "yaml", "csv", "markdown", "raw"])
 def test_sessions_list_supports_existing_output_formats(app, output_format: str) -> None:
     response = _sessions_response()
-    with patch("nemo_agents_plugin.cli._api_request", return_value=response):
+    transport, _requests = _scripted_responses(response)
+    with transport:
         result = runner.invoke(app, ["sessions", "list", "--format", output_format])
 
     assert result.exit_code == 0, result.output
@@ -96,80 +125,65 @@ def test_sessions_list_supports_existing_output_formats(app, output_format: str)
 
 def test_sessions_list_filters_by_deployment_name(app) -> None:
     response = _sessions_response()
-    with patch(
-        "nemo_agents_plugin.cli._api_request",
-        side_effect=[{"id": "deployment-id", "name": "fabric-deployment"}, response],
-    ) as api_request:
+    transport, requests = _scripted_responses({"id": "deployment-id", "name": "fabric-deployment"}, response)
+    with transport:
         result = runner.invoke(
             app,
             ["sessions", "list", "--agent-deployment", "fabric-deployment", "--format", "json"],
         )
 
     assert result.exit_code == 0, result.output
-    assert api_request.call_args_list == [
-        call(
-            "GET",
-            "http://localhost:8080",
-            "/apis/agents/v2/workspaces/default/deployments/fabric-deployment",
-        ),
-        call(
-            "GET",
-            "http://localhost:8080",
-            "/apis/agents/v2/workspaces/default/sessions?filter%5Bdeployment_id%5D=deployment-id",
-        ),
+    assert [(request.method, request.url.path) for request in requests] == [
+        ("GET", "/apis/agents/v2/workspaces/default/deployments/fabric-deployment"),
+        ("GET", "/apis/agents/v2/workspaces/default/sessions"),
     ]
+    assert requests[1].url.params["filter[deployment_id]"] == "deployment-id"
 
 
-@pytest.mark.parametrize("deployment", [None, {}, {"id": None}, {"id": ""}, {"id": 123}])
+@pytest.mark.parametrize("deployment", [{}, {"id": None}, {"id": ""}])
 def test_sessions_list_rejects_invalid_deployment_response(app, deployment: Any) -> None:
-    with patch("nemo_agents_plugin.cli._api_request", return_value=deployment) as api_request:
+    transport, requests = _scripted_responses(deployment)
+    with transport:
         result = runner.invoke(app, ["sessions", "list", "--agent-deployment", "fabric-deployment"])
 
     assert result.exit_code == 1
     assert "Deployment 'fabric-deployment' returned an invalid response" in result.stderr
-    api_request.assert_called_once_with(
-        "GET",
-        "http://localhost:8080",
-        "/apis/agents/v2/workspaces/default/deployments/fabric-deployment",
-    )
+    assert [(request.method, request.url.path) for request in requests] == [
+        ("GET", "/apis/agents/v2/workspaces/default/deployments/fabric-deployment")
+    ]
 
 
 def test_sessions_list_rejects_empty_deployment_filter(app) -> None:
-    with patch("nemo_agents_plugin.cli._api_request") as api_request:
-        result = runner.invoke(app, ["sessions", "list", "--agent-deployment", ""])
+    result = runner.invoke(app, ["sessions", "list", "--agent-deployment", ""])
 
     assert result.exit_code == 2
     assert "--agent-deployment must not be empty" in result.stderr
-    api_request.assert_not_called()
 
 
 def test_sessions_get_prints_full_session_json(app) -> None:
     session = _sessions_response()["data"][0]
-    with patch("nemo_agents_plugin.cli._api_request", return_value=session) as api_request:
+    transport, requests = _scripted_responses(session)
+    with transport:
         result = runner.invoke(app, ["sessions", "get", "debug-auth", "--base-url", "http://test"])
 
     assert result.exit_code == 0, result.output
     assert json.loads(result.stdout) == session
-    api_request.assert_called_once_with(
-        "GET",
-        "http://test",
-        "/apis/agents/v2/workspaces/default/sessions/debug-auth",
-    )
+    assert [(request.method, request.url.path) for request in requests] == [
+        ("GET", "/apis/agents/v2/workspaces/default/sessions/debug-auth")
+    ]
 
 
 def test_sessions_close_requires_confirmation(app) -> None:
-    with patch("nemo_agents_plugin.cli._api_request") as api_request:
-        result = runner.invoke(app, ["sessions", "close", "debug-auth"], input="n\n")
+    result = runner.invoke(app, ["sessions", "close", "debug-auth"], input="n\n")
 
     assert result.exit_code == 1
     assert "cannot be resumed" in result.stdout
-    api_request.assert_not_called()
 
 
 def test_sessions_close_accepts_yes_and_calls_close_endpoint(app) -> None:
-    with patch(
-        "nemo_agents_plugin.cli._api_request", return_value={"name": "debug-auth", "status": "closed"}
-    ) as api_request:
+    session = {**_sessions_response()["data"][0], "status": "closed"}
+    transport, requests = _scripted_responses(session)
+    with transport:
         result = runner.invoke(
             app,
             ["sessions", "close", "debug-auth", "--yes", "--workspace", "team-a", "--base-url", "http://test"],
@@ -177,8 +191,6 @@ def test_sessions_close_accepts_yes_and_calls_close_endpoint(app) -> None:
 
     assert result.exit_code == 0, result.output
     assert "Session 'debug-auth' closed." in result.stdout
-    api_request.assert_called_once_with(
-        "POST",
-        "http://test",
-        "/apis/agents/v2/workspaces/team-a/sessions/debug-auth/close",
-    )
+    assert [(request.method, request.url.path) for request in requests] == [
+        ("POST", "/apis/agents/v2/workspaces/team-a/sessions/debug-auth/close")
+    ]

--- a/plugins/nemo-agents/tests/unit/test_evaluate_agent_job.py
+++ b/plugins/nemo-agents/tests/unit/test_evaluate_agent_job.py
@@ -90,21 +90,28 @@ def test_resolve_eval_config_fileset_downloads_via_sdk(tmp_path: Path, ctx: JobC
     )
 
     sdk = MagicMock()
+    manager = MagicMock()
 
-    def _fake_download(local_path: str, fileset: str, workspace: str) -> None:
-        Path(local_path, "config.yml").write_text("eval: {}")
+    def _fake_download(_ref: str, *, local_dir: Path) -> None:
+        Path(local_dir, "config.yml").write_text("eval: {}")
 
-    sdk.files.download.side_effect = _fake_download
+    manager.download_from_url.side_effect = _fake_download
 
-    with job._resolve_eval_config(spec, ctx=ctx, sdk=sdk) as resolved:
-        assert resolved.exists()
-        assert resolved.name == "config.yml"
-        assert resolved.read_text() == "eval: {}"
+    with (
+        patch("nemo_agents_plugin.jobs.evaluate_agent.client_from_platform", return_value=MagicMock()),
+        patch("nemo_agents_plugin.jobs.evaluate_agent.FilesetFileSystem", return_value=MagicMock()),
+        patch("nemo_agents_plugin.jobs.evaluate_agent.FilesetFileManager", return_value=manager) as manager_cls,
+    ):
+        with job._resolve_eval_config(spec, ctx=ctx, sdk=sdk) as resolved:
+            assert resolved.exists()
+            assert resolved.name == "config.yml"
+            assert resolved.read_text() == "eval: {}"
 
-    sdk.files.download.assert_called_once()
-    kwargs = sdk.files.download.call_args.kwargs
-    assert kwargs["fileset"] == "nemo-agent-eval-calc"
-    assert kwargs["workspace"] == "default"
+    manager_cls.assert_called_once()
+    assert manager_cls.call_args.kwargs["fileset_name"] == "nemo-agent-eval-calc"
+    assert manager_cls.call_args.kwargs["workspace"] == "default"
+    manager.download_from_url.assert_called_once()
+    assert manager.download_from_url.call_args.args == ("default/nemo-agent-eval-calc",)
 
 
 def test_resolve_eval_config_fileset_without_sdk_raises(tmp_path: Path, ctx: JobContext) -> None:
@@ -119,28 +126,37 @@ def test_resolve_eval_config_fileset_without_sdk_raises(tmp_path: Path, ctx: Job
 def test_resolve_output_fileset_uploads_on_clean_exit(tmp_path: Path, ctx: JobContext) -> None:
     job = EvaluateAgentJob()
     sdk = MagicMock()
-    sdk.files.upload.return_value = MagicMock(name="fake-fileset")
+    manager = MagicMock()
 
-    with job._resolve_output(FilesetRef("eval-out"), workspace="default", ctx=ctx, sdk=sdk):
-        pass
+    with (
+        patch("nemo_agents_plugin.jobs.evaluate_agent.client_from_platform", return_value=MagicMock()),
+        patch("nemo_agents_plugin.jobs.evaluate_agent.FilesetFileSystem", return_value=MagicMock()),
+        patch("nemo_agents_plugin.jobs.evaluate_agent.FilesetFileManager", return_value=manager) as manager_cls,
+    ):
+        with job._resolve_output(FilesetRef("eval-out"), workspace="default", ctx=ctx, sdk=sdk):
+            pass
 
-    sdk.files.upload.assert_called_once()
-    kwargs = sdk.files.upload.call_args.kwargs
-    assert kwargs["fileset"] == "eval-out"
-    assert kwargs["workspace"] == "default"
-    assert kwargs["fileset_auto_create"] is True
-    assert kwargs["local_path"].endswith("/")
+    manager_cls.assert_called_once()
+    assert manager_cls.call_args.kwargs["fileset_name"] == "eval-out"
+    assert manager_cls.call_args.kwargs["workspace"] == "default"
+    assert manager_cls.call_args.kwargs["ensure_fileset_exists"] is True
+    manager.validate_storage.assert_called_once_with()
+    manager.upload.assert_called_once()
+    assert manager.upload.call_args.kwargs["remote_path"] == ""
 
 
 def test_resolve_output_fileset_skips_upload_when_body_raises(tmp_path: Path, ctx: JobContext) -> None:
     job = EvaluateAgentJob()
     sdk = MagicMock()
 
-    with pytest.raises(RuntimeError, match="nat eval blew up"):
+    with (
+        patch.object(EvaluateAgentJob, "_upload_to_fileset") as upload,
+        pytest.raises(RuntimeError, match="nat eval blew up"),
+    ):
         with job._resolve_output(FilesetRef("eval-out"), workspace="default", ctx=ctx, sdk=sdk):
             raise RuntimeError("nat eval blew up")
 
-    sdk.files.upload.assert_not_called()
+    upload.assert_not_called()
 
 
 def test_run_failed_subprocess_skips_fileset_upload(tmp_path: Path, ctx: JobContext) -> None:
@@ -156,11 +172,14 @@ def test_run_failed_subprocess_skips_fileset_upload(tmp_path: Path, ctx: JobCont
     }
 
     cpe = subprocess.CalledProcessError(returncode=2, cmd=["nat", "eval"])
-    with patch("nemo_agents_plugin.jobs.evaluate_agent.subprocess.run", side_effect=cpe):
+    with (
+        patch.object(EvaluateAgentJob, "_upload_to_fileset") as upload,
+        patch("nemo_agents_plugin.jobs.evaluate_agent.subprocess.run", side_effect=cpe),
+    ):
         result = EvaluateAgentJob().run(spec, ctx=ctx, sdk=sdk)
 
     assert result == {"status": "failed", "returncode": 2}
-    sdk.files.upload.assert_not_called()
+    upload.assert_not_called()
 
 
 def test_run_subprocess_timeout_skips_fileset_upload(tmp_path: Path, ctx: JobContext) -> None:
@@ -178,11 +197,14 @@ def test_run_subprocess_timeout_skips_fileset_upload(tmp_path: Path, ctx: JobCon
     }
 
     timeout = subprocess.TimeoutExpired(cmd=["nat", "eval"], timeout=3600)
-    with patch("nemo_agents_plugin.jobs.evaluate_agent.subprocess.run", side_effect=timeout):
+    with (
+        patch.object(EvaluateAgentJob, "_upload_to_fileset") as upload,
+        patch("nemo_agents_plugin.jobs.evaluate_agent.subprocess.run", side_effect=timeout),
+    ):
         result = EvaluateAgentJob().run(spec, ctx=ctx, sdk=sdk)
 
     assert result == {"status": "failed", "returncode": 124}
-    sdk.files.upload.assert_not_called()
+    upload.assert_not_called()
 
 
 def test_resolve_output_no_output_uses_persistent_results(tmp_path: Path, ctx: JobContext) -> None:
@@ -204,17 +226,23 @@ def test_resolve_eval_config_fileset_tempdir_lands_under_ctx_ephemeral(tmp_path:
         workspace="default",
     )
     sdk = MagicMock()
+    manager = MagicMock()
 
     seen: dict[str, Path] = {}
 
-    def _fake_download(local_path: str, fileset: str, workspace: str) -> None:
-        seen["local_path"] = Path(local_path)
-        Path(local_path, "config.yml").write_text("eval: {}")
+    def _fake_download(_ref: str, *, local_dir: Path) -> None:
+        seen["local_path"] = local_dir
+        Path(local_dir, "config.yml").write_text("eval: {}")
 
-    sdk.files.download.side_effect = _fake_download
+    manager.download_from_url.side_effect = _fake_download
 
-    with job._resolve_eval_config(spec, ctx=ctx, sdk=sdk):
-        pass
+    with (
+        patch("nemo_agents_plugin.jobs.evaluate_agent.client_from_platform", return_value=MagicMock()),
+        patch("nemo_agents_plugin.jobs.evaluate_agent.FilesetFileSystem", return_value=MagicMock()),
+        patch("nemo_agents_plugin.jobs.evaluate_agent.FilesetFileManager", return_value=manager),
+    ):
+        with job._resolve_eval_config(spec, ctx=ctx, sdk=sdk):
+            pass
 
     assert seen["local_path"].parent == ctx.storage.ephemeral
 
@@ -225,7 +253,8 @@ def test_resolve_output_fileset_tempdir_lands_under_ctx_ephemeral(tmp_path: Path
     sdk = MagicMock()
 
     captured: dict[str, Path] = {}
-    with job._resolve_output(FilesetRef("eval-out"), workspace="default", ctx=ctx, sdk=sdk) as base:
-        captured["base"] = base
+    with patch.object(EvaluateAgentJob, "_upload_to_fileset"):
+        with job._resolve_output(FilesetRef("eval-out"), workspace="default", ctx=ctx, sdk=sdk) as base:
+            captured["base"] = base
 
     assert captured["base"].parent == ctx.storage.ephemeral

--- a/plugins/nemo-agents/tests/unit/test_execute_job.py
+++ b/plugins/nemo-agents/tests/unit/test_execute_job.py
@@ -61,6 +61,14 @@ from nemo_platform_plugin.jobs.exceptions import PlatformJobCompilationError
 from nemo_platform_plugin.jobs.routes import add_job_routes
 
 
+class _TypedFilesResponse:
+    def __init__(self, data: list[object]) -> None:
+        self._body = SimpleNamespace(data=data)
+
+    def data(self) -> SimpleNamespace:
+        return self._body
+
+
 def _agent_config(**environment: str) -> dict[str, Any]:
     config = {
         "config_format": "nemo-agents-spec-v1",
@@ -81,7 +89,7 @@ def _agent(name: str = "calc", workspace: str = "default", config_format: str = 
 
 def _sdk_with_files(data: list[object] | None = None) -> MagicMock:
     sdk = MagicMock()
-    sdk.files.list = AsyncMock(return_value=SimpleNamespace(data=data if data is not None else [object()]))
+    sdk.files.list_files = AsyncMock(return_value=_TypedFilesResponse(data if data is not None else [object()]))
     return sdk
 
 
@@ -223,18 +231,23 @@ async def test_to_spec_validates_and_canonicalizes_base_workdir() -> None:
     entity_client.get.return_value = _agent()
     sdk = _sdk_with_files()
 
-    spec = await ExecuteAgentJob.to_spec(
-        ExecuteAgentJobConfig(agent="calc", input="hello", workdir=AgentWorkdir(base_workdir="source#project")),
-        workspace="default",
-        entity_client=entity_client,
-        async_sdk=sdk,
-        is_local=False,
-    )
+    with patch("nemo_agents_plugin.jobs.execute.client_from_platform", return_value=sdk.files):
+        spec = await ExecuteAgentJob.to_spec(
+            ExecuteAgentJobConfig(agent="calc", input="hello", workdir=AgentWorkdir(base_workdir="source#project")),
+            workspace="default",
+            entity_client=entity_client,
+            async_sdk=sdk,
+            is_local=False,
+        )
 
     step_config = ExecuteAgentStepConfig.model_validate(spec)
     assert step_config.workdir is not None
     assert step_config.workdir.base_workdir == "default/source#project/"
-    sdk.files.list.assert_awaited_once_with(remote_path="default/source#project/")
+    sdk.files.list_files.assert_awaited_once_with(
+        workspace="default",
+        name="source",
+        query_params={"path": "project/"},
+    )
 
 
 @pytest.mark.asyncio
@@ -292,13 +305,19 @@ async def test_to_spec_rejects_single_file_base_workdir() -> None:
     entity_client.get.return_value = _agent()
 
     with pytest.raises(ValueError, match="non-empty directory"):
-        await ExecuteAgentJob.to_spec(
-            ExecuteAgentJobConfig(agent="calc", input="hello", workdir=AgentWorkdir(base_workdir="source#README.md")),
-            workspace="default",
-            entity_client=entity_client,
-            async_sdk=_sdk_with_files(data=[]),
-            is_local=False,
-        )
+        sdk = _sdk_with_files(data=[])
+        with patch("nemo_agents_plugin.jobs.execute.client_from_platform", return_value=sdk.files):
+            await ExecuteAgentJob.to_spec(
+                ExecuteAgentJobConfig(
+                    agent="calc",
+                    input="hello",
+                    workdir=AgentWorkdir(base_workdir="source#README.md"),
+                ),
+                workspace="default",
+                entity_client=entity_client,
+                async_sdk=sdk,
+                is_local=False,
+            )
 
 
 def test_canonical_base_workdir_ref_rejects_path_escape() -> None:
@@ -371,7 +390,7 @@ def test_workdir_spec_allows_sibling_mount_paths() -> None:
 @pytest.mark.asyncio
 async def test_validate_agent_workdir_canonicalizes_refs() -> None:
     files_client = MagicMock()
-    files_client.list = AsyncMock(return_value=SimpleNamespace(data=[object()]))
+    files_client.list_files = AsyncMock(return_value=_TypedFilesResponse([object()]))
 
     spec = await validate_agent_workdir(
         AgentWorkdir(
@@ -387,78 +406,81 @@ async def test_validate_agent_workdir_canonicalizes_refs() -> None:
     assert spec.artifact_mounts == [
         AgentWorkdirArtifactMount(ref="default/artifacts#notes.txt", mount_path="notes.txt")
     ]
-    files_client.list.assert_has_awaits(
-        [call(remote_path="default/source#project/"), call(remote_path="default/artifacts#notes.txt")]
+    files_client.list_files.assert_has_awaits(
+        [
+            call(workspace="default", name="source", query_params={"path": "project/"}),
+            call(workspace="default", name="artifacts", query_params={"path": "notes.txt"}),
+        ]
     )
 
 
 def test_materialize_agent_workdir_downloads_base_and_mounts(tmp_path: Path) -> None:
     files_client = MagicMock()
-    calls: list[tuple[str, str]] = []
+    calls: list[tuple[str, Path]] = []
 
-    def _download(*, remote_path: str, local_path: str) -> None:
-        calls.append((remote_path, local_path))
-        local = Path(local_path)
-        local.parent.mkdir(parents=True, exist_ok=True)
-        if remote_path == "default/source#project/":
+    def _download(_files_client: object, ref: str, *, local_dir: Path) -> SimpleNamespace:
+        del _files_client
+        calls.append((ref, local_dir))
+        local_dir.mkdir(parents=True, exist_ok=True)
+        if ref == "default/source#project/":
+            local = local_dir
             local.mkdir(parents=True, exist_ok=True)
             (local / "config.yaml").write_text("name: calc\n")
         else:
+            local = local_dir / "notes.txt"
             local.write_text("mounted artifact\n")
+        return SimpleNamespace(path=local, tmp_dir=local_dir)
 
-    files_client.download.side_effect = _download
     target = tmp_path / "workdir"
 
-    materialize_agent_workdir(
-        AgentWorkdir(
-            base_workdir="default/source#project/",
-            artifact_mounts=[AgentWorkdirArtifactMount(ref="default/artifacts#notes.txt", mount_path="notes.txt")],
-        ),
-        files_client,
-        target,
-    )
+    with patch("nemo_agents_plugin.tasks.execute.workdir._download_fileset_ref", side_effect=_download):
+        materialize_agent_workdir(
+            AgentWorkdir(
+                base_workdir="default/source#project/",
+                artifact_mounts=[AgentWorkdirArtifactMount(ref="default/artifacts#notes.txt", mount_path="notes.txt")],
+            ),
+            files_client,
+            target,
+        )
 
-    assert calls == [
-        ("default/source#project/", str(target)),
-        ("default/artifacts#notes.txt", str(target / "notes.txt")),
-    ]
+    assert [ref for ref, _ in calls] == ["default/source#project/", "default/artifacts#notes.txt"]
+    assert calls[0][1] == target
     assert (target / "config.yaml").read_text() == "name: calc\n"
     assert (target / "notes.txt").read_text() == "mounted artifact\n"
 
 
 def test_materialize_agent_workdir_replaces_base_directory_for_directory_mount(tmp_path: Path) -> None:
     files_client = MagicMock()
-    calls: list[tuple[str, str]] = []
+    calls: list[tuple[str, Path]] = []
 
-    def _download(*, remote_path: str, local_path: str) -> None:
-        calls.append((remote_path, local_path))
-        local = Path(local_path)
-        local.parent.mkdir(parents=True, exist_ok=True)
-        if remote_path == "default/source#project/":
+    def _download(_files_client: object, ref: str, *, local_dir: Path) -> SimpleNamespace:
+        del _files_client
+        calls.append((ref, local_dir))
+        local_dir.mkdir(parents=True, exist_ok=True)
+        if ref == "default/source#project/":
+            local = local_dir
             (local / "data").mkdir(parents=True)
             (local / "data" / "stale.txt").write_text("stale\n")
         else:
-            if local.is_dir():
-                raise IsADirectoryError(local)
+            local = local_dir / "data"
             local.mkdir(parents=True)
             (local / "mounted.txt").write_text("mounted artifact\n")
+        return SimpleNamespace(path=local, tmp_dir=local_dir)
 
-    files_client.download.side_effect = _download
     target = tmp_path / "workdir"
 
-    materialize_agent_workdir(
-        AgentWorkdir(
-            base_workdir="default/source#project/",
-            artifact_mounts=[AgentWorkdirArtifactMount(ref="default/artifacts#data/", mount_path="data")],
-        ),
-        files_client,
-        target,
-    )
+    with patch("nemo_agents_plugin.tasks.execute.workdir._download_fileset_ref", side_effect=_download):
+        materialize_agent_workdir(
+            AgentWorkdir(
+                base_workdir="default/source#project/",
+                artifact_mounts=[AgentWorkdirArtifactMount(ref="default/artifacts#data/", mount_path="data")],
+            ),
+            files_client,
+            target,
+        )
 
-    assert calls == [
-        ("default/source#project/", str(target)),
-        ("default/artifacts#data/", str(target / "data")),
-    ]
+    assert [ref for ref, _ in calls] == ["default/source#project/", "default/artifacts#data/"]
+    assert calls[0][1] == target
     assert not (target / "data" / "stale.txt").exists()
     assert (target / "data" / "mounted.txt").read_text() == "mounted artifact\n"
 
@@ -624,7 +646,7 @@ async def test_to_spec_mcp_secret_indirection_through_environment() -> None:
     config), and the server's env references the value by name so the running
     step reads it from the process env the substrate populates.
     """
-    mcp_agent_config = {
+    mcp_agent_config: dict[str, Any] = {
         "config_format": "nemo-agents-spec-v1",
         "name": "calc",
         "default_harness": "hermes",
@@ -986,24 +1008,29 @@ def test_run_downloads_and_registers_input_workdir(ctx: JobContext) -> None:
     sdk = MagicMock()
     download_calls: list[tuple[str, str]] = []
 
-    def _download(*, remote_path: str, local_path: str) -> None:
-        download_calls.append((remote_path, local_path))
-        local = Path(local_path)
-        local.parent.mkdir(parents=True, exist_ok=True)
-        if remote_path == "default/source#project/":
+    def _download(_files_client: object, ref: str, *, local_dir: Path) -> SimpleNamespace:
+        del _files_client
+        download_calls.append((ref, str(local_dir)))
+        local_dir.mkdir(parents=True, exist_ok=True)
+        if ref == "default/source#project/":
+            local = local_dir
             local.mkdir(parents=True, exist_ok=True)
-            Path(local_path, "config.yaml").write_text("name: calc\n")
+            (local / "config.yaml").write_text("name: calc\n")
         else:
+            local = local_dir / "notes.txt"
             local.write_text("mounted artifact\n")
-
-    sdk.files.download.side_effect = _download
+        return SimpleNamespace(path=local, tmp_dir=local_dir)
 
     async def _invoke(request: Any) -> FabricRuntimeResult:
         (request.base_dir / "workspace" / "answer.txt").write_text("done\n")
         (request.base_dir / "artifacts" / "artifact.txt").write_text("artifact\n")
         return FabricRuntimeResult(status="succeeded", response="done")
 
-    with patch("nemo_agents_plugin.jobs.execute.invoke_agent_config_request_once", _invoke):
+    with (
+        patch("nemo_agents_plugin.jobs.execute.client_from_platform", return_value=sdk.files),
+        patch("nemo_agents_plugin.tasks.execute.workdir._download_fileset_ref", side_effect=_download),
+        patch("nemo_agents_plugin.jobs.execute.invoke_agent_config_request_once", _invoke),
+    ):
         result = ExecuteAgentJob().run(spec.model_dump(mode="json"), ctx=ctx, sdk=sdk)
 
     assert result["status"] == "completed"
@@ -1033,19 +1060,23 @@ def test_run_clears_stale_input_workdir_before_materializing(ctx: JobContext) ->
     (stale_workdir / "stale.txt").write_text("stale\n")
     sdk = MagicMock()
 
-    def _download(*, remote_path: str, local_path: str) -> None:
-        assert remote_path == "default/source#project/"
-        local = Path(local_path)
+    def _download(_files_client: object, ref: str, *, local_dir: Path) -> SimpleNamespace:
+        del _files_client
+        assert ref == "default/source#project/"
+        local = local_dir
         assert not (local / "stale.txt").exists()
         local.mkdir(parents=True, exist_ok=True)
         (local / "config.yaml").write_text("name: calc\n")
-
-    sdk.files.download.side_effect = _download
+        return SimpleNamespace(path=local, tmp_dir=local_dir)
 
     async def _invoke(request: Any) -> FabricRuntimeResult:
         return FabricRuntimeResult(status="succeeded")
 
-    with patch("nemo_agents_plugin.jobs.execute.invoke_agent_config_request_once", _invoke):
+    with (
+        patch("nemo_agents_plugin.jobs.execute.client_from_platform", return_value=sdk.files),
+        patch("nemo_agents_plugin.tasks.execute.workdir._download_fileset_ref", side_effect=_download),
+        patch("nemo_agents_plugin.jobs.execute.invoke_agent_config_request_once", _invoke),
+    ):
         result = ExecuteAgentJob().run(spec.model_dump(mode="json"), ctx=ctx, sdk=sdk)
 
     assert result["status"] == "completed"
@@ -1089,9 +1120,15 @@ def test_run_failed_download_does_not_register_partial_result(ctx: JobContext) -
         workdir=AgentWorkdir(base_workdir="default/source#project/"),
     )
     sdk = MagicMock()
-    sdk.files.download.side_effect = RuntimeError("download failed")
 
-    with pytest.raises(RuntimeError, match="download failed"):
+    with (
+        patch("nemo_agents_plugin.jobs.execute.client_from_platform", return_value=sdk.files),
+        patch(
+            "nemo_agents_plugin.tasks.execute.workdir._download_fileset_ref",
+            side_effect=RuntimeError("download failed"),
+        ),
+        pytest.raises(RuntimeError, match="download failed"),
+    ):
         ExecuteAgentJob().run(spec.model_dump(mode="json"), ctx=ctx, sdk=sdk)
 
     assert not (ctx.storage.persistent / "results" / "input_workdir").exists()
@@ -1208,7 +1245,10 @@ def test_execute_job_create_route_stores_canonical_step_config() -> None:
         return response
 
     fake_jobs = SimpleNamespace(create_job=_create_job)
-    with patch("nemo_platform_plugin.jobs.api_factory.client_from_platform", return_value=fake_jobs):
+    with (
+        patch("nemo_platform_plugin.jobs.api_factory.client_from_platform", return_value=fake_jobs),
+        patch("nemo_agents_plugin.jobs.execute.client_from_platform", return_value=sdk.files),
+    ):
         response = TestClient(app).post(
             "/apis/agents/v2/workspaces/default/jobs/execute",
             json={

--- a/plugins/nemo-agents/tests/unit/test_fabric_artifact_staging.py
+++ b/plugins/nemo-agents/tests/unit/test_fabric_artifact_staging.py
@@ -7,20 +7,23 @@ from __future__ import annotations
 
 from pathlib import Path, PurePosixPath
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
 import yaml
 from nemo_agents_plugin.runner.fabric_artifact_staging import (
     FabricArtifactStagingError,
+    FabricEthosFilesetNotFound,
+    _download_fileset,
     stage_fabric_ethos_config_files,
     stage_fabric_ethos_dir,
     validate_referenced_skill_paths,
 )
 from nemo_deployments_plugin.entities import ConfigFile
-from nemo_platform import NotFoundError
+from nemo_platform_plugin.client.errors import NemoHTTPError
 from nemo_platform_plugin.client.errors import NotFoundError as PluginClientNotFoundError
+from nemo_platform_plugin.files.client import AsyncFilesClient
 
 
 def _fabric_config(*, skills_paths: list[str] | None = None) -> dict[str, Any]:
@@ -40,6 +43,109 @@ def _fabric_config(*, skills_paths: list[str] | None = None) -> dict[str, Any]:
     return config
 
 
+def _plugin_not_found(message: str = "missing fileset") -> PluginClientNotFoundError:
+    response = httpx.Response(
+        404,
+        request=httpx.Request("GET", "http://platform/filesets/fabric-agent-ethos"),
+        json={"detail": message},
+    )
+    return PluginClientNotFoundError(response)
+
+
+@pytest.fixture
+def patched_download_fileset(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _download_fileset(
+        files_client: AsyncMock,
+        *,
+        workspace: str,
+        fileset_name: str,
+        local_path: Path,
+    ) -> None:
+        try:
+            await files_client.download(local_path=str(local_path), fileset=fileset_name, workspace=workspace)
+        except (FileNotFoundError, PluginClientNotFoundError) as exc:
+            raise FabricEthosFilesetNotFound("missing fileset") from exc
+
+    monkeypatch.setattr(
+        "nemo_agents_plugin.runner.fabric_artifact_staging._download_fileset",
+        _download_fileset,
+    )
+
+
+def _fileset_file(path: str, content: bytes) -> dict[str, Any]:
+    return {
+        "file_ref": f"fileset://default/fabric-agent-ethos#{path}",
+        "file_url": f"fileset://default/fabric-agent-ethos#{path}",
+        "path": path,
+        "size": len(content),
+    }
+
+
+@pytest.mark.asyncio
+async def test_download_fileset_downloads_listed_files_with_typed_client(tmp_path: Path) -> None:
+    content = {
+        "agent.yaml": b"name: fabric-agent\n",
+        "skills/review/SKILL.md": b"# Review\n",
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if str(request.url).endswith("/files"):
+            return httpx.Response(200, json={"data": [_fileset_file(path, data) for path, data in content.items()]})
+        encoded_path = str(request.url).split("/-/", 1)[1]
+        path = encoded_path.replace("%2F", "/")
+        return httpx.Response(200, content=content[path])
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http_client:
+        files_client = AsyncFilesClient(base_url="http://test", workspace="default", http_client=http_client)
+        await _download_fileset(
+            files_client,
+            workspace="default",
+            fileset_name="fabric-agent-ethos",
+            local_path=tmp_path,
+        )
+
+    assert (tmp_path / "agent.yaml").read_bytes() == b"name: fabric-agent\n"
+    assert (tmp_path / "skills" / "review" / "SKILL.md").read_bytes() == b"# Review\n"
+
+
+@pytest.mark.asyncio
+async def test_stage_fabric_ethos_config_files_real_missing_fileset_falls_back() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, json={"detail": "missing fileset"})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http_client:
+        files_client = AsyncFilesClient(base_url="http://test", workspace="default", http_client=http_client)
+        result = await stage_fabric_ethos_config_files(
+            workspace="default",
+            agent_name="fabric-agent",
+            rewritten_agent_config=_fabric_config(),
+            agent_yaml_path="/workspace/agent.yaml",
+            files_client=files_client,
+        )
+
+    assert result == [
+        ConfigFile(path="/workspace/agent.yaml", content=yaml.safe_dump(_fabric_config(), sort_keys=False)),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_stage_fabric_ethos_config_files_preserves_files_service_errors() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={"detail": "files service unavailable"})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http_client:
+        files_client = AsyncFilesClient(base_url="http://test", workspace="default", http_client=http_client)
+        with pytest.raises(NemoHTTPError, match="HTTP 500"):
+            await stage_fabric_ethos_config_files(
+                workspace="default",
+                agent_name="fabric-agent",
+                rewritten_agent_config=_fabric_config(),
+                agent_yaml_path="/workspace/agent.yaml",
+                files_client=files_client,
+            )
+
+
+@pytest.mark.usefixtures("patched_download_fileset")
 @pytest.mark.asyncio
 async def test_stage_fabric_ethos_config_files_without_agent_name_returns_inline_yaml() -> None:
     config = _fabric_config()
@@ -49,77 +155,81 @@ async def test_stage_fabric_ethos_config_files_without_agent_name_returns_inline
         agent_name="",
         rewritten_agent_config=rewritten,
         agent_yaml_path="/workspace/agent.yaml",
-        sdk=AsyncMock(),
+        files_client=AsyncMock(),
     )
     assert result == [
         ConfigFile(path="/workspace/agent.yaml", content=yaml.safe_dump(rewritten, sort_keys=False)),
     ]
 
 
+@pytest.mark.usefixtures("patched_download_fileset")
 @pytest.mark.asyncio
 async def test_stage_fabric_ethos_config_files_missing_fileset_falls_back() -> None:
     config = _fabric_config()
-    sdk = AsyncMock()
-    sdk.download = AsyncMock(side_effect=FileNotFoundError("missing"))
+    files_client = AsyncMock()
+    files_client.download = AsyncMock(side_effect=FileNotFoundError("missing"))
 
     result = await stage_fabric_ethos_config_files(
         workspace="default",
         agent_name="fabric-agent",
         rewritten_agent_config=config,
         agent_yaml_path="/workspace/agent.yaml",
-        sdk=sdk,
+        files_client=files_client,
     )
 
     assert len(result) == 1
     assert result[0].path == "/workspace/agent.yaml"
-    sdk.download.assert_awaited_once()
-    await_args = sdk.download.await_args
+    files_client.download.assert_awaited_once()
+    await_args = files_client.download.await_args
     assert await_args is not None
     assert await_args.kwargs["fileset"] == "fabric-agent-ethos"
     assert await_args.kwargs["workspace"] == "default"
 
 
+@pytest.mark.usefixtures("patched_download_fileset")
 @pytest.mark.asyncio
 async def test_stage_fabric_ethos_config_files_not_found_error_falls_back() -> None:
     config = _fabric_config()
-    sdk = AsyncMock()
-    sdk.download = AsyncMock(side_effect=NotFoundError("missing fileset", response=MagicMock(), body=None))
+    files_client = AsyncMock()
+    files_client.download = AsyncMock(side_effect=_plugin_not_found())
 
     result = await stage_fabric_ethos_config_files(
         workspace="default",
         agent_name="fabric-agent",
         rewritten_agent_config=config,
         agent_yaml_path="/workspace/agent.yaml",
-        sdk=sdk,
+        files_client=files_client,
     )
 
     assert len(result) == 1
     assert result[0].path == "/workspace/agent.yaml"
 
 
+@pytest.mark.usefixtures("patched_download_fileset")
 @pytest.mark.asyncio
 async def test_stage_fabric_ethos_config_files_plugin_client_not_found_error_falls_back() -> None:
     config = _fabric_config()
-    sdk = AsyncMock()
+    files_client = AsyncMock()
     response = httpx.Response(
         404,
         request=httpx.Request("GET", "http://platform/filesets/fabric-agent-ethos"),
         json={"detail": "Fileset not found"},
     )
-    sdk.download = AsyncMock(side_effect=PluginClientNotFoundError(response))
+    files_client.download = AsyncMock(side_effect=PluginClientNotFoundError(response))
 
     result = await stage_fabric_ethos_config_files(
         workspace="default",
         agent_name="fabric-agent",
         rewritten_agent_config=config,
         agent_yaml_path="/workspace/agent.yaml",
-        sdk=sdk,
+        files_client=files_client,
     )
 
     assert len(result) == 1
     assert result[0].path == "/workspace/agent.yaml"
 
 
+@pytest.mark.usefixtures("patched_download_fileset")
 @pytest.mark.asyncio
 async def test_stage_fabric_ethos_config_files_stages_sibling_artifacts() -> None:
     async def _fake_download(*, local_path: str, fileset: str | None, workspace: str | None) -> None:
@@ -136,15 +246,15 @@ async def test_stage_fabric_ethos_config_files_stages_sibling_artifacts() -> Non
 
     rewritten = _fabric_config(skills_paths=["skills/review"])
     rewritten["models"] = {"default": {"provider": "openai", "model": "gpt", "settings": {"base_url": "http://igw"}}}
-    sdk = AsyncMock()
-    sdk.download = AsyncMock(side_effect=_fake_download)
+    files_client = AsyncMock()
+    files_client.download = AsyncMock(side_effect=_fake_download)
 
     result = await stage_fabric_ethos_config_files(
         workspace="default",
         agent_name="fabric-agent",
         rewritten_agent_config=rewritten,
         agent_yaml_path="/workspace/agent.yaml",
-        sdk=sdk,
+        files_client=files_client,
     )
 
     by_path = {item.path: item.content for item in result}
@@ -158,10 +268,11 @@ async def test_stage_fabric_ethos_config_files_stages_sibling_artifacts() -> Non
     assert "stale" not in by_path["/workspace/agent.yaml"]
 
 
+@pytest.mark.usefixtures("patched_download_fileset")
 @pytest.mark.asyncio
 async def test_stage_fabric_ethos_config_files_missing_fileset_rejects_configured_skills() -> None:
-    sdk = AsyncMock()
-    sdk.download = AsyncMock(side_effect=NotFoundError("missing fileset", response=MagicMock(), body=None))
+    files_client = AsyncMock()
+    files_client.download = AsyncMock(side_effect=_plugin_not_found())
 
     with pytest.raises(FabricArtifactStagingError, match="skills/review"):
         await stage_fabric_ethos_config_files(
@@ -169,10 +280,11 @@ async def test_stage_fabric_ethos_config_files_missing_fileset_rejects_configure
             agent_name="fabric-agent",
             rewritten_agent_config=_fabric_config(skills_paths=["skills/review"]),
             agent_yaml_path="/workspace/agent.yaml",
-            sdk=sdk,
+            files_client=files_client,
         )
 
 
+@pytest.mark.usefixtures("patched_download_fileset")
 @pytest.mark.asyncio
 async def test_stage_fabric_ethos_config_files_rejects_non_utf8_artifact() -> None:
     async def _fake_download(*, local_path: str, fileset: str | None, workspace: str | None) -> None:
@@ -181,8 +293,8 @@ async def test_stage_fabric_ethos_config_files_rejects_non_utf8_artifact() -> No
         (root / "agent.yaml").write_text("name: fabric-agent\n", encoding="utf-8")
         (root / "logo.bin").write_bytes(b"\xff\xfe\x00binary")
 
-    sdk = AsyncMock()
-    sdk.download = AsyncMock(side_effect=_fake_download)
+    files_client = AsyncMock()
+    files_client.download = AsyncMock(side_effect=_fake_download)
 
     with pytest.raises(FabricArtifactStagingError, match="non-UTF-8"):
         await stage_fabric_ethos_config_files(
@@ -190,10 +302,11 @@ async def test_stage_fabric_ethos_config_files_rejects_non_utf8_artifact() -> No
             agent_name="fabric-agent",
             rewritten_agent_config=_fabric_config(),
             agent_yaml_path="/workspace/agent.yaml",
-            sdk=sdk,
+            files_client=files_client,
         )
 
 
+@pytest.mark.usefixtures("patched_download_fileset")
 @pytest.mark.asyncio
 async def test_stage_fabric_ethos_config_files_rejects_oversized_fileset() -> None:
     async def _fake_download(*, local_path: str, fileset: str | None, workspace: str | None) -> None:
@@ -202,8 +315,8 @@ async def test_stage_fabric_ethos_config_files_rejects_oversized_fileset() -> No
         (root / "agent.yaml").write_text("name: fabric-agent\n", encoding="utf-8")
         (root / "huge.md").write_text("x" * 1_000_000, encoding="utf-8")
 
-    sdk = AsyncMock()
-    sdk.download = AsyncMock(side_effect=_fake_download)
+    files_client = AsyncMock()
+    files_client.download = AsyncMock(side_effect=_fake_download)
 
     with pytest.raises(FabricArtifactStagingError, match="exceeding"):
         await stage_fabric_ethos_config_files(
@@ -211,10 +324,11 @@ async def test_stage_fabric_ethos_config_files_rejects_oversized_fileset() -> No
             agent_name="fabric-agent",
             rewritten_agent_config=_fabric_config(),
             agent_yaml_path="/workspace/agent.yaml",
-            sdk=sdk,
+            files_client=files_client,
         )
 
 
+@pytest.mark.usefixtures("patched_download_fileset")
 @pytest.mark.asyncio
 async def test_stage_fabric_ethos_config_files_rejects_missing_skill_path() -> None:
     async def _fake_download(*, local_path: str, fileset: str | None, workspace: str | None) -> None:
@@ -222,8 +336,8 @@ async def test_stage_fabric_ethos_config_files_rejects_missing_skill_path() -> N
         root = Path(local_path)
         (root / "agent.yaml").write_text("name: fabric-agent\n", encoding="utf-8")
 
-    sdk = AsyncMock()
-    sdk.download = AsyncMock(side_effect=_fake_download)
+    files_client = AsyncMock()
+    files_client.download = AsyncMock(side_effect=_fake_download)
 
     with pytest.raises(FabricArtifactStagingError, match="skills/review"):
         await stage_fabric_ethos_config_files(
@@ -231,10 +345,11 @@ async def test_stage_fabric_ethos_config_files_rejects_missing_skill_path() -> N
             agent_name="fabric-agent",
             rewritten_agent_config=_fabric_config(skills_paths=["skills/review"]),
             agent_yaml_path="/workspace/agent.yaml",
-            sdk=sdk,
+            files_client=files_client,
         )
 
 
+@pytest.mark.usefixtures("patched_download_fileset")
 @pytest.mark.asyncio
 async def test_stage_fabric_ethos_dir_stages_sibling_artifacts(tmp_path: Path) -> None:
     async def _fake_download(*, local_path: str, fileset: str | None, workspace: str | None) -> None:
@@ -246,45 +361,47 @@ async def test_stage_fabric_ethos_dir_stages_sibling_artifacts(tmp_path: Path) -
         skill_dir.mkdir(parents=True)
         (skill_dir / "SKILL.md").write_text("# Review\n", encoding="utf-8")
 
-    sdk = AsyncMock()
-    sdk.download = AsyncMock(side_effect=_fake_download)
+    files_client = AsyncMock()
+    files_client.download = AsyncMock(side_effect=_fake_download)
 
     await stage_fabric_ethos_dir(
         workspace="default",
         agent_name="fabric-agent",
         agent_config=_fabric_config(skills_paths=["skills/review"]),
         base_dir=tmp_path,
-        sdk=sdk,
+        files_client=files_client,
     )
 
     assert (tmp_path / "mcps" / "calculator.py").read_text(encoding="utf-8") == "print(1)\n"
     assert (tmp_path / "skills" / "review" / "SKILL.md").exists()
-    await_args = sdk.download.await_args
+    await_args = files_client.download.await_args
     assert await_args is not None
     assert await_args.kwargs["fileset"] == "fabric-agent-ethos"
-    assert await_args.kwargs["local_path"] == str(tmp_path)
+    assert Path(await_args.kwargs["local_path"]) != tmp_path
 
 
+@pytest.mark.usefixtures("patched_download_fileset")
 @pytest.mark.asyncio
 async def test_stage_fabric_ethos_dir_missing_fileset_is_not_fatal(tmp_path: Path) -> None:
-    sdk = AsyncMock()
-    sdk.download = AsyncMock(side_effect=NotFoundError("missing fileset", response=MagicMock(), body=None))
+    files_client = AsyncMock()
+    files_client.download = AsyncMock(side_effect=_plugin_not_found())
 
     await stage_fabric_ethos_dir(
         workspace="default",
         agent_name="fabric-agent",
         agent_config=_fabric_config(),
         base_dir=tmp_path,
-        sdk=sdk,
+        files_client=files_client,
     )
 
     assert list(tmp_path.iterdir()) == []
 
 
+@pytest.mark.usefixtures("patched_download_fileset")
 @pytest.mark.asyncio
 async def test_stage_fabric_ethos_dir_missing_fileset_rejects_configured_skills(tmp_path: Path) -> None:
-    sdk = AsyncMock()
-    sdk.download = AsyncMock(side_effect=FileNotFoundError("missing"))
+    files_client = AsyncMock()
+    files_client.download = AsyncMock(side_effect=FileNotFoundError("missing"))
 
     with pytest.raises(FabricArtifactStagingError, match="skills/review"):
         await stage_fabric_ethos_dir(
@@ -292,10 +409,11 @@ async def test_stage_fabric_ethos_dir_missing_fileset_rejects_configured_skills(
             agent_name="fabric-agent",
             agent_config=_fabric_config(skills_paths=["skills/review"]),
             base_dir=tmp_path,
-            sdk=sdk,
+            files_client=files_client,
         )
 
 
+@pytest.mark.usefixtures("patched_download_fileset")
 @pytest.mark.asyncio
 async def test_stage_fabric_ethos_dir_without_downloader_skips_download(tmp_path: Path) -> None:
     await stage_fabric_ethos_dir(
@@ -303,32 +421,34 @@ async def test_stage_fabric_ethos_dir_without_downloader_skips_download(tmp_path
         agent_name="",
         agent_config=_fabric_config(),
         base_dir=tmp_path,
-        sdk=None,
+        files_client=None,
     )
 
     assert list(tmp_path.iterdir()) == []
 
 
+@pytest.mark.usefixtures("patched_download_fileset")
 @pytest.mark.asyncio
 async def test_stage_fabric_ethos_dir_allows_oversized_tree(tmp_path: Path) -> None:
     async def _fake_download(*, local_path: str, fileset: str | None, workspace: str | None) -> None:
         del fileset, workspace
         (Path(local_path) / "huge.md").write_text("x" * 1_000_000, encoding="utf-8")
 
-    sdk = AsyncMock()
-    sdk.download = AsyncMock(side_effect=_fake_download)
+    files_client = AsyncMock()
+    files_client.download = AsyncMock(side_effect=_fake_download)
 
     await stage_fabric_ethos_dir(
         workspace="default",
         agent_name="fabric-agent",
         agent_config=_fabric_config(),
         base_dir=tmp_path,
-        sdk=sdk,
+        files_client=files_client,
     )
 
     assert (tmp_path / "huge.md").exists()
 
 
+@pytest.mark.usefixtures("patched_download_fileset")
 @pytest.mark.asyncio
 async def test_stage_fabric_ethos_dir_removes_files_dropped_from_fileset(tmp_path: Path) -> None:
     (tmp_path / "skills").mkdir()
@@ -340,15 +460,15 @@ async def test_stage_fabric_ethos_dir_removes_files_dropped_from_fileset(tmp_pat
         (Path(local_path) / "mcps").mkdir()
         (Path(local_path) / "mcps" / "calculator.py").write_text("print(1)\n", encoding="utf-8")
 
-    sdk = AsyncMock()
-    sdk.download = AsyncMock(side_effect=_fake_download)
+    files_client = AsyncMock()
+    files_client.download = AsyncMock(side_effect=_fake_download)
 
     await stage_fabric_ethos_dir(
         workspace="default",
         agent_name="fabric-agent",
         agent_config=_fabric_config(),
         base_dir=tmp_path,
-        sdk=sdk,
+        files_client=files_client,
     )
 
     assert not (tmp_path / "skills").exists()
@@ -356,14 +476,15 @@ async def test_stage_fabric_ethos_dir_removes_files_dropped_from_fileset(tmp_pat
     assert (tmp_path / "mcps" / "calculator.py").exists()
 
 
+@pytest.mark.usefixtures("patched_download_fileset")
 @pytest.mark.asyncio
 async def test_stage_fabric_ethos_dir_missing_fileset_does_not_accept_stale_skills(tmp_path: Path) -> None:
     skill_dir = tmp_path / "skills" / "review"
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text("# Stale\n", encoding="utf-8")
 
-    sdk = AsyncMock()
-    sdk.download = AsyncMock(side_effect=FileNotFoundError("missing"))
+    files_client = AsyncMock()
+    files_client.download = AsyncMock(side_effect=FileNotFoundError("missing"))
 
     with pytest.raises(FabricArtifactStagingError, match="skills/review"):
         await stage_fabric_ethos_dir(
@@ -371,10 +492,11 @@ async def test_stage_fabric_ethos_dir_missing_fileset_does_not_accept_stale_skil
             agent_name="fabric-agent",
             agent_config=_fabric_config(skills_paths=["skills/review"]),
             base_dir=tmp_path,
-            sdk=sdk,
+            files_client=files_client,
         )
 
 
+@pytest.mark.usefixtures("patched_download_fileset")
 @pytest.mark.asyncio
 async def test_stage_fabric_ethos_dir_preserves_runtime_directories(tmp_path: Path) -> None:
     (tmp_path / "artifacts").mkdir()
@@ -386,15 +508,15 @@ async def test_stage_fabric_ethos_dir_preserves_runtime_directories(tmp_path: Pa
     config = _fabric_config()
     config["environment"] = {"workspace": "./workspace", "artifacts": "./artifacts"}
 
-    sdk = AsyncMock()
-    sdk.download = AsyncMock(side_effect=FileNotFoundError("missing"))
+    files_client = AsyncMock()
+    files_client.download = AsyncMock(side_effect=FileNotFoundError("missing"))
 
     await stage_fabric_ethos_dir(
         workspace="default",
         agent_name="fabric-agent",
         agent_config=config,
         base_dir=tmp_path,
-        sdk=sdk,
+        files_client=files_client,
     )
 
     assert (tmp_path / "artifacts" / "events.atof.jsonl").exists()
@@ -419,6 +541,7 @@ def test_validate_referenced_skill_paths_does_not_match_sibling_prefix() -> None
         )
 
 
+@pytest.mark.usefixtures("patched_download_fileset")
 @pytest.mark.asyncio
 async def test_stage_fabric_ethos_dir_preserves_runtime_dir_through_parent_traversal(tmp_path: Path) -> None:
     (tmp_path / "workspace").mkdir()
@@ -429,28 +552,29 @@ async def test_stage_fabric_ethos_dir_preserves_runtime_dir_through_parent_trave
     config = _fabric_config()
     config["environment"] = {"workspace": "foo/../workspace", "artifacts": "../outside"}
 
-    sdk = AsyncMock()
-    sdk.download = AsyncMock(side_effect=FileNotFoundError("missing"))
+    files_client = AsyncMock()
+    files_client.download = AsyncMock(side_effect=FileNotFoundError("missing"))
 
     await stage_fabric_ethos_dir(
         workspace="default",
         agent_name="fabric-agent",
         agent_config=config,
         base_dir=tmp_path,
-        sdk=sdk,
+        files_client=files_client,
     )
 
     assert (tmp_path / "workspace" / "scratch.txt").exists()
     assert not (tmp_path / "foo").exists()
 
 
+@pytest.mark.usefixtures("patched_download_fileset")
 @pytest.mark.asyncio
 async def test_stage_fabric_ethos_dir_fails_when_stale_tree_cannot_be_removed(tmp_path: Path) -> None:
     (tmp_path / "skills").mkdir()
     (tmp_path / "skills" / "SKILL.md").write_text("# Stale\n", encoding="utf-8")
 
-    sdk = AsyncMock()
-    sdk.download = AsyncMock()
+    files_client = AsyncMock()
+    files_client.download = AsyncMock()
 
     with patch(
         "nemo_agents_plugin.runner.fabric_artifact_staging.shutil.rmtree",
@@ -462,16 +586,17 @@ async def test_stage_fabric_ethos_dir_fails_when_stale_tree_cannot_be_removed(tm
                 agent_name="fabric-agent",
                 agent_config=_fabric_config(),
                 base_dir=tmp_path,
-                sdk=sdk,
+                files_client=files_client,
             )
 
-    sdk.download.assert_not_awaited()
+    files_client.download.assert_not_awaited()
 
 
+@pytest.mark.usefixtures("patched_download_fileset")
 @pytest.mark.asyncio
 async def test_stage_fabric_ethos_config_files_missing_fileset_rejects_agent_root_skill() -> None:
-    sdk = AsyncMock()
-    sdk.download = AsyncMock(side_effect=NotFoundError("missing fileset", response=MagicMock(), body=None))
+    files_client = AsyncMock()
+    files_client.download = AsyncMock(side_effect=_plugin_not_found())
 
     with pytest.raises(FabricArtifactStagingError, match=r"skills\.paths entry|was not found"):
         await stage_fabric_ethos_config_files(
@@ -479,38 +604,40 @@ async def test_stage_fabric_ethos_config_files_missing_fileset_rejects_agent_roo
             agent_name="fabric-agent",
             rewritten_agent_config=_fabric_config(skills_paths=["."]),
             agent_yaml_path="/workspace/agent.yaml",
-            sdk=sdk,
+            files_client=files_client,
         )
 
 
+@pytest.mark.usefixtures("patched_download_fileset")
 @pytest.mark.asyncio
 async def test_stage_fabric_ethos_config_files_accepts_agent_root_skill_from_fileset() -> None:
     async def _fake_download(*, local_path: str, fileset: str | None, workspace: str | None) -> None:
         del fileset, workspace
         (Path(local_path) / "SKILL.md").write_text("# Root skill\n", encoding="utf-8")
 
-    sdk = AsyncMock()
-    sdk.download = AsyncMock(side_effect=_fake_download)
+    files_client = AsyncMock()
+    files_client.download = AsyncMock(side_effect=_fake_download)
 
     result = await stage_fabric_ethos_config_files(
         workspace="default",
         agent_name="fabric-agent",
         rewritten_agent_config=_fabric_config(skills_paths=["."]),
         agent_yaml_path="/workspace/agent.yaml",
-        sdk=sdk,
+        files_client=files_client,
     )
 
     assert "/workspace/SKILL.md" in {item.path for item in result}
 
 
+@pytest.mark.usefixtures("patched_download_fileset")
 @pytest.mark.asyncio
 async def test_stage_fabric_ethos_config_files_ethos_md_alone_does_not_satisfy_root_skill() -> None:
     async def _fake_download(*, local_path: str, fileset: str | None, workspace: str | None) -> None:
         del fileset, workspace
         (Path(local_path) / "ETHOS.md").write_text("# Ethos\n", encoding="utf-8")
 
-    sdk = AsyncMock()
-    sdk.download = AsyncMock(side_effect=_fake_download)
+    files_client = AsyncMock()
+    files_client.download = AsyncMock(side_effect=_fake_download)
 
     with pytest.raises(FabricArtifactStagingError, match="was not found"):
         await stage_fabric_ethos_config_files(
@@ -518,18 +645,19 @@ async def test_stage_fabric_ethos_config_files_ethos_md_alone_does_not_satisfy_r
             agent_name="fabric-agent",
             rewritten_agent_config=_fabric_config(skills_paths=["."]),
             agent_yaml_path="/workspace/agent.yaml",
-            sdk=sdk,
+            files_client=files_client,
         )
 
 
+@pytest.mark.usefixtures("patched_download_fileset")
 @pytest.mark.asyncio
 async def test_stage_fabric_ethos_config_files_legacy_contract_alone_does_not_satisfy_root_skill() -> None:
     async def _fake_download(*, local_path: str, fileset: str | None, workspace: str | None) -> None:
         del fileset, workspace
         (Path(local_path) / "AGENT-SPEC.md").write_text("# Legacy contract\n", encoding="utf-8")
 
-    sdk = AsyncMock()
-    sdk.download = AsyncMock(side_effect=_fake_download)
+    files_client = AsyncMock()
+    files_client.download = AsyncMock(side_effect=_fake_download)
 
     with pytest.raises(FabricArtifactStagingError, match="was not found"):
         await stage_fabric_ethos_config_files(
@@ -537,10 +665,11 @@ async def test_stage_fabric_ethos_config_files_legacy_contract_alone_does_not_sa
             agent_name="fabric-agent",
             rewritten_agent_config=_fabric_config(skills_paths=["."]),
             agent_yaml_path="/workspace/agent.yaml",
-            sdk=sdk,
+            files_client=files_client,
         )
 
 
+@pytest.mark.usefixtures("patched_download_fileset")
 @pytest.mark.asyncio
 async def test_stage_fabric_ethos_dir_drops_contract_markdown(tmp_path: Path) -> None:
     async def _fake_download(*, local_path: str, fileset: str | None, workspace: str | None) -> None:
@@ -551,15 +680,15 @@ async def test_stage_fabric_ethos_dir_drops_contract_markdown(tmp_path: Path) ->
         (root / "mcps").mkdir()
         (root / "mcps" / "calculator.py").write_text("print(1)\n", encoding="utf-8")
 
-    sdk = AsyncMock()
-    sdk.download = AsyncMock(side_effect=_fake_download)
+    files_client = AsyncMock()
+    files_client.download = AsyncMock(side_effect=_fake_download)
 
     await stage_fabric_ethos_dir(
         workspace="default",
         agent_name="fabric-agent",
         agent_config=_fabric_config(),
         base_dir=tmp_path,
-        sdk=sdk,
+        files_client=files_client,
     )
 
     assert not (tmp_path / "ETHOS.md").exists()
@@ -567,6 +696,7 @@ async def test_stage_fabric_ethos_dir_drops_contract_markdown(tmp_path: Path) ->
     assert (tmp_path / "mcps" / "calculator.py").exists()
 
 
+@pytest.mark.usefixtures("patched_download_fileset")
 @pytest.mark.asyncio
 async def test_stage_fabric_ethos_dir_rejects_symlink_escaping_base_dir(tmp_path: Path) -> None:
     outside = tmp_path / "outside"
@@ -579,8 +709,8 @@ async def test_stage_fabric_ethos_dir_rejects_symlink_escaping_base_dir(tmp_path
         del fileset, workspace
         (Path(local_path) / "escape").symlink_to(outside)
 
-    sdk = AsyncMock()
-    sdk.download = AsyncMock(side_effect=_fake_download)
+    files_client = AsyncMock()
+    files_client.download = AsyncMock(side_effect=_fake_download)
 
     with pytest.raises(FabricArtifactStagingError, match="escapes the agent base directory"):
         await stage_fabric_ethos_dir(
@@ -588,10 +718,45 @@ async def test_stage_fabric_ethos_dir_rejects_symlink_escaping_base_dir(tmp_path
             agent_name="fabric-agent",
             agent_config=_fabric_config(),
             base_dir=base_dir,
-            sdk=sdk,
+            files_client=files_client,
         )
 
 
+@pytest.mark.usefixtures("patched_download_fileset")
+@pytest.mark.asyncio
+async def test_stage_fabric_ethos_dir_rejects_fileset_paths_under_preserved_runtime_dirs(tmp_path: Path) -> None:
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    base_dir = tmp_path / "base"
+    (base_dir / "artifacts").mkdir(parents=True)
+    (base_dir / "artifacts" / "link").symlink_to(outside)
+
+    config = _fabric_config()
+    config["environment"] = {"artifacts": "./artifacts"}
+
+    async def _fake_download(*, local_path: str, fileset: str | None, workspace: str | None) -> None:
+        del fileset, workspace
+        target = Path(local_path) / "artifacts" / "link"
+        target.mkdir(parents=True)
+        (target / "secret.txt").write_text("nope\n", encoding="utf-8")
+
+    files_client = AsyncMock()
+    files_client.download = AsyncMock(side_effect=_fake_download)
+
+    with pytest.raises(FabricArtifactStagingError, match="preserved runtime directory"):
+        await stage_fabric_ethos_dir(
+            workspace="default",
+            agent_name="fabric-agent",
+            agent_config=config,
+            base_dir=base_dir,
+            files_client=files_client,
+        )
+
+    assert not (outside / "secret.txt").exists()
+    assert (base_dir / "artifacts" / "link").is_symlink()
+
+
+@pytest.mark.usefixtures("patched_download_fileset")
 @pytest.mark.asyncio
 async def test_stage_fabric_ethos_dir_allows_symlinks_inside_runtime_directories(tmp_path: Path) -> None:
     outside = tmp_path / "outside"
@@ -603,15 +768,15 @@ async def test_stage_fabric_ethos_dir_allows_symlinks_inside_runtime_directories
     config = _fabric_config()
     config["environment"] = {"workspace": "./workspace", "artifacts": "./artifacts"}
 
-    sdk = AsyncMock()
-    sdk.download = AsyncMock(side_effect=FileNotFoundError("missing"))
+    files_client = AsyncMock()
+    files_client.download = AsyncMock(side_effect=FileNotFoundError("missing"))
 
     await stage_fabric_ethos_dir(
         workspace="default",
         agent_name="fabric-agent",
         agent_config=config,
         base_dir=base_dir,
-        sdk=sdk,
+        files_client=files_client,
     )
 
     assert (base_dir / "artifacts" / "link").is_symlink()

--- a/plugins/nemo-agents/tests/unit/test_fileset_io.py
+++ b/plugins/nemo-agents/tests/unit/test_fileset_io.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from nemo_agents_plugin.jobs.fileset_io import resolve_output, resolve_staged_config, split_fileset_ref
@@ -28,28 +28,34 @@ def test_split_fileset_ref_rejects_invalid_refs(ref: str) -> None:
 
 def test_resolve_staged_config_fileset_downloads_via_sdk(tmp_path: Path, ctx: JobContext) -> None:
     sdk = MagicMock()
+    manager = MagicMock()
 
-    def _fake_download(local_path: str, fileset: str, workspace: str) -> None:
-        Path(local_path, "optimize.yml").write_text("optimizer: {}")
+    def _fake_download(_ref: str, *, local_dir: Path) -> None:
+        Path(local_dir, "optimize.yml").write_text("optimizer: {}")
 
-    sdk.files.download.side_effect = _fake_download
+    manager.download_from_url.side_effect = _fake_download
 
-    with resolve_staged_config(
-        "optimize.yml",
-        FilesetRef("nemo-agent-optimize-calc"),
-        workspace="default",
-        ctx=ctx,
-        sdk=sdk,
-        kind="optimize-config",
-    ) as resolved:
-        assert resolved.is_file()
-        assert resolved.name == "optimize.yml"
-        assert resolved.read_text() == "optimizer: {}"
+    with (
+        patch("nemo_agents_plugin.jobs.fileset_io.client_from_platform", return_value=MagicMock()),
+        patch("nemo_agents_plugin.jobs.fileset_io._fileset_manager", return_value=manager) as manager_factory,
+    ):
+        with resolve_staged_config(
+            "optimize.yml",
+            FilesetRef("nemo-agent-optimize-calc"),
+            workspace="default",
+            ctx=ctx,
+            sdk=sdk,
+            kind="optimize-config",
+        ) as resolved:
+            assert resolved.is_file()
+            assert resolved.name == "optimize.yml"
+            assert resolved.read_text() == "optimizer: {}"
 
-    sdk.files.download.assert_called_once()
-    kwargs = sdk.files.download.call_args.kwargs
-    assert kwargs["fileset"] == "nemo-agent-optimize-calc"
-    assert kwargs["workspace"] == "default"
+    manager_factory.assert_called_once()
+    assert manager_factory.call_args.kwargs["fileset"] == "nemo-agent-optimize-calc"
+    assert manager_factory.call_args.kwargs["workspace"] == "default"
+    manager.download_from_url.assert_called_once()
+    assert manager.download_from_url.call_args.args == ("default/nemo-agent-optimize-calc",)
 
 
 def test_resolve_staged_config_fileset_without_sdk_raises(ctx: JobContext) -> None:
@@ -81,8 +87,12 @@ def test_resolve_staged_config_empty_fileset_ref_is_invalid(ctx: JobContext) -> 
 
 def test_resolve_staged_config_rejects_path_escape(ctx: JobContext) -> None:
     sdk = MagicMock()
-    sdk.files.download.side_effect = lambda local_path, fileset, workspace: None
-    with pytest.raises(ValueError, match="outside the downloaded fileset"):
+    manager = MagicMock()
+    with (
+        patch("nemo_agents_plugin.jobs.fileset_io.client_from_platform", return_value=MagicMock()),
+        patch("nemo_agents_plugin.jobs.fileset_io._fileset_manager", return_value=manager),
+        pytest.raises(ValueError, match="outside the downloaded fileset"),
+    ):
         with resolve_staged_config(
             "../evil.yml",
             FilesetRef("fs"),
@@ -102,25 +112,35 @@ def test_resolve_output_none_uses_persistent_results(ctx: JobContext) -> None:
 
 def test_resolve_output_fileset_uploads_on_clean_exit(ctx: JobContext) -> None:
     sdk = MagicMock()
-    sdk.files.upload.return_value = MagicMock(name="fake-fileset")
+    manager = MagicMock()
 
-    with resolve_output(FilesetRef("optimize-out"), workspace="default", ctx=ctx, sdk=sdk, kind="optimize"):
-        pass
+    with (
+        patch("nemo_agents_plugin.jobs.fileset_io.client_from_platform", return_value=MagicMock()),
+        patch("nemo_agents_plugin.jobs.fileset_io._fileset_manager", return_value=manager) as manager_factory,
+    ):
+        with resolve_output(FilesetRef("optimize-out"), workspace="default", ctx=ctx, sdk=sdk, kind="optimize"):
+            pass
 
-    sdk.files.upload.assert_called_once()
-    kwargs = sdk.files.upload.call_args.kwargs
-    assert kwargs["fileset"] == "optimize-out"
-    assert kwargs["workspace"] == "default"
-    assert kwargs["fileset_auto_create"] is True
-    assert kwargs["local_path"].endswith("/")
+    manager_factory.assert_called_once()
+    assert manager_factory.call_args.kwargs["fileset"] == "optimize-out"
+    assert manager_factory.call_args.kwargs["workspace"] == "default"
+    assert manager_factory.call_args.kwargs["ensure_fileset_exists"] is True
+    manager.validate_storage.assert_called_once_with()
+    manager.upload.assert_called_once()
+    assert manager.upload.call_args.kwargs["remote_path"] == ""
 
 
 def test_resolve_output_fileset_skips_upload_when_body_raises(ctx: JobContext) -> None:
     sdk = MagicMock()
+    manager = MagicMock()
     with pytest.raises(RuntimeError, match="boom"):
-        with resolve_output(FilesetRef("optimize-out"), workspace="default", ctx=ctx, sdk=sdk, kind="optimize"):
-            raise RuntimeError("boom")
-    sdk.files.upload.assert_not_called()
+        with (
+            patch("nemo_agents_plugin.jobs.fileset_io.client_from_platform", return_value=MagicMock()),
+            patch("nemo_agents_plugin.jobs.fileset_io._fileset_manager", return_value=manager),
+        ):
+            with resolve_output(FilesetRef("optimize-out"), workspace="default", ctx=ctx, sdk=sdk, kind="optimize"):
+                raise RuntimeError("boom")
+    manager.upload.assert_not_called()
 
 
 def test_resolve_output_empty_fileset_ref_is_invalid(ctx: JobContext) -> None:
@@ -128,4 +148,3 @@ def test_resolve_output_empty_fileset_ref_is_invalid(ctx: JobContext) -> None:
     with pytest.raises(ValueError, match="invalid entity reference"):
         with resolve_output(FilesetRef(""), workspace="default", ctx=ctx, sdk=sdk, kind="optimize"):
             pass
-    sdk.files.upload.assert_not_called()

--- a/plugins/nemo-agents/tests/unit/test_optimize_prepare_fileset_cli.py
+++ b/plugins/nemo-agents/tests/unit/test_optimize_prepare_fileset_cli.py
@@ -6,8 +6,8 @@
 from __future__ import annotations
 
 import json
+from contextlib import ExitStack
 from pathlib import Path
-from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
 
@@ -55,23 +55,36 @@ def app() -> typer.Typer:
     return group
 
 
-def uploads(record: dict[str, Any]) -> Any:
-    class _StubFiles:
-        def upload(self, *, local_path: str, fileset: str, workspace: str, fileset_auto_create: bool) -> Any:
-            record.update(
-                local_path=local_path,
-                fileset=fileset,
-                workspace=workspace,
-                auto_create=fileset_auto_create,
-            )
-            return SimpleNamespace(name=fileset)
+class _StubSDK:
+    pass
 
-    return SimpleNamespace(files=_StubFiles())
+
+def _patch_upload(record: dict[str, Any]) -> ExitStack:
+    class _StubManager:
+        def validate_storage(self) -> None:
+            record["validated"] = True
+
+        def upload(self, *, local_path: Path, remote_path: str) -> None:
+            record.update(local_path=local_path, remote_path=remote_path)
+
+    def manager(_files_client: object, *, workspace: str, fileset: str, ensure_fileset_exists: bool) -> _StubManager:
+        record.update(
+            fileset=fileset,
+            workspace=workspace,
+            auto_create=ensure_fileset_exists,
+        )
+        return _StubManager()
+
+    stack = ExitStack()
+    stack.enter_context(patch("nemo_agents_plugin.jobs.optimize_cli._platform_sdk", return_value=_StubSDK()))
+    stack.enter_context(patch("nemo_agents_plugin.jobs.fileset_io.client_from_platform", return_value=object()))
+    stack.enter_context(patch("nemo_agents_plugin.jobs.fileset_io._fileset_manager", side_effect=manager))
+    return stack
 
 
 def test_uploads_the_bundle_and_prints_the_submit_command(app: typer.Typer, bundle: Path) -> None:
     record: dict[str, Any] = {}
-    with patch("nemo_agents_plugin.jobs.optimize_cli._platform_sdk", return_value=uploads(record)):
+    with _patch_upload(record):
         result = CliRunner().invoke(
             app,
             [
@@ -90,15 +103,16 @@ def test_uploads_the_bundle_and_prints_the_submit_command(app: typer.Typer, bund
     assert record["fileset"] == "my-opt-fs"
     assert record["workspace"] == "default"
     assert record["auto_create"] is True
-    # Trailing slash uploads the directory's contents, not the directory itself.
-    assert record["local_path"].endswith("/")
+    assert record["validated"] is True
+    assert record["local_path"] == bundle
+    assert record["remote_path"] == ""
     assert "--optimize-config-fileset default/my-opt-fs" in result.output
     assert "--optimize-config optimize.yml" in result.output
 
 
 def test_honours_a_workspace_qualified_fileset_ref(app: typer.Typer, bundle: Path) -> None:
     record: dict[str, Any] = {}
-    with patch("nemo_agents_plugin.jobs.optimize_cli._platform_sdk", return_value=uploads(record)):
+    with _patch_upload(record):
         result = CliRunner().invoke(
             app,
             [

--- a/plugins/nemo-agents/tests/unit/test_package_agent_job.py
+++ b/plugins/nemo-agents/tests/unit/test_package_agent_job.py
@@ -191,7 +191,9 @@ class TestRun:
     def test_builds_from_staged_ethos_fileset(self, tmp_path: Path) -> None:
         captured: dict[str, Any] = {}
 
-        async def _stage(*, workspace: str, agent_name: str, agent_config: dict, base_dir: Path, sdk: Any) -> None:
+        async def _stage(
+            *, workspace: str, agent_name: str, agent_config: dict, base_dir: Path, files_client: Any
+        ) -> None:
             captured["workspace"] = workspace
             captured["agent_name"] = agent_name
             (base_dir / "skills").mkdir()

--- a/plugins/nemo-agents/tests/unit/test_runner_deployments.py
+++ b/plugins/nemo-agents/tests/unit/test_runner_deployments.py
@@ -1331,6 +1331,7 @@ async def test_create_deployment_fabric_docker_stages_fileset_artifacts() -> Non
         ConfigFile(path="/tmp/nemo/skills/review/SKILL.md", content="# Review\n"),
     ]
     sdk = MagicMock()
+    files_client = object()
 
     with (
         patch("nemo_agents_plugin.runner.deployments_backend.get_base_url", return_value="http://localhost:8080"),
@@ -1338,6 +1339,7 @@ async def test_create_deployment_fabric_docker_stages_fileset_artifacts() -> Non
             "nemo_agents_plugin.runner.deployments_backend.get_async_platform_sdk",
             return_value=sdk,
         ),
+        patch("nemo_agents_plugin.runner.deployments_backend.client_from_platform", return_value=files_client),
         patch(
             "nemo_agents_plugin.runner.deployments_backend.stage_fabric_ethos_config_files",
             new_callable=AsyncMock,
@@ -1355,6 +1357,9 @@ async def test_create_deployment_fabric_docker_stages_fileset_artifacts() -> Non
 
     assert info.status == "starting"
     mock_stage.assert_awaited_once()
+    stage_args = mock_stage.await_args
+    assert stage_args is not None
+    assert stage_args.kwargs["files_client"] is files_client
     created_config = entities.create.await_args_list[0].args[0]
     assert len(created_config.config_files) == 2
     assert not any(e.name == "STAGED_CONFIG_FILES_B64_JSON" for e in created_config.containers[0].env)
@@ -1381,6 +1386,7 @@ async def test_create_deployment_fabric_k8s_stages_fileset_artifacts() -> None:
         ConfigFile(path="/tmp/nemo/skills/review/SKILL.md", content="# Review\n"),
     ]
     sdk = MagicMock()
+    files_client = object()
 
     with (
         patch("nemo_agents_plugin.runner.deployments_backend.get_base_url", return_value="http://localhost:8080"),
@@ -1388,6 +1394,7 @@ async def test_create_deployment_fabric_k8s_stages_fileset_artifacts() -> None:
             "nemo_agents_plugin.runner.deployments_backend.get_async_platform_sdk",
             return_value=sdk,
         ),
+        patch("nemo_agents_plugin.runner.deployments_backend.client_from_platform", return_value=files_client),
         patch(
             "nemo_agents_plugin.runner.deployments_backend.stage_fabric_ethos_config_files",
             new_callable=AsyncMock,
@@ -1422,6 +1429,7 @@ async def test_create_deployment_fabric_staging_error_fails_before_entity_create
         "harnesses": {"main": {"kind": "codex", "settings": {}}},
     }
     sdk = MagicMock()
+    files_client = object()
 
     with (
         patch("nemo_agents_plugin.runner.deployments_backend.get_base_url", return_value="http://localhost:8080"),
@@ -1429,6 +1437,7 @@ async def test_create_deployment_fabric_staging_error_fails_before_entity_create
             "nemo_agents_plugin.runner.deployments_backend.get_async_platform_sdk",
             return_value=sdk,
         ),
+        patch("nemo_agents_plugin.runner.deployments_backend.client_from_platform", return_value=files_client),
         patch(
             "nemo_agents_plugin.runner.deployments_backend.stage_fabric_ethos_config_files",
             new_callable=AsyncMock,

--- a/plugins/nemo-agents/tests/unit/test_runner_in_memory.py
+++ b/plugins/nemo-agents/tests/unit/test_runner_in_memory.py
@@ -550,9 +550,9 @@ async def test_create_deployment_stages_ethos_fileset_into_base_dir(tmp_path: Pa
         agent_name: str,
         agent_config: dict[str, Any],
         base_dir: Path,
-        sdk: Any,
+        files_client: Any | None,
     ) -> None:
-        del sdk
+        del files_client
         staged.append({"workspace": workspace, "agent_name": agent_name, "base_dir": base_dir})
         assert not (base_dir / "agent.yaml").exists()
         (base_dir / "mcps").mkdir()
@@ -575,6 +575,7 @@ async def test_create_deployment_stages_ethos_fileset_into_base_dir(tmp_path: Pa
         patch("nemo_agents_plugin.runner.in_memory.validate_platform_agent_config", _validate_platform_agent_config),
         patch("nemo_agents_plugin.runner.in_memory.stage_fabric_ethos_dir", _stage_fabric_ethos_dir),
         patch("nemo_agents_plugin.runner.in_memory.get_async_platform_sdk", MagicMock()),
+        patch("nemo_agents_plugin.runner.in_memory.client_from_platform", return_value=MagicMock()),
         patch.object(InMemoryRunnerBackend, "_spawn_fabric", _spawn_fabric),
     ):
         info = await backend.create_deployment("ws", "fabric-dep", config, port=49212, agent="fabric-agent")
@@ -604,6 +605,7 @@ async def test_create_deployment_cleans_base_dir_when_staging_fails(tmp_path: Pa
     with (
         patch("nemo_agents_plugin.runner.in_memory.stage_fabric_ethos_dir", _stage_fabric_ethos_dir),
         patch("nemo_agents_plugin.runner.in_memory.get_async_platform_sdk", MagicMock()),
+        patch("nemo_agents_plugin.runner.in_memory.client_from_platform", return_value=MagicMock()),
     ):
         with pytest.raises(FabricArtifactStagingError, match="skills/review"):
             await backend.create_deployment("ws", "fabric-dep", config, port=0, agent="fabric-agent")
@@ -623,16 +625,23 @@ async def test_redeploy_after_crash_does_not_merge_previous_fileset(tmp_path: Pa
         "models": {"default": {"provider": "openai", "model": "openai/gpt-5.4"}},
     }
 
-    def _sdk_serving(skill_name: str) -> MagicMock:
+    def _files_client_serving(skill_name: str) -> SimpleNamespace:
         async def _download(*, local_path: str, fileset: str | None = None, workspace: str | None = None) -> None:
             del fileset, workspace
             skills = Path(local_path) / "skills"
             skills.mkdir(parents=True, exist_ok=True)
             (skills / skill_name).write_text("# skill\n")
 
-        sdk = MagicMock()
-        sdk.files = SimpleNamespace(download=_download)
-        return sdk
+        return SimpleNamespace(download=_download)
+
+    async def _download_fileset(
+        files_client: Any,
+        *,
+        workspace: str,
+        fileset_name: str,
+        local_path: Path,
+    ) -> None:
+        await files_client.download(local_path=str(local_path), fileset=fileset_name, workspace=workspace)
 
     async def _validate(config_: dict[str, Any], *, base_dir: Path) -> Any:
         del config_, base_dir
@@ -648,12 +657,15 @@ async def test_redeploy_after_crash_does_not_merge_previous_fileset(tmp_path: Pa
 
     base_dirs: list[Path] = []
     for skill_name in ("old.md", "new.md"):
+        files_client = _files_client_serving(skill_name)
         with (
             patch("nemo_agents_plugin.runner.in_memory.validate_platform_agent_config", _validate),
             patch(
                 "nemo_agents_plugin.runner.in_memory.get_async_platform_sdk",
-                return_value=_sdk_serving(skill_name),
+                return_value=MagicMock(),
             ),
+            patch("nemo_agents_plugin.runner.in_memory.client_from_platform", return_value=files_client),
+            patch("nemo_agents_plugin.runner.fabric_artifact_staging._download_fileset", _download_fileset),
             patch.object(InMemoryRunnerBackend, "_spawn_fabric", _spawn_fabric),
         ):
             info = await backend.create_deployment("ws", "dep", config, port=49300, agent="fabric-agent")

--- a/plugins/nemo-agents/tests/unit/test_sdk.py
+++ b/plugins/nemo-agents/tests/unit/test_sdk.py
@@ -4,8 +4,7 @@
 from __future__ import annotations
 
 import json
-from contextlib import AbstractContextManager
-from types import SimpleNamespace
+from collections.abc import Callable, Mapping
 from typing import Any
 from unittest.mock import patch
 
@@ -19,17 +18,39 @@ from nemo_agents_plugin.entities import (
 )
 from nemo_agents_plugin.sdk import AgentsResource, AsyncAgentsResource, agents_sdk_resources
 from nemo_agents_plugin.session_protocol import SESSION_ID_HEADER
+from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
+
+_Handler = Callable[[httpx.Request], httpx.Response]
 
 
-def _install_mock_transport(handler) -> AbstractContextManager[Any]:
-    transport = httpx.MockTransport(handler)
-    real_client = httpx.Client
+def _read_json(req: httpx.Request) -> dict[str, Any]:
+    body = json.loads(req.read())
+    assert isinstance(body, dict)
+    return body
 
-    def _factory(*args, **kwargs):
-        kwargs["transport"] = transport
-        return real_client(*args, **kwargs)
 
-    return patch("nemo_agents_plugin.sdk.httpx.Client", _factory)
+def _platform(
+    handler: _Handler,
+    *,
+    workspace: str | None = "team-a",
+    default_headers: Mapping[str, str] | None = None,
+) -> NeMoPlatform:
+    return NeMoPlatform(
+        base_url="http://test",
+        workspace=workspace,
+        default_headers=default_headers,
+        http_client=httpx.Client(transport=httpx.MockTransport(handler)),
+        max_retries=0,
+    )
+
+
+def _async_platform(handler: _Handler, *, workspace: str | None = "team-a") -> AsyncNeMoPlatform:
+    return AsyncNeMoPlatform(
+        base_url="http://test",
+        workspace=workspace,
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        max_retries=0,
+    )
 
 
 def test_create_resolves_default_model_placeholder_before_post() -> None:
@@ -37,16 +58,13 @@ def test_create_resolves_default_model_placeholder_before_post() -> None:
 
     def handler(req: httpx.Request) -> httpx.Response:
         captured["path"] = req.url.path
-        captured["body"] = json.loads(req.read())
+        captured["body"] = _read_json(req)
         return httpx.Response(201, json={"name": "calc"})
 
-    client = AgentsResource(SimpleNamespace(base_url="http://test", workspace="team-a"))
+    client = AgentsResource(_platform(handler))
     config = {"llms": {"llm": {"_type": "openai", "model_name": "${NEMO_DEFAULT_MODEL}"}}}
 
-    with (
-        _install_mock_transport(handler),
-        patch("nemo_agents_plugin.utils.get_default_model", return_value="team-a/nemotron"),
-    ):
+    with patch("nemo_agents_plugin.utils.get_default_model", return_value="team-a/nemotron"):
         result = client.create(name="calc", config=config)
 
     assert result == {"name": "calc"}
@@ -59,15 +77,46 @@ def test_create_rejects_unresolved_default_model_placeholder() -> None:
     def handler(_req: httpx.Request) -> httpx.Response:
         raise AssertionError("should not POST unresolved agent config")
 
-    client = AgentsResource(SimpleNamespace(base_url="http://test", workspace="team-a"))
+    client = AgentsResource(_platform(handler))
     config = {"llms": {"llm": {"_type": "openai", "model_name": "$NEMO_DEFAULT_MODEL"}}}
 
     with (
-        _install_mock_transport(handler),
         patch("nemo_agents_plugin.utils.get_default_model", return_value=None),
         pytest.raises(ValueError, match="NEMO_DEFAULT_MODEL"),
     ):
         client.create(name="calc", config=config)
+
+
+def test_agents_resource_uses_default_workspace_when_platform_workspace_is_unset() -> None:
+    paths: list[str] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        paths.append(req.url.path)
+        return httpx.Response(201, json={"name": "calc"})
+
+    resource = AgentsResource(_platform(handler, workspace=None))
+
+    resource.create(name="calc", config={})
+    resource.jobs.execute.create(spec={"agent": "calc", "input": "2+2"})
+
+    assert paths == [
+        "/apis/agents/v2/workspaces/default/agents",
+        "/apis/agents/v2/workspaces/default/jobs/execute",
+    ]
+
+
+async def test_async_agents_resource_uses_default_workspace_when_platform_workspace_is_unset() -> None:
+    paths: list[str] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        paths.append(req.url.path)
+        return httpx.Response(201, json={"name": "execute-a1b2"})
+
+    await AsyncAgentsResource(_async_platform(handler, workspace=None)).jobs.execute.create(
+        spec={"agent": "calc", "input": "2+2"}
+    )
+
+    assert paths == ["/apis/agents/v2/workspaces/default/jobs/execute"]
 
 
 def test_deployments_create_uses_client_workspace_by_default() -> None:
@@ -75,13 +124,12 @@ def test_deployments_create_uses_client_workspace_by_default() -> None:
 
     def handler(req: httpx.Request) -> httpx.Response:
         captured["path"] = req.url.path
-        captured["body"] = json.loads(req.read())
+        captured["body"] = _read_json(req)
         return httpx.Response(201, json={"name": "calc-dep"})
 
-    client = AgentsResource(SimpleNamespace(base_url="http://test", workspace="team-a"))
+    client = AgentsResource(_platform(handler))
 
-    with _install_mock_transport(handler):
-        result = client.deployments.create(agent="calc", deployment_mode="k8s", image="repo/calc:1.0")
+    result = client.deployments.create(agent="calc", deployment_mode="k8s", image="repo/calc:1.0")
 
     assert result == {"name": "calc-dep"}
     assert captured["path"] == "/apis/agents/v2/workspaces/team-a/deployments"
@@ -92,18 +140,17 @@ def test_deployments_create_forwards_image_entrypoint_mode() -> None:
     captured: dict[str, Any] = {}
 
     def handler(req: httpx.Request) -> httpx.Response:
-        captured["body"] = json.loads(req.read())
+        captured["body"] = _read_json(req)
         return httpx.Response(201, json={"name": "calc-dep"})
 
-    client = AgentsResource(SimpleNamespace(base_url="http://test", workspace="team-a"))
+    client = AgentsResource(_platform(handler))
 
-    with _install_mock_transport(handler):
-        client.deployments.create(
-            agent="calc",
-            deployment_mode="docker",
-            image="repo/calc:1.0",
-            use_image_entrypoint=True,
-        )
+    client.deployments.create(
+        agent="calc",
+        deployment_mode="docker",
+        image="repo/calc:1.0",
+        use_image_entrypoint=True,
+    )
 
     assert captured["body"] == {
         "agent": "calc",
@@ -117,9 +164,9 @@ def test_deployments_create_rejects_image_entrypoint_for_subprocess() -> None:
     def handler(_req: httpx.Request) -> httpx.Response:
         raise AssertionError("should not POST image entrypoint mode for subprocess")
 
-    client = AgentsResource(SimpleNamespace(base_url="http://test", workspace="team-a"))
+    client = AgentsResource(_platform(handler))
 
-    with _install_mock_transport(handler), pytest.raises(ValueError, match="use_image_entrypoint"):
+    with pytest.raises(ValueError, match="use_image_entrypoint"):
         client.deployments.create(agent="calc", use_image_entrypoint=True)
 
 
@@ -128,14 +175,13 @@ def test_invoke_sends_session_id_as_header() -> None:
 
     def handler(req: httpx.Request) -> httpx.Response:
         captured["path"] = req.url.path
-        captured["body"] = json.loads(req.read())
+        captured["body"] = _read_json(req)
         captured["session_id"] = req.headers.get(SESSION_ID_HEADER)
         return httpx.Response(200, json={"id": "completion-id"})
 
-    client = AgentsResource(SimpleNamespace(base_url="http://test", workspace="team-a"))
+    client = AgentsResource(_platform(handler))
 
-    with _install_mock_transport(handler):
-        result = client.invoke(input="Continue", deployment="calc-dep", session_id="session-entity-id")
+    result = client.invoke(input="Continue", deployment="calc-dep", session_id="session-entity-id")
 
     assert result == {"id": "completion-id"}
     assert captured["path"] == "/apis/agents/v2/workspaces/team-a/deployments/calc-dep/-/v1/chat/completions"
@@ -153,10 +199,9 @@ def test_invoke_without_session_id_omits_header() -> None:
         captured["session_id"] = req.headers.get(SESSION_ID_HEADER)
         return httpx.Response(200, json={"id": "completion-id"})
 
-    client = AgentsResource(SimpleNamespace(base_url="http://test", workspace="team-a"))
+    client = AgentsResource(_platform(handler))
 
-    with _install_mock_transport(handler):
-        client.invoke(input="Hello", agent="calc")
+    client.invoke(input="Hello", agent="calc")
 
     assert captured["session_id"] is None
 
@@ -165,9 +210,9 @@ def test_invoke_rejects_empty_session_id() -> None:
     def handler(_req: httpx.Request) -> httpx.Response:
         raise AssertionError("should not invoke with an empty session ID")
 
-    client = AgentsResource(SimpleNamespace(base_url="http://test", workspace="team-a"))
+    client = AgentsResource(_platform(handler))
 
-    with _install_mock_transport(handler), pytest.raises(ValueError, match="session_id must not be empty"):
+    with pytest.raises(ValueError, match="session_id must not be empty"):
         client.invoke(input="Hello", agent="calc", session_id="")
 
 
@@ -180,12 +225,11 @@ def test_deployments_create_forwards_environment() -> None:
     captured: dict[str, Any] = {}
 
     def handler(req: httpx.Request) -> httpx.Response:
-        captured["body"] = json.loads(req.read())
+        captured["body"] = _read_json(req)
         return httpx.Response(201, json={"name": "d1"})
 
-    client = AgentsResource(SimpleNamespace(base_url="http://test", workspace="default"))
-    with _install_mock_transport(handler):
-        client.deployments.create(agent="calc", environment="default/env1")
+    client = AgentsResource(_platform(handler, workspace="default"))
+    client.deployments.create(agent="calc", environment="default/env1")
 
     assert captured["body"]["environment"] == "default/env1"
 
@@ -195,14 +239,13 @@ def test_environment_specs_create_posts_inline_fields() -> None:
 
     def handler(req: httpx.Request) -> httpx.Response:
         captured["path"] = req.url.path
-        captured["body"] = json.loads(req.read())
+        captured["body"] = _read_json(req)
         return httpx.Response(201, json={"name": "ben"})
 
-    client = AgentsResource(SimpleNamespace(base_url="http://test", workspace="team-a"))
-    with _install_mock_transport(handler):
-        result = client.environment_specs.create(
-            name="ben", spec={"env": {"LOG_LEVEL": "debug"}, "secrets": {"TOK": "default/tok"}}
-        )
+    client = AgentsResource(_platform(handler))
+    result = client.environment_specs.create(
+        name="ben", spec={"env": {"LOG_LEVEL": "debug"}, "secrets": {"TOK": "default/tok"}}
+    )
 
     assert result == {"name": "ben"}
     assert captured["path"] == "/apis/agents/v2/workspaces/team-a/environment-specs"
@@ -214,12 +257,11 @@ def test_environments_create_with_refs() -> None:
 
     def handler(req: httpx.Request) -> httpx.Response:
         captured["path"] = req.url.path
-        captured["body"] = json.loads(req.read())
+        captured["body"] = _read_json(req)
         return httpx.Response(201, json={"name": "env1"})
 
-    client = AgentsResource(SimpleNamespace(base_url="http://test", workspace="default"))
-    with _install_mock_transport(handler):
-        client.environments.create(name="env1", environment_spec="default/ben", compute_spec="default/big")
+    client = AgentsResource(_platform(handler, workspace="default"))
+    client.environments.create(name="env1", environment_spec="default/ben", compute_spec="default/big")
 
     assert captured["path"] == "/apis/agents/v2/workspaces/default/environments"
     assert captured["body"]["environment_spec"] == "default/ben"
@@ -230,12 +272,11 @@ def test_environments_create_omits_unset_refs() -> None:
     captured: dict[str, Any] = {}
 
     def handler(req: httpx.Request) -> httpx.Response:
-        captured["body"] = json.loads(req.read())
+        captured["body"] = _read_json(req)
         return httpx.Response(201, json={"name": "env2"})
 
-    client = AgentsResource(SimpleNamespace(base_url="http://test", workspace="default"))
-    with _install_mock_transport(handler):
-        client.environments.create(name="env2", environment_spec="default/ben")
+    client = AgentsResource(_platform(handler, workspace="default"))
+    client.environments.create(name="env2", environment_spec="default/ben")
 
     assert "compute_spec" not in captured["body"]
     assert captured["body"]["environment_spec"] == "default/ben"
@@ -250,84 +291,94 @@ def test_compute_specs_get_and_delete() -> None:
             return httpx.Response(204)
         return httpx.Response(200, json={"name": "big"})
 
-    client = AgentsResource(SimpleNamespace(base_url="http://test", workspace="team-a"))
-    with _install_mock_transport(handler):
-        got = client.compute_specs.get("big")
-        client.compute_specs.delete("big")
+    client = AgentsResource(_platform(handler))
+    got = client.compute_specs.get("big")
+    client.compute_specs.delete("big")
 
     assert got == {"name": "big"}
     assert ("GET", "/apis/agents/v2/workspaces/team-a/compute-specs/big") in captured["calls"]
     assert ("DELETE", "/apis/agents/v2/workspaces/team-a/compute-specs/big") in captured["calls"]
 
 
-class _RecordingPlatform:
-    """Stand-in for the platform client's request pipeline.
-
-    The job resources deliberately go through ``platform.post`` / ``platform.get``
-    rather than a bare ``httpx`` client, so the caller's auth headers, base URL,
-    and retry policy are applied. Recording those calls is enough to pin the
-    request shape.
-    """
-
-    def __init__(self, response: Any = None, workspace: str | None = None) -> None:
-        self.calls: list[dict[str, Any]] = []
-        self._response = response if response is not None else {"name": "execute-a1b2"}
-        self.workspace = workspace
-
-    def post(self, path: str, *, body: Any = None, cast_to: Any = None) -> Any:
-        self.calls.append({"method": "POST", "path": path, "body": body, "cast_to": cast_to})
-        return self._response
-
-    def get(self, path: str, *, cast_to: Any = None) -> Any:
-        self.calls.append({"method": "GET", "path": path, "cast_to": cast_to})
-        return self._response
-
-
 def test_execute_job_create_posts_spec_to_job_collection() -> None:
-    platform = _RecordingPlatform()
-    resource = AgentsResource(platform)
+    captured: dict[str, Any] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        captured["method"] = req.method
+        captured["path"] = req.url.path
+        captured["body"] = _read_json(req)
+        return httpx.Response(201, json={"name": "execute-a1b2"})
+
+    resource = AgentsResource(_platform(handler))
 
     result = resource.jobs.execute.create(spec={"agent": "calc", "input": "2+2"}, workspace="team-a")
 
     assert result == {"name": "execute-a1b2"}
-    assert platform.calls == [
-        {
-            "method": "POST",
-            "path": "/apis/agents/v2/workspaces/team-a/jobs/execute",
-            "body": {"spec": {"agent": "calc", "input": "2+2"}},
-            "cast_to": dict[str, Any],
-        }
-    ]
+    assert captured == {
+        "method": "POST",
+        "path": "/apis/agents/v2/workspaces/team-a/jobs/execute",
+        "body": {"spec": {"agent": "calc", "input": "2+2"}},
+    }
 
 
 def test_execute_job_create_omits_name_when_unset() -> None:
     """An omitted name lets the Jobs service generate a unique one."""
-    platform = _RecordingPlatform()
+    captured: dict[str, Any] = {}
 
-    AgentsResource(platform).jobs.execute.create(spec={"agent": "calc", "input": "hi"})
+    def handler(req: httpx.Request) -> httpx.Response:
+        captured["body"] = _read_json(req)
+        return httpx.Response(201, json={"name": "execute-a1b2"})
 
-    assert "name" not in platform.calls[0]["body"]
+    AgentsResource(_platform(handler)).jobs.execute.create(spec={"agent": "calc", "input": "hi"})
+
+    assert isinstance(captured["body"], dict)
+    assert "name" not in captured["body"]
 
 
 def test_execute_job_create_includes_name_and_description_when_given() -> None:
-    platform = _RecordingPlatform()
+    captured: dict[str, Any] = {}
 
-    AgentsResource(platform).jobs.execute.create(
+    def handler(req: httpx.Request) -> httpx.Response:
+        captured["body"] = _read_json(req)
+        return httpx.Response(201, json={"name": "execute-a1b2"})
+
+    AgentsResource(_platform(handler)).jobs.execute.create(
         spec={"agent": "calc", "input": "hi"}, name="run-1", description="demo"
     )
 
-    assert platform.calls[0]["body"]["name"] == "run-1"
-    assert platform.calls[0]["body"]["description"] == "demo"
+    assert isinstance(captured["body"], dict)
+    assert captured["body"]["name"] == "run-1"
+    assert captured["body"]["description"] == "demo"
 
 
 def test_execute_job_get_and_list_results_paths() -> None:
-    platform = _RecordingPlatform()
-    jobs = AgentsResource(platform).jobs.execute
+    paths: list[str] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        paths.append(req.url.path)
+        if req.url.path.endswith("/results"):
+            return httpx.Response(
+                200,
+                json={
+                    "data": [
+                        {
+                            "name": "result",
+                            "job": "execute-a1b2",
+                            "workspace": "team-a",
+                            "artifact_url": "fileset://result",
+                            "artifact_storage_type": "fileset",
+                        }
+                    ]
+                },
+            )
+        return httpx.Response(200, json={"name": "execute-a1b2"})
+
+    jobs = AgentsResource(_platform(handler)).jobs.execute
 
     jobs.get("execute-a1b2", workspace="team-a")
     jobs.list_results("execute-a1b2", workspace="team-a")
 
-    assert [call["path"] for call in platform.calls] == [
+    assert paths == [
         "/apis/agents/v2/workspaces/team-a/jobs/execute/execute-a1b2",
         "/apis/agents/v2/workspaces/team-a/jobs/execute/execute-a1b2/results",
     ]
@@ -335,64 +386,95 @@ def test_execute_job_get_and_list_results_paths() -> None:
 
 def test_execute_job_get_accepts_workspace_positionally() -> None:
     """Mirrors sibling ``get``/``delete`` methods, which take workspace positional-or-keyword."""
-    platform = _RecordingPlatform()
-    jobs = AgentsResource(platform).jobs.execute
+    paths: list[str] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        paths.append(req.url.path)
+        return httpx.Response(200, json={"name": "execute-a1b2"})
+
+    jobs = AgentsResource(_platform(handler)).jobs.execute
 
     jobs.get("execute-a1b2", "team-a")
 
-    assert platform.calls[0]["path"] == "/apis/agents/v2/workspaces/team-a/jobs/execute/execute-a1b2"
+    assert paths[0] == "/apis/agents/v2/workspaces/team-a/jobs/execute/execute-a1b2"
 
 
 def test_execute_job_create_uses_client_workspace_by_default() -> None:
-    platform = _RecordingPlatform(workspace="team-a")
+    paths: list[str] = []
 
-    AgentsResource(platform).jobs.execute.create(spec={"agent": "calc", "input": "2+2"})
+    def handler(req: httpx.Request) -> httpx.Response:
+        paths.append(req.url.path)
+        return httpx.Response(201, json={"name": "execute-a1b2"})
 
-    assert platform.calls[0]["path"] == "/apis/agents/v2/workspaces/team-a/jobs/execute"
+    AgentsResource(_platform(handler, workspace="team-a")).jobs.execute.create(spec={"agent": "calc", "input": "2+2"})
+
+    assert paths[0] == "/apis/agents/v2/workspaces/team-a/jobs/execute"
 
 
 def test_execute_job_get_and_list_results_use_client_workspace_by_default() -> None:
-    platform = _RecordingPlatform(workspace="team-a")
-    jobs = AgentsResource(platform).jobs.execute
+    paths: list[str] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        paths.append(req.url.path)
+        if req.url.path.endswith("/results"):
+            return httpx.Response(
+                200,
+                json={
+                    "data": [
+                        {
+                            "name": "result",
+                            "job": "execute-a1b2",
+                            "workspace": "team-a",
+                            "artifact_url": "fileset://result",
+                            "artifact_storage_type": "fileset",
+                        }
+                    ]
+                },
+            )
+        return httpx.Response(200, json={"name": "execute-a1b2"})
+
+    jobs = AgentsResource(_platform(handler, workspace="team-a")).jobs.execute
 
     jobs.get("execute-a1b2")
     jobs.list_results("execute-a1b2")
 
-    assert [call["path"] for call in platform.calls] == [
+    assert paths == [
         "/apis/agents/v2/workspaces/team-a/jobs/execute/execute-a1b2",
         "/apis/agents/v2/workspaces/team-a/jobs/execute/execute-a1b2/results",
     ]
 
 
 async def test_async_execute_job_create_uses_client_workspace_by_default() -> None:
-    class _AsyncRecordingPlatform(_RecordingPlatform):
-        async def post(self, path: str, *, body: Any = None, cast_to: Any = None) -> Any:
-            return super().post(path, body=body, cast_to=cast_to)
+    paths: list[str] = []
 
-        async def get(self, path: str, *, cast_to: Any = None) -> Any:
-            return super().get(path, cast_to=cast_to)
+    def handler(req: httpx.Request) -> httpx.Response:
+        paths.append(req.url.path)
+        return httpx.Response(201, json={"name": "execute-a1b2"})
 
-    platform = _AsyncRecordingPlatform(workspace="team-a")
+    platform = _async_platform(handler, workspace="team-a")
 
     await AsyncAgentsResource(platform).jobs.execute.create(spec={"agent": "calc", "input": "2+2"})
 
-    assert platform.calls[0]["path"] == "/apis/agents/v2/workspaces/team-a/jobs/execute"
+    assert paths[0] == "/apis/agents/v2/workspaces/team-a/jobs/execute"
 
 
 async def test_async_execute_job_create_mirrors_sync_shape() -> None:
-    class _AsyncRecordingPlatform(_RecordingPlatform):
-        async def post(self, path: str, *, body: Any = None, cast_to: Any = None) -> Any:
-            return super().post(path, body=body, cast_to=cast_to)
+    captured: dict[str, Any] = {}
 
-    platform = _AsyncRecordingPlatform()
+    def handler(req: httpx.Request) -> httpx.Response:
+        captured["path"] = req.url.path
+        captured["body"] = _read_json(req)
+        return httpx.Response(201, json={"name": "execute-a1b2"})
+
+    platform = _async_platform(handler, workspace=None)
 
     result = await AsyncAgentsResource(platform).jobs.execute.create(
         spec={"agent": "calc", "input": "2+2"}, workspace="team-a"
     )
 
     assert result == {"name": "execute-a1b2"}
-    assert platform.calls[0]["path"] == "/apis/agents/v2/workspaces/team-a/jobs/execute"
-    assert platform.calls[0]["body"] == {"spec": {"agent": "calc", "input": "2+2"}}
+    assert captured["path"] == "/apis/agents/v2/workspaces/team-a/jobs/execute"
+    assert captured["body"] == {"spec": {"agent": "calc", "input": "2+2"}}
 
 
 def test_agents_sdk_resources_registers_both_sync_and_async() -> None:
@@ -405,13 +487,12 @@ def test_environment_specs_create_accepts_typed_model() -> None:
     captured: dict[str, Any] = {}
 
     def handler(req: httpx.Request) -> httpx.Response:
-        captured["body"] = json.loads(req.read())
+        captured["body"] = _read_json(req)
         return httpx.Response(201, json={"name": "ben"})
 
-    client = AgentsResource(SimpleNamespace(base_url="http://test", workspace="team-a"))
+    client = AgentsResource(_platform(handler))
     spec = EnvironmentSpecInline(env={"LOG_LEVEL": "debug"}, secrets={"TOK": "default/tok"})
-    with _install_mock_transport(handler):
-        client.environment_specs.create(name="ben", spec=spec)
+    client.environment_specs.create(name="ben", spec=spec)
 
     # exclude_unset: provider/description/etc. are NOT sent because the caller
     # never set them — matching the old **spec behavior.
@@ -423,12 +504,11 @@ def test_environment_specs_create_accepts_dict_spec() -> None:
     captured: dict[str, Any] = {}
 
     def handler(req: httpx.Request) -> httpx.Response:
-        captured["body"] = json.loads(req.read())
+        captured["body"] = _read_json(req)
         return httpx.Response(201, json={"name": "ben"})
 
-    client = AgentsResource(SimpleNamespace(base_url="http://test", workspace="team-a"))
-    with _install_mock_transport(handler):
-        client.environment_specs.create(name="ben", spec={"provider": "local"})
+    client = AgentsResource(_platform(handler))
+    client.environment_specs.create(name="ben", spec={"provider": "local"})
 
     assert captured["body"] == {"name": "ben", "provider": "local"}
 
@@ -443,12 +523,11 @@ def test_environment_specs_create_name_arg_is_authoritative() -> None:
     captured: dict[str, Any] = {}
 
     def handler(req: httpx.Request) -> httpx.Response:
-        captured["body"] = json.loads(req.read())
+        captured["body"] = _read_json(req)
         return httpx.Response(201, json={"name": "wanted"})
 
-    client = AgentsResource(SimpleNamespace(base_url="http://test", workspace="team-a"))
-    with _install_mock_transport(handler):
-        client.environment_specs.create(name="wanted", spec={"name": "sneaky", "provider": "local"})
+    client = AgentsResource(_platform(handler))
+    client.environment_specs.create(name="wanted", spec={"name": "sneaky", "provider": "local"})
 
     assert captured["body"]["name"] == "wanted"
 
@@ -458,13 +537,12 @@ def test_compute_specs_create_accepts_typed_model() -> None:
 
     def handler(req: httpx.Request) -> httpx.Response:
         captured["path"] = req.url.path
-        captured["body"] = json.loads(req.read())
+        captured["body"] = _read_json(req)
         return httpx.Response(201, json={"name": "big"})
 
-    client = AgentsResource(SimpleNamespace(base_url="http://test", workspace="team-a"))
+    client = AgentsResource(_platform(handler))
     spec = ComputeSpecInline(resources=ComputeResources(limits={"cpu": "2"}))
-    with _install_mock_transport(handler):
-        client.compute_specs.create(name="big", spec=spec)
+    client.compute_specs.create(name="big", spec=spec)
 
     assert captured["path"] == "/apis/agents/v2/workspaces/team-a/compute-specs"
     assert captured["body"] == {"name": "big", "resources": {"limits": {"cpu": "2"}}}
@@ -475,13 +553,12 @@ def test_environments_create_accepts_typed_model() -> None:
     captured: dict[str, Any] = {}
 
     def handler(req: httpx.Request) -> httpx.Response:
-        captured["body"] = json.loads(req.read())
+        captured["body"] = _read_json(req)
         return httpx.Response(201, json={"name": "env1"})
 
-    client = AgentsResource(SimpleNamespace(base_url="http://test", workspace="default"))
+    client = AgentsResource(_platform(handler, workspace="default"))
     spec = AgentEnvironmentInline(environment_spec="default/ben")
-    with _install_mock_transport(handler):
-        client.environments.create(name="env1", spec=spec, compute_spec="default/big")
+    client.environments.create(name="env1", spec=spec, compute_spec="default/big")
 
     assert captured["body"]["name"] == "env1"
     assert captured["body"]["environment_spec"] == "default/ben"
@@ -491,23 +568,17 @@ def test_environments_create_accepts_typed_model() -> None:
 
 def test_default_headers_are_sent_on_every_request() -> None:
     """``platform.default_headers`` (how the CLI threads its token) reach the wire."""
-    captured: dict[str, Any] = {}
+    auth_headers: list[str | None] = []
 
     def handler(req: httpx.Request) -> httpx.Response:
-        captured.setdefault("auth", []).append(req.headers.get("authorization"))
+        auth_headers.append(req.headers.get("authorization"))
         if req.method == "DELETE":
             return httpx.Response(204)
         return httpx.Response(200, json={"name": "big"})
 
-    platform = SimpleNamespace(
-        base_url="http://test",
-        workspace="team-a",
-        default_headers={"Authorization": "Bearer tok-123"},
-    )
-    client = AgentsResource(platform)
-    with _install_mock_transport(handler):
-        client.compute_specs.create(name="big", spec=ComputeSpecInline())
-        client.compute_specs.get("big")
-        client.compute_specs.delete("big")
+    client = AgentsResource(_platform(handler, default_headers={"Authorization": "Bearer tok-123"}))
+    client.compute_specs.create(name="big", spec=ComputeSpecInline())
+    client.compute_specs.get("big")
+    client.compute_specs.delete("big")
 
-    assert captured["auth"] == ["Bearer tok-123", "Bearer tok-123", "Bearer tok-123"]
+    assert auth_headers == ["Bearer tok-123", "Bearer tok-123", "Bearer tok-123"]

--- a/plugins/nemo-agents/tests/unit/test_utils.py
+++ b/plugins/nemo-agents/tests/unit/test_utils.py
@@ -20,8 +20,10 @@ Covers:
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
+from unittest.mock import Mock
 
+import httpx
 import pytest
 import yaml
 from nemo_agents_plugin.jobs.evaluate_agent import EvaluateAgentJob, EvaluateAgentSpec
@@ -38,6 +40,8 @@ from nemo_agents_plugin.utils import (
     temp_injected_config,
     validate_llm_models,
 )
+from nemo_platform import NeMoPlatform
+from nemo_platform_plugin.client.errors import NotFoundError as ClientNotFoundError
 from nemo_platform_plugin.job_context import JobContext
 from nemo_platform_plugin.refs import EndpointURL, FilesetRef, LocalDir
 from nemo_platform_plugin.run_dependencies import LocalRunError
@@ -735,7 +739,7 @@ class TestResolveOutput:
     def test_fileset_ref_uploads_on_clean_exit(
         self, tmp_path: Path, ctx: JobContext, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Successful exit forwards the staged tempdir to ``sdk.files.upload``."""
+        """Successful exit forwards the staged tempdir to the fileset uploader."""
         captured: dict[str, object] = {}
 
         def fake_upload(
@@ -751,12 +755,12 @@ class TestResolveOutput:
             captured["sdk"] = sdk
 
         monkeypatch.setattr(EvaluateAgentJob, "_upload_to_fileset", staticmethod(fake_upload))
-        sentinel_sdk = object()
+        sentinel_sdk = _platform_sdk_stub()
         job = EvaluateAgentJob()
         with job._resolve_output(
             FilesetRef("eval-results"),
             workspace="default",
-            sdk=sentinel_sdk,  # type: ignore[arg-type]
+            sdk=sentinel_sdk,
             ctx=ctx,
         ) as base:
             (base / "summary.json").write_text("{}")
@@ -788,7 +792,7 @@ class TestResolveOutput:
         with job._resolve_output(
             FilesetRef("prod/eval-results"),
             workspace="default",
-            sdk=object(),  # type: ignore[arg-type]  # type: ignore[arg-type]
+            sdk=_platform_sdk_stub(),
             ctx=ctx,
         ) as _:
             pass
@@ -818,7 +822,7 @@ class TestResolveOutput:
             with job._resolve_output(
                 FilesetRef("eval-results"),
                 workspace="default",
-                sdk=object(),  # type: ignore[arg-type]
+                sdk=_platform_sdk_stub(),
                 ctx=ctx,
             ) as base:
                 (base / "partial.json").write_text("{}")
@@ -847,7 +851,7 @@ class TestResolveOutput:
         with job._resolve_output(
             FilesetRef("eval-results"),
             workspace="default",
-            sdk=object(),
+            sdk=_platform_sdk_stub(),
             ctx=ctx,
         ) as base:
             captured_path = base
@@ -867,37 +871,28 @@ class TestResolveOutput:
             with job._resolve_output(FilesetRef("eval-results"), workspace="default", sdk=None, ctx=ctx):
                 pass
 
-    def test_upload_to_fileset_delegates_to_sdk_files(self) -> None:
-        """``_upload_to_fileset`` is a thin wrapper over ``sdk.files.upload``."""
+    def test_upload_to_fileset_delegates_to_typed_file_manager(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``_upload_to_fileset`` uploads through a typed Files manager."""
+        manager = Mock()
+        manager_cls = Mock(return_value=manager)
+        monkeypatch.setattr("nemo_agents_plugin.jobs.evaluate_agent.client_from_platform", Mock())
+        monkeypatch.setattr("nemo_agents_plugin.jobs.evaluate_agent.FilesetFileSystem", Mock())
+        monkeypatch.setattr("nemo_agents_plugin.jobs.evaluate_agent.FilesetFileManager", manager_cls)
 
-        class _StubFiles:
-            def __init__(self) -> None:
-                self.calls: list[dict[str, object]] = []
-
-            def upload(self, **kwargs: object) -> object:
-                self.calls.append(kwargs)
-                return type("_Fileset", (), {"name": kwargs["fileset"]})()
-
-        class _StubSDK:
-            def __init__(self) -> None:
-                self.files = _StubFiles()
-
-        sdk = _StubSDK()
+        sdk = Mock()
         EvaluateAgentJob._upload_to_fileset(
             Path("/tmp/eval-out"),
             fileset="eval-results",
             workspace="prod",
-            sdk=sdk,  # type: ignore[arg-type]  # type: ignore[arg-type]
+            sdk=sdk,
         )
 
-        assert sdk.files.calls == [
-            {
-                "local_path": "/tmp/eval-out/",
-                "fileset": "eval-results",
-                "workspace": "prod",
-                "fileset_auto_create": True,
-            }
-        ]
+        manager_cls.assert_called_once()
+        assert manager_cls.call_args.kwargs["fileset_name"] == "eval-results"
+        assert manager_cls.call_args.kwargs["workspace"] == "prod"
+        assert manager_cls.call_args.kwargs["ensure_fileset_exists"] is True
+        manager.validate_storage.assert_called_once_with()
+        manager.upload.assert_called_once_with(local_path=Path("/tmp/eval-out"), remote_path="")
 
 
 # ---------------------------------------------------------------------------
@@ -1379,31 +1374,22 @@ llms:
 # ---------------------------------------------------------------------------
 
 
-def _make_not_found_error(message: str) -> Any:
-    """Build a real :class:`nemo_platform.NotFoundError` for use as an SDK side-effect.
-
-    The Stainless-generated exception requires a ``response`` and ``body``;
-    we hand-roll a minimal stub rather than pulling in :mod:`unittest.mock`
-    just for this — keeps the test module's import surface small and
-    matches the existing stub-class style used throughout this file.
-    """
-    from nemo_platform import NotFoundError
-
-    class _StubResponse:
-        status_code = 404
-        headers: dict[str, str] = {}
-        request = None
-
-    return NotFoundError(message=message, response=_StubResponse(), body={"detail": message})  # type: ignore[arg-type]
+def _make_not_found_error(message: str) -> ClientNotFoundError:
+    response = httpx.Response(
+        404,
+        request=httpx.Request("GET", "http://platform/apis/inference-gateway/v2/workspaces/default/virtual-models/x"),
+        json={"detail": message},
+    )
+    return ClientNotFoundError(response)
 
 
 class _RecordingVirtualModels:
-    """Stub for ``sdk.inference.virtual_models`` that records ``retrieve`` calls.
+    """Stub for the typed VirtualModels client that records lookup calls.
 
     ``missing`` is the set of ``model_name`` values that should raise
-    :class:`nemo_platform.NotFoundError`; everything else returns a sentinel
-    object.  ``side_effect`` overrides this to raise an arbitrary exception
-    on every call (used to exercise the soft-fail branch).
+    :class:`nemo_platform_plugin.client.errors.NotFoundError`; everything else
+    returns a sentinel object. ``side_effect`` overrides this to raise an
+    arbitrary exception on every call (used to exercise the soft-fail branch).
     """
 
     def __init__(
@@ -1416,7 +1402,7 @@ class _RecordingVirtualModels:
         self.side_effect = side_effect
         self.calls: list[dict[str, str]] = []
 
-    def retrieve(self, *, name: str, workspace: str) -> object:
+    def get_virtual_model(self, *, name: str, workspace: str) -> object:
         self.calls.append({"name": name, "workspace": workspace})
         if self.side_effect is not None:
             raise self.side_effect
@@ -1432,12 +1418,35 @@ class _StubInference:
 
 class _StubSDKWithVirtualModels:
     def __init__(self, virtual_models: _RecordingVirtualModels) -> None:
+        self.virtual_models = virtual_models
         self.inference = _StubInference(virtual_models)
+
+
+def _platform_sdk_stub() -> NeMoPlatform:
+    return cast(NeMoPlatform, object())
+
+
+def _virtual_model_sdk(virtual_models: _RecordingVirtualModels) -> NeMoPlatform:
+    return cast(NeMoPlatform, _StubSDKWithVirtualModels(virtual_models))
+
+
+@pytest.fixture(autouse=True)
+def _adapt_virtual_model_stub(monkeypatch: pytest.MonkeyPatch) -> None:
+    from nemo_agents_plugin import utils as utils_module
+
+    real_client_from_platform = utils_module.client_from_platform
+
+    def _client_from_platform(sdk: object, client_cls: type[object]) -> object:
+        if isinstance(sdk, _StubSDKWithVirtualModels):
+            return sdk.virtual_models
+        return cast(Any, real_client_from_platform)(sdk, client_cls)
+
+    monkeypatch.setattr(utils_module, "client_from_platform", _client_from_platform)
 
 
 class TestValidateLLMModels:
     def test_happy_path_dedupes_repeated_model_names(self) -> None:
-        """Same ``model_name`` under multiple LLM keys → one ``retrieve`` call."""
+        """Same ``model_name`` under multiple LLM keys -> one lookup call."""
         config = {
             "llms": {
                 "judge_llm": {"_type": "openai", "model_name": "shared-model"},
@@ -1445,14 +1454,14 @@ class TestValidateLLMModels:
             }
         }
         vms = _RecordingVirtualModels()
-        sdk = _StubSDKWithVirtualModels(vms)
+        sdk = _virtual_model_sdk(vms)
 
-        validate_llm_models(config, workspace="default", sdk=sdk)  # type: ignore[arg-type]
+        validate_llm_models(config, workspace="default", sdk=sdk)
 
         assert vms.calls == [{"name": "shared-model", "workspace": "default"}]
 
     def test_strips_workspace_qualifier_before_lookup(self) -> None:
-        """A ``{workspace}/model`` value is stripped to bare ``model`` before retrieve.
+        """A ``{workspace}/model`` value is stripped to bare ``model`` before lookup.
 
         Mirrors IGW's OpenAI proxy. ``nemo setup`` stores the qualified form as
         the default, so ``${NEMO_DEFAULT_MODEL}`` resolves to e.g.
@@ -1465,9 +1474,9 @@ class TestValidateLLMModels:
             }
         }
         vms = _RecordingVirtualModels()
-        sdk = _StubSDKWithVirtualModels(vms)
+        sdk = _virtual_model_sdk(vms)
 
-        validate_llm_models(config, workspace="default", sdk=sdk)  # type: ignore[arg-type]
+        validate_llm_models(config, workspace="default", sdk=sdk)
 
         assert vms.calls == [{"name": "nvidia-nemotron", "workspace": "default"}]
 
@@ -1485,15 +1494,15 @@ class TestValidateLLMModels:
             }
         }
         vms = _RecordingVirtualModels()
-        sdk = _StubSDKWithVirtualModels(vms)
+        sdk = _virtual_model_sdk(vms)
 
-        validate_llm_models(config, workspace="default", sdk=sdk)  # type: ignore[arg-type]
+        validate_llm_models(config, workspace="default", sdk=sdk)
 
         calls = sorted((c["workspace"], c["name"]) for c in vms.calls)
         assert calls == [("default", "plain-model"), ("prod", "foo")]
 
     def test_qualified_and_bare_forms_dedupe_to_one_lookup(self) -> None:
-        """``default/foo`` and ``foo`` normalize to the same name → one retrieve.
+        """``default/foo`` and ``foo`` normalize to the same name -> one lookup.
 
         Dedup happens *after* stripping, so the same model spelled both ways
         across LLM keys costs a single lookup.
@@ -1505,9 +1514,9 @@ class TestValidateLLMModels:
             }
         }
         vms = _RecordingVirtualModels()
-        sdk = _StubSDKWithVirtualModels(vms)
+        sdk = _virtual_model_sdk(vms)
 
-        validate_llm_models(config, workspace="default", sdk=sdk)  # type: ignore[arg-type]
+        validate_llm_models(config, workspace="default", sdk=sdk)
 
         assert vms.calls == [{"name": "foo", "workspace": "default"}]
 
@@ -1522,9 +1531,9 @@ class TestValidateLLMModels:
             }
         }
         vms = _RecordingVirtualModels()
-        sdk = _StubSDKWithVirtualModels(vms)
+        sdk = _virtual_model_sdk(vms)
 
-        validate_llm_models(config, workspace="default", sdk=sdk)  # type: ignore[arg-type]
+        validate_llm_models(config, workspace="default", sdk=sdk)
 
         assert vms.calls == []
 
@@ -1536,9 +1545,9 @@ class TestValidateLLMModels:
             }
         }
         vms = _RecordingVirtualModels()
-        sdk = _StubSDKWithVirtualModels(vms)
+        sdk = _virtual_model_sdk(vms)
 
-        validate_llm_models(config, workspace="ws", sdk=sdk)  # type: ignore[arg-type]  # type: ignore[arg-type]  # type: ignore[arg-type]  # type: ignore[arg-type]  # type: ignore[arg-type]  # type: ignore[arg-type]  # type: ignore[arg-type]  # type: ignore[arg-type]
+        validate_llm_models(config, workspace="ws", sdk=sdk)
 
         names = sorted(call["name"] for call in vms.calls)
         assert names == ["model-a", "model-b"]
@@ -1551,10 +1560,10 @@ class TestValidateLLMModels:
             }
         }
         vms = _RecordingVirtualModels(missing={"missing-model"})
-        sdk = _StubSDKWithVirtualModels(vms)
+        sdk = _virtual_model_sdk(vms)
 
         with pytest.raises(ValueError) as exc_info:
-            validate_llm_models(config, workspace="default", sdk=sdk)  # type: ignore[arg-type]  # type: ignore[arg-type]
+            validate_llm_models(config, workspace="default", sdk=sdk)
 
         message = str(exc_info.value)
         # Names the missing model + the YAML key + the workspace, and points
@@ -1573,7 +1582,7 @@ class TestValidateLLMModels:
             }
         }
         vms = _RecordingVirtualModels(missing={"missing-1", "missing-2"})
-        sdk = _StubSDKWithVirtualModels(vms)
+        sdk = _virtual_model_sdk(vms)
 
         with pytest.raises(ValueError) as exc_info:
             validate_llm_models(config, workspace="default", sdk=sdk)
@@ -1594,7 +1603,7 @@ class TestValidateLLMModels:
             }
         }
         vms = _RecordingVirtualModels()
-        sdk = _StubSDKWithVirtualModels(vms)
+        sdk = _virtual_model_sdk(vms)
 
         validate_llm_models(config, workspace="ws", sdk=sdk)
 
@@ -1613,7 +1622,7 @@ class TestValidateLLMModels:
             }
         }
         vms = _RecordingVirtualModels()
-        sdk = _StubSDKWithVirtualModels(vms)
+        sdk = _virtual_model_sdk(vms)
 
         validate_llm_models(config, workspace="ws", sdk=sdk)
 
@@ -1627,7 +1636,7 @@ class TestValidateLLMModels:
             }
         }
         vms = _RecordingVirtualModels()
-        sdk = _StubSDKWithVirtualModels(vms)
+        sdk = _virtual_model_sdk(vms)
 
         validate_llm_models(config, workspace="ws", sdk=sdk)
 
@@ -1642,7 +1651,7 @@ class TestValidateLLMModels:
             }
         }
         vms = _RecordingVirtualModels()
-        sdk = _StubSDKWithVirtualModels(vms)
+        sdk = _virtual_model_sdk(vms)
 
         validate_llm_models(config, workspace="ws", sdk=sdk)
 
@@ -1651,7 +1660,7 @@ class TestValidateLLMModels:
     def test_empty_llms_block_is_noop(self) -> None:
         config: dict[str, Any] = {"llms": {}}
         vms = _RecordingVirtualModels()
-        sdk = _StubSDKWithVirtualModels(vms)
+        sdk = _virtual_model_sdk(vms)
 
         validate_llm_models(config, workspace="ws", sdk=sdk)
 
@@ -1661,7 +1670,7 @@ class TestValidateLLMModels:
         """Configs that don't declare any LLMs (e.g. trace-only fragments)."""
         config: dict[str, Any] = {"general": {"telemetry": {}}}
         vms = _RecordingVirtualModels()
-        sdk = _StubSDKWithVirtualModels(vms)
+        sdk = _virtual_model_sdk(vms)
 
         validate_llm_models(config, workspace="ws", sdk=sdk)
 
@@ -1675,12 +1684,12 @@ class TestValidateLLMModels:
             }
         }
         vms = _RecordingVirtualModels(side_effect=RuntimeError("connection refused"))
-        sdk = _StubSDKWithVirtualModels(vms)
+        sdk = _virtual_model_sdk(vms)
 
         with caplog.at_level("WARNING"):
             # Must not raise — the underlying eval/optimize call will surface
             # the real error if the model truly isn't reachable.
-            validate_llm_models(config, workspace="ws", sdk=sdk)  # type: ignore[arg-type]
+            validate_llm_models(config, workspace="ws", sdk=sdk)
 
         assert any("Could not validate LLM" in record.message for record in caplog.records)
 
@@ -1693,7 +1702,7 @@ class TestValidateLLMModels:
             }
         }
         vms = _RecordingVirtualModels()
-        sdk = _StubSDKWithVirtualModels(vms)
+        sdk = _virtual_model_sdk(vms)
 
         validate_llm_models(config, workspace="ws", sdk=sdk)
 
@@ -1720,9 +1729,9 @@ class TestPreflightValidateLLMModels:
             "llms:\n  judge_llm:\n    _type: openai\n    model_name: real-model\n",
         )
         vms = _RecordingVirtualModels()
-        sdk = _StubSDKWithVirtualModels(vms)
+        sdk = _virtual_model_sdk(vms)
 
-        preflight_validate_llm_models(config_path, workspace="ws", sdk=sdk)  # type: ignore[arg-type]  # type: ignore[arg-type]
+        preflight_validate_llm_models(config_path, workspace="ws", sdk=sdk)
 
         assert vms.calls == [{"name": "real-model", "workspace": "ws"}]
 
@@ -1741,7 +1750,7 @@ class TestPreflightValidateLLMModels:
             "llms:\n  judge_llm:\n    _type: openai\n    model_name: ${NEMO_DEFAULT_MODEL}\n",
         )
         vms = _RecordingVirtualModels()
-        sdk = _StubSDKWithVirtualModels(vms)
+        sdk = _virtual_model_sdk(vms)
 
         preflight_validate_llm_models(config_path, workspace="ws", sdk=sdk)
 
@@ -1767,7 +1776,7 @@ class TestPreflightValidateLLMModels:
             },
         }
         vms = _RecordingVirtualModels()
-        sdk = _StubSDKWithVirtualModels(vms)
+        sdk = _virtual_model_sdk(vms)
 
         preflight_validate_llm_models(
             config_path,
@@ -1786,10 +1795,10 @@ class TestPreflightValidateLLMModels:
             "llms:\n  judge_llm:\n    _type: openai\n    model_name: missing-model\n",
         )
         vms = _RecordingVirtualModels(missing={"missing-model"})
-        sdk = _StubSDKWithVirtualModels(vms)
+        sdk = _virtual_model_sdk(vms)
 
         with pytest.raises(ValueError) as exc_info:
-            preflight_validate_llm_models(config_path, workspace="default", sdk=sdk)  # type: ignore[arg-type]
+            preflight_validate_llm_models(config_path, workspace="default", sdk=sdk)
 
         # Sanity-check the message shape; full message coverage lives in
         # TestValidateLLMModels.

--- a/plugins/nemo-optimization/tests/test_optimize_job.py
+++ b/plugins/nemo-optimization/tests/test_optimize_job.py
@@ -356,31 +356,81 @@ def test_run_rejects_endpoint_agent(tmp_path: Path, ctx: JobContext) -> None:
 # ---------------------------------------------------------------------------
 
 
-def bundle_sdk(bundle: dict[str, str], *, downloaded: dict[str, Any] | None = None) -> NeMoPlatform:
-    """An SDK stub whose ``files.download`` materializes *bundle* (relative path → contents)."""
+@contextlib.contextmanager
+def bundle_sdk(
+    bundle: dict[str, str] | None = None,
+    *,
+    downloaded: dict[str, Any] | None = None,
+    uploaded: dict[str, Any] | None = None,
+) -> Iterator[NeMoPlatform]:
+    """Patch fileset staging helpers so typed-manager calls materialize *bundle*."""
 
-    class _StubFiles:
-        def download(self, *, local_path: str, fileset: str, workspace: str) -> None:
-            if downloaded is not None:
-                downloaded.update(fileset=fileset, workspace=workspace)
-            for relative, contents in bundle.items():
-                target = Path(local_path) / relative
-                target.parent.mkdir(parents=True, exist_ok=True)
-                target.write_text(contents)
+    bundle = bundle or {}
+    sdk = MagicMock(spec=NeMoPlatform)
+    files_client = MagicMock()
 
-    class _StubSDK:
-        files = _StubFiles()
+    def _manager(
+        _files_client: object,
+        *,
+        workspace: str,
+        fileset: str,
+        ensure_fileset_exists: bool,
+    ) -> object:
+        del _files_client
 
-    return cast(NeMoPlatform, _StubSDK())
+        class _StubManager:
+            def validate_storage(self) -> None:
+                pass
+
+            def download_from_url(self, _url: str, local_dir: str | Path | None = None) -> Any:
+                assert local_dir is not None
+                if downloaded is not None:
+                    downloaded.update(fileset=fileset, workspace=workspace)
+                root = Path(local_dir)
+                root.mkdir(parents=True, exist_ok=True)
+                for relative, contents in bundle.items():
+                    target = root / relative
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    target.write_text(contents)
+                return SimpleNamespace(path=root, tmp_dir=root)
+
+            def upload(
+                self,
+                *,
+                local_path: Path,
+                remote_path: str,
+                ignore_patterns: list[str] | str | None = None,
+            ) -> str:
+                del ignore_patterns
+                if uploaded is not None:
+                    uploaded.update(
+                        local_path=local_path,
+                        remote_path=remote_path,
+                        fileset=fileset,
+                        workspace=workspace,
+                        auto_create=ensure_fileset_exists,
+                        names=sorted(p.name for p in local_path.rglob("*") if p.is_file()),
+                    )
+                return f"{workspace}/{fileset}"
+
+        return _StubManager()
+
+    with (
+        patch("nemo_agents_plugin.jobs.fileset_io.client_from_platform", return_value=files_client),
+        patch("nemo_agents_plugin.jobs.fileset_io._fileset_manager", side_effect=_manager),
+    ):
+        yield cast(NeMoPlatform, sdk)
 
 
 def test_run_stages_the_config_from_the_fileset(ctx: JobContext) -> None:
     downloaded: dict[str, Any] = {}
-    sdk = bundle_sdk({"configs/optimize.yml": yaml.safe_dump(MINIMAL_CONFIG)}, downloaded=downloaded)
 
-    with patch(
-        "nemo_optimization.jobs.optimize.OptimizeRouter.dispatch", return_value={"status": "completed"}
-    ) as dispatch:
+    with (
+        bundle_sdk({"configs/optimize.yml": yaml.safe_dump(MINIMAL_CONFIG)}, downloaded=downloaded) as sdk,
+        patch(
+            "nemo_optimization.jobs.optimize.OptimizeRouter.dispatch", return_value={"status": "completed"}
+        ) as dispatch,
+    ):
         result = OptimizeJob().run(
             {
                 "optimize_config": "configs/optimize.yml",
@@ -405,12 +455,6 @@ def test_run_resolves_relative_assets_against_the_staged_bundle(ctx: JobContext)
             "fabric": {"base_dir": "."},
         },
     }
-    sdk = bundle_sdk(
-        {
-            "optimize.yml": yaml.safe_dump(config),
-            "data/rows.json": json.dumps([{"question": "q", "answer": "a"}]),
-        }
-    )
     observed: dict[str, Any] = {}
 
     def _dispatch(**kwargs: Any) -> dict[str, Any]:
@@ -420,7 +464,15 @@ def test_run_resolves_relative_assets_against_the_staged_bundle(ctx: JobContext)
         return {"status": "completed"}
 
     cwd = Path.cwd()
-    with patch("nemo_optimization.jobs.optimize.OptimizeRouter.dispatch", side_effect=_dispatch):
+    with (
+        bundle_sdk(
+            {
+                "optimize.yml": yaml.safe_dump(config),
+                "data/rows.json": json.dumps([{"question": "q", "answer": "a"}]),
+            }
+        ) as sdk,
+        patch("nemo_optimization.jobs.optimize.OptimizeRouter.dispatch", side_effect=_dispatch),
+    ):
         OptimizeJob().run(
             {
                 "optimize_config": "optimize.yml",
@@ -438,10 +490,10 @@ def test_run_resolves_relative_assets_against_the_staged_bundle(ctx: JobContext)
 
 
 def test_run_restores_the_working_directory_when_the_study_raises(ctx: JobContext) -> None:
-    sdk = bundle_sdk({"optimize.yml": yaml.safe_dump(MINIMAL_CONFIG)})
     cwd = Path.cwd()
 
     with (
+        bundle_sdk({"optimize.yml": yaml.safe_dump(MINIMAL_CONFIG)}) as sdk,
         patch("nemo_optimization.jobs.optimize.OptimizeRouter.dispatch", side_effect=RuntimeError("study blew up")),
         pytest.raises(RuntimeError, match="study blew up"),
     ):
@@ -459,9 +511,10 @@ def test_run_restores_the_working_directory_when_the_study_raises(ctx: JobContex
 
 
 def test_run_rejects_a_staged_config_missing_from_the_fileset(ctx: JobContext) -> None:
-    sdk = bundle_sdk({"other.yml": yaml.safe_dump(MINIMAL_CONFIG)})
-
-    with pytest.raises(FileNotFoundError, match="was not found in fileset"):
+    with (
+        bundle_sdk({"other.yml": yaml.safe_dump(MINIMAL_CONFIG)}) as sdk,
+        pytest.raises(FileNotFoundError, match="was not found in fileset"),
+    ):
         OptimizeJob().run(
             {
                 "optimize_config": "optimize.yml",
@@ -499,24 +552,18 @@ def _config_with_dataset(dataset: Any) -> dict[str, Any]:
 
 def test_run_stages_dataset_from_fileset_ref(tmp_path: Path, ctx: JobContext) -> None:
     downloaded: dict[str, Any] = {}
-
-    class _StubFiles:
-        def download(self, *, local_path: str, fileset: str, workspace: str) -> None:
-            downloaded.update(fileset=fileset, workspace=workspace)
-            (Path(local_path) / "rows.json").write_text('[{"question": "q", "answer": "a"}]')
-
-    class _StubSDK:
-        files = _StubFiles()
-
     optimize_config = write_config(tmp_path, _config_with_dataset({"file_path": "default/evals#rows.json"}))
 
-    with patch(
-        "nemo_optimization.jobs.optimize.OptimizeRouter.dispatch", return_value={"status": "completed"}
-    ) as dispatch:
+    with (
+        bundle_sdk({"rows.json": '[{"question": "q", "answer": "a"}]'}, downloaded=downloaded) as sdk,
+        patch(
+            "nemo_optimization.jobs.optimize.OptimizeRouter.dispatch", return_value={"status": "completed"}
+        ) as dispatch,
+    ):
         OptimizeJob().run(
             {"optimize_config": optimize_config, "workspace": "default"},
             ctx=ctx,
-            sdk=cast(NeMoPlatform, _StubSDK()),
+            sdk=sdk,
         )
 
     assert downloaded == {"fileset": "evals", "workspace": "default"}
@@ -555,39 +602,27 @@ def _write_study_artifacts(ctx: JobContext) -> Path:
 
 def test_run_publishes_results_to_fileset(tmp_path: Path, ctx: JobContext) -> None:
     uploaded: dict[str, Any] = {}
-
-    class _StubFiles:
-        def upload(self, *, local_path: str, fileset: str, workspace: str, fileset_auto_create: bool) -> Any:
-            uploaded.update(
-                local_path=local_path,
-                fileset=fileset,
-                workspace=workspace,
-                auto_create=fileset_auto_create,
-                names=sorted(p.name for p in Path(local_path).rglob("*") if p.is_file()),
-            )
-            return SimpleNamespace(name=fileset)
-
-    class _StubSDK:
-        files = _StubFiles()
-
     optimize_config = write_config(tmp_path, MINIMAL_CONFIG)
 
     def _dispatch(**kwargs: Any) -> dict[str, Any]:
         _write_study_artifacts(ctx)
         return {"status": "completed", "best_trial": 3}
 
-    with patch("nemo_optimization.jobs.optimize.OptimizeRouter.dispatch", side_effect=_dispatch):
+    with (
+        bundle_sdk(uploaded=uploaded) as sdk,
+        patch("nemo_optimization.jobs.optimize.OptimizeRouter.dispatch", side_effect=_dispatch),
+    ):
         result = OptimizeJob().run(
             {"optimize_config": optimize_config, "workspace": "default", "output": "tuned-results"},
             ctx=ctx,
-            sdk=cast(NeMoPlatform, _StubSDK()),
+            sdk=sdk,
         )
 
     assert uploaded["fileset"] == "tuned-results"
     assert uploaded["workspace"] == "default"
     assert uploaded["auto_create"] is True
-    # Trailing slash uploads contents, not the dir itself.
-    assert uploaded["local_path"].endswith("/")
+    assert uploaded["local_path"] == ctx.storage.persistent / "results"
+    assert uploaded["remote_path"] == ""
     assert uploaded["names"] == ["optimized_config.yml", "study_summary.json"]
     # The study's own summary survives alongside the new pointer.
     assert result["best_trial"] == 3
@@ -614,14 +649,16 @@ def test_run_publishes_results_to_local_dir(tmp_path: Path, ctx: JobContext) -> 
 
 def test_run_publishes_staged_results_after_leaving_the_bundle(ctx: JobContext, tmp_path: Path) -> None:
     """Publishing happens outside the chdir, so a relative --output lands where the caller meant."""
-    sdk_bundle = bundle_sdk({"optimize.yml": yaml.safe_dump(MINIMAL_CONFIG)})
     dest = tmp_path / "published"
 
     def _dispatch(**kwargs: Any) -> dict[str, Any]:
         _write_study_artifacts(ctx)
         return {"status": "completed"}
 
-    with patch("nemo_optimization.jobs.optimize.OptimizeRouter.dispatch", side_effect=_dispatch):
+    with (
+        bundle_sdk({"optimize.yml": yaml.safe_dump(MINIMAL_CONFIG)}) as sdk,
+        patch("nemo_optimization.jobs.optimize.OptimizeRouter.dispatch", side_effect=_dispatch),
+    ):
         result = OptimizeJob().run(
             {
                 "optimize_config": "optimize.yml",
@@ -630,7 +667,7 @@ def test_run_publishes_staged_results_after_leaving_the_bundle(ctx: JobContext, 
                 "output": str(dest),
             },
             ctx=ctx,
-            sdk=sdk_bundle,
+            sdk=sdk,
         )
 
     assert (dest / "optimizer_results" / "study_summary.json").is_file()
@@ -652,25 +689,20 @@ def test_run_without_output_publishes_nothing(tmp_path: Path, ctx: JobContext) -
 
 def test_run_does_not_publish_when_study_fails(tmp_path: Path, ctx: JobContext) -> None:
     """A crashed study must not leave partial artifacts in the target fileset."""
-
-    class _StubFiles:
-        def upload(self, **kwargs: Any) -> Any:
-            raise AssertionError("upload must not run when the study raises")
-
-    class _StubSDK:
-        files = _StubFiles()
-
+    uploaded: dict[str, Any] = {}
     optimize_config = write_config(tmp_path, MINIMAL_CONFIG)
 
     with (
+        bundle_sdk(uploaded=uploaded) as sdk,
         patch("nemo_optimization.jobs.optimize.OptimizeRouter.dispatch", side_effect=RuntimeError("study blew up")),
         pytest.raises(RuntimeError, match="study blew up"),
     ):
         OptimizeJob().run(
             {"optimize_config": optimize_config, "workspace": "default", "output": "tuned-results"},
             ctx=ctx,
-            sdk=cast(NeMoPlatform, _StubSDK()),
+            sdk=sdk,
         )
+    assert uploaded == {}
 
 
 def test_run_rejects_fileset_output_without_sdk(tmp_path: Path, ctx: JobContext) -> None:

--- a/web/packages/studio/src/api/agents/loadSampleAgentConfig.ts
+++ b/web/packages/studio/src/api/agents/loadSampleAgentConfig.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import type { CreateAgentRequestConfig } from '@nemo/sdk/generated/agents/schema/CreateAgentRequestConfig';
 import { fetchSampleText } from '@studio/api/agents/fetchSampleText';
 import YAML from 'yaml';
 
@@ -21,9 +22,9 @@ export const loadSampleAgentConfig = async (
   agentConfigPath: string,
   modelName: string,
   workspace: string
-): Promise<Record<string, unknown>> => {
+): Promise<CreateAgentRequestConfig> => {
   const text = await fetchSampleText(agentConfigPath);
-  const config = YAML.parse(text) as Record<string, unknown>;
+  const config = YAML.parse(text) as CreateAgentRequestConfig;
 
   const configFormat = config?.config_format;
 

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/CreateExampleAgentModal/index.tsx
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/CreateExampleAgentModal/index.tsx
@@ -11,6 +11,7 @@ import {
   getAgentsListAgentsQueryKey,
   useAgentsCreateAgent,
 } from '@nemo/sdk/generated/agents/agents';
+import type { CreateAgentRequestConfig } from '@nemo/sdk/generated/agents/schema/CreateAgentRequestConfig';
 import { useModelsListModels } from '@nemo/sdk/generated/platform/models';
 import { loadSampleAgentConfig } from '@studio/api/agents/loadSampleAgentConfig';
 import { DEFAULT_LARGE_PAGE_SIZE } from '@studio/constants/constants';
@@ -147,7 +148,7 @@ const CreateExampleAgentModalInner: FC<CreateExampleAgentModalProps> = ({
   const onSubmit: SubmitHandler<ExampleAgentFormData> = async (formData) => {
     const example = getSampleAgent(formData.exampleKey);
     setLoadError(undefined);
-    let config: Record<string, unknown>;
+    let config: CreateAgentRequestConfig;
     try {
       config = await loadSampleAgentConfig(example.agentConfigPath, formData.modelName, workspace);
     } catch (err) {

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/NewAgentModal/utils.ts
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/NewAgentModal/utils.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import type { CreateAgentRequestConfig } from '@nemo/sdk/generated/agents/schema/CreateAgentRequestConfig';
 import {
   AGENT_CONFIG_FILENAME,
   AGENT_SPEC_FILENAME,
@@ -167,7 +168,7 @@ export const findNonUtf8Path = async (entries: UploadAgentEntry[]): Promise<stri
 
 export class AgentConfigParseError extends Error {}
 
-export const parseAgentConfig = (text: string): Record<string, unknown> => {
+export const parseAgentConfig = (text: string): CreateAgentRequestConfig => {
   let parsed: unknown;
   try {
     parsed = YAML.parse(text);
@@ -181,7 +182,7 @@ export const parseAgentConfig = (text: string): Record<string, unknown> => {
     throw new AgentConfigParseError(`${AGENT_CONFIG_FILENAME} must contain a YAML mapping.`);
   }
 
-  const config = parsed as Record<string, unknown>;
+  const config = parsed as CreateAgentRequestConfig;
   const configFormat = config.config_format;
   if (configFormat !== FABRIC_CONFIG_FORMAT) {
     throw new AgentConfigParseError(


### PR DESCRIPTION
## Summary
Migrates `nemo-agents` off Stainless-shaped SDK request plumbing and onto source-owned typed clients while preserving the public CLI and `client.agents` compatibility behavior. Review follow-ups fix paginated deployment resolution, request-model validation errors, and Fabric artifact staging safety, with OpenAPI YAML restored to the base version to avoid generated-spec churn.

## Changes
- Expanded source-owned Agents typed-client DTOs, endpoints, and sync/async client methods for agents, deployments, sessions, environments, compute specs, deployment logs, gateway invocation, and Agents job collections.
- Routed the `client.agents` facade, public `nemo agents` commands, agent jobs, fileset staging, deployment backends, telemetry export, and model preflight paths through concrete typed clients.
- Added `NemoClient.with_workspace()` for adapted clients that need a default workspace while sharing transport state.
- Fixed review findings for all-page deployment resolution in `undeploy --agent`, `logs --agent`, and `deployments wait --agent`, including newest-by-created-at selection for wait/log resolution.
- Added controlled CLI handling for Pydantic request-body validation failures.
- Hardened Fabric Ethos directory staging by downloading into a temporary tree, validating resolved destinations, and rejecting fileset writes under preserved runtime directories.
- Restored `openapi.yaml` outputs to `origin/main` so this refactor does not include generated OpenAPI churn.
- Added and updated focused coverage for typed transport behavior, CLI parity, SDK facade compatibility, fileset/workdir staging, telemetry export, and the migrated job/backend paths.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `uv run --frozen pytest plugins/nemo-agents/tests/unit/test_cli_delete_undeploy.py plugins/nemo-agents/tests/unit/test_fabric_artifact_staging.py plugins/nemo-agents/tests/unit/test_cli.py -v` — passed, 98 tests.
- `uv run --frozen pytest plugins/nemo-agents/tests/unit/test_cli_deploy_logs.py -v` — passed, 14 tests.
- `uv run --frozen ruff check plugins/nemo-agents/src/nemo_agents_plugin/cli.py plugins/nemo-agents/tests/unit/test_cli_deploy_logs.py` — passed.
- `uv run --frozen ruff format --check plugins/nemo-agents/src/nemo_agents_plugin/cli.py plugins/nemo-agents/tests/unit/test_cli_deploy_logs.py` — passed.
- `uv run --frozen ty check plugins/nemo-agents/src/nemo_agents_plugin/cli.py plugins/nemo-agents/tests/unit/test_cli_deploy_logs.py` — passed.
- `uv run pre-commit run -a` — passed.
- `git diff --name-status origin/main...HEAD | rg '(^|/)openapi\.yaml$|openapi/openapi\.yaml|\.nmpcontext/openapi\.yaml'` — no output; OpenAPI files are not in the PR diff.
