### PR TITLE
fix(evaluator): adapt injected platform clients at the job run boundary

### DIFF
--- a/packages/nemo_platform_plugin/tests/client/test_adapter.py
+++ b/packages/nemo_platform_plugin/tests/client/test_adapter.py
@@ -115,3 +115,55 @@ def test_client_from_platform_carries_disabled_timeout() -> None:
 
     # Not the transport's 60s: httpx reads an all-None Timeout as "wait forever".
     assert client._timeout == httpx.Timeout(None)
+
+
+def test_client_from_platform_carries_authorization_header() -> None:
+    """A statically configured bearer reaches the typed client.
+
+    The CLI hands config-file credentials to the generated SDK as a default ``Authorization``
+    header, so dropping the headers here would silently produce an unauthenticated client.
+    """
+    http_client = httpx.Client(transport=httpx.MockTransport(lambda request: httpx.Response(200, request=request)))
+    platform = NeMoPlatform(
+        base_url="http://test",
+        workspace="default",
+        default_headers={"Authorization": "Bearer static-token"},
+        http_client=http_client,
+    )
+
+    client = client_from_platform(platform, JobsClient)
+
+    assert client._default_headers["Authorization"] == "Bearer static-token"
+
+
+def test_client_from_platform_shares_the_transport_so_token_refresh_survives() -> None:
+    """OAuth callers refresh the bearer from a request event hook on the httpx client, not from a
+    header. Rebuilding the transport here would leave only the stale seeded token and break refresh
+    for every adapter caller, with nothing failing until a request hit an authenticated deployment.
+    """
+    seen: list[str | None] = []
+
+    def refresh(request: httpx.Request) -> None:
+        request.headers["Authorization"] = f"Bearer refreshed-{len(seen) + 1}"
+
+    def record(request: httpx.Request) -> httpx.Response:
+        seen.append(request.headers.get("Authorization"))
+        return httpx.Response(200, request=request)
+
+    http_client = httpx.Client(
+        transport=httpx.MockTransport(record),
+        event_hooks={"request": [refresh]},
+    )
+    platform = NeMoPlatform(
+        base_url="http://test",
+        workspace="default",
+        default_headers={"Authorization": "Bearer seeded"},
+        http_client=http_client,
+    )
+
+    client = client_from_platform(platform, JobsClient)
+
+    assert client._client is http_client
+    client._client.get("http://test/one")
+    client._client.get("http://test/two")
+    assert seen == ["Bearer refreshed-1", "Bearer refreshed-2"]

--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/agent_evaluate.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/agent_evaluate.py
@@ -55,6 +55,7 @@ from nemo_evaluator.jobs.gym_sandbox import (
 from nemo_evaluator.jobs.metric_resolution import resolve_metrics_to_inline, to_runtime_bundle
 from nemo_evaluator.jobs.publication import publish_agent_eval_result
 from nemo_evaluator.jobs.result_persistence import persist_agent_eval_result
+from nemo_evaluator.jobs.utils import as_async_nemo_client, as_nemo_client
 from nemo_evaluator.shared.metric_bundles.bundles import unbundle_metric
 from nemo_evaluator.task_refs import resolve_agent_eval_tasks
 from nemo_evaluator_sdk.agent_eval.evaluator import AgentEvaluator
@@ -66,7 +67,7 @@ from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalRunConfig, AgentEvalTas
 from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTarget
 from nemo_evaluator_sdk.metrics.protocol import Metric
 from nemo_evaluator_sdk.values import RunConfigOnline, RunConfigOnlineModel
-from nemo_platform import AsyncNeMoPlatform
+from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
 from nemo_platform_plugin.client.adapter import client_from_platform
 from nemo_platform_plugin.client.client import AsyncNemoClient, NemoClient
 from nemo_platform_plugin.client.errors import (
@@ -609,10 +610,12 @@ class AgentEvalJob(NemoJob):
         config: dict,
         *,
         ctx: JobContext,
-        sdk: NemoClient | None = None,
-        async_sdk: AsyncNemoClient | None = None,
+        sdk: NemoClient | NeMoPlatform | None = None,
+        async_sdk: AsyncNemoClient | AsyncNeMoPlatform | None = None,
     ) -> dict:
         """Run the agent evaluation locally and persist its result bundle as artifacts."""
+        client = as_nemo_client(sdk)
+        async_client = as_async_nemo_client(async_sdk)
         spec = AgentEvalSpec.model_validate(config)
         tasks = [_to_runtime_task(task) for task in spec.tasks]
         target, prompt_template, params = self._resolve_target(spec.target, ctx)
@@ -623,10 +626,9 @@ class AgentEvalJob(NemoJob):
             labels=spec.labels,
             fail_fast=spec.fail_fast,
         )
