### PR TITLE
fix(data-designer): Ensure DD library plugins are inherited in the pl…

### DIFF
--- a/packages/nemo_platform/pyproject.toml
+++ b/packages/nemo_platform/pyproject.toml
@@ -644,6 +644,10 @@ nmp = "nemo_platform.cli.app:cli"
 
 [project.entry-points]
 # Generated from [tool.bundle-package]; do not edit this table by hand.
+[project.entry-points."data_designer.plugins"]
+fileset-seed-datasets = "data_designer_nemo.plugins:fileset_seed_datasets_plugin"
+
+# Generated from [tool.bundle-package]; do not edit this table by hand.
 [project.entry-points."nat.components"]
 nat_claude_code_agent_adapter = "nat_claude_code_agent_adapter.register"
 nat_codex_agent_adapter = "nat_codex_agent_adapter.register"
@@ -862,7 +866,7 @@ nemo-auditor-plugin = { source = "../../plugins/nemo-auditor/src/nemo_auditor", 
 # training images; these carry only compile-side deps, so they are safe to bundle.
 nemo-automodel-plugin = { source = "../../plugins/nemo-automodel/src/nemo_automodel_plugin", module = "nemo_automodel_plugin", inherit = { "entry-points" = ["nemo.*"] } }
 nemo-customizer-plugin = { source = "../../plugins/nemo-customizer/src/nemo_customizer", module = "nemo_customizer", inherit = { "entry-points" = ["nemo.*"] } }
-nemo-data-designer-plugin = { source = "../../plugins/nemo-data-designer/src/nemo_data_designer_plugin", module = "nemo_data_designer_plugin", inherit = { "entry-points" = ["nemo.*"] } }
+nemo-data-designer-plugin = { source = "../../plugins/nemo-data-designer/src/nemo_data_designer_plugin", module = "nemo_data_designer_plugin", inherit = { "entry-points" = ["nemo.*", "data_designer.plugins"] } }
 nemo-deployments-plugin = { source = "../../plugins/nemo-deployments/src/nemo_deployments_plugin", module = "nemo_deployments_plugin", inherit = { "entry-points" = ["nemo.*"] } }
 nemo-evaluator-plugin = { source = "../../plugins/nemo-evaluator/src/nemo_evaluator", module = "nemo_evaluator", inherit = { "entry-points" = ["nemo.*"] } }
 nemo-experimentalist-plugin = { source = "../../plugins/nemo-experimentalist/src/nemo_experimentalist_plugin", module = "nemo_experimentalist_plugin", inherit = { "entry-points" = ["nemo.*"] } }


### PR DESCRIPTION
…atform wheel

<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
The data-designer platform plugin defines and uses a data-designer **library** plugin, but this definition was not making its way to the built nemo-platform wheel. We need to explicitly inherit the DD library plugin entry-point.

## Changes
Extend the list of inherited entry-points for data-designer, and re-vendor.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [x] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

<!-- List each command and result. Explain skipped, blocked, or non-successful checks without marking them as passed. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added plugin registration for Nemo seed datasets.
  * Updated the plugin bundle to include registered data designer plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->