### PR TITLE
fix(eval-author): clarify and streamline trace environment skill

### DIFF
--- a/plugins/nemo-eval-author/skills/eval-author-trace-environment/SKILL.md
+++ b/plugins/nemo-eval-author/skills/eval-author-trace-environment/SKILL.md
@@ -50,7 +50,8 @@ workspaces in Git.
 
 ## Artifact contract
 
-Use one workspace per task:
+Use one workspace per task. Paths below are generated workspace artifacts, not
+bundled skill files; `extra.*` names elsewhere are ATIF fields, not file paths.
 
 ```text
 .eval-author/trace-environments/
@@ -231,63 +232,9 @@ binaries into the task.
 ## Step 5: decide candidate or no_candidate
 
 Read only `safe/trace.atif.json`. Later user corrections outrank earlier turns.
-Every decision must cite real ATIF `step_id` values. Write `candidate.json` with
-this shape:
-
-```json
-{
-  "schema": "nemo.eval_author.trace_environment_candidate.v2",
-  "status": "candidate",
-  "decision_basis": "safe_atif_only",
-  "instruction": "Observable task instruction without private values",
-  "requirements": [
-    {"description": "Objectively testable requirement", "evidence_steps": [1, 2]}
-  ],
-  "verification_mode": "execution",
-  "evidence_steps": [1, 2],
-  "uncertainties": [],
-  "reason_codes": [],
-  "ground_truth": {
-    "availability": "available",
-    "use": "comparison_only",
-    "artifacts": [
-      {
-        "kind": "expected_output",
-        "path": "private/ground-truth/expected.json",
-        "sha256": "sha256:<64-hex-digest>",
-        "provenance": {
-          "kind": "external",
-          "step_ids": [],
-          "uri": "https://example.test/fixture.json",
-          "revision": "<immutable-revision>",
-          "source_id": null
-        },
-        "notes": "Expected output attached to the recorded task."
-      }
-    ],
-    "absence_reason": null
-  },
-  "software_requirements": [
-    {
-      "name": "ExampleCAD",
-      "category": "desktop_application",
-      "required": true,
-      "version": "2026",
-      "license": "proprietary",
-      "availability": "unknown",
-      "redistributable": false,
-      "provenance": {
-        "kind": "atif_step",
-        "step_ids": [1, 2],
-        "uri": null,
-        "revision": null,
-        "source_id": null
-      },
-      "notes": "The requested edit and verifier depend on native CAD behavior."
-    }
-  ]
-}
-```
+Every decision must cite real ATIF `step_id` values. Read
+[references/candidate-record.md](references/candidate-record.md) for the
+`candidate.json` shape before writing the decision.
 
 Use `candidate` only when the request and expected outcome are complete,
 reproducible without private or live external state, and objectively testable.
@@ -347,51 +294,9 @@ workspace wholesale.
 Read and follow `references/environment-integrity.md` for agent-network,
 contamination, portability, repeat-run, and negative-control requirements.
 
-```toml
-[verifier]
-environment_mode = "separate"
-network_mode = "no-network"
-
-[verifier.environment]
-network_mode = "no-network"
-
-[environment]
-network_mode = "no-network"
-```
-
-Add a step-local environment only when that step needs a different verifier
-image or resource configuration:
-
-```toml
-[[steps]]
-name = "grade"
-
-[steps.verifier]
-environment_mode = "separate"
-
-[steps.verifier.environment]
-network_mode = "no-network"
-```
-
-The task README is not passed to the agent. Give it a level-one task title and
-these substantive level-two sections:
-
-- `Difficulty explanation`: why the task is difficult for agents and humans;
-- `Environment and software requirements`: runtimes, services, hardware,
-  versions, licensing, and availability constraints;
-- `Ground-truth provenance`: what establishes correctness and where that
-  evidence came from, without exposing private values;
-- `Solution explanation`: the high-level reference approach without duplicating
-  `solution/solve.sh`;
-- `Verification explanation`: the observable outcomes and how the verifier
-  distinguishes success from failure; and
-- `Relevant experience`: human-supplied experience relevant to authoring or
-  reviewing the task.
-
-Keep each section concise and evidence-backed. Do not repeat `instruction.md`,
-reveal verifier internals to the agent, or invent author experience. If a human
-cannot supply and review `Relevant experience`, keep the environment `unproven`
-rather than claiming it is ready.
+Write the reviewer-only task README using the integrity reference's required
+sections. Human-supplied or reviewed `Relevant experience` is necessary for
+readiness; never invent it.
 
 Do not copy private trace payloads into the task. Include only the minimal files
 needed to reproduce the starting state. Pin external source to an exact public
@@ -404,9 +309,8 @@ python <skill_dir>/scripts/trace_environment.py record-reproducibility \
   --task-dir <task-dir>
 ```
 
