### PR TITLE
chore: forward merge sandbox cleanup into main

### DIFF
--- a/packages/sandboxed_gym/src/sandboxed_gym/backends/_opensandbox_driver.py
+++ b/packages/sandboxed_gym/src/sandboxed_gym/backends/_opensandbox_driver.py
@@ -17,9 +17,11 @@ so egress verification can still ask the sandbox what policy it actually applied
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Mapping
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any
+from uuid import uuid4
 
 from sandboxed_gym.backends.base import EpisodeBackendError, UnsupportedEpisodeOperationError
 from sandboxed_gym.sandbox_types import (
@@ -32,8 +34,13 @@ from sandboxed_gym.sandbox_types import (
 if TYPE_CHECKING:
     from opensandbox import Sandbox
 
+LOGGER = logging.getLogger(__name__)
+
 #: Provider name stamped onto handles.
 PROVIDER_NAME = "opensandbox"
+
+#: Correlates one create request with a resource whose response may have been lost.
+_SANDBOX_CREATE_ATTEMPT_ID_METADATA_KEY = "sandbox_create_attempt_id"
 
 #: Sandbox lifecycle names the SDK reports that do not match ours one-for-one.
 _STATUS_ALIASES = {
@@ -180,25 +187,43 @@ class OpenSandboxDriver:
         if spec.image is None:
             raise EpisodeBackendError("an episode image is required")
 
-        sandbox = await Sandbox.create(
-            spec.image,
-            timeout=timedelta(seconds=spec.ttl_s) if spec.ttl_s is not None else None,
-            ready_timeout=timedelta(seconds=spec.ready_timeout_s or 30.0),
-            env=dict(spec.env) or None,
-            metadata=dict(spec.metadata) or None,
-            resource_requests=_resource_requests(spec) or None,
-            network_policy=_network_policy(self._create_options),
-            entrypoint=list(spec.entrypoint) if spec.entrypoint else None,
-            volumes=_volumes(spec) or None,
-            # Large runtime images flake on the SDK's create-time probe, and the job host polls
-            # `/health` itself once routes resolve. The caller decides; the SDK default stands.
-            skip_health_check=bool(self._create_options.get("skip_health_check", False)),
-            connection_config=self._connection_config,
-        )
-        sandbox_id = getattr(sandbox, "sandbox_id", None) or (await sandbox.get_info()).id
-        if spec.workdir:
-            self._workdirs[sandbox_id] = spec.workdir
-        return SandboxHandle(sandbox_id=sandbox_id, provider_name=self.name, raw=sandbox)
+        create_attempt_id = uuid4().hex
+        metadata = {**spec.metadata, _SANDBOX_CREATE_ATTEMPT_ID_METADATA_KEY: create_attempt_id}
+        try:
+            sandbox = await Sandbox.create(
+                spec.image,
+                timeout=timedelta(seconds=spec.ttl_s) if spec.ttl_s is not None else None,
+                ready_timeout=timedelta(seconds=spec.ready_timeout_s or 30.0),
+                env=dict(spec.env) or None,
+                metadata=metadata,
+                resource_requests=_resource_requests(spec) or None,
+                network_policy=_network_policy(self._create_options),
+                entrypoint=list(spec.entrypoint) if spec.entrypoint else None,
+                volumes=_volumes(spec) or None,
+                # Large runtime images flake on the SDK's create-time probe, and the job host polls
+                # `/health` itself once routes resolve. The caller decides; the SDK default stands.
+                skip_health_check=bool(self._create_options.get("skip_health_check", False)),
+                connection_config=self._connection_config,
+            )
+            sandbox_id = getattr(sandbox, "sandbox_id", None) or (await sandbox.get_info()).id
+            if spec.workdir:
+                self._workdirs[sandbox_id] = spec.workdir
+            return SandboxHandle(sandbox_id=sandbox_id, provider_name=self.name, raw=sandbox)
+        except BaseException:
+            try:
+                removed = await self.destroy_sandboxes_matching(
+                    {_SANDBOX_CREATE_ATTEMPT_ID_METADATA_KEY: create_attempt_id}
+                )
+                if removed:
+                    LOGGER.warning(
+                        "destroyed sandboxes after create attempt %s failed: %s",
+                        create_attempt_id,
+                        ", ".join(removed),
+                    )
+            except BaseException:
+                # Preserve the create failure: it is the actionable cause.
+                LOGGER.exception("failed to reconcile sandbox create attempt %s", create_attempt_id)
+            raise
 
     def _sandbox(self, handle: SandboxHandle) -> Sandbox:
         return handle.raw  # ty: ignore[invalid-return-type] - provider-owned opaque state
@@ -267,6 +292,38 @@ class OpenSandboxDriver:
     async def close(self, handle: SandboxHandle) -> None:
         self._workdirs.pop(handle.sandbox_id, None)
         await self._sandbox(handle).destroy()
+
+    async def destroy_sandboxes_matching(self, metadata: Mapping[str, str]) -> tuple[str, ...]:
+        """Destroy every sandbox matching ``metadata``.
+
+        OpenSandbox creates the Kubernetes resource before waiting for it to become ready. If the
+        client loses that request, no ``SandboxHandle`` comes back, so normal handle-based cleanup
+        cannot reach the resource. A unique create-attempt ID makes metadata lookup an exact rollback.
+        """
+        if not metadata:
+            raise ValueError("sandbox cleanup requires at least one metadata selector")
+
+        from opensandbox.manager import SandboxManager
+        from opensandbox.models.sandboxes import SandboxFilter
+
+        manager = await SandboxManager.create(connection_config=self._connection_config)
+        try:
+            sandbox_ids: list[str] = []
+            page = 1
+
+            while True:
+                result = await manager.list_sandbox_infos(SandboxFilter(metadata=dict(metadata), page=page))
+                sandbox_ids.extend(info.id for info in result.sandbox_infos)
+                if not result.pagination.has_next_page:
+                    break
+                page += 1
+
+            for sandbox_id in sandbox_ids:
+                await manager.kill_sandbox(sandbox_id)
+
+            return tuple(sandbox_ids)
+        finally:
+            await manager.close()
 
     async def aclose(self) -> None:
         """No provider-scoped client to close: each sandbox owns its own SDK connection."""

--- a/packages/sandboxed_gym/tests/test_opensandbox_driver.py
+++ b/packages/sandboxed_gym/tests/test_opensandbox_driver.py
@@ -11,15 +11,27 @@ command output and lifecycle status map onto the SDK's shapes.
 
 from __future__ import annotations
 
+import importlib
+import importlib.util
+from collections.abc import Mapping
+from typing import cast
+
 import pytest
 from sandboxed_gym.backends._opensandbox_driver import (
+    _SANDBOX_CREATE_ATTEMPT_ID_METADATA_KEY,
     _STATUS_ALIASES,
+    OpenSandboxDriver,
     _exec_identity,
     _joined_output,
     _resource_requests,
 )
 from sandboxed_gym.backends.base import UnsupportedEpisodeOperationError
 from sandboxed_gym.sandbox_types import SandboxResources, SandboxSpec, SandboxStatus
+
+requires_opensandbox = pytest.mark.skipif(
+    importlib.util.find_spec("opensandbox") is None,
+    reason="needs the OpenSandbox SDK; install the `opensandbox` extra to run",
+)
 
 
 def spec_with(**resources: object) -> SandboxSpec:
@@ -82,3 +94,110 @@ def test_every_status_alias_maps_onto_a_real_contract_status() -> None:
     # here would resolve to UNKNOWN at runtime and look like a dead sandbox.
     assert all(isinstance(value, SandboxStatus) for value in _STATUS_ALIASES.values())
     assert "running" not in _STATUS_ALIASES, "statuses that already match must not be aliased"
+
+
+@requires_opensandbox
+async def test_destroy_sandboxes_matching_lists_every_page_and_kills_each(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from types import SimpleNamespace
+
+    SandboxManager = getattr(importlib.import_module("opensandbox.manager"), "SandboxManager")
+
+    manager = SimpleNamespace(
+        filters=[],
+        killed=[],
+        closed=False,
+    )
+
+    async def list_sandbox_infos(sandbox_filter: object) -> object:
+        manager.filters.append(sandbox_filter)
+        page = getattr(sandbox_filter, "page")
+        return SimpleNamespace(
+            sandbox_infos=[SimpleNamespace(id=f"orphan-{page}")],
+            pagination=SimpleNamespace(has_next_page=page == 1),
+        )
+
+    async def kill_sandbox(sandbox_id: str) -> None:
+        manager.killed.append(sandbox_id)
+
+    async def close() -> None:
+        manager.closed = True
+
+    manager.list_sandbox_infos = list_sandbox_infos
+    manager.kill_sandbox = kill_sandbox
+    manager.close = close
+
+    async def create_manager(*, connection_config: object) -> object:
+        return manager
+
+    monkeypatch.setattr(SandboxManager, "create", create_manager)
+
+    metadata = {_SANDBOX_CREATE_ATTEMPT_ID_METADATA_KEY: "create-1"}
+    removed = await OpenSandboxDriver().destroy_sandboxes_matching(metadata)
+
+    assert removed == ("orphan-1", "orphan-2")
+    assert manager.killed == ["orphan-1", "orphan-2"]
+    assert [sandbox_filter.metadata for sandbox_filter in manager.filters] == [
+        metadata,
+        metadata,
+    ]
+    assert manager.closed is True
+
+
+async def test_destroy_sandboxes_matching_refuses_an_empty_selector() -> None:
+    with pytest.raises(ValueError, match="at least one metadata selector"):
+        await OpenSandboxDriver().destroy_sandboxes_matching({})
+
+
+@requires_opensandbox
+async def test_create_reclaims_only_its_creation_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    Sandbox = getattr(importlib.import_module("opensandbox"), "Sandbox")
+
+    driver = OpenSandboxDriver()
+    captured_metadata: dict[str, str] = {}
+    cleanup_filters: list[dict[str, str]] = []
+
+    async def fail_create(image: str, **kwargs: object) -> object:
+        captured_metadata.update(cast(Mapping[str, str], kwargs["metadata"]))
+        raise RuntimeError("create failed")
+
+    async def cleanup(metadata: Mapping[str, str]) -> tuple[str, ...]:
+        cleanup_filters.append(dict(metadata))
+        return ("orphan-1",)
+
+    monkeypatch.setattr(Sandbox, "create", staticmethod(fail_create))
+    monkeypatch.setattr(driver, "destroy_sandboxes_matching", cleanup)
+
+    with pytest.raises(RuntimeError, match="create failed"):
+        await driver.create(SandboxSpec(image="img:1", metadata={"existing": "value"}))
+
+    create_attempt_id = captured_metadata[_SANDBOX_CREATE_ATTEMPT_ID_METADATA_KEY]
+    assert len(create_attempt_id) == 32
+    assert captured_metadata["existing"] == "value"
+    assert cleanup_filters == [{_SANDBOX_CREATE_ATTEMPT_ID_METADATA_KEY: create_attempt_id}]
+
+
+@requires_opensandbox
+async def test_cleanup_failure_does_not_mask_create_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    Sandbox = getattr(importlib.import_module("opensandbox"), "Sandbox")
+
+    driver = OpenSandboxDriver()
+
+    async def fail_create(image: str, **kwargs: object) -> object:
+        raise RuntimeError("create failed")
+
+    async def fail_cleanup(metadata: Mapping[str, str]) -> tuple[str, ...]:
+        raise RuntimeError("cleanup failed")
+
+    monkeypatch.setattr(Sandbox, "create", staticmethod(fail_create))
+    monkeypatch.setattr(driver, "destroy_sandboxes_matching", fail_cleanup)
+
+    with caplog.at_level("ERROR", logger="sandboxed_gym.backends._opensandbox_driver"):
+        with pytest.raises(RuntimeError, match="create failed"):
+            await driver.create(SandboxSpec(image="img:1"))
+
+    assert "failed to reconcile sandbox create attempt" in caplog.text


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
Brings the sandbox-cleanup fix from #1983 into `main`, preserving the release history for the remaining forward merge in #1989. Failed OpenSandbox creation attempts clean up resources matching their unique attempt ID while preserving the original error.

## Changes
- Merge `release/0.6` into `main` without conflicts or additional code edits.
- Carry over the cleanup implementation and its regression tests; only two files change.

## Type of Change
- [x] Code change (bug fix)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [x] Documentation not applicable — internal cleanup behavior; no API or configuration changes.

## Verification
- [x] Pull request title follows the repository's Conventional Commit format
- [ ] Every commit includes an appropriate `Signed-off-by:` trailer — the original release commit is retained unchanged; its DCO check flags an author/signoff email mismatch. The recovery merge has a signoff.
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass
- [x] No secrets, API keys, or credentials are included

Targeted OpenSandbox driver and host-provider tests: **18 passed**, using the checked-out source and OpenSandbox `0.1.16` from the workspace lockfile. `git diff --check` passes.

Full pre-commit run: blocked on a config-docs generator tied to another checkout, missing `helm-docs` and Studio `lint-staged`, and the local uv version differing from the lock-update version.

## Reviewer notes
Use **Create a merge commit**, bypassing the squash queue, to preserve release history. Keep #1989 open until the release commits reach `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when sandbox creation fails or loses connectivity by identifying and cleaning up orphaned sandboxes.
  * Preserved the original creation error when cleanup encounters additional failures.
  * Added safer, metadata-scoped cleanup across paginated sandbox results.
  * Preserved sandbox metadata during creation and cleanup operations.

* **Tests**
  * Expanded coverage for failed creation recovery, pagination, metadata handling, cleanup validation, and unavailable SDK scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->