### PR TITLE
fix(data-designer): retrieval hf_token and num_records

### DIFF
--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/functions/retrieval_preview.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/functions/retrieval_preview.py
@@ -10,11 +10,14 @@ from pathlib import Path
 from typing import ClassVar, Literal
 
 from data_designer_nemo.context import create_data_designer_context
+from data_designer_nemo.errors import NDDInvalidConfigError
 from data_designer_nemo.sdk_translation import async_to_sync_sdk
 from nemo_data_designer_plugin.jobs.retrieval_spec import RetrievalPreviewSpec
 from nemo_data_designer_plugin.retrieval.corpus import materialize_corpus
 from nemo_data_designer_plugin.retrieval.providers import build_retrieval_model_configs, resolve_retrieval_providers
+from nemo_data_designer_plugin.retrieval.secrets import resolve_hf_token
 from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
+from nemo_platform_plugin.client.errors import NemoClientError
 from nemo_platform_plugin.function import NemoFunction
 from nemo_platform_plugin.function_context import FunctionContext
 from nemo_platform_plugin.functions.frames import Done, Error
@@ -25,6 +28,18 @@ class RetrievalPreviewFrame(BaseModel):
     kind: Literal["retrieval_preview"] = "retrieval_preview"
     num_seed_records: int
     num_preview_records: int
+
+
+async def _resolve_hf_token_or_raise(
+    async_sdk: AsyncNeMoPlatform,
+    hf_token_secret: str | None,
+    workspace: str,
+) -> str | None:
+    """Resolve the spec's secret reference, reporting a bad reference as invalid config."""
+    try:
+        return await resolve_hf_token(async_sdk, hf_token_secret, workspace)
+    except NemoClientError as exc:
+        raise NDDInvalidConfigError(f"Could not access secret {hf_token_secret!r} named by hf_token_secret.") from exc
 
 
 class RetrievalPreviewFunction(NemoFunction[RetrievalPreviewSpec]):
@@ -51,11 +66,11 @@ class RetrievalPreviewFunction(NemoFunction[RetrievalPreviewSpec]):
             quality_judge_model=job.quality_judge_model,
             embed_model=job.embed_model,
         )
-        try:
-            model_providers = await resolve_retrieval_providers(dd_ctx, model_configs)
-        except Exception as exc:
-            yield Error(message=str(exc), details={"type": type(exc).__name__})
-            return
+        # These can raise NDDInvalidConfigError or NDDInternalError, which map to
+        # appropriate error-coded responses rather than returning a 200 with a
+        # response stream that only holds an Error frame
+        model_providers = await resolve_retrieval_providers(dd_ctx, model_configs)
+        hf_token = await _resolve_hf_token_or_raise(async_sdk, job.hf_token_secret, ctx.workspace)
 
         def run_preview() -> BaseModel:
             from nemo_data_designer_plugin.retrieval.generation import (
@@ -71,6 +86,7 @@ class RetrievalPreviewFunction(NemoFunction[RetrievalPreviewSpec]):
                     dest=tmp_path / "corpus",
                     sdk=sdk,
                     workspace=ctx.workspace,
+                    hf_token=hf_token,
                     allow_local_path=is_local,
                 )
                 run_config = build_generation_run_config(
@@ -102,7 +118,7 @@ class RetrievalPreviewFunction(NemoFunction[RetrievalPreviewSpec]):
                     quality_judge_model=job.quality_judge_model,
                     embed_model=job.embed_model,
                 )