-Run at least two independent NOP jobs, two Oracle jobs, and one task-specific
-negative-control job. Record each run's inputs before Harbor creates its job
-directory. Each invocation must create fresh task containers. For example:
+Execute the repeat-run protocol in `references/environment-integrity.md`.
+For example, record the first NOP job's inputs and then run it:
 
 ```bash
 python <skill_dir>/scripts/trace_environment.py record-run-inputs \
@@ -422,13 +326,9 @@ command. Never hand-write rewards, job IDs, exceptions, or checksums. Do not
 weaken the verifier to make Oracle pass. Failed proof remains technical evidence.
 
 If Harbor or Docker is missing, technical status is `not_run` and the environment
-is `unproven`; do not describe it as ready. Two NOP=0 runs, two Oracle=1 runs,
-and a task-specific negative-control=0 run without exceptions establish technical
-status `passed` only when their recorded agents and task snapshots match. They
-do not establish human review or container freshness. Reports distinguish
-verified distinct job IDs/paths from `container_freshness: "unverified"`. The
-helper independently requires the task configuration and every retained Harbor
-result to report separate verification.
+is `unproven`; do not describe it as ready. The integrity reference defines the
+conditions for technical status `passed` and the limits of that claim; passing
+proof does not establish human review.
 
 ## Step 7: finalize and verify the summary
 

--- a/plugins/nemo-eval-author/skills/eval-author-trace-environment/SKILL.md
+++ b/plugins/nemo-eval-author/skills/eval-author-trace-environment/SKILL.md
@@ -175,6 +175,11 @@ text field in `safe/trace.atif.json`, every audit finding and host, then record
 who performed this trace review. Generated task files do not exist yet; review
 the complete publication separately after finalization.
 
+Use the audit's field and character denominator to plan bounded reads. If a tool
+truncates output, continue through the omitted fields or character ranges; a
+truncated display does not establish missing trace evidence. If review cannot
+finish, retain that limitation without issuing a complete review attestation.
+
 ```bash
 python <skill_dir>/scripts/trace_environment.py review-privacy \
   --task-dir <task-dir> \
@@ -235,6 +240,8 @@ Read only `safe/trace.atif.json`. Later user corrections outrank earlier turns.
 Every decision must cite real ATIF `step_id` values. Read
 [references/candidate-record.md](references/candidate-record.md) for the
 `candidate.json` shape before writing the decision.
+Run its read-only `check-candidate` command before construction; it checks
+metadata, not execution, privacy review or readiness.
 
 Use `candidate` only when the request and expected outcome are complete,
 reproducible without private or live external state, and objectively testable.
@@ -259,7 +266,8 @@ folding them into `insufficient_trace_evidence`: use `malformed_atif`,
 `source_too_large`, `build_dependency_unavailable`,
 `verifier_dependency_unavailable`, `network_dependency_required`, and
 `verifier_not_isolated` where applicable. Record the concrete failed command or
-contract check in `did_not_work`; keep `reason_codes` stable and aggregateable.
+contract check in the summary using Step 7's `finalize --did-not-work`, not as an
+extra field in `candidate.json`; keep `reason_codes` stable and aggregateable.
 
 ## Step 6: author and prove a candidate environment
 

--- a/plugins/nemo-eval-author/skills/eval-author-trace-environment/references/candidate-record.md
+++ b/plugins/nemo-eval-author/skills/eval-author-trace-environment/references/candidate-record.md
@@ -1,0 +1,63 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Candidate record shape
+
+Read this when writing the Step 5 decision. Replace illustrative values with
+reviewed evidence; this example is not a ready candidate while required software
+availability remains unknown. The helper validates the record during finalization.
+
+```json
+{
+  "schema": "nemo.eval_author.trace_environment_candidate.v2",
+  "status": "candidate",
+  "decision_basis": "safe_atif_only",
+  "instruction": "Observable task instruction without private values",
+  "requirements": [
+    {"description": "Objectively testable requirement", "evidence_steps": [1, 2]}
+  ],
+  "verification_mode": "execution",
+  "evidence_steps": [1, 2],
+  "uncertainties": [],
+  "reason_codes": [],
+  "ground_truth": {
+    "availability": "available",
+    "use": "comparison_only",
+    "artifacts": [
+      {
+        "kind": "expected_output",
+        "path": "private/ground-truth/expected.json",
+        "sha256": "sha256:<64-hex-digest>",
+        "provenance": {
+          "kind": "external",
+          "step_ids": [],
+          "uri": "https://example.test/fixture.json",
+          "revision": "<immutable-revision>",
+          "source_id": null
+        },
+        "notes": "Expected output attached to the recorded task."
+      }
+    ],
+    "absence_reason": null
+  },
+  "software_requirements": [
+    {
+      "name": "ExampleCAD",
+      "category": "desktop_application",
+      "required": true,
+      "version": "2026",
+      "license": "proprietary",
+      "availability": "unknown",
+      "redistributable": false,
+      "provenance": {
+        "kind": "atif_step",
+        "step_ids": [1, 2],
+        "uri": null,
+        "revision": null,
+        "source_id": null
+      },
+      "notes": "The requested edit and verifier depend on native CAD behavior."
+    }
+  ]
+}
+```

