### PR TITLE
perf(rl): split the rl-base dependency layer so cheap edits stay cheap

### DIFF
--- a/docker/rl/Dockerfile.nmp-rl-base
+++ b/docker/rl/Dockerfile.nmp-rl-base
@@ -275,6 +275,36 @@ uv sync ${UV_SYNC_MODE} --extra modelopt  --no-install-project   # quantization 
 uv sync ${UV_SYNC_MODE} --extra nemo_gym  --no-install-project   # NeMo-Gym (uv workspace member)
 uv sync ${UV_SYNC_MODE} --all-groups      --no-install-project   # build/test/etc groups
 
+# CVE GHSA-mqqc-3gqh-h2x8: drop ray's bundled old aiohttp from the uv cache.
+find "${UV_CACHE_DIR}" -type d -path "*ray/_private/runtime_env/agent/thirdparty_files/aiohttp*" -exec rm -rf {} + || true
+
+# jackson-databind / jackson-core CVEs: drop ray's bundled ray_dist.jar, which only backs Ray's Java
+# worker support (unused - no JVM here). Removed before the prefetch so no venv symlinks to it.
+find "${UV_CACHE_DIR}" -type d -path "*/ray/jars" -exec rm -rf {} + || true
+
+# FFmpeg CVEs (CVE-2026-8461 + CVE-2026-64830..64835): PyNvVideoCodec bundles FFmpeg 8.1.1 shared
+# libraries, which the scan reports as `ffmpeg` whatever the Python package version is. vLLM pins it
+# so it cannot leave the lock, but nothing on the DPO/GRPO path reaches it: vLLM defaults to the
+# `opencv` video backend and imports PyNvVideoCodec inside decode_frames_pynvvideocodec(), so only
+# the opt-in `pynvvideocodec` backend breaks. Upgrading does not help - 2.2.0 ships FFmpeg 8.1.2,
+# which fixes only one of the seven. The second pattern is the wheel's vendored FFmpeg source
+# tarball. Removed before the prefetch so no venv symlinks into it; only these two directories go,
+# so uv still sees the package as cached and does not re-download it.
+find "${UV_CACHE_DIR}" -type d \
+    \( -name PyNvVideoCodec -o -name 'pynvvideocodec-*.data' \) -exec rm -rf {} + || true
+EOF
+
+# Everything above is ~80 minutes of compiling; this is seconds. Docker keys a RUN on its whole
+# script, so while they shared one, editing a pin here rebuilt Transformer Engine there. The CVE
+# removals stay above: `nmp-rl-base` is `FROM builder`, so a file deleted in a later layer is still
+# present in the earlier one and a layer-aware scan still finds it.
+#
+# These run after the removals rather than before, as they did when the blocks were one. None of
+# them reaches ray or PyNvVideoCodec, so there is nothing for them to reintroduce.
+RUN <<"EOF" bash -exu
+umask 022
+export UV_LINK_MODE=symlink
+
 # Gym sandbox CLIENT SDK (OpenSandbox provider). The OpenSandbox SERVER is deployed separately on
 # the cluster; this is the client the Gym stack imports to call it. Source-independent, so it stays
 # in this cached compile layer (the editable ROOT install moves below, after the full-source COPY).
@@ -299,24 +329,6 @@ uv pip install --python /opt/nemo_rl_venv/bin/python \
 # pydantic (already present). Resolving Gym's full dependency set here could move RL's pinned stack.
 uv pip install --python /opt/nemo_rl_venv/bin/python --no-deps \
     -e /opt/nemo-rl/3rdparty/Gym-workspace/Gym
-
-# CVE GHSA-mqqc-3gqh-h2x8: drop ray's bundled old aiohttp from the uv cache.
-find "${UV_CACHE_DIR}" -type d -path "*ray/_private/runtime_env/agent/thirdparty_files/aiohttp*" -exec rm -rf {} + || true
-
-# jackson-databind / jackson-core CVEs: drop ray's bundled ray_dist.jar, which only backs Ray's Java
-# worker support (unused - no JVM here). Removed before the prefetch so no venv symlinks to it.
-find "${UV_CACHE_DIR}" -type d -path "*/ray/jars" -exec rm -rf {} + || true
-
-# FFmpeg CVEs (CVE-2026-8461 + CVE-2026-64830..64835): PyNvVideoCodec bundles FFmpeg 8.1.1 shared
-# libraries, which the scan reports as `ffmpeg` whatever the Python package version is. vLLM pins it
-# so it cannot leave the lock, but nothing on the DPO/GRPO path reaches it: vLLM defaults to the
-# `opencv` video backend and imports PyNvVideoCodec inside decode_frames_pynvvideocodec(), so only
-# the opt-in `pynvvideocodec` backend breaks. Upgrading does not help - 2.2.0 ships FFmpeg 8.1.2,
-# which fixes only one of the seven. The second pattern is the wheel's vendored FFmpeg source
-# tarball. Removed before the prefetch so no venv symlinks into it; only these two directories go,
-# so uv still sees the package as cached and does not re-download it.
-find "${UV_CACHE_DIR}" -type d \
-    \( -name PyNvVideoCodec -o -name 'pynvvideocodec-*.data' \) -exec rm -rf {} + || true
 EOF
 
 # Full RL source (Automodel + Gym). Copied AFTER the heavy uv sync so a source-only RL bump is a