-        # `run` may be injected a sync `sdk` (submitted jobs, via get_task_nemo_client) and/or an
-        # `async_sdk`; forward whichever identity is present, preferring async when both are — the
-        # same precedence the SDK-backed dataset resolver uses.
-        evaluator = self._build_evaluator(async_sdk or sdk, spec.target)
+        # Forward whichever identity is present, preferring async when both are — the same
+        # precedence the SDK-backed dataset resolver uses.
+        evaluator = self._build_evaluator(async_client or client, spec.target)
         result = evaluator.run_sync(tasks=tasks, trials=spec.trials, target=target, config=run_config)
 
         files = self._write_result_files(result, ctx.storage.persistent)
@@ -639,7 +641,7 @@ class AgentEvalJob(NemoJob):
         # otherwise-successful eval — log and continue.
         try:
             persist_agent_eval_result(
-                result, target=spec.target, ctx=ctx, bundle_ref=artifact.artifact_url, async_sdk=async_sdk
+                result, target=spec.target, ctx=ctx, bundle_ref=artifact.artifact_url, async_sdk=async_client
             )
         except Exception:
             logger.warning(
@@ -654,7 +656,7 @@ class AgentEvalJob(NemoJob):
         # can fail the job (when `required`), which is why nothing depends on its result.
         publication = spec.publication.intake if spec.publication is not None else None
         if publication is not None:
-            intake = AsyncIntakeClient.from_client(async_sdk) if async_sdk is not None else None
+            intake = AsyncIntakeClient.from_client(async_client) if async_client is not None else None
             outcome = publish_agent_eval_result(
                 result,
                 spec=publication,

--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/environment_stage.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/environment_stage.py
@@ -11,6 +11,8 @@ from pathlib import Path
 import fsspec.asyn
 from filesets import FilesetFileSystem, FilesetPathError, parse_fileset_ref
 from nemo_evaluator.filesets import FilesetRef
+from nemo_evaluator.jobs.utils import as_nemo_client
+from nemo_platform import NeMoPlatform
 from nemo_platform_plugin.client.client import NemoClient
 from nemo_platform_plugin.files.client import FilesClient
 from nemo_platform_plugin.job import NemoJob
@@ -57,8 +59,9 @@ class EnvironmentStageJob(NemoJob):
     container = "nmp-cpu-tasks"
     spec_schema = EnvironmentStageSpec
 
-    def run(self, config: dict, *, ctx: JobContext, sdk: NemoClient) -> dict:
+    def run(self, config: dict, *, ctx: JobContext, sdk: NemoClient | NeMoPlatform) -> dict:
         """Download the FileSet into ``persistent/environment``, replacing any previous tree."""
+        client = as_nemo_client(sdk)
         spec = EnvironmentStageSpec.model_validate(config)
         try:
             workspace, fileset, file_path = parse_fileset_ref(
@@ -79,7 +82,7 @@ class EnvironmentStageJob(NemoJob):
 
         try:
             _download_fileset_contents(
-                sdk=sdk,
+                sdk=client,
                 destination=staging,
                 fileset=fileset,
                 workspace=workspace,

--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/evaluate.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/evaluate.py
@@ -27,7 +27,7 @@ from nemo_evaluator.jobs.metric_resolution import (
 from nemo_evaluator.jobs.publication import publish_row_eval_result
 from nemo_evaluator.jobs.publication_spec import RowPublicationSpec
 from nemo_evaluator.jobs.result_persistence import persist_evaluate_result
-from nemo_evaluator.jobs.utils import run_with_isolated_async_client
+from nemo_evaluator.jobs.utils import as_async_nemo_client, as_nemo_client, run_with_isolated_async_client
 from nemo_evaluator.metric_refs import MetricRefOrInline
 from nemo_evaluator.shared.metric_bundles.bundles import unbundle_metric
 from nemo_evaluator_sdk import Evaluator
@@ -43,7 +43,7 @@ from nemo_evaluator_sdk.values import (
 )
 from nemo_evaluator_sdk.values.multi_metric_results import BenchmarkEvaluationResult
 from nemo_evaluator_sdk.values.results import EvaluationResult
-from nemo_platform import AsyncNeMoPlatform
+from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
 from nemo_platform_plugin.client.client import AsyncNemoClient, NemoClient
 from nemo_platform_plugin.entities import EntityClient
 from nemo_platform_plugin.intake.client import AsyncIntakeClient
@@ -294,10 +294,12 @@ class EvaluateJob(NemoJob):
         config: dict,
         *,
         ctx: JobContext,
-        sdk: NemoClient | None = None,
-        async_sdk: AsyncNemoClient | None = None,
+        sdk: NemoClient | NeMoPlatform | None = None,
+        async_sdk: AsyncNemoClient | AsyncNeMoPlatform | None = None,
     ) -> dict:
         """Run the evaluator job locally and persist its result artifact."""
+        client = as_nemo_client(sdk)
+        async_client = as_async_nemo_client(async_sdk)
         spec = EvaluateSpec.model_validate(config)
         # Stamped here because the row evaluator records no timing at all and `EvaluationResult` has
         # nowhere to put it. Publication needs a start time that is a function of the run, not of
@@ -309,8 +311,8 @@ class EvaluateJob(NemoJob):
         dataset = _resolve_run_dataset(
             spec.dataset,
             ctx=ctx,
-            client=sdk,
-            async_client=async_sdk,
+            client=client,
+            async_client=async_client,
         )
         if isinstance(spec.target, Model):
             if not isinstance(params, RunConfigOnlineModel):
@@ -368,7 +370,7 @@ class EvaluateJob(NemoJob):
                 metric_types=[metric.type for metric in metrics],
                 ctx=ctx,
                 bundle_ref=artifact.artifact_url,
-                async_sdk=async_sdk,
+                async_sdk=async_client,
             )
         except Exception:
             logger.warning(
@@ -394,7 +396,7 @@ class EvaluateJob(NemoJob):
         # can fail the job (when `required`).
         publication = spec.publication.intake if spec.publication is not None else None
         if publication is not None:
-            intake = AsyncIntakeClient.from_client(async_sdk) if async_sdk is not None else None
+            intake = AsyncIntakeClient.from_client(async_client) if async_client is not None else None
             outcome = publish_row_eval_result(
                 result,
                 spec=publication,

--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/retrieve_eval.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/retrieve_eval.py
@@ -27,7 +27,7 @@ from nemo_evaluator.jobs.evaluate import (
 )
 from nemo_evaluator.jobs.metric_resolution import PlatformMetricModelResolver
 from nemo_evaluator.jobs.secret_env import build_task_environment
-from nemo_evaluator.jobs.utils import run_with_isolated_async_client
+from nemo_evaluator.jobs.utils import as_async_nemo_client, as_nemo_client, run_with_isolated_async_client
 from nemo_evaluator_sdk import Evaluator
 from nemo_evaluator_sdk.metrics.retrieval import (
     RetrievalMAPMetric,
@@ -38,7 +38,7 @@ from nemo_evaluator_sdk.metrics.retrieval import (
 from nemo_evaluator_sdk.values.models import Model, ModelRef
 from nemo_evaluator_sdk.values.multi_metric_results import BenchmarkEvaluationResult
 from nemo_evaluator_sdk.values.retrieval import Retrieval, Truncation
-from nemo_platform import AsyncNeMoPlatform
+from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
 from nemo_platform_plugin.client.client import AsyncNemoClient, NemoClient
 from nemo_platform_plugin.job import NemoJob
 from nemo_platform_plugin.job_context import JobContext
@@ -200,20 +200,22 @@ class RetrieveEvalJob(NemoJob):
         self,
         config: dict,
         ctx: JobContext,
-        sdk: NemoClient | None = None,
-        async_sdk: AsyncNemoClient | None = None,
+        sdk: NemoClient | NeMoPlatform | None = None,
+        async_sdk: AsyncNemoClient | AsyncNeMoPlatform | None = None,
     ) -> dict:
         """Download, validate, score, and persist a BEIR retrieval result."""
+        client = as_nemo_client(sdk)
+        async_client = as_async_nemo_client(async_sdk)
         spec = RetrieveEvalSpec.model_validate(config)
-        if sdk is not None:
+        if client is not None:
             dataset_path = download_dataset_sync(
-                client=sdk,
+                client=client,
                 dataset=spec.dataset,
                 destination=str(ctx.storage.persistent / "dataset"),
             )
-        elif async_sdk is not None:
+        elif async_client is not None:
             dataset_path = run_with_isolated_async_client(
-                async_sdk,
+                async_client,
                 lambda isolated_client: download_dataset(
                     client=isolated_client,
                     dataset=spec.dataset,

--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/utils.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/utils.py
@@ -6,14 +6,46 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from typing import TypeVar
+from typing import TypeVar, overload
 
 import httpx
 from nemo_evaluator_sdk.execution.metric_execution import run_sync
-from nemo_platform_plugin.client.client import AsyncNemoClient
+from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
+from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.client.client import AsyncNemoClient, NemoClient
 
 T = TypeVar("T")
 AsyncClientT = TypeVar("AsyncClientT", bound=AsyncNemoClient)
+
+
+@overload
+def as_nemo_client(sdk: NemoClient | NeMoPlatform) -> NemoClient: ...
+@overload
+def as_nemo_client(sdk: None) -> None: ...
+
+
+def as_nemo_client(sdk: NemoClient | NeMoPlatform | None) -> NemoClient | None:
+    """Return *sdk* as a typed :class:`NemoClient`, adapting a generated SDK handle if needed.
+
+    Task containers inject typed clients and the local CLI injects generated ``NeMoPlatform``
+    handles, so a job ``run`` receives either.
+    """
+    if isinstance(sdk, NeMoPlatform):
+        return client_from_platform(sdk, NemoClient)
+    return sdk
+
+
+@overload
+def as_async_nemo_client(async_sdk: AsyncNemoClient | AsyncNeMoPlatform) -> AsyncNemoClient: ...
+@overload
+def as_async_nemo_client(async_sdk: None) -> None: ...
+
+
+def as_async_nemo_client(async_sdk: AsyncNemoClient | AsyncNeMoPlatform | None) -> AsyncNemoClient | None:
+    """Async counterpart of :func:`as_nemo_client`."""
+    if isinstance(async_sdk, AsyncNeMoPlatform):
+        return client_from_platform(async_sdk, AsyncNemoClient)
+    return async_sdk
 
 
 def run_with_isolated_async_client(

--- a/plugins/nemo-evaluator/tests/test_agent_evaluate.py
+++ b/plugins/nemo-evaluator/tests/test_agent_evaluate.py
@@ -576,6 +576,81 @@ def test_build_evaluator_without_platform_forwards_no_headers() -> None:
     assert AgentEvalJob._build_evaluator(None, target).default_headers is None
 
 
+def _sync_platform_with_identity() -> NeMoPlatform:
+    return NeMoPlatform(
+        base_url="http://platform",
+        workspace="dev",
+        default_headers=_SDK_IDENTITY_HEADERS,
+        http_client=MagicMock(spec=httpx.Client),
+    )
+
+
+def _async_platform_with_identity() -> AsyncNeMoPlatform:
+    return AsyncNeMoPlatform(
+        base_url="http://platform",
+        workspace="dev",
+        default_headers=_SDK_IDENTITY_HEADERS,
+        http_client=AsyncMock(spec=httpx.AsyncClient),
+    )
+
+
+def _capture_evaluator_headers(mocker: MockerFixture) -> dict[str, dict[str, str] | None]:
+    """Swap in a fake ``AgentEvaluator`` that records the headers ``_build_evaluator`` computed."""
+    captured: dict[str, dict[str, str] | None] = {}
+
+    def _factory(*, default_headers: dict[str, str] | None = None) -> _FakeEvaluator:
+        captured["default_headers"] = default_headers
+        return _FakeEvaluator()
+
+    mocker.patch("nemo_evaluator.jobs.agent_evaluate.AgentEvaluator", _factory)
+    return captured
+
+
+@pytest.mark.parametrize("inject_async", [False, True], ids=["sdk", "async_sdk"])
+def test_run_accepts_the_generated_sdk_the_local_cli_injects(
+    tmp_path: Path, mocker: MockerFixture, inject_async: bool
+) -> None:
+    """A local ``nemo evaluator agent-evaluate run`` is handed a generated ``NeMoPlatform``, not a
+    typed client, and every platform call in ``run`` is typed-client-only. Without adaptation the job
+    dies with ``AttributeError: 'AsyncNeMoPlatform' object has no attribute 'is_platform_url'``
+    before it issues a single target request.
+
+    Adapting must not widen what reaches the target: the allowlist still applies, so the bearer and
+    the trace header the generated SDK carried stay behind.
+    """
+    captured = _capture_evaluator_headers(mocker)
+    config = AgentEvalSpec(
+        tasks=[_task_spec()],
+        target=_model_target(
+            "http://platform/apis/inference-gateway/v2/workspaces/default/model/m/-/v1/chat/completions"
+        ),
+    ).model_dump()
+    ctx = _job_context(tmp_path)
+
+    if inject_async:
+        result = AgentEvalJob().run(config, ctx=ctx, async_sdk=_async_platform_with_identity())
+    else:
+        result = AgentEvalJob().run(config, ctx=ctx, sdk=_sync_platform_with_identity())
+
+    assert result["status"] == "completed"
+    assert captured["default_headers"] == _FORWARDED_IDENTITY_HEADERS
+
+
+def test_run_sends_no_identity_to_a_third_party_target_via_generated_sdk(tmp_path: Path, mocker: MockerFixture) -> None:
+    """The same-origin guard is what keeps the delegated user's email and groups inside the platform.
+    Adaptation reconstructs the client the guard compares against, so a regression here would leak
+    that PII to whatever endpoint the submitter named."""
+    captured = _capture_evaluator_headers(mocker)
+    spec = AgentEvalSpec(tasks=[_task_spec()], target=_model_target("https://api.openai.com/v1/chat/completions"))
+
+    result = AgentEvalJob().run(
+        spec.model_dump(), ctx=_job_context(tmp_path), async_sdk=_async_platform_with_identity()
+    )
+
+    assert result["status"] == "completed"
+    assert captured["default_headers"] is None
+
+
 def test_input_spec_accepts_stored_metric_reference() -> None:
     spec = AgentEvalInputSpec(
         tasks=[

--- a/plugins/nemo-evaluator/tests/test_environment_stage.py
+++ b/plugins/nemo-evaluator/tests/test_environment_stage.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import httpx
 import pytest
 from nemo_evaluator.jobs.environment_stage import EnvironmentStageJob
+from nemo_platform import NeMoPlatform
 from nemo_platform_plugin.client.client import NemoClient
 from nemo_platform_plugin.job_context import JobContext, StoragePaths
 from nemo_platform_plugin.job_results import LocalJobResults
@@ -128,3 +129,25 @@ def test_failed_download_removes_partial_staging_without_replacing_environment(
     assert (environment / "existing.txt").read_text() == "complete"
     assert not (ctx.storage.persistent / ".environment-staging").exists()
     assert (ctx.storage.persistent / "workspace").is_dir()
+
+
+def test_run_adapts_the_generated_sdk_the_local_cli_injects(tmp_path: Path, mocker: MockerFixture) -> None:
+    """``nemo evaluator stage-environment run`` injects a generated ``NeMoPlatform``, but staging
+    reaches the Files service through ``FilesClient.from_client``, which only accepts a typed
+    client."""
+    received: dict[str, object] = {}
+
+    def download_contents(*, sdk: object, workspace: str, fileset: str, destination: Path) -> None:
+        received["sdk"] = sdk
+        Path(destination, "nemo-environment.yaml").write_text("format: wheels-v1\n")
+
+    mocker.patch(
+        "nemo_evaluator.jobs.environment_stage._download_fileset_contents",
+        side_effect=download_contents,
+    )
+    platform = NeMoPlatform(base_url="http://platform.test", workspace="dev", http_client=httpx.Client())
+
+    result = EnvironmentStageJob().run({"environment": "shared/custom-gym"}, ctx=_context(tmp_path), sdk=platform)
+
+    assert result["status"] == "completed"
+    assert isinstance(received["sdk"], NemoClient)

--- a/plugins/nemo-evaluator/tests/test_evaluate_job.py
+++ b/plugins/nemo-evaluator/tests/test_evaluate_job.py
@@ -1258,6 +1258,24 @@ class TestEvaluateJobRun:
         assert call_kwargs["target"] is None
         assert call_kwargs["prompt_template"] is None
 
+    def test_run_adapts_the_generated_sdk_the_local_cli_injects(self, tmp_path: Path, mocker: MockerFixture) -> None:
+        """``nemo evaluator evaluate run`` injects a generated ``NeMoPlatform``, but resolving a
+        ``FilesetRef`` dataset only accepts a typed client."""
+        evaluator = mocker.Mock()
+        evaluator.run_sync.return_value = _empty_evaluation_result()
+        mocker.patch("nemo_evaluator.jobs.evaluate.Evaluator", return_value=evaluator)
+        download_dataset_sync = mocker.patch(
+            "nemo_evaluator.jobs.evaluate.download_dataset_sync",
+            return_value=tmp_path / "persistent" / "dataset" / "default" / "helpsteer2" / "validation.jsonl",
+            create=True,
+        )
+        platform = NeMoPlatform(base_url="http://platform.test", workspace="dev", http_client=httpx.Client())
+        config = {**_exact_match_spec(), "dataset": FilesetRef(root="default/helpsteer2#validation.jsonl")}
+
+        EvaluateJob().run(config, ctx=_make_job_context(tmp_path), sdk=platform)
+
+        assert isinstance(download_dataset_sync.call_args.kwargs["client"], NemoClient)
+
     def test_prefers_sync_sdk_for_fileset_ref_when_both_sdks_injected(
         self, tmp_path: Path, mocker: MockerFixture
     ) -> None:

--- a/plugins/nemo-evaluator/tests/test_retrieve_eval_job.py
+++ b/plugins/nemo-evaluator/tests/test_retrieve_eval_job.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
 
+import httpx
 import pytest
 from nemo_evaluator.filesets import FilesetRef
 from nemo_evaluator.jobs.retrieve_eval import (
@@ -23,6 +24,7 @@ from nemo_evaluator_sdk.values.models import Model
 from nemo_evaluator_sdk.values.multi_metric_results import BenchmarkEvaluationResult
 from nemo_evaluator_sdk.values.results import AggregatedMetricResult, AggregateRangeScore
 from nemo_evaluator_sdk.values.retrieval import Retrieval
+from nemo_platform import NeMoPlatform
 from nemo_platform_plugin.client.client import NemoClient
 from nemo_platform_plugin.job_context import JobContext, StoragePaths
 from nemo_platform_plugin.job_results import LocalJobResults
@@ -259,3 +261,22 @@ def test_run_records_started_at_before_evaluation(tmp_path: Path, mocker: Mocker
     metadata = json.loads((ctx.storage.persistent / "artifacts" / "run-metadata.json").read_text())
     assert metadata["started_at"] == started.isoformat()
     evaluator.run_sync.assert_called_once()
+
+
+def test_run_adapts_the_generated_sdk_the_local_cli_injects(tmp_path: Path, mocker: MockerFixture) -> None:
+    """``nemo evaluator retrieve-eval run`` injects a generated ``NeMoPlatform``, but the BEIR
+    fileset download only accepts a typed client."""
+    download = mocker.patch(
+        "nemo_evaluator.jobs.retrieve_eval.download_dataset_sync",
+        return_value=tmp_path / "downloaded",
+    )
+    mocker.patch("nemo_evaluator.jobs.retrieve_eval.load_beir_dataset", return_value=mocker.Mock(spec=BeirDataset))
+    evaluator = mocker.Mock()
+    evaluator.run_sync.return_value = _result()
+    mocker.patch("nemo_evaluator.jobs.retrieve_eval.Evaluator", return_value=evaluator)
+    platform = NeMoPlatform(base_url="http://platform.test", workspace="dev", http_client=httpx.Client())
+
+    output = RetrieveEvalJob().run(_spec().model_dump(mode="json"), ctx=_context(tmp_path), sdk=platform)
+
+    assert isinstance(download.call_args.kwargs["client"], NemoClient)
+    assert output["eval_results"]["ndcg_cut_10"] == 0.75


### PR DESCRIPTION
## Summary

`nemo evaluator agent-evaluate run` crashes with `AttributeError: 'AsyncNeMoPlatform' object has no attribute 'is_platform_url'` before it issues a single target request. The local CLI injects a **generated** `NeMoPlatform` handle, while submitted jobs inject a **typed** `NemoClient`/`AsyncNemoClient` — and every platform call inside the evaluator `run` methods is typed-client-only. This normalizes whichever handle arrives into a typed client at each job's `run` boundary, so local runs behave like submitted ones.

Before: local run dies during evaluator construction. After: the run completes and a failed target request is recorded as a failed generation trial, as documented.

## Changes

- Add `as_nemo_client` / `as_async_nemo_client` to `plugins/nemo-evaluator/src/nemo_evaluator/jobs/utils.py`. They adapt a generated SDK via the existing `client_from_platform`, and pass typed clients (and anything else, including test doubles) through untouched.
- Call them at the top of `run()` in `agent_evaluate.py`, `evaluate.py`, `retrieve_eval.py` and `environment_stage.py`, and use the typed handles at every downstream call site (`_build_evaluator`, dataset download, result persistence, intake publication, fileset staging).
- Widen the `run()` `sdk`/`async_sdk` annotations to state what actually arrives, matching the `AGENTS.md` rule to adapt at the boundary rather than merge the two into one public type.
- Regression tests for all four jobs that inject the generated SDK the shipped CLI actually supplies.
- Two tests in `packages/nemo_platform_plugin/tests/client/test_adapter.py` pinning that `client_from_platform` preserves authentication: a static bearer is carried as a header, and the httpx transport is handed over rather than rebuilt so an OAuth caller's per-request token-refresh hook still fires. That second property is what the four jobs above rely on in an authenticated deployment, and nothing covered it.

### Why here, and not in `resolve_run_kwargs`

`resolve_run_kwargs` binds `sdk`/`async_sdk` by parameter **name** and never inspects the annotation, so the declared type is not enforced for any plugin. Fixing it there would make the contract real repo-wide, but the evaluator is currently the only plugin on typed clients — every other plugin still declares `NeMoPlatform` — so that is a shared-infrastructure change that does not belong on a release branch. `AIRCORE-883` already scopes that work (its seam 4 covers `tasks/dispatcher.py` / `resolve_run_kwargs`); note its Linear status is stale — `#799` was folded into `#800`, which merged on 2026-08-12 and delivered only the provider and FastAPI DI seams. When that lands and the local path hands over typed clients, these helpers become no-ops and can be deleted.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: restores the documented behavior of an existing command; no user-facing interface changes.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `make lint` — **16 passed, 2 failed**. `lint-openapi` and `lint-sdk-vendored` fail with `mapfile: command not found`; `mapfile` is a bash 4 builtin and this host runs `/bin/bash` 3.2.57 (macOS). Both scripts complete their real work before dying at the file-collection step, so the invariants were verified by hand instead: `make vendor` and the license-header pass both ran and left the tree clean apart from the files in this PR. This diff also touches no API, datamodel or service-API file, so OpenAPI drift is not possible. `lint-pre-commit-all`, `lint-python-style`, `lint-python-types` and `lint-cli` all passed.
- `pytest plugins/nemo-evaluator/tests/` — 1020 passed, 26 skipped. `pytest packages/nemo_platform_plugin/tests/` — 1415 passed.
- `ty check` on each changed file — clean. (The repo-wide run reports 1126 pre-existing diagnostics; none are in these files.)
- `ruff check` / `ruff format --check` on `plugins/nemo-evaluator` — clean.
- **Mutation check**: with the adaptation reverted, all five job tests fail — the agent-eval ones with the exact `AttributeError` from the report, the other three on their `isinstance(..., NemoClient)` assertions. The two adapter tests were likewise confirmed against targeted mutations — dropping the copied headers, and rebuilding the httpx client while keeping its transport.
- **Live before/after, every job**, against a local platform (7 services — entities, evaluator, files, inference-gateway, jobs, models, secrets — plus the models controller; `/health/ready` → `ready`). Each was run with the fix reverted, then restored and re-run:

  | Job | Invoked via | Without the fix | With the fix |
  |---|---|---|---|
  | `agent-evaluate` | `nemo evaluator agent-evaluate run` | `AttributeError: 'AsyncNeMoPlatform' object has no attribute 'is_platform_url'` | completes; bundle records `failed: 1, scored: 0` and metric `count: 0, nan_count: 1` — the result the ticket specifies |
  | `evaluate` | `nemo evaluator evaluate run` | `AttributeError: 'NeMoPlatform' object has no attribute '_auth'` | completes; `count: 2, mean: 0.5` over two rows downloaded from the live Files service |
  | `retrieve-eval` | `nemo evaluator retrieve-eval run` | `AttributeError: 'NeMoPlatform' object has no attribute '_auth'` | downloads the BEIR fileset, parses it, and reaches the embedding call (fails only at the deliberately dead embedder) |
  | `stage-environment` | `NemoJobScheduler.run_local` | `AttributeError: 'NeMoPlatform' object has no attribute '_auth'` | stages the fileset from the live Files service into `persistent/environment` |

  Two things worth flagging from this. First, `evaluate`, `retrieve-eval` and `stage-environment` fail on `_auth`, **not** on `is_platform_url` — so the report captured one symptom of a fault with several distinct manifestations. Second, `stage-environment` has no CLI verb: `service.py` registers only `evaluate`, `agent-evaluate` and `retrieve-eval`, and it otherwise runs as a task-container step where typed clients are already supplied. It is still reachable with a generated SDK through the public `run_local` API, which is how it was exercised above.

  Also verified on the platform-routed path: an `agent-evaluate` run against an IGW URL reaches the gateway (502 for a fixture model with no upstream), confirming the same-origin branch executes and issues a real request.
- **Independent review** (Codex, read-only): verdict `safe_to_merge`, no findings. It separately confirmed no identity-header leak, no missed call sites, and that no in-repo caller injects a `nemo_platform_ext.client.enhanced` client into these runs.

## Not verified here

- Every job in this change now has live before/after evidence (table above), so nothing here rests on symmetry alone.
- Acceptance criteria 1 and 2 of NMP-131 ask for the two DevTest cases (T6220554 / T6220555) to be rerun on an auth-equivalent deployment, and for a *reachable* model target and a generic agent target. The local platform here has no live model backend, and no agent target was exercised, so that half needs QA's environment.

NMP-131

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Evaluation workflows now support both platform-provided and plugin-provided SDK clients.
  * Local evaluation runs can resolve environments, datasets, results, and publication intake through the provided platform connection.

* **Bug Fixes**
  * Improved synchronous and asynchronous client adaptation.
  * Preserved authorization and identity forwarding, including token refresh behavior during requests.

* **Tests**
  * Added coverage for platform-client support across evaluation, environment staging, dataset retrieval, and agent evaluation workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