--- a/plugins/nemo-eval-author/skills/eval-author-trace-environment/references/candidate-record.md
+++ b/plugins/nemo-eval-author/skills/eval-author-trace-environment/references/candidate-record.md
@@ -5,7 +5,46 @@
 
 Read this when writing the Step 5 decision. Replace illustrative values with
 reviewed evidence; this example is not a ready candidate while required software
-availability remains unknown. The helper validates the record during finalization.
+availability remains unknown. Validate metadata before building a task:
+
+```bash
+python <skill_dir>/scripts/trace_environment.py check-candidate --task-dir <task-dir>
+```
+
+This read-only check validates the existing record, prepared safe-trace digest,
+evidence step references and retained ground-truth artifacts. It does not edit
+values, finalize the workspace, attest privacy review or prove the environment.
+Finalization still enforces its full contract.
+
+## Accepted values
+
+Use these exact enum values, not product names, SPDX identifiers or descriptive
+synonyms. Put those details in `name`, `version` or `notes` instead.
+
+| Field | Accepted values |
+| --- | --- |
+| `ground_truth.availability` | `available`, `partial`, `absent`, `unknown` |
+| `ground_truth.use` | `none`, `comparison_only`, `verification` |
+| Artifact `kind` | `reference_trace`, `expected_output`, `dataset`, `fixture`, `verifier`, `human_feedback`, `other` |
+| Software `category` | `library`, `cli`, `desktop_application`, `service`, `hardware`, `other` |
+| Software `license` | `open_source`, `proprietary`, `commercial`, `unknown`, `not_applicable` |
+| Software `availability` | `available`, `installable`, `unavailable`, `unknown` |
+| Provenance `kind` | `atif_step`, `external` |
+
+Software `required` is a boolean; `redistributable` is a boolean or null.
+`version` is nonempty text or null. Software names must be unique ignoring case.
+Every software item and ground-truth artifact needs nonempty `notes` and complete
+provenance; use the skill's ATIF-versus-external evidence rules.
+
+Available or partial ground truth must retain at least one hashed artifact and
+declare comparison or verification use. Partial ground truth needs an
+`absence_reason`; available ground truth sets it to null. Absent or unknown
+ground truth needs an empty artifact list, `use: "none"`, and a nonempty reason.
+
+## Example
+
+Include exactly the keys shown below. Summary fields such as `did_not_work`
+belong to `finalize` arguments, not the candidate record.
 
 ```json
 {

--- a/plugins/nemo-eval-author/skills/eval-author-trace-environment/references/environment-integrity.md
+++ b/plugins/nemo-eval-author/skills/eval-author-trace-environment/references/environment-integrity.md
@@ -43,6 +43,58 @@ complete build and runtime dependency closure before grading.
 This is an authoring requirement, not a claim that the static helper verifies
 the complete dependency closure.
 
+### Configuration examples
+
+Minimal isolated task configuration:
+
+```toml
+[verifier]
+environment_mode = "separate"
+network_mode = "no-network"
+
+[verifier.environment]
+network_mode = "no-network"
+
+[environment]
+network_mode = "no-network"
+```
+
+Add a step-local environment only when that step needs a different verifier
+image or resource configuration:
+
+```toml
+[[steps]]
+name = "grade"
+
+[steps.verifier]
+environment_mode = "separate"
+
+[steps.verifier.environment]
+network_mode = "no-network"
+```
+
+## Reviewer documentation
+
+The task README is not passed to the agent. Give it a level-one task title and
+these substantive level-two sections:
+
+- `Difficulty explanation`: why the task is difficult for agents and humans;
+- `Environment and software requirements`: runtimes, services, hardware,
+  versions, licensing, and availability constraints;
+- `Ground-truth provenance`: what establishes correctness and where that
+  evidence came from, without exposing private values;
+- `Solution explanation`: the high-level reference approach without duplicating
+  `solution/solve.sh`;
+- `Verification explanation`: the observable outcomes and how the verifier
+  distinguishes success from failure; and
+- `Relevant experience`: human-supplied experience relevant to authoring or
+  reviewing the task.
+
+Keep each section concise and evidence-backed. Do not repeat `instruction.md`,
+reveal verifier internals to the agent, or invent author experience. If a human
+cannot supply and review `Relevant experience`, keep the environment `unproven`
+rather than claiming it is ready.
+
 ## Reproducibility manifest
 
 Record the exact task tree before running Harbor:

--- a/plugins/nemo-eval-author/skills/eval-author-trace-environment/references/environment-integrity.md
+++ b/plugins/nemo-eval-author/skills/eval-author-trace-environment/references/environment-integrity.md
@@ -33,6 +33,16 @@ accepts separate verification; the task-specific preflight fails closed there.
 Do not flatten a multi-step task just to pass. Every actual job must still pass
 the existing checksum, identity, reward and separate-mode result checks.
 
+## Preserve the recorded task's scope
+
+Minimal construction does not authorize narrowing the requested outcome or
+permitted implementation choices. Preserve allowed languages, dependencies and
+multi-file deliverables; declare their complete output closure for transfer
+instead of imposing a single-file or standard-library-only solution for
+convenience. Record any evidence-backed generalization explicitly. If necessary
+dependencies or outputs cannot be supported within isolation, retain that
+limitation rather than silently substituting an easier task.
+
 ## Network isolation
 
 In addition to the separate no-network verifier contract, require the agent
@@ -72,6 +82,49 @@ environment_mode = "separate"
 [steps.verifier.environment]
 network_mode = "no-network"
 ```