-                result = execute_generation(run_config, preview=True)
+                result = execute_generation(run_config, preview=True, num_records=spec.num_records)
                 return RetrievalPreviewFrame(
                     num_seed_records=getattr(result, "num_seed_records", 0),
                     num_preview_records=getattr(result, "num_preview_records", spec.num_records),

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/jobs/retrieval_common.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/jobs/retrieval_common.py
@@ -9,10 +9,12 @@ from pathlib import Path
 from typing import Any
 
 from nemo_data_designer_plugin.config import get_config
+from nemo_data_designer_plugin.retrieval.corpus import HF_TOKEN_ENVVAR
 from nemo_platform_plugin.jobs.api_factory import (
     ContainerSpec,
     CPUExecutionProviderSpec,
     EnvironmentVariable,
+    EnvironmentVariableFromSecret,
     GPUExecutionProviderSpec,
     PlatformJobStep,
 )
@@ -31,6 +33,22 @@ def _persistent_storage_environment() -> list[EnvironmentVariable]:
     return [EnvironmentVariable(name=PERSISTENT_JOB_STORAGE_PATH_ENVVAR, value=DEFAULT_JOB_STORAGE_PATH)]
 
 
+def _hf_token_environment(hf_token_secret: str | None) -> list[EnvironmentVariable]:
+    """Project a ``hf_token_secret`` reference into the step env, never its plaintext.
+
+    The jobs service resolves ``from_secret`` against the job workspace, so an
+    unqualified secret name works the same way it does for every other job.
+    """
+    if not hf_token_secret:
+        return []
+    return [
+        EnvironmentVariable(
+            name=HF_TOKEN_ENVVAR,
+            from_secret=EnvironmentVariableFromSecret(name=hf_token_secret),
+        )
+    ]
+
+
 def cpu_retrieval_step(
     name: str,
     module: str,
@@ -38,6 +56,7 @@ def cpu_retrieval_step(
     profile: str | None,
     module_args: list[str] | None = None,
     image: str = "nmp-cpu-tasks",
+    hf_token_secret: str | None = None,
 ) -> PlatformJobStep:
     return PlatformJobStep(
         name=name,
@@ -51,7 +70,7 @@ def cpu_retrieval_step(
             ),
         ),
         config=spec.model_dump(mode="json"),
-        environment=_persistent_storage_environment(),
+        environment=[*_persistent_storage_environment(), *_hf_token_environment(hf_token_secret)],
     )
 
 
@@ -88,11 +107,13 @@ async def retrieval_step(
     profile: str | None,
     async_sdk: object,
     gpu: bool = False,
+    hf_token_secret: str | None = None,
 ) -> PlatformJobStep:
     del async_sdk
     if gpu:
+        # The GPU mining step runs with ``HF_HUB_OFFLINE``; it never reaches the Hub.
         return gpu_retrieval_step(name, module, spec, profile)
-    return cpu_retrieval_step(name, module, spec, profile)
+    return cpu_retrieval_step(name, module, spec, profile, hf_token_secret=hf_token_secret)
 
 
 async def model_download_step(

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/jobs/retrieval_generate.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/jobs/retrieval_generate.py
@@ -8,7 +8,7 @@ from typing import ClassVar, cast
 from data_designer_nemo.context import create_data_designer_context
 from nemo_data_designer_plugin.jobs.retrieval_common import retrieval_step, work_dir
 from nemo_data_designer_plugin.jobs.retrieval_spec import RetrievalGenerateJobConfig, RetrievalGenerateStepConfig
-from nemo_data_designer_plugin.retrieval.corpus import materialize_corpus
+from nemo_data_designer_plugin.retrieval.corpus import hf_token_from_env, materialize_corpus
 from nemo_data_designer_plugin.retrieval.providers import build_retrieval_model_configs, resolve_retrieval_providers
 from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
 from nemo_platform_plugin.job import NemoJob
@@ -66,6 +66,7 @@ class RetrievalGenerateJob(NemoJob):
         profile: str | None = None,
         options: dict | None = None,
     ) -> PlatformJobSpec:
+        spec = cast(RetrievalGenerateStepConfig, spec)
         return PlatformJobSpec(
             steps=[
                 await retrieval_step(
@@ -74,6 +75,7 @@ class RetrievalGenerateJob(NemoJob):
                     spec,
                     profile=profile,
                     async_sdk=async_sdk,
+                    hf_token_secret=spec.job_config.hf_token_secret,
                 )
             ]
         )
@@ -90,6 +92,7 @@ class RetrievalGenerateJob(NemoJob):
             dest=ctx.storage.ephemeral / "corpus",
             sdk=sdk,
             workspace=ctx.workspace,
+            hf_token=hf_token_from_env(),
         )
         run_config = build_generation_run_config(
             corpus_dir=corpus_dir,

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/jobs/retrieval_prepare.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/jobs/retrieval_prepare.py
@@ -14,7 +14,7 @@ from nemo_data_designer_plugin.jobs.retrieval_common import (
     work_dir,
 )
 from nemo_data_designer_plugin.jobs.retrieval_spec import RetrievalPrepareJobConfig, RetrievalPrepareStepConfig
-from nemo_data_designer_plugin.retrieval.corpus import materialize_corpus
+from nemo_data_designer_plugin.retrieval.corpus import hf_token_from_env, materialize_corpus
 from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
 from nemo_platform_plugin.job import NemoJob
 from nemo_platform_plugin.job_context import JobContext
@@ -82,6 +82,7 @@ class RetrievalPrepareJob(NemoJob):
                 spec,
                 profile=profile,
                 async_sdk=async_sdk,
+                hf_token_secret=spec.job_config.hf_token_secret,
             )
         ]
         if spec.job_config.enable_mining:
