### PR TITLE
fix(studio): proxy /plugin-ui through the dev server

### DIFF
--- a/web/packages/studio/vite.config.ts
+++ b/web/packages/studio/vite.config.ts
@@ -584,6 +584,11 @@ export default defineConfig(({ mode }) => {
                 changeOrigin: true,
                 secure: false,
               },
+              '/plugin-ui': {
+                target: proxyDomain,
+                changeOrigin: true,
+                secure: false,
+              },
             },
           }
         : {}),


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Studio's Vite dev server only proxied `/apis` to the platform backend, so requests for plugin UI bundles served under `/plugin-ui` fell through to the dev server's SPA fallback and returned `index.html`. Plugin UIs therefore failed to load when running Studio locally against a platform backend. After this change the dev proxy forwards `/plugin-ui` to the same target as `/apis`, and plugin bundles resolve correctly in local development.

## Changes

- `web/packages/studio/vite.config.ts`: add a `/plugin-ui` entry to `server.proxy`, using the same `target`/`changeOrigin`/`secure` settings as the existing `/apis` entry. The proxy block remains gated on `shouldProxyPlatform`, so production builds are unaffected.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: this is dev-server-only configuration inside the `shouldProxyPlatform` branch of `vite.config.ts`. It does not run in production builds and is not exercised by the unit or e2e suites; verifying it requires a live dev server pointed at a platform backend.
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: no user-visible product behavior changes; this only affects local development against a remote/local platform backend.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `pnpm exec prettier --check packages/studio/vite.config.ts` (from `web/`) — passed, "All matched files use Prettier code style!"
- `pnpm exec eslint packages/studio/vite.config.ts --report-unused-disable-directives --max-warnings 0` (from `web/`) — passed, no output.
- `pnpm --filter nemo-studio-ui run typecheck` (from `web/`) — passed, `tsc --noEmit` clean.
- `uv run pre-commit run --files web/packages/studio/vite.config.ts` — passed; all Python/Helm/uv hooks reported "no files to check" for this single-file TypeScript change. The full `-a` run was scoped to the changed file to avoid re-running unrelated repo-wide generators; the pre-commit and pre-push hooks also ran automatically on commit and push (including "Run UI lint-staged", "Run UI typecheck", and the DCO check), all passing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development-time loading of plugin interface requests by routing them through the configured platform proxy.
  * Added support for proxy environments with rewritten origins and untrusted certificates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->