+
+### Artifact handoff and verifier images
+
+In Harbor's separate environment, explicitly declared artifacts are restored at
+their original `source` paths. An artifact `destination` changes the host result
+layout, not the path used by the verifier. For example:
+
+```toml
+# Top-level task.toml, before any section header:
+artifacts = [{ source = "/app/result.txt", destination = "submission/result.txt" }]
+```
+
+The verifier reads `/app/result.txt`, not `/logs/artifacts/submission/result.txt`.
+The conventional `/logs/artifacts` directory is a different publish mechanism;
+do not mix these layouts. Check the installed Harbor artifact API when using a
+different provider revision, and prove the actual handoff with NOP and Oracle.
+Transfer only the declared outputs; do not broaden the transfer to make a path
+mismatch disappear.
+
+Choose one verifier image path and include its complete offline grading closure:
+
+- **Build recipe:** provide `tests/Dockerfile` with the required runtime and
+  `COPY . /tests/`; leave `[verifier.environment].docker_image` unset so Harbor
+  builds that recipe. The resulting image must contain `/tests/test.sh` and every
+  file it needs.
+- **Prebuilt image:** set `docker_image` to an immutable image already containing
+  the complete `/tests` tree and runtime. A vanilla language image does not
+  contain the authored tests. Do not assume a sibling Dockerfile is built or
+  tests are uploaded when a prebuilt image is selected.
+
+Check inherited image entrypoints, commands, users and environment variables
+against Harbor's startup and execution lifecycle. A successful image build does
+not prove that the container stays available or its tools work under the
+configured user. Retain build, startup and grading failures separately; do not
+infer a verifier or reference-solution defect when execution never reached them.
+
+Separate verification does not preserve the agent's running processes. For a
+configuration deliverable, a fresh verifier-owned service can test the declared
+configuration. This proves replay, not that the agent left a service running.
+Do not substitute replay for a requested live-state outcome; if the provider
+cannot test that outcome within the isolation contract, retain the limitation
+and use `verifier_not_isolated` rather than weakening the task. Label agent-side
+collected observations as untrusted evidence, not independent runtime proof.
 
 ## Reviewer documentation
 
@@ -129,6 +182,11 @@ credentials, credential-bearing URLs, and symlinks. It is a static task-tree
 gate, not an inspection of opaque image layers. Keep image-construction
 transcripts private and inspect pre-existing opaque images separately.
 
+A duplicate-file finding establishes byte equality, not the file's semantic role:
+public starting-state fixtures can also be retained by the verifier. Report that
+distinction when supported by the instruction and file contents, while retaining
+the failed gate. Do not reformat duplicates or weaken the scanner to evade it.
+
 ## Repeat and negative-control proof
 
 Run every arm as an independent Harbor invocation with new task containers.
@@ -140,6 +198,11 @@ The negative control must be a deliberately incomplete or subtly incorrect,
 non-crashing solution relevant to the task and must receive reward `0`. Do not
 reuse NOP as the negative control. Record the mutation in private construction
 notes without exposing verifier logic.
+
+Check the installed Harbor custom-agent constructor and execution interface
+before choosing a base class. Built-in Oracle may receive task paths and other
+orchestration arguments that custom import-path agents do not; importing an
+Oracle subclass alone does not prove it can be instantiated as a custom control.
 
 Before **every** invocation, run `record-run-inputs` with its arm and future job
 directory (see the skill's NOP example). This writes an owner-private receipt

--- a/plugins/nemo-eval-author/skills/eval-author-trace-environment/scripts/trace_environment.py
+++ b/plugins/nemo-eval-author/skills/eval-author-trace-environment/scripts/trace_environment.py
@@ -967,14 +967,14 @@ def _validate_ground_truth(task_dir: Path, value: Any, step_ids: set[int]) -> di
     if not isinstance(value, dict) or set(value) != _GROUND_TRUTH_KEYS:
         raise ContractError("candidate.ground_truth fields do not match the versioned contract")
     availability = value.get("availability")
-    if availability not in {"available", "partial", "absent", "unknown"}:
+    if not isinstance(availability, str) or availability not in {"available", "partial", "absent", "unknown"}:
         raise ContractError("candidate.ground_truth.availability is not recognized")
     artifacts = value.get("artifacts")
     if not isinstance(artifacts, list):
         raise ContractError("candidate.ground_truth.artifacts must be a list")
     absence_reason = value.get("absence_reason")
     use = value.get("use")
-    if use not in {"none", "comparison_only", "verification"}:
+    if not isinstance(use, str) or use not in {"none", "comparison_only", "verification"}:
         raise ContractError("candidate.ground_truth.use is not recognized")
     if absence_reason is not None and (not isinstance(absence_reason, str) or not absence_reason.strip()):
         raise ContractError("candidate.ground_truth.absence_reason must be null or nonempty text")
@@ -1004,7 +1004,7 @@ def _validate_ground_truth(task_dir: Path, value: Any, step_ids: set[int]) -> di
         label = f"candidate.ground_truth.artifacts[{index}]"
         if not isinstance(artifact, dict) or set(artifact) != _GROUND_TRUTH_ARTIFACT_KEYS:
             raise ContractError(f"{label} fields do not match the versioned contract")
-        if artifact.get("kind") not in allowed_kinds:
+        if not isinstance(artifact.get("kind"), str) or artifact["kind"] not in allowed_kinds:
             raise ContractError(f"{label}.kind is not recognized")
         relative_path = artifact.get("path")
         if not isinstance(relative_path, str) or not relative_path.startswith("private/ground-truth/"):
@@ -1044,16 +1044,19 @@ def _validate_software_requirements(value: Any, step_ids: set[int]) -> list[dict
         if not isinstance(name, str) or not name.strip() or name.casefold() in names:
             raise ContractError(f"{label}.name must be nonempty and unique")
         names.add(name.casefold())
-        if requirement.get("category") not in allowed_categories:
+        if not isinstance(requirement.get("category"), str) or requirement["category"] not in allowed_categories:
             raise ContractError(f"{label}.category is not recognized")
         if type(requirement.get("required")) is not bool:
             raise ContractError(f"{label}.required must be a boolean")
         version = requirement.get("version")
         if version is not None and (not isinstance(version, str) or not version.strip()):
             raise ContractError(f"{label}.version must be null or nonempty text")
-        if requirement.get("license") not in allowed_licenses:
+        if not isinstance(requirement.get("license"), str) or requirement["license"] not in allowed_licenses:
             raise ContractError(f"{label}.license is not recognized")
-        if requirement.get("availability") not in allowed_availability:
+        if (
+            not isinstance(requirement.get("availability"), str)
+            or requirement["availability"] not in allowed_availability
+        ):
             raise ContractError(f"{label}.availability is not recognized")
         redistributable = requirement.get("redistributable")
         if redistributable is not None and type(redistributable) is not bool:
@@ -1101,6 +1104,36 @@ def _validate_candidate(task_dir: Path, status: str, step_ids: set[int]) -> dict
         if candidate.get("requirements") != []:
             raise ContractError("no_candidate records must set requirements to an empty list")
     return candidate
+
+
+def _check_candidate(args: argparse.Namespace) -> dict[str, Any]:
+    """Check authored metadata against its prepared evidence without changing it."""
+    task_dir = _ensure_task_dir(args.task_dir)
+    summary = _load_summary(task_dir)
+    source = summary["source"]
+    if source is None:
+        raise ContractError("prepare ATIF evidence before checking candidate metadata")
+    safe_path = task_dir / source["safe_path"]
+    if safe_path.is_symlink() or not safe_path.is_file():
+        raise ContractError("safe ATIF must be a retained regular file")
+    if safe_path.stat().st_size > MAX_CANONICAL_BYTES:
+        raise ContractError(f"safe ATIF exceeds the {MAX_CANONICAL_BYTES}-byte limit")
+    safe_bytes = safe_path.read_bytes()
+    if _sha256(safe_bytes) != source["safe_sha256"] or len(safe_bytes) != source["safe_size_bytes"]:
+        raise ContractError("safe ATIF digest or size changed")
+    safe_payload = _load_object(safe_path, label="safe ATIF")
+    _validate_trajectory(safe_payload)
+    status = _load_object(task_dir / "candidate.json", label="candidate").get("status")
+    if status not in ("candidate", "no_candidate"):
+        raise ContractError("candidate.status must be candidate or no_candidate")
+    _validate_candidate(task_dir, status, {step["step_id"] for step in safe_payload["steps"]})
+    return {
+        "task_dir": str(task_dir),
+        "valid": True,
+        "scope": "candidate_metadata",
+        "status": status,
+        "execution_verified": False,
+    }
 
 
 def _task_tree_info(root: Path) -> dict[str, Any]:
@@ -2501,6 +2534,13 @@ def _parser() -> argparse.ArgumentParser:
     review.add_argument("--reviewer-kind", choices=("agent", "human"), required=True)
     review.add_argument("--note", required=True)
     review.set_defaults(run=_review_privacy)
+
+    candidate_check = subparsers.add_parser(
+        "check-candidate",
+        help="read-only metadata and evidence-reference check; does not prove execution or privacy review",
+    )
+    candidate_check.add_argument("--task-dir", required=True, type=Path)
+    candidate_check.set_defaults(run=_check_candidate)
 
     reproducibility = subparsers.add_parser(
         "record-reproducibility", help="hash the task tree and record portability and contamination evidence"

--- a/plugins/nemo-eval-author/skills/eval-author-trace-environment/scripts/trace_environment.py
+++ b/plugins/nemo-eval-author/skills/eval-author-trace-environment/scripts/trace_environment.py
@@ -336,13 +336,13 @@ def _init(args: argparse.Namespace) -> dict[str, Any]:
     if ".eval-author" not in root.parts:
         raise ContractError("task workspace root must stay under a .eval-author directory")
     _mkdir_private(root)
-    ignore = root / ".gitignore"
-    ignore_text = "*\n!.gitignore\n"
-    if ignore.exists():
-        if ignore.is_symlink() or ignore.read_text(encoding="utf-8") != ignore_text:
-            raise ContractError(f"refusing to replace unexpected ignore rules at {ignore}")
+    gitignore_path = root / ".gitignore"
+    expected_gitignore = "*\n!.gitignore\n"
+    if gitignore_path.exists():
+        if gitignore_path.is_symlink() or gitignore_path.read_text(encoding="utf-8") != expected_gitignore:
+            raise ContractError(f"workspace .gitignore must contain only the required exclusions: {gitignore_path}")
     else:
-        _write_text(ignore, ignore_text)
+        _write_text(gitignore_path, expected_gitignore)
 
     task_dir = root / args.task_id
     if task_dir.exists():
@@ -2107,7 +2107,9 @@ def _check(args: argparse.Namespace) -> dict[str, Any]:
                     or not privacy["contextual_review_complete"]
                     or privacy["blocking_reasons"]
                 ):
-                    errors.append("finalized candidate lacks a clear contextual privacy review")
+                    errors.append(
+                        "finalized candidate lacks a completed contextual privacy review with no blocking findings"
+                    )
                 task_contract = _validate_task(task_dir)
                 _validate_reproducibility(task_dir)
                 if environment.get("verifier_environment_mode") != task_contract["verifier_environment_mode"]:

--- a/plugins/nemo-eval-author/tests/test_trace_environment.py
+++ b/plugins/nemo-eval-author/tests/test_trace_environment.py
@@ -131,6 +131,159 @@ def _candidate(
     _write_json(task_dir / "candidate.json", payload)
 
 
+@pytest.mark.parametrize("status", ["candidate", "no_candidate"])
+def test_check_candidate_is_read_only_before_construction(tmp_path: Path, status: str) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _candidate(task_dir, status=status)
+    before = {
+        path.relative_to(task_dir): (path.read_bytes(), path.stat().st_mode)
+        for path in task_dir.rglob("*")
+        if path.is_file()
+    }
+
+    code, result = _run("check-candidate", "--task-dir", str(task_dir))
+
+    assert code == 0, result
+    assert result["scope"] == "candidate_metadata"
+    assert result["execution_verified"] is False
+    assert result["status"] == status
+    assert not (task_dir / "task/task.toml").exists()
+    assert json.loads((task_dir / "summary.json").read_text())["status"] == "pending"
+    assert before == {
+        path.relative_to(task_dir): (path.read_bytes(), path.stat().st_mode)
+        for path in task_dir.rglob("*")
+        if path.is_file()
+    }
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("category", "runtime"),
+        ("license", "Apache-2.0"),
+        ("availability", "not_installed"),
+        ("category", []),
+        ("license", {}),
+        ("availability", []),
+    ],
+)
+def test_check_candidate_rejects_unknown_software_enum_without_repair(tmp_path: Path, field: str, value: Any) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    software = _software(required=False, availability="unknown")
+    software[field] = value
+    _candidate(task_dir, software_requirements=[software])
+    before = (task_dir / "candidate.json").read_bytes()
+
+    code, result = _run("check-candidate", "--task-dir", str(task_dir))
+
+    assert code == 1
+    assert f"software_requirements[0].{field} is not recognized" in result["error"]
+    assert (task_dir / "candidate.json").read_bytes() == before
+
+
+@pytest.mark.parametrize("field,value", [("availability", []), ("use", {})])
+def test_check_candidate_rejects_invalid_ground_truth_enum(tmp_path: Path, field: str, value: Any) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _candidate(task_dir)
+    path = task_dir / "candidate.json"
+    candidate = json.loads(path.read_text())
+    candidate["ground_truth"][field] = value
+    _write_json(path, candidate)
+    code, result = _run("check-candidate", "--task-dir", str(task_dir))
+    assert code == 1
+    assert f"ground_truth.{field} is not recognized" in result["error"]
+
+
+def test_check_candidate_rejects_unknown_evidence_step(tmp_path: Path) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _candidate(task_dir)
+    path = task_dir / "candidate.json"
+    candidate = json.loads(path.read_text())
+    candidate["evidence_steps"] = [999]
+    _write_json(path, candidate)
+
+    code, result = _run("check-candidate", "--task-dir", str(task_dir))
+
+    assert code == 1
+    assert "evidence_steps" in result["error"]
+
+
+def test_check_candidate_rejects_changed_safe_trace(tmp_path: Path) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _candidate(task_dir)
+    path = task_dir / "safe/trace.atif.json"
+    safe = json.loads(path.read_text())
+    safe["steps"][0]["message"] = "Changed evidence"
+    _write_json(path, safe)
+
+    code, result = _run("check-candidate", "--task-dir", str(task_dir))
+
+    assert code == 1
+    assert "safe ATIF digest or size changed" in result["error"]
+
+
+@pytest.mark.parametrize("status", ["pending", [], None])
+def test_check_candidate_rejects_invalid_status(tmp_path: Path, status: Any) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _candidate(task_dir)
+    path = task_dir / "candidate.json"
+    candidate = json.loads(path.read_text())
+    candidate["status"] = status
+    _write_json(path, candidate)
+    code, result = _run("check-candidate", "--task-dir", str(task_dir))
+    assert code == 1
+    assert "candidate.status" in result["error"]
+
+
+def test_check_candidate_requires_prepared_evidence(tmp_path: Path) -> None:
+    root = tmp_path / ".eval-author" / "trace-environments"
+    code, result = _run("init", "--root", str(root), "--task-id", "repair-fixture")
+    assert code == 0, result
+    task_dir = Path(result["task_dir"])
+    _candidate(task_dir)
+    code, result = _run("check-candidate", "--task-dir", str(task_dir))
+    assert code == 1
+    assert "prepare ATIF evidence" in result["error"]
+
+
+def test_check_candidate_rejects_summary_fields_without_moving_them(tmp_path: Path) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _candidate(task_dir, status="no_candidate")
+    path = task_dir / "candidate.json"
+    candidate = json.loads(path.read_text())
+    candidate["did_not_work"] = ["Construction note for the summary."]
+    _write_json(path, candidate)
+    before = path.read_bytes()
+    summary_before = (task_dir / "summary.json").read_bytes()
+    code, result = _run("check-candidate", "--task-dir", str(task_dir))
+    assert code == 1
+    assert "candidate fields do not match" in result["error"]
+    assert path.read_bytes() == before
+    assert (task_dir / "summary.json").read_bytes() == summary_before
+
+
+def test_check_candidate_rejects_oversized_safe_trace_before_loading(tmp_path: Path) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _candidate(task_dir)
+    path = task_dir / "safe/trace.atif.json"
+    with path.open("wb") as stream:
+        stream.truncate(25 * 1024 * 1024 + 1)
+    code, result = _run("check-candidate", "--task-dir", str(task_dir))
+    assert code == 1
+    assert "safe ATIF exceeds" in result["error"]
+
+
+def test_check_candidate_rejects_symlinked_safe_trace(tmp_path: Path) -> None:
+    task_dir, source = _workspace(tmp_path)
+    _candidate(task_dir)
+    path = task_dir / "safe/trace.atif.json"
+    path.unlink()
+    path.symlink_to(source)
+    code, result = _run("check-candidate", "--task-dir", str(task_dir))
+    assert code == 1
+    assert "safe ATIF must be a retained regular file" in result["error"]
+
+
 def _review_privacy(task_dir: Path, *, reviewer_kind: str = "agent") -> None:
     code, result = _run(
         "review-privacy",

--- a/plugins/nemo-eval-author/tests/test_trace_environment.py
+++ b/plugins/nemo-eval-author/tests/test_trace_environment.py
@@ -319,6 +319,26 @@ def test_init_creates_private_gitignored_workspace(tmp_path: Path) -> None:
         assert (task_dir / "summary.json").stat().st_mode & 0o777 == 0o600
 
 
+@pytest.mark.parametrize("symlink", [False, True])
+def test_init_preserves_unexpected_gitignore(tmp_path: Path, symlink: bool) -> None:
+    root = tmp_path / ".eval-author" / "trace-environments"
+    root.mkdir(parents=True)
+    ignore = root / ".gitignore"
+    original = "*\n!.gitignore\n" if symlink else "existing-user-rule\n"
+    target = tmp_path / "existing-ignore" if symlink else ignore
+    target.write_text(original, encoding="utf-8")
+    if symlink:
+        ignore.symlink_to(target)
+
+    code, result = _run("init", "--root", str(root), "--task-id", "repair-fixture")
+
+    assert code == 1
+    assert "workspace .gitignore" in result["error"]
+    assert target.read_text(encoding="utf-8") == original
+    assert ignore.is_symlink() is symlink
+    assert not (root / "repair-fixture").exists()
+
+
 def test_init_refuses_to_write_outside_eval_author(tmp_path: Path) -> None:
     code, result = _run("init", "--root", str(tmp_path / "elsewhere"), "--task-id", "repair-fixture")
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
<!-- In 1-3 plain sentences, explain what changes and why. Describe before-and-after behavior when it applies. -->

Streamline the trace-environment skill while preserving its evidence, verifier-isolation, proof, and review requirements. Incorporate the candidate-contract and environment-handoff improvements merged from #2011. Clarify helper diagnostics that the security scanner misinterpreted as instructions, and consolidate the duplicated proof guidance. This does not change the core Eval Author skill, the frontmatter schema, scanner permissions/exclusions, or benchmark tasks; remaining evaluator failures are documented below rather than presented as passing.

## Changes
<!-- List the concrete changes included in this pull request. -->

- Move the candidate JSON example into `references/candidate-record.md`, linked at the decision step.
- Consolidate verifier configuration examples and reviewer README requirements in `references/environment-integrity.md`; keep the repeat/negative-control protocol authoritative there.
- Distinguish generated workspace artifacts and ATIF field names from bundled skill files.
- Use descriptive `.gitignore` variable names and precise `.gitignore`/privacy-review error messages without changing the checks.
- Add two regression cases proving initialization preserves unexpected user rules and rejects symlinked ignore files without creating a task workspace.

- Add read-only `check-candidate` validation, explicit metadata contract guidance, and regression coverage for malformed metadata and prepared evidence.
- Clarify separate-verifier image closure and artifact paths, bounded privacy review, startup compatibility, negative-control construction, and preservation of the requested task scope.
- Correct the squash commit's author email to match its DCO sign-off; no file content changed in this metadata-only repair.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

<!-- List each command and result. Explain skipped, blocked, or non-successful checks without marking them as passed. -->

- `uv --cache-dir /tmp/trace-skill-uv-cache run --no-project --python .venv/bin/python -m pytest plugins/nemo-eval-author/tests -q --tb=short`: **340 passed**, with 94 existing Harbor `Task.checksum` deprecation warnings. Run in this worktree's isolated environment.
- Applicable pre-commit hooks on all five changed files: **passed**, including Ruff, formatting, type checks, copyright, and conflict checks. `git diff --cached --check`: **passed**.
- `make lint`: **15 groups passed, 2 failed** because Studio dependencies were missing (`tsx` and `lint-staged`). The all-file pre-commit rerun outside Flox also lacked `helm-docs`/`yq` and used a different uv version than the repository pin. The checkbox above acknowledges these documented blockers; it does not claim the all-file gate is green.
- DCO audit after the approved metadata-only amendment: both PR commits (`806235892` and `323d51b34`) have sign-offs matching their authors. `git diff --exit-code a86138ea158583e1d943c4a69b976e3c34bd6d5c HEAD` passed: the complete file tree is unchanged. New-head CI is checked independently of historical results.
- Current-head dedicated tests: `PYTHONDONTWRITEBYTECODE=1 uv --cache-dir /tmp/trace-skill-uv-cache run --no-project --python /home/asutermorris/src/harbor/.venv/bin/python -m pytest --confcutdir=plugins/nemo-eval-author/tests plugins/nemo-eval-author/tests/test_trace_environment.py -q` — **170 passed**, 94 Harbor deprecation warnings.
- Current-head all-file gate: `uv --cache-dir /tmp/trace-skill-uv-cache run --no-project --python /home/asutermorris/src/nemo-platform/.venv/bin/python -m pre_commit run -a` — Ruff, formatting, ty, config-reference, lock-drift, copyright, UI lint-staged, import-boundary, merge-conflict and Flox-lock checks passed. Helm documentation and version checks remain blocked by missing `helm-docs`/`yq` and uv 0.12.3 versus required 0.9.14. This is not an all-file pass.

Historical validation of the pre-#2011 hardening revision (not a rerun of the merged head):

SkillEvaluator 0.2.1 / SkillSpector 2.11.2 were exercised with `validate` (both tiers), `validate --no-dedup`, direct static scanning, and a diagnostic `validate --llm-verify` run. Hub-backed checks used `azure/openai/text-embedding-3-small` and `azure/openai/gpt-4.1` with process-local credentials; no keys or provider configuration are committed.

- **Length/quality passes:** 4,776 tokens, grade B (81.5/100).
- **Tier 1 remains 9/11:** the requested schema mismatch is intentionally unchanged. Original script-partial/ambiguous privacy-wording findings are gone, and the direct scan fully inspected all five source files. Security still reports overall incompleteness because it treats generated paths and dotted ATIF fields as missing local references, plus a network-permission finding caused by `urllib.parse` used only for local URL parsing. LLM verification returned an uncertain verdict and did not clear it.
- **Tier 2 remains failing:** the original duplicated proof instructions are resolved; the final finding concerns only repeated SPDX copyright/license preambles in the three reference files. Required legal headers remain intact. No thresholds, suppressions, or exclusions were added to force a pass.

A fresh 89-trace experiment is ongoing using its unchanged frozen skill snapshot; the DCO repair does not update campaign inputs or generated tasks. No completed all-89 comparison or causal candidate-performance improvement is claimed here. Remaining scanner findings require evaluator-side handling; this PR stays scoped to the trace-environment skill and its dedicated tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a read-only candidate validation check for metadata, evidence integrity, status, size limits, and symlink safety.
  - Added clearer handling for recording failed commands and contract checks.

- **Documentation**
  - Added guidance for candidate records, artifact handoff, verifier and agent environments, ground-truth provenance, and reviewer requirements.
  - Clarified artifact-path semantics, privacy review expectations, repeat-run guidance, and technical-status limitations.

- **Bug Fixes**
  - Initialization now safely detects conflicting ignore files without modifying existing files or creating task directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