@@ -115,15 +116,16 @@ class RetrievalPrepareJob(NemoJob):
 
 
 def _materialize_input(ref: str, dest: Path, ctx: JobContext, sdk: NeMoPlatform) -> Path:
+    hf_token = hf_token_from_env()
     if Path(ref).is_absolute():
-        return materialize_corpus(ref, dest=dest, sdk=sdk, workspace=ctx.workspace)
+        return materialize_corpus(ref, dest=dest, sdk=sdk, workspace=ctx.workspace, hf_token=hf_token)
     storage_root = (ctx.storage.persistent or ctx.storage.ephemeral).resolve()
     staged = (storage_root / ref).resolve()
     if not staged.is_relative_to(storage_root):
         raise ValueError(f"Staged input path escapes job storage: {ref}")
     if staged.exists():
         return staged
-    return materialize_corpus(ref, dest=dest, sdk=sdk, workspace=ctx.workspace)
+    return materialize_corpus(ref, dest=dest, sdk=sdk, workspace=ctx.workspace, hf_token=hf_token)
 
 
 def _run_convert(job: RetrievalPrepareJobConfig, output_dir: Path, ctx: JobContext, sdk: NeMoPlatform) -> dict:

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/retrieval/corpus.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/retrieval/corpus.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path, PurePosixPath
 
 from data_designer_nemo.filesystem import make_filesystem
@@ -10,6 +11,14 @@ from filesets import FilesetPathError, build_fileset_ref, parse_fileset_ref
 from nemo_platform import NeMoPlatform
 
 _HF_PREFIX = "hf://"
+
+#: Env var the job steps populate from the spec's ``hf_token_secret`` reference.
+HF_TOKEN_ENVVAR = "HF_TOKEN"  # pragma: allowlist secret
+
+
+def hf_token_from_env() -> str | None:
+    """Read the Hugging Face token a job step received from its secret reference."""
+    return os.environ.get(HF_TOKEN_ENVVAR) or None
 
 
 def materialize_corpus(

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/retrieval/generation.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/retrieval/generation.py
@@ -107,15 +107,16 @@ def build_generation_run_config(
 
 
 def execute_generation(
-    config: GenerationRunConfig, preview: bool = False
+    config: GenerationRunConfig, preview: bool = False, num_records: int = 1
 ) -> GenerationResult | GenerationPreviewResult:
+    """Run or preview generation. ``num_records`` sizes the preview and is ignored for a full run."""
     try:
         from data_designer_retrieval_sdg import preview_generation, run_generation
     except ImportError as exc:
         raise ImportError("Retrieval generate and preview requires nemo-data-designer-plugin[retrieval-sdg].") from exc
 
     if preview:
-        return preview_generation(config)
+        return preview_generation(config, num_records)
     result = run_generation(config)
     write_generation_manifest(
         output_dir=config.output_dir,

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/retrieval/secrets.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/retrieval/secrets.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Resolve a retrieval spec's ``hf_token_secret`` reference.
+
+Job steps never resolve the reference themselves: ``retrieval_common`` compiles it
+into a ``from_secret`` environment variable so the plaintext stays out of the job
+spec. Retrieval preview runs in-process instead of as a job step, so it reads the
+value through the Secrets service here.
+"""
+
+from __future__ import annotations
+
+from nemo_platform import AsyncNeMoPlatform
+from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.secrets.client import AsyncSecretsClient
+
+
+async def resolve_hf_token(
+    async_sdk: AsyncNeMoPlatform,
+    hf_token_secret: str | None,
+    workspace: str,
+) -> str | None:
+    """Return the plaintext token for ``workspace/name`` (or ``name``) secret reference."""
+    if not hf_token_secret:
+        return None
+    secret_workspace, _, name = hf_token_secret.rpartition("/")
+    secrets = client_from_platform(async_sdk, AsyncSecretsClient)
+    response = (await secrets.access_secret(name=name, workspace=secret_workspace or workspace)).data()
+    return response.value or None

--- a/plugins/nemo-data-designer/tests/unit/test_retrieval_jobs.py
+++ b/plugins/nemo-data-designer/tests/unit/test_retrieval_jobs.py
@@ -488,3 +488,110 @@ def test_retrieval_cli_shell_quotes_workspace_and_spec() -> None:
     quoted = shlex.join(["--workspace", "team's-ws"])
     assert quoted in result.output
     assert "--spec" in result.output
+
+
+def _secret_env(step: PlatformJobStep) -> dict[str, str]:
+    return {
+        item["name"]: item["from_secret"]["name"] for item in step["environment"] if item.get("from_secret") is not None
+    }
+
+
+@pytest.mark.asyncio
+async def test_retrieval_generate_compile_projects_hf_token_secret() -> None:
+    spec = RetrievalGenerateStepConfig(
+        job_config=_generate_config(corpus="hf://example/private-corpus", hf_token_secret="default/hf-token"),
+        model_providers=[dd.ModelProvider(name="default/nvidia-build", endpoint="http://igw")],
+        chat_provider_name="default/nvidia-build",
+        embed_provider_name="default/nvidia-build",
+    )
+    compiled = await RetrievalGenerateJob.compile(
+        workspace="default",
+        spec=spec,
+        entity_client=Mock(),
+        job_name=None,
+        async_sdk=AsyncMock(),
+    )
+    step = _steps(compiled)[0]
+    assert _secret_env(step) == {"HF_TOKEN": "default/hf-token"}
+    # The reference travels as a secret ref, never as a plaintext value in the spec.
+    assert "default/hf-token" not in [item.get("value") for item in step["environment"]]
+
+
+@pytest.mark.asyncio
+async def test_retrieval_generate_compile_omits_hf_token_without_secret() -> None:
+    spec = RetrievalGenerateStepConfig(
+        job_config=_generate_config(),
+        model_providers=[dd.ModelProvider(name="default/nvidia-build", endpoint="http://igw")],
+        chat_provider_name="default/nvidia-build",
+        embed_provider_name="default/nvidia-build",
+    )
+    compiled = await RetrievalGenerateJob.compile(
+        workspace="default",
+        spec=spec,
+        entity_client=Mock(),
+        job_name=None,
+        async_sdk=AsyncMock(),
+    )
+    assert _secret_env(_steps(compiled)[0]) == {}
+
+
+@pytest.mark.asyncio
+async def test_retrieval_prepare_compile_projects_hf_token_secret_on_convert_only() -> None:
+    spec = RetrievalPrepareStepConfig(
+        job_config=RetrievalPrepareJobConfig(
+            sdg_input="hf://example/private-stage0",
+            enable_mining=True,
+            hf_token_secret="hf-token",
+        ),
+        phase="convert",
+        model_fileset="default/retrieval-model",
+    )
+    compiled = await RetrievalPrepareJob.compile(
+        workspace="default",
+        spec=spec,
+        entity_client=Mock(),
+        job_name=None,
+        async_sdk=AsyncMock(),
+    )
+    steps = _steps(compiled)
+    assert _secret_env(steps[0]) == {"HF_TOKEN": "hf-token"}
+    # Mining runs offline in the automodel image, so it gets no Hub credential.
+    assert _secret_env(steps[2]) == {}
+
+
+def test_retrieval_generate_run_forwards_hf_token_to_corpus_staging(tmp_path: Path, monkeypatch) -> None:
+    ctx = _ctx(tmp_path)
+    spec = RetrievalGenerateStepConfig(
+        job_config=_generate_config(corpus="hf://example/private-corpus", hf_token_secret="default/hf-token"),
+        model_providers=[dd.ModelProvider(name="default/nvidia-build", endpoint="http://igw")],
+        chat_provider_name="default/nvidia-build",
+        embed_provider_name="default/nvidia-build",
+    )
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    monkeypatch.setenv("HF_TOKEN", "hf_secret_value")
+    result = SimpleNamespace(dataset_name="retrieval_sdg", num_records=3, output_path=tmp_path / "out.jsonl")
+    with (
+        patch(
+            "nemo_data_designer_plugin.jobs.retrieval_generate.materialize_corpus",
+            return_value=corpus,
+        ) as materialize,
+        patch("nemo_data_designer_plugin.retrieval.generation.execute_generation", return_value=result),
+        patch("nemo_data_designer_plugin.retrieval.generation.build_generation_run_config") as build_cfg,
+    ):
+        build_cfg.return_value = SimpleNamespace()
+        RetrievalGenerateJob().run(spec.model_dump(mode="json"), ctx=ctx, sdk=Mock())
+
+    assert materialize.call_args.kwargs["hf_token"] == "hf_secret_value"
+
+
+def test_retrieval_prepare_materialize_input_forwards_hf_token(tmp_path: Path, monkeypatch) -> None:
+    ctx = _ctx(tmp_path)
+    monkeypatch.setenv("HF_TOKEN", "hf_secret_value")
+    with patch(
+        "nemo_data_designer_plugin.jobs.retrieval_prepare.materialize_corpus",
+        return_value=tmp_path / "staged",
+    ) as materialize:
+        _materialize_input("hf://example/private-stage0", tmp_path / "dest", ctx, Mock())
+
+    assert materialize.call_args.kwargs["hf_token"] == "hf_secret_value"

--- a/plugins/nemo-data-designer/tests/unit/test_retrieval_preview.py
+++ b/plugins/nemo-data-designer/tests/unit/test_retrieval_preview.py
@@ -7,9 +7,12 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
 
 import data_designer.config as dd
+import httpx
 import pytest
+from data_designer_nemo.errors import NDDInvalidConfigError
 from nemo_data_designer_plugin.functions.retrieval_preview import RetrievalPreviewFrame, RetrievalPreviewFunction
 from nemo_data_designer_plugin.jobs.retrieval_spec import RetrievalGenerateJobConfig, RetrievalPreviewSpec
+from nemo_platform_plugin.client.errors import PermissionDeniedError
 from nemo_platform_plugin.functions.frames import Done, Error
 
 
@@ -97,3 +100,139 @@ async def test_retrieval_preview_returns_error_frame_for_worker_failure(tmp_path
     assert len(frames) == 1
     assert isinstance(frames[0], Error)
     assert frames[0].message == "bad corpus"
+
+
+@pytest.mark.asyncio
+async def test_retrieval_preview_forwards_num_records(tmp_path) -> None:
+    spec = RetrievalPreviewSpec(generate=_generate_config(tmp_path), num_records=2)
+    (tmp_path / "doc.txt").write_text("hello", encoding="utf-8")
+    providers = [dd.ModelProvider(name="default/nvidia-build", endpoint="http://igw")]
+    dd_ctx = AsyncMock()
+    dd_ctx.get_model_providers = AsyncMock(return_value=providers)
+    ctx = Mock(workspace="default")
+    preview_result = SimpleNamespace(num_seed_records=2, num_preview_records=2)
+    frames = []
+    with (
+        patch(
+            "nemo_data_designer_plugin.functions.retrieval_preview.create_data_designer_context",
+            return_value=dd_ctx,
+        ),
+        patch(
+            "nemo_data_designer_plugin.retrieval.generation.execute_generation",
+            return_value=preview_result,
+        ) as execute,
+        patch(
+            "nemo_data_designer_plugin.functions.retrieval_preview.async_to_sync_sdk",
+            return_value=Mock(),
+        ),
+    ):
+        async for frame in RetrievalPreviewFunction().run(spec, ctx=ctx, async_sdk=AsyncMock(), is_local=True):
+            frames.append(frame)
+
+    assert execute.call_args.kwargs["num_records"] == 2
+    frame = frames[0]
+    assert isinstance(frame, RetrievalPreviewFrame)
+    assert frame.num_preview_records == 2
+
+
+@pytest.mark.asyncio
+async def test_retrieval_preview_resolves_hf_token_secret(tmp_path) -> None:
+    config = _generate_config(tmp_path)
+    config = config.model_copy(update={"corpus": "hf://example/private-corpus", "hf_token_secret": "default/hf-token"})
+    spec = RetrievalPreviewSpec(generate=config)
+    providers = [dd.ModelProvider(name="default/nvidia-build", endpoint="http://igw")]
+    dd_ctx = AsyncMock()
+    dd_ctx.get_model_providers = AsyncMock(return_value=providers)
+    ctx = Mock(workspace="default")
+    preview_result = SimpleNamespace(num_seed_records=1, num_preview_records=1)
+    resolved: dict[str, str | None] = {}
+
+    async def resolve(async_sdk: object, hf_token_secret: str | None, workspace: str) -> str:
+        resolved.update(secret=hf_token_secret, workspace=workspace)
+        return "hf_secret_value"
+
+    with (
+        patch(
+            "nemo_data_designer_plugin.functions.retrieval_preview.create_data_designer_context",
+            return_value=dd_ctx,
+        ),
+        patch(
+            "nemo_data_designer_plugin.functions.retrieval_preview.resolve_hf_token",
+            new=resolve,
+        ),
+        patch(
+            "nemo_data_designer_plugin.functions.retrieval_preview.materialize_corpus",
+            return_value=tmp_path,
+        ) as materialize,
+        patch(
+            "nemo_data_designer_plugin.retrieval.generation.execute_generation",
+            return_value=preview_result,
+        ),
+        patch(
+            "nemo_data_designer_plugin.functions.retrieval_preview.async_to_sync_sdk",
+            return_value=Mock(),
+        ),
+    ):
+        frames = [
+            frame
+            async for frame in RetrievalPreviewFunction().run(spec, ctx=ctx, async_sdk=AsyncMock(), is_local=False)
+        ]
+
+    assert resolved == {"secret": "default/hf-token", "workspace": "default"}
+    assert materialize.call_args.kwargs["hf_token"] == "hf_secret_value"
+    assert isinstance(frames[-1], Done)
+
+
+@pytest.mark.asyncio
+async def test_retrieval_preview_raises_invalid_config_for_unauthorized_secret(tmp_path) -> None:
+    config = _generate_config(tmp_path).model_copy(
+        update={"corpus": "hf://example/private-corpus", "hf_token_secret": "other/hf-token"}
+    )
+    spec = RetrievalPreviewSpec(generate=config)
+    providers = [dd.ModelProvider(name="default/nvidia-build", endpoint="http://igw")]
+    dd_ctx = AsyncMock()
+    dd_ctx.get_model_providers = AsyncMock(return_value=providers)
+    ctx = Mock(workspace="default")
+
+    with (
+        patch(
+            "nemo_data_designer_plugin.functions.retrieval_preview.create_data_designer_context",
+            return_value=dd_ctx,
+        ),
+        patch(
+            "nemo_data_designer_plugin.functions.retrieval_preview.resolve_hf_token",
+            new=AsyncMock(
+                side_effect=PermissionDeniedError(
+                    httpx.Response(403, json={"detail": "denied"}, request=httpx.Request("GET", "http://secrets"))
+                )
+            ),
+        ),
+        patch(
+            "nemo_data_designer_plugin.functions.retrieval_preview.async_to_sync_sdk",
+            return_value=Mock(),
+        ),
+    ):
+        with pytest.raises(NDDInvalidConfigError, match="other/hf-token"):
+            async for _ in RetrievalPreviewFunction().run(spec, ctx=ctx, async_sdk=AsyncMock(), is_local=False):
+                pass
+
+
+@pytest.mark.asyncio
+async def test_retrieval_preview_raises_invalid_config_for_unresolvable_providers(tmp_path) -> None:
+    spec = RetrievalPreviewSpec(generate=_generate_config(tmp_path))
+    dd_ctx = AsyncMock()
+    ctx = Mock(workspace="default")
+
+    with (
+        patch(
+            "nemo_data_designer_plugin.functions.retrieval_preview.create_data_designer_context",
+            return_value=dd_ctx,
+        ),
+        patch(
+            "nemo_data_designer_plugin.functions.retrieval_preview.resolve_retrieval_providers",
+            new=AsyncMock(side_effect=NDDInvalidConfigError("no providers")),
+        ),
+    ):
+        with pytest.raises(NDDInvalidConfigError, match="no providers"):
+            async for _ in RetrievalPreviewFunction().run(spec, ctx=ctx, async_sdk=AsyncMock(), is_local=True):
+                pass

--- a/plugins/nemo-data-designer/tests/unit/test_retrieval_resources.py
+++ b/plugins/nemo-data-designer/tests/unit/test_retrieval_resources.py
@@ -5,15 +5,16 @@ import json
 import sys
 import types
 from pathlib import Path
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
-from nemo_data_designer_plugin.retrieval.corpus import _download_fileset, materialize_corpus
+from nemo_data_designer_plugin.retrieval.corpus import _download_fileset, hf_token_from_env, materialize_corpus
 from nemo_data_designer_plugin.retrieval.manifest import (
     GENERATION_MANIFEST_SCHEMA_VERSION,
     resolve_generation_input,
     write_generation_manifest,
 )
+from nemo_data_designer_plugin.retrieval.secrets import resolve_hf_token
 
 
 def test_fileset_corpus_must_match_job_workspace(tmp_path: Path) -> None:
@@ -137,3 +138,64 @@ def test_generation_and_preview_require_retrieval_extra(monkeypatch: pytest.Monk
 
     with pytest.raises(ImportError, match=r"Retrieval generate and preview requires"):
         execute_generation(Mock(), preview=True)
+
+
+def test_hf_corpus_passes_token_to_snapshot_download(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+    fake_hub = types.ModuleType("huggingface_hub")
+
+    def snapshot_download(**kwargs: object) -> str:
+        captured.update(kwargs)
+        return str(tmp_path / "snapshot")
+
+    setattr(fake_hub, "snapshot_download", snapshot_download)
+    monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hub)
+
+    materialize_corpus(
+        "hf://org/private-dataset",
+        dest=tmp_path / "corpus",
+        sdk=Mock(),
+        workspace="default",
+        hf_token="hf_secret_value",
+    )
+
+    assert captured["token"] == "hf_secret_value"
+
+
+def test_hf_token_from_env_reads_step_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    assert hf_token_from_env() is None
+    monkeypatch.setenv("HF_TOKEN", "")
+    assert hf_token_from_env() is None
+    monkeypatch.setenv("HF_TOKEN", "hf_secret_value")
+    assert hf_token_from_env() == "hf_secret_value"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("reference", "expected_workspace", "expected_name"),
+    [
+        ("default/hf-token", "default", "hf-token"),
+        ("hf-token", "shared", "hf-token"),
+    ],
+)
+async def test_resolve_hf_token_reads_named_secret(reference: str, expected_workspace: str, expected_name: str) -> None:
+    requested: dict[str, str] = {}
+
+    async def access_secret(name: str, workspace: str) -> Mock:
+        requested.update(name=name, workspace=workspace)
+        return Mock(data=Mock(return_value=Mock(value="hf_secret_value")))
+
+    secrets = Mock(access_secret=access_secret)
+    with patch("nemo_data_designer_plugin.retrieval.secrets.client_from_platform", return_value=secrets):
+        token = await resolve_hf_token(Mock(), reference, "shared")
+
+    assert token == "hf_secret_value"
+    assert requested == {"name": expected_name, "workspace": expected_workspace}
+
+
+@pytest.mark.asyncio
+async def test_resolve_hf_token_without_reference_skips_secrets_service() -> None:
+    with patch("nemo_data_designer_plugin.retrieval.secrets.client_from_platform") as client:
+        assert await resolve_hf_token(Mock(), None, "default") is None
+    client.assert_not_called()


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
Fixes a few bugs in the new Data Designer retrieval workloads:
- Preview `num_records` was not recognized
- `hf_token_secret` was not getting recognized
- Preview validation was leading to `200 + Error` rather than `422/500`

## Changes
- Pass `num_records` from preview
- Resolve `hf_token_secret`: in preview, use the client to look it up; in jobs, set an Env Var From Secret
- Change the try/except block in preview to let NDD errors bubble out rather than yielding an `Error`

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

<!-- List each command and result. Explain skipped, blocked, or non-successful checks without marking them as passed. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Retrieval workflows can now authenticate to Hugging Face using configured secrets.
  - Retrieval previews support explicitly selecting the number of records to generate.
  - Hugging Face authentication is applied securely during supported CPU-based retrieval tasks.

- **Bug Fixes**
  - Invalid secret configurations and retrieval provider errors now produce clear configuration errors instead of being returned as streamed results.
  - Missing or blank Hugging Face tokens are handled gracefully without disrupting retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->