### PR TITLE
fix(studio): Fix deployment indicator

### DIFF
--- a/web/packages/studio/src/components/dataViews/CustomModelsDataView/DeploymentIndicator.tsx
+++ b/web/packages/studio/src/components/dataViews/CustomModelsDataView/DeploymentIndicator.tsx
@@ -28,29 +28,29 @@ const getStatusColor = (status: ModelDeploymentStatus) => {
 interface DeploymentIndicatorProps {
   workspace: string;
   providerIds?: string[];
-  baseModel: string;
+  modelName: string;
 }
 
 export const DeploymentIndicator: FC<DeploymentIndicatorProps> = ({
   workspace,
   providerIds,
-  baseModel,
+  modelName,
 }) => {
-  const { data: baseModelEntity, isLoading: isLoadingBaseModel } = useModelsGetModel(
+  const { data: modelEntity, isLoading: isLoadingModel } = useModelsGetModel(
     workspace,
-    baseModel,
+    modelName,
     undefined,
-    { query: { enabled: Boolean(baseModel), retry: false } }
+    { query: { enabled: Boolean(modelName), retry: false } }
   );
 
   const resolvedModel =
-    providerIds?.length && baseModelEntity
-      ? { ...baseModelEntity, model_providers: providerIds }
-      : baseModelEntity;
+    providerIds?.length && modelEntity
+      ? { ...modelEntity, model_providers: providerIds }
+      : modelEntity;
 
   const { status, isLoading: isStatusLoading } = useModelDeploymentStatus(resolvedModel);
 
-  const isLoading = isLoadingBaseModel || isStatusLoading;
+  const isLoading = isLoadingModel || isStatusLoading;
 
   if (isLoading) return <Skeleton animated className="size-2 rounded-full" />;
   if (!status) {

--- a/web/packages/studio/src/components/dataViews/CustomModelsDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/CustomModelsDataView/index.tsx
@@ -249,7 +249,7 @@ export const CustomModelsDataView: FC<CustomModelsDataViewProps> = ({
             <DeploymentIndicator
               workspace={workspace}
               providerIds={row.original.model_providers}
-              baseModel={row.original.base_model ?? ''}
+              modelName={row.original.name ?? ''}
             />
           )}
         </span>


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
https://linear.app/nvidia/issue/ASTD-598/fix-status-light-always-showing-red-on-custom-models

<img width="1073" height="966" alt="image" src="https://github.com/user-attachments/assets/bd3b5a89-59a0-4fde-b862-89c8c81328e4" />

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [ ] Pull request title follows the repository's Conventional Commit format
- [ ] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [ ] Targeted tests pass, or tests are marked not applicable above
- [ ] No secrets, API keys, or credentials are included

Targeted validation:

<!-- List each command and result. Explain skipped, blocked, or non-successful checks without marking them as passed. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated deployment status displays to consistently use the model’s name, improving consistency without changing user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->