### PR DESCRIPTION
## Summary

One `RUN` in `Dockerfile.nmp-rl-base` held both ~80 minutes of compiling and three seconds of pip installs. Docker keys a `RUN` on its whole script, so changing a pin at the bottom rebuilt Transformer-Engine, mamba-ssm, causal-conv1d, deep_ep and deep_gemm at the top.

Measured, not estimated: while working on #1875 I added one `uv pip install` line to that block. It cost a full **4761s** rebuild of the step against ~2.5s of actual new work.

## Changes

Split the block in two:

- **RUN A** — `uv venv`, the base sync, the torch patch, every `--extra` sync, and the CVE removals. The expensive half.
- **RUN B** — the three `uv pip install` invocations (`opensandbox`/`tenacity`, the logging floors, the driver's Gym install). Seconds.

Both remain above the full-source `COPY`, so a source-only RL bump still reaches neither.

## Two things a reviewer should check

**The CVE removals deliberately stay in the expensive half.** `nmp-rl-base` is `FROM builder`, not a `COPY --from=builder`, so every builder layer ships in the final image. A file deleted in a later layer is still present in the earlier one, and a layer-aware scan still finds it. My first attempt moved them down with the rest of the cheap work, which would have quietly undone the ray-aiohttp (GHSA-mqqc-3gqh-h2x8), `ray_dist.jar` and PyNvVideoCodec-FFmpeg removals.

**This reorders the three installs to run after the removals** rather than before, which is the one behavioural change. None of them reaches ray or PyNvVideoCodec, so there is nothing for them to reintroduce — but it is the assumption worth a second opinion.

## Verification

Built and measured on an Apple-silicon Docker Desktop builder, against an integration branch carrying this change plus #1875, #1906 and #1929 (main's Dockerfile cannot build the RL branch directly — it does not copy `vendor/`).

### Image size: +32MB, 0.13%

| | bytes |
|---|---|
| Pre-split image | 23,977,311,931 |
| Split image | 24,009,224,993 |
| **Delta** | **~32MB** |

The second `RUN` produces a 118MB layer, which bounds any duplication; the measured delta sits well under it, consistent with `UV_LINK_MODE=symlink` meaning the duplicated bytes are symlinks and whiteouts rather than payload. Not a perfectly matched pair — the pre-split image had one extra patch applied — but that shifts the number by kilobytes.

### Cache benefit: 6786s -> 273s, a 25x speedup

Measured by changing one pin in the cheap `RUN` (`opensandbox>=0.1.9` -> `>=0.1.10`) and rebuilding. Same edit, same tree, both times.

| Builder cache budget | Rebuild after the one-line edit | Heavy layer |
|---|---|---|
| 20GiB (default) | **6786s** | re-ran, 5496s |
| 100GiB | **273s** | `CACHED` |

The first run is why this needs saying: the split alone did nothing. BuildKit's GC policy reserved 20GiB while the layer it must retain is 34.6GB, so that layer was evicted after every build and rebuilt from scratch regardless of what changed. `docker buildx inspect` reports the policy; raising `builder.gc.defaultKeepStorage` in `daemon.json` above the layer size and restarting the daemon fixes it.

With the budget raised, the split does what it was written to do: 19 steps cached, the 34.6GB layer reused, and only the 118MB layer rebuilt in ~19s.

**Both halves are required.** The cache budget alone is not enough -- while the expensive and cheap work share one `RUN`, a pin change invalidates the whole thing no matter how much cache is available. The split alone is not enough either, as the 6786s run shows. This PR is the half that lives in the repo; the other half is builder configuration.

Worth checking what CI's builders reserve. If it is below ~40GB they are paying a full rebuild on every change to this file today, and this PR will not help them until that is raised.

### Image size: +32MB, 0.13%

| | bytes |
|---|---|
| Pre-split | 23,977,311,931 |
| Split | 24,009,224,993 |

The second `RUN` produces a 118MB layer, bounding any duplication; the measured delta sits well under it, consistent with `UV_LINK_MODE=symlink` meaning the duplicated bytes are symlinks and whiteouts rather than payload.

### Method

Built on an Apple-silicon Docker Desktop builder against an integration branch carrying this change plus #1875, #1906 and #1929 -- `main`'s Dockerfile cannot build the RL branch directly, as it does not copy `vendor/`. Baseline full build 6402s; incremental 273s. Images 24.010GB and 24.011GB respectively.

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` — not run; this changes only a Dockerfile and no hook covers it
- [ ] Targeted tests — not applicable; there is no test for Dockerfile layer boundaries
- [x] No secrets, API keys, or credentials are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Updated bundled dependencies and media-processing components to address known vulnerabilities.

- **Reliability**
  - Improved the container build process by separating dependency preparation from subsequent installation and setup steps, supporting more consistent builds and reuse of completed build stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->