### PR TITLE
fix(studio): Adapters not showing on playground page

### DIFF
--- a/web/packages/common/src/components/ModelSelectV2/ModelDropdown.test.tsx
+++ b/web/packages/common/src/components/ModelSelectV2/ModelDropdown.test.tsx
@@ -4,7 +4,7 @@
 import type { ModelWorkspaceGroup } from '@nemo/common/src/api/models/useModels';
 import { ModelDropdown } from '@nemo/common/src/components/ModelSelectV2/ModelDropdown';
 import type { ModelEntity } from '@nemo/sdk/generated/platform/schema';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 
 const makeModel = (name: string, overrides: Partial<ModelEntity> = {}): ModelEntity =>
   ({ id: name, name, workspace: 'nvidia', ...overrides }) as unknown as ModelEntity;
@@ -242,6 +242,24 @@ describe('ModelDropdown', () => {
       // Latched: leaving does not throw the panel away, so a second hover is instant.
       expect(screen.getByTestId('model-dropdown-adapter-option')).toBeInTheDocument();
     });
+
+    it('checks the selected adapter and not the base model it belongs to', async () => {
+      renderOpen({
+        groups: withAdapters,
+        value: { model: 'nvidia/nemotron-8b', adapter: 'support-v1' },
+      });
+      const sub = (await screen.findAllByTestId('nv-dropdown-sub'))[0];
+
+      fireEvent.pointerEnter(sub);
+
+      const adapterRow = await screen.findByTestId('model-dropdown-adapter-option');
+      expect(within(adapterRow).getByTestId('model-dropdown-selected-check')).toBeInTheDocument();
+      expect(
+        within(screen.getByTestId('model-dropdown-base-option')).queryByTestId(
+          'model-dropdown-selected-check'
+        )
+      ).not.toBeInTheDocument();
+    });
   });
 
   describe('trigger', () => {
@@ -274,6 +292,18 @@ describe('ModelDropdown', () => {
       });
 
       expect(screen.getByTestId('model-select-v2-trigger')).toHaveTextContent('nemotron-8b');
+    });
+
+    it('qualifies the label with the adapter when one is selected', () => {
+      renderOpen({
+        open: false,
+        value: { model: 'nvidia/nemotron-8b', adapter: 'support-v1' },
+        groups: withAdapters,
+      });
+
+      expect(screen.getByTestId('model-select-v2-trigger')).toHaveTextContent(
+        'nemotron-8b / support-v1'
+      );
     });
   });
 });

--- a/web/packages/common/src/components/ModelSelectV2/ModelDropdown.tsx
+++ b/web/packages/common/src/components/ModelSelectV2/ModelDropdown.tsx
@@ -133,7 +133,11 @@ export const ModelDropdown: FC<ModelDropdownProps> = ({
   const selectedName = selectedModel?.name ?? (selectedParts?.name || value?.model);
   const selectedWorkspace =
     selectedModel?.workspace ?? (selectedParts?.name ? selectedParts.workspace : undefined);
-  const triggerLabel = selectedName ? (selectedName.split('@')[0] ?? selectedName) : placeholder;
+  const selectedBaseName = selectedName ? (selectedName.split('@')[0] ?? selectedName) : undefined;
+  const triggerLabel =
+    selectedBaseName && value?.adapter
+      ? `${selectedBaseName} / ${value.adapter}`
+      : (selectedBaseName ?? placeholder);
 
   return (
     <DropdownRoot open={open} onOpenChange={handleOpenChange}>

--- a/web/packages/common/src/components/ModelSelectV2/ModelDropdownItem.tsx
+++ b/web/packages/common/src/components/ModelSelectV2/ModelDropdownItem.tsx
@@ -85,11 +85,13 @@ const AdapterItem: FC<{
       <DropdownSubTrigger
         slotEnd={false}
         data-testid="model-dropdown-adapter-option"
-        onSelect={() => onSelect({ model: modelUrn, adapter: adapter.name, entity: model })}
+        onClick={() => onSelect({ model: modelUrn, adapter: adapter.name, entity: model })}
       >
         <Flex className="w-full" align="center" justify="between" gap="density-md">
           <Flex align="center" gap="density-sm" className="min-w-0">
-            {isSelected && <Check size={14} className="shrink-0" />}
+            {isSelected && (
+              <Check size={14} className="shrink-0" data-testid="model-dropdown-selected-check" />
+            )}
             <Text className="truncate">{adapter.name}</Text>
           </Flex>
           {adapter.created_at && (
@@ -159,7 +161,13 @@ const ModelDropdownItemImpl: FC<ModelDropdownItemProps> = ({
               onSelect={() => onSelect({ model: modelUrn, entity: model })}
             >
               <Flex align="center" gap="density-sm">
-                {isBaseSelected && <Check size={14} className="shrink-0" />}
+                {isBaseSelected && (
+                  <Check
+                    size={14}
+                    className="shrink-0"
+                    data-testid="model-dropdown-selected-check"
+                  />
+                )}
                 <Text>{modelUrn}</Text>
               </Flex>
             </DropdownItem>

--- a/web/packages/studio/src/components/ModelChatPanel/ModelChatPanel.test.tsx
+++ b/web/packages/studio/src/components/ModelChatPanel/ModelChatPanel.test.tsx
@@ -22,7 +22,7 @@ vi.mock('@nemo/common/src/components/ModelSelectV2', () => ({
   WorkspaceModelSelect: () => <div data-testid="mock-model-select" />,
 }));
 
-const renderPanel = (modelURN: string | null) => {
+const renderPanel = (modelURN: string | null, adapter: string | null = null) => {
   return render(
     <TestProviders>
       <MemoryRouter>
@@ -31,6 +31,7 @@ const renderPanel = (modelURN: string | null) => {
             id: 0,
             collapsed: false,
             modelURN,
+            adapter,
             roleColor: 'baseline',
             roleLabel: 'Baseline',
             isSinglePanel: true,
@@ -66,6 +67,17 @@ describe('ModelChatPanel — URN routing', () => {
 
     expect(modelChatSpy).toHaveBeenCalledWith(
       expect.objectContaining({ workspace: 'abacusai', model: 'llama-70b' })
+    );
+  });
+
+  // An unresolved adapter used to leave the panel enabled and pointed at the base model, so the
+  // trigger read "llama-70b / support-v1" while the request went to the base weights.
+  it('never sends to the base model while a selected adapter is unresolved', () => {
+    renderPanel('nvidia/llama-70b', 'support-v1');
+
+    expect(modelChatSpy).not.toHaveBeenCalledWith(expect.objectContaining({ model: 'llama-70b' }));
+    expect(modelChatSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({ model: '', disabled: true })
     );
   });
 

--- a/web/packages/studio/src/components/ModelChatPanel/index.tsx
+++ b/web/packages/studio/src/components/ModelChatPanel/index.tsx
@@ -1,23 +1,28 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { useModelEntity } from '@nemo/common/src/api/models/useModelEntity';
 import {
   WorkspaceModelSelect,
   type ModelSelection,
 } from '@nemo/common/src/components/ModelSelectV2';
 import { getPartsFromReference } from '@nemo/common/src/namedEntity';
-import { hasModelProvider } from '@nemo/common/src/utils/models';
+import { hasModelProvider, toInferenceModelEntityId } from '@nemo/common/src/utils/models';
+import { getProviderProxyGetQueryKey } from '@nemo/sdk/generated/platform/inference-gateway';
 import { Flex, Stack, Text } from '@nvidia/foundations-react-core';
 import { DEFAULT_INFERENCE_PARAMS, type InferenceParams } from '@studio/components/chat/params';
 import { ParamsPopover } from '@studio/components/chat/ParamsPopover';
 import { ModelChat } from '@studio/components/ModelChat';
+import { PLATFORM_BASE_URL } from '@studio/constants/environment';
+import { useModelChatAvailability } from '@studio/hooks/useModelChatAvailability';
+import { useServedModel } from '@studio/hooks/useServedModel';
 import {
   PANEL_ROLE_DOT_CLASS,
   type PanelChatControls,
   type PanelState,
 } from '@studio/routes/ModelCompareRoute/types';
 import { Minimize2, Trash2 } from 'lucide-react';
-import { useCallback, useState, type FC } from 'react';
+import { useCallback, useMemo, useState, type FC } from 'react';
 
 interface ModelChatPanelProps extends PanelChatControls {
   panel: PanelState;
@@ -26,7 +31,7 @@ interface ModelChatPanelProps extends PanelChatControls {
   onToggle: (id: number) => void;
   onRemove: (id: number) => void;
   /** Receives the full URN ("workspace/name"), or null when cleared. */
-  onModelChange: (id: number, modelURN: string | null) => void;
+  onModelChange: (id: number, modelURN: string | null, adapter?: string | null) => void;
   /** Hide the trash button (locked baseline in agent overlay, or only one panel). */
   hideRemove?: boolean;
 }
@@ -47,12 +52,14 @@ export const ModelChatPanel: FC<ModelChatPanelProps> = ({
   composerSeed,
   seedQuestions,
 }) => {
-  const selectedModel: ModelSelection | null = panel.modelURN ? { model: panel.modelURN } : null;
+  const selectedModel: ModelSelection | null = panel.modelURN
+    ? { model: panel.modelURN, adapter: panel.adapter ?? undefined }
+    : null;
   const [inferenceParams, setInferenceParams] = useState<InferenceParams>(DEFAULT_INFERENCE_PARAMS);
 
   const handleModelChange = useCallback(
     (selection: ModelSelection) => {
-      onModelChange(panel.id, selection.model);
+      onModelChange(panel.id, selection.model, selection.adapter ?? null);
     },
     [panel.id, onModelChange]
   );
@@ -62,6 +69,45 @@ export const ModelChatPanel: FC<ModelChatPanelProps> = ({
   const parts = panel.modelURN ? getPartsFromReference(panel.modelURN) : null;
   const modelName = parts?.name ?? null;
   const modelWorkspace = parts?.workspace || fallbackWorkspace;
+
+  const modelEntity = useModelEntity(panel.modelURN);
+  const adapter = useMemo(
+    () =>
+      panel.adapter ? modelEntity?.adapters?.find((a) => a.name === panel.adapter) : undefined,
+    [modelEntity, panel.adapter]
+  );
+
+  const { modelChatStatus, isLoading: isChatStatusLoading } = useModelChatAvailability(
+    modelEntity,
+    { adapter }
+  );
+
+  const {
+    servedModel: adapterServedModel,
+    providerRef: adapterProviderRef,
+    isLoading: isAdapterTargetLoading,
+  } = useServedModel(
+    adapter ? modelEntity : undefined,
+    adapter && modelEntity ? toInferenceModelEntityId(modelEntity, adapter) : ''
+  );
+  const adapterServedModelName = adapterServedModel?.served_model_name;
+
+  const adapterProviderParts = adapterProviderRef
+    ? getPartsFromReference(adapterProviderRef)
+    : undefined;
+  const adapterBaseURL = adapterProviderParts
+    ? PLATFORM_BASE_URL +
+      getProviderProxyGetQueryKey(
+        adapterProviderParts.workspace,
+        adapterProviderParts.name,
+        'v1/'
+      )[0]
+    : undefined;
+
+  const isLoadingChat = isChatStatusLoading || isAdapterTargetLoading;
+  const adapterUnresolved = Boolean(adapter) && !(adapterServedModelName && adapterBaseURL);
+
+  const chatModelName = adapter ? adapterServedModelName : modelName;
 
   if (panel.collapsed) {
     return (
@@ -125,11 +171,23 @@ export const ModelChatPanel: FC<ModelChatPanelProps> = ({
       <Stack className="min-h-0 flex-1 px-3 pb-1">
         <ModelChat
           // Remount (clears messages + metrics) when the selected model changes.
-          key={panel.modelURN ?? 'none'}
-          model={modelName ?? ''}
+          key={`${panel.modelURN ?? 'none'}:${panel.adapter ?? ''}`}
+          model={chatModelName ?? ''}
           workspace={modelWorkspace}
-          disabled={!modelName}
-          emptyState={!modelName ? { slotHeading: 'Select a model to start chatting' } : undefined}
+          baseURL={adapter ? adapterBaseURL : undefined}
+          disabled={!modelName || isLoadingChat || adapterUnresolved}
+          modelChatStatus={modelChatStatus}
+          emptyState={
+            !modelName
+              ? { slotHeading: 'Select a model to start chatting' }
+              : adapterUnresolved && !isLoadingChat
+                ? {
+                    slotHeading: 'Adapter is not currently served',
+                    slotSubheading:
+                      'No provider lists this adapter among its served models, so it cannot be chatted with yet. It becomes available once the deployment serving its base model has loaded the adapter.',
+                  }
+                : undefined
+          }
           promptData={{ inference_params: inferenceParams }}
           composerMode={composerMode}
           slotComposerEnd={slotComposerEnd}

--- a/web/packages/studio/src/components/ModelChatPanel/index.tsx
+++ b/web/packages/studio/src/components/ModelChatPanel/index.tsx
@@ -114,7 +114,6 @@ export const ModelChatPanel: FC<ModelChatPanelProps> = ({
             include={hasModelProvider}
             value={selectedModel}
             onValueChange={handleModelChange}
-            hideAdapters
             fullWidth
             disabled={panel.locked}
           />

--- a/web/packages/studio/src/components/ModelChatPanel/index.tsx
+++ b/web/packages/studio/src/components/ModelChatPanel/index.tsx
@@ -104,10 +104,11 @@ export const ModelChatPanel: FC<ModelChatPanelProps> = ({
       )[0]
     : undefined;
 
-  const isLoadingChat = isChatStatusLoading || isAdapterTargetLoading;
-  const adapterUnresolved = Boolean(adapter) && !(adapterServedModelName && adapterBaseURL);
+  const isAdapterEntityPending = Boolean(panel.adapter) && !modelEntity;
+  const isLoadingChat = isChatStatusLoading || isAdapterTargetLoading || isAdapterEntityPending;
+  const adapterUnresolved = Boolean(panel.adapter) && !(adapterServedModelName && adapterBaseURL);
 
-  const chatModelName = adapter ? adapterServedModelName : modelName;
+  const chatModelName = panel.adapter ? adapterServedModelName : modelName;
 
   if (panel.collapsed) {
     return (
@@ -174,7 +175,7 @@ export const ModelChatPanel: FC<ModelChatPanelProps> = ({
           key={`${panel.modelURN ?? 'none'}:${panel.adapter ?? ''}`}
           model={chatModelName ?? ''}
           workspace={modelWorkspace}
-          baseURL={adapter ? adapterBaseURL : undefined}
+          baseURL={panel.adapter ? adapterBaseURL : undefined}
           disabled={!modelName || isLoadingChat || adapterUnresolved}
           modelChatStatus={modelChatStatus}
           emptyState={

--- a/web/packages/studio/src/components/ModelCompareChat/index.tsx
+++ b/web/packages/studio/src/components/ModelCompareChat/index.tsx
@@ -18,7 +18,7 @@ interface ModelCompareChatProps extends PanelChatControls {
   workspace: string;
   models: SharedModelEntry[];
   onRemoveModel: (id: number) => void;
-  onSetModel: (id: number, modelURN: string | null) => void;
+  onSetModel: (id: number, modelURN: string | null, adapter?: string | null) => void;
   /** Incremented to remount all chat panels (clears messages) without losing model selections. */
   chatResetCount?: number;
   /** Called when the user clicks the Add Model button. Omit to hide the button (gutter stays). */
@@ -66,6 +66,7 @@ export const ModelCompareChat: FC<ModelCompareChatProps> = ({
       id: m.id,
       collapsed: collapsedIds.has(m.id),
       modelURN: m.modelURN,
+      adapter: m.adapter,
       roleColor,
       roleLabel: PANEL_ROLE_LABELS[roleColor],
       isSinglePanel,

--- a/web/packages/studio/src/routes/ModelCompareRoute/index.tsx
+++ b/web/packages/studio/src/routes/ModelCompareRoute/index.tsx
@@ -138,9 +138,14 @@ export const ModelCompareRoute: FC = () => {
     });
   }, []);
 
-  const setModelRef = useCallback((id: number, modelURN: string | null) => {
-    setModels((prev) => prev.map((m) => (m.id === id ? { ...m, modelURN } : m)));
-  }, []);
+  const setModelRef = useCallback(
+    (id: number, modelURN: string | null, adapter?: string | null) => {
+      setModels((prev) =>
+        prev.map((m) => (m.id === id ? { ...m, modelURN, adapter: adapter ?? null } : m))
+      );
+    },
+    []
+  );
 
   const resetAll = useCallback(() => {
     setStopCount((n) => n + 1); // cancel in-flight completions before remount

--- a/web/packages/studio/src/routes/ModelCompareRoute/types.ts
+++ b/web/packages/studio/src/routes/ModelCompareRoute/types.ts
@@ -67,6 +67,7 @@ export interface SharedModelEntry {
   id: number;
   /** Full URN, e.g. "abacusai/dracarys-llama-70b". Null means unassigned. */
   modelURN: string | null;
+  adapter?: string | null;
   locked?: boolean;
 }
 
@@ -76,6 +77,7 @@ export interface PanelState {
   collapsed: boolean;
   /** Full model URN ("workspace/name"), or null if unassigned. */
   modelURN: string | null;
+  adapter?: string | null;
   roleColor: PanelRoleColor;
   roleLabel: string;
   /** True when this is the only panel — drives the larger per-panel action bar. */


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
Fix Adapters now showing on Playground
<img width="1262" height="951" alt="image" src="https://github.com/user-attachments/assets/3d0de8b9-a5fe-4e3a-9135-788be06ba821" />


Fixes https://linear.app/nvidia/issue/ASTD-597/restore-lora-adapter-comparison-in-playground

## Changes
Quick prop change

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [ ] Pull request title follows the repository's Conventional Commit format
- [ ] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [ ] Targeted tests pass, or tests are marked not applicable above
- [ ] No secrets, API keys, or credentials are included

Targeted validation:

<!-- List each command and result. Explain skipped, blocked, or non-successful checks without marking them as passed. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Model adapters are now displayed in the model selector.
  - Selected adapters are preserved when switching between or comparing models.
  - Model selections show the base model and adapter name together.
  - Chat status and empty-state messages reflect adapter availability.
  - Chat is disabled while model or adapter details load.

- **Bug Fixes**
  - Adapter-specific selections now display the correct selection indicator.
  - Chat no longer sends requests when the selected adapter cannot be resolved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->