### PR TITLE
docs(agents): filling in gaps

### DIFF
--- a/docs/agents/deploy-agents.mdx
+++ b/docs/agents/deploy-agents.mdx
@@ -327,6 +327,15 @@ uv sync --package nemo-agents-plugin --extra container
 The examples below use the calculator agent that ships with the source
 checkout. Run them from the repository root. Its config is located at
 `plugins/nemo-agents/examples/nemo-agent-config/calculator-agent/agent.yaml`.
+Build a wheel from the checkout and select it for packaging:
+
+```bash
+uv build --package nemo-platform --wheel --out-dir dist
+export NEMO_AGENTS_WHEEL=LATEST
+```
+
+`LATEST` selects the newest `nemo_platform-*.whl` file in `dist`. You can instead
+set `NEMO_AGENTS_WHEEL` to an absolute wheel path.
 
 <Tabs>
 
@@ -345,6 +354,9 @@ nemo agents package \
   --publish \
   --registry <your-registry>
 ```
+
+The Docker host running the command must already be authenticated to the
+registry.
 
 </Tab>
 
@@ -540,6 +552,25 @@ response = client.agents.invoke(
 
 </Tabs>
 ---
+
+## Interact with a Deployed Agent
+
+Start an interactive, multi-turn session with a running deployment:
+
+```bash
+nemo agents chat \
+  --agent-deployment calculator-agent-k8s \
+  --session-name calculator-chat
+```
+
+Leaving the chat does not close the session. Resume or manage it with:
+
+```bash
+nemo agents chat --session calculator-chat
+nemo agents sessions list --agent-deployment calculator-agent-k8s
+nemo agents sessions get calculator-chat
+nemo agents sessions close calculator-chat
+```
 
 ## Model Access from a Deployed Agent
 

--- a/docs/agents/execute-agent-jobs.mdx
+++ b/docs/agents/execute-agent-jobs.mdx
@@ -112,14 +112,15 @@ print(job["name"], job["status"])
 | `environment` | No | A `workspace/name` ref to a stored `AgentEnvironment`, or an inline environment. Supplies secrets, environment variables, tool settings, and compute. |
 | `workdir` | No | The [working directory](#working-directories) the agent starts from. |
 | `timeout_seconds` | No | Maximum time to wait for a result. Defaults to 3600 (one hour). |
+| `auto_telemetry` | No | Automatically configures supported ATIF telemetry to export to Intake. Defaults to `true`. |
 | `extension` | No | A trusted [execute extension](#execute-extensions) contributed by an installed plugin. |
 
 The CLI generates one flag per spec field (`--agent`, `--input`,
-`--environment`, `--workdir.base-workdir`, `--timeout-seconds`). Fields that do
-not reduce to a single flag — an inline agent, an inline environment,
-`workdir.artifact_mounts` — are supplied with `--spec` (a JSON string) or
-`--spec-file` (a YAML or JSON file). Individual flags override values from the
-supplied spec.
+`--environment`, `--workdir.base-workdir`, `--timeout-seconds`,
+`--auto-telemetry`). Fields that do not reduce to a single flag — an inline
+agent, an inline environment, `workdir.artifact_mounts` — are supplied with
+`--spec` (a JSON string) or `--spec-file` (a YAML or JSON file). Individual
+flags override values from the supplied spec.
 
 ## Track a Job and Fetch Its Results
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary

Documents user-facing agent workflows that were previously covered only by the
generated CLI reference or plugin README. The updates cover deployment-backed
chat sessions, packaging an agent from a source checkout, publishing the image
to a registry, and automatic telemetry for execute-agent jobs.

## Changes

- Add `auto_telemetry` to the execute-agent job spec fields and document its
  default behavior.
- Show how to build a `nemo-platform` wheel from a source checkout and select it
  with `NEMO_AGENTS_WHEEL=LATEST` or an absolute path.
- Clarify how to publish a packaged agent image to an authenticated registry.
- Add an "Interact with a Deployed Agent" section covering persistent chat
  sessions and the commands to resume, list, inspect, and close them.

The generic fully-qualified adapter and multiple-model configuration is not
documented here because the supported Insights Analyst workflow constructs that
inline agent configuration before submitting its execute-agent job.

## Type of Change

- [ ] Code change
- [x] Documentation only

## Verification

- [x] MDX validation passes: 226 files parsed successfully.
- [x] `git diff --check` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for building and selecting a local Platform wheel when packaging agents in container mode.
  * Clarified Docker registry authentication prerequisites.
  * Documented commands for managing persistent, multi-turn agent chat sessions.
  * Documented the optional `auto_telemetry` job setting, including its default behavior and CLI flag.
  * Clarified how to provide complex job fields and how individual flags take precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
