### PR TITLE
feat(evaluator): expose agent_kwargs on HarborRunnerTarget

### DIFF
--- a/docs/evaluator/agent-eval/harbor-runner.mdx
+++ b/docs/evaluator/agent-eval/harbor-runner.mdx
@@ -139,6 +139,27 @@ Swap `agent_name` (or `agent_import_path`) for your own agent to get a real scor
 - **`agent_import_path`** — your own Harbor agent, e.g. `"my_agent_module:MyAgent"`. Set `agent_dir`
   as well when it's a loose file rather than an installed package. Overrides `agent_name`.
 - **`agent_model_name`** — the model slug handed to the agent.
+- **`agent_kwargs`** — keyword arguments forwarded to the agent's constructor, the equivalent of
+  Harbor's `--ak key=value` flags. Values must be JSON (strings, numbers, booleans, lists, mappings).
+  They are recorded in the run's provenance with credential-looking keys (`api_key`, `token`,
+  `secret`, ...) redacted; still prefer passing secrets through the environment.
+
+For example, a Harbor agent whose constructor takes `fabric_adapter_id` and `fabric_telemetry`:
+
+```python
+config = HarborRuntimeConfig(
+    jobs_dir=Path("./harbor-jobs"),
+    agent_import_path="nemo_fabric.integrations.harbor:FabricAgent",
+    agent_kwargs={
+        "fabric_adapter_id": "nvidia.fabric.codex",
+        "fabric_package": "nemo-fabric[codex]==0.3.0b1",
+        "fabric_telemetry": "relay",
+    },
+)
+```
+
+The same fields appear on the platform job's `HarborRunnerTarget`, so a spec submitted as a job carries
+them as `runner.agent_kwargs`.
 
 ## How scoring works
 
@@ -270,7 +291,8 @@ On a repeated SDK call:
 The SDK stores the cache stamp in `jobs_dir/<job_name>/.nemo-eval-harbor-cache.json`:
 
 - **`version`** — stamp schema; must match exactly.
-- **`options`** — SHA-256 of result-affecting `HarborRuntimeConfig` fields; must match exactly.
+- **`options`** — SHA-256 of result-affecting `HarborRuntimeConfig` fields, including `agent_kwargs`;
+  must match exactly.
 - **`agent`** — digest of `agent_dir` contents, or `"<none>"` when unset; must match exactly.
 - **`tasks`** — every requested task digest must match; extra cached tasks are ignored. Cached A, B, C
   can serve A, but cached A cannot serve A and B.

--- a/docs/evaluator/agent-eval/targets-and-runners.mdx
+++ b/docs/evaluator/agent-eval/targets-and-runners.mdx
@@ -119,7 +119,9 @@ The SDK ships three runners you'll usually reach for first:
   [Quickstart](/documentation/evaluate-models/agent-eval/quickstart). Return a `TrialDraft` to attach
   a trajectory or other evidence (see [Score by Component](/documentation/evaluate-models/agent-eval/score-by-component)).
 - **`HarborAgentTaskRunner`** runs a [Harbor](https://www.harborframework.com) task suite in Docker and
-  scores its verifier reward. See [Harbor Task Suite](/documentation/evaluate-models/agent-eval/harbor-runner).
+  scores its verifier reward. Point `agent_import_path` at your own Harbor agent and pass its
+  constructor arguments as `agent_kwargs` (Harbor's `--ak`). See
+  [Harbor Task Suite](/documentation/evaluate-models/agent-eval/harbor-runner).
 - **`GymAgentTaskRunner`** runs a [NeMo Gym](https://github.com/NVIDIA-NeMo/Gym) environment and agent,
   and scores each rollout's reward. See [NeMo Gym Environment](/documentation/evaluate-models/agent-eval/gym-runner).
 

--- a/packages/nemo_evaluator_sdk/examples/harbor/README.md
+++ b/packages/nemo_evaluator_sdk/examples/harbor/README.md
@@ -114,6 +114,8 @@ config = HarborRuntimeConfig(
 config = HarborRuntimeConfig(
     jobs_dir=jobs_dir,
     agent_import_path="mypkg.agent:WrappedAgent",
+    # Constructor arguments for the agent — Harbor's `--ak key=value`.
+    agent_kwargs={"max_turns": 20},
 )
 
 result = await run_harbor_eval(config, "hello_world_dataset")

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/config.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/config.py
@@ -33,9 +33,6 @@ HYDRA_SUBDIR = "gym_hydra"
 _CAPTURE_SUBDIR = "model_calls"
 #: `gym env start`'s combined output, under the run's work dir. Named here because a *collection*
 #: failure often has to point at it: the eval logs show the symptom, this shows the cause.
-_SECRET_KEY_MARKERS = ("api_key", "apikey", "token", "secret", "password", "passwd", "credential")
-#: Stand-in written in place of a redacted override value.
-_REDACTED = "<redacted>"
 
 
 #: Dict keys Hydra reads back unchanged. Its ``dictKey`` rule accepts no quoting, so a key is
@@ -128,44 +125,6 @@ def _flatten_overrides(overrides: Mapping[str, Any], _prefix: str = "") -> list[
         else:
             arguments.append(f"++{path}={hydra_scalar(value)}")
     return arguments
-
-
-def redact_hydra_params(overrides: Mapping[str, Any], _prefix: str = "") -> dict[str, Any]:
-    """Redact credential-looking values from overrides before they are recorded as provenance.
-
-    ``hydra_params`` is a free-form escape hatch forwarded to Gym, so nothing stops a caller passing
-    ``{"model": {"api_key": "sk-..."}}``. ``RunnerInfo.config`` is persisted into the run bundle, so a
-    value that looks like a credential must not be written there.
-
-    The *key* is always kept — knowing that a run overrode ``model.api_key`` is useful provenance;
-    knowing the value is a leak. Matching is on the full dotted path, so a marker anywhere in it
-    redacts, and nesting cannot hide a credential behind an innocuous leaf name.
-
-    Lists are walked too, since a mapping inside one — ``{"models": [{"api_key": "sk-..."}]}`` —
-    reaches Gym just as a nested mapping does. The index contributes no path segment: what marks a
-    value as a credential is the key it sits under, not where in a list it happens to fall.
-    """
-    redacted: dict[str, Any] = {}
-    for key, value in overrides.items():
-        path = f"{_prefix}{key}"
-        if isinstance(value, Mapping):
-            redacted[key] = redact_hydra_params(value, f"{path}.")
-        elif any(marker in path.casefold() for marker in _SECRET_KEY_MARKERS):
-            redacted[key] = _REDACTED
-        elif isinstance(value, (list, tuple)):
-            redacted[key] = [_redact_list_item(item, path) for item in value]
-        else:
-            redacted[key] = value
-    return redacted
-
-
-def _redact_list_item(item: Any, path: str) -> Any:
-    """Redact inside one element of a list-valued override. See :func:`redact_hydra_params`."""
-    if isinstance(item, Mapping):
-        return redact_hydra_params(item, f"{path}.")
-    if isinstance(item, (list, tuple)):
-        return [_redact_list_item(nested, path) for nested in item]
-    return item
 
 
 def selection_args(config: GymRuntimeConfig, work_dir: Path) -> list[str]:

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/runtime.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/runtime.py
@@ -24,7 +24,6 @@ from nemo_evaluator_sdk.agent_eval.runtimes.gym.config import (
     GymRuntimeConfig,
     hydra_scalar,
     model_call_capture_dir,
-    redact_hydra_params,
     selection_args,
 )
 from nemo_evaluator_sdk.agent_eval.runtimes.gym.dataset import materialize_dataset, source_datasets
@@ -46,6 +45,7 @@ from nemo_evaluator_sdk.agent_eval.runtimes.gym.results import (
     require_full_coverage,
     trials_from_rollouts,
 )
+from nemo_evaluator_sdk.agent_eval.runtimes.provenance import redact_credentials
 from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalRunConfig, AgentEvalTask
 from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial, RunnerInfo
 from nemo_evaluator_sdk.values.results import AggregateScore
@@ -96,7 +96,7 @@ class GymAgentTaskRunner:
 
         Credentials normally live in the Gym checkout's gitignored ``env.yaml`` and never reach this
         object — but ``hydra_params`` and ``env_vars`` are free-form escape hatches, so their values
-        are redacted by key (see :func:`redact_hydra_params`) rather than trusted. ``env_vars``
+        are redacted by key (see :func:`redact_credentials`) rather than trusted. ``env_vars``
         needs it at least as much: environment variables are the conventional way to pass an API
         key, so a caller doing the obvious thing would otherwise write one into the run bundle.
         """
@@ -112,8 +112,8 @@ class GymAgentTaskRunner:
                 "num_repeats": cfg.num_repeats,
                 "concurrency": cfg.concurrency,
                 "bind_resources_server": cfg.bind_resources_server,
-                "hydra_params": redact_hydra_params(cfg.hydra_params),
-                "env_vars": redact_hydra_params(cfg.env_vars),
+                "hydra_params": redact_credentials(cfg.hydra_params),
+                "env_vars": redact_credentials(cfg.env_vars),
                 "reward_key": cfg.reward_key,
             },
         )

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/harbor_runtime.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/harbor_runtime.py
@@ -61,12 +61,13 @@ from nemo_evaluator_sdk.agent_eval.runtimes.harbor_trial_adapter import (
     _iter_harbor_trial_results,
     _trial_from_harbor_result,
 )
+from nemo_evaluator_sdk.agent_eval.runtimes.provenance import redact_credentials
 from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalRunConfig, AgentEvalTask, AgentEvalTaskset
 from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial, RunnerInfo
 from nemo_evaluator_sdk.enums import MetricType
 from nemo_evaluator_sdk.metrics.protocol import Metric
 from nemo_evaluator_sdk.metrics.utils import metric_type_name
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, JsonValue, model_validator
 
 logger = logging.getLogger(__name__)
 
@@ -90,7 +91,7 @@ _IMPORT_DIGEST_CHARS = 12
 # a stale one. A file, not a directory: Harbor rmtree's stray directories in a job dir.
 CACHE_STAMP_FILENAME = ".nemo-eval-harbor-cache.json"
 # Public so downstreams can assert the SDK is new enough to own cache staleness.
-CACHE_STAMP_VERSION = 1
+CACHE_STAMP_VERSION = 2
 # Excluded from the cache fingerprint — see :func:`_cache_stamp` for why each one.
 _CACHE_IRRELEVANT_OPTIONS = frozenset(
     {"jobs_dir", "job_name", "force_rerun", "quiet", "n_concurrent_trials", "agent_dir", "reward_key"}
@@ -149,6 +150,13 @@ class HarborRuntimeConfig(BaseModel):
         ),
     )
     agent_model_name: str | None = Field(default=None, description="Optional model slug passed to the Harbor agent.")
+    agent_kwargs: dict[str, JsonValue] = Field(
+        default_factory=dict,
+        description=(
+            "Keyword arguments forwarded to the Harbor agent's constructor, the equivalent of Harbor's "
+            "``--ak key=value``. Recorded in run provenance with credential-looking values redacted."
+        ),
+    )
     n_attempts: int = Field(default=1, ge=1, description="Number of attempts Harbor runs per task.")
     n_concurrent_trials: int = Field(default=4, ge=1, description="Maximum concurrent Harbor trials.")
     quiet: bool = Field(default=True, description="Suppress Harbor's trial progress displays.")
@@ -247,6 +255,7 @@ class HarborAgentTaskRunner:
                 "agent_name": config.agent_name if config is not None else None,
                 "agent_import_path": config.agent_import_path if config is not None else None,
                 "agent_model_name": config.agent_model_name if config is not None else None,
+                "agent_kwargs": redact_credentials(config.agent_kwargs) if config is not None else None,
                 "effective_agent": _effective_harbor_agent(config),
                 "n_attempts": config.n_attempts if config is not None else None,
                 # Native mode resolves the concrete job directory inside run_tasks (the name defaults
@@ -917,8 +926,11 @@ def _build_native_job(
                 shutil.rmtree(job_dir)
                 await _attempt()
 
+        agent_kwargs = dict(config.agent_kwargs)
         if config.agent_import_path is None:
-            await _create_and_run(AgentConfig(name=config.agent_name or "oracle", model_name=config.agent_model_name))
+            await _create_and_run(
+                AgentConfig(name=config.agent_name or "oracle", model_name=config.agent_model_name, kwargs=agent_kwargs)
+            )
         elif config.agent_dir is not None:
             # Loose wrapper file: make its directory importable for the run. The
             # jobs_dir exclusion must match _cache_stamp's, or a jobs_dir nested under
@@ -928,10 +940,16 @@ def _build_native_job(
             with scoped_harbor_agent_import(
                 agent_dir, config.agent_import_path, exclude=excluded_roots
             ) as scoped_import:
-                await _create_and_run(AgentConfig(import_path=scoped_import, model_name=config.agent_model_name))
+                await _create_and_run(
+                    AgentConfig(import_path=scoped_import, model_name=config.agent_model_name, kwargs=agent_kwargs)
+                )
         else:
             # Already-importable module (installed package): let Harbor import it directly.
-            await _create_and_run(AgentConfig(import_path=config.agent_import_path, model_name=config.agent_model_name))
+            await _create_and_run(
+                AgentConfig(
+                    import_path=config.agent_import_path, model_name=config.agent_model_name, kwargs=agent_kwargs
+                )
+            )
 
     return job_dir, run_job
 

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/provenance.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/provenance.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Redaction of credential-looking values before free-form runner settings are recorded as provenance."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+_SECRET_KEY_MARKERS = ("api_key", "apikey", "token", "secret", "password", "passwd", "credential")
+_REDACTED = "<redacted>"
+
+
+def redact_credentials(settings: Mapping[str, Any], _prefix: str = "") -> dict[str, Any]:
+    """Redact credential-looking values from free-form settings before they are recorded as provenance.
+
+    Runner configs carry escape hatches forwarded verbatim to the harness (Gym's ``hydra_params``,
+    Harbor's ``agent_kwargs``), so nothing stops a caller passing ``{"model": {"api_key": "sk-..."}}``.
+    ``RunnerInfo.config`` is persisted into the run bundle, so a value that looks like a credential
+    must not be written there.
+
+    The *key* is always kept — knowing that a run set ``model.api_key`` is useful provenance; knowing
+    the value is a leak. Matching is on the full dotted path, so a marker anywhere in it redacts, and
+    nesting cannot hide a credential behind an innocuous leaf name.
+
+    Lists are walked too, since a mapping inside one — ``{"models": [{"api_key": "sk-..."}]}`` —
+    reaches the harness just as a nested mapping does. The index contributes no path segment: what
+    marks a value as a credential is the key it sits under, not where in a list it happens to fall.
+    """
+    redacted: dict[str, Any] = {}
+    for key, value in settings.items():
+        path = f"{_prefix}{key}"
+        if isinstance(value, Mapping):
+            redacted[key] = redact_credentials(value, f"{path}.")
+        elif any(marker in path.casefold() for marker in _SECRET_KEY_MARKERS):
+            redacted[key] = _REDACTED
+        elif isinstance(value, (list, tuple)):
+            redacted[key] = [_redact_list_item(item, path) for item in value]
+        else:
+            redacted[key] = value
+    return redacted
+
+
+def _redact_list_item(item: Any, path: str) -> Any:
+    """Redact inside one element of a list-valued setting. See :func:`redact_credentials`."""
+    if isinstance(item, Mapping):
+        return redact_credentials(item, f"{path}.")
+    if isinstance(item, (list, tuple)):
+        return [_redact_list_item(nested, path) for nested in item]
+    return item

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_harbor_runtime.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_harbor_runtime.py
@@ -12,7 +12,7 @@ from collections.abc import Awaitable, Callable, Mapping
 from datetime import datetime, timezone
 from pathlib import Path
 from types import ModuleType
-from typing import cast
+from typing import Any, cast
 
 import pytest
 
@@ -941,7 +941,7 @@ async def test_under_covered_job_resumes_when_harbor_can(tmp_path: Path, monkeyp
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("mutation", ["agent", "task", "option"])
+@pytest.mark.parametrize("mutation", ["agent", "agent_kwargs", "task", "option"])
 async def test_changed_inputs_invalidate_the_cache(tmp_path: Path, mutation: str) -> None:
     # Each of these changes what a run would produce, so the stamped dir must not be
     # served. Reaching run_job (and failing there) is the observable signal.
@@ -957,12 +957,63 @@ async def test_changed_inputs_invalidate_the_cache(tmp_path: Path, mutation: str
         config = config.model_copy(
             update={"agent_import_path": "wrapper:Agent", "agent_dir": agent_dir},
         )
+    elif mutation == "agent_kwargs":
+        config = config.model_copy(update={"agent_kwargs": {"fabric_telemetry": "relay"}})
     elif mutation == "task":
         (dataset_path / "t" / "task.toml").write_text('[task]\nname = "t"\nchanged = true\n')
     else:
         config = config.model_copy(update={"n_attempts": 2})
 
     assert _cache_is_stale(job_dir, _cache_stamp(config, dataset_path, [task])) is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("agent_shape", ["builtin", "installed_import_path", "agent_dir"])
+async def test_agent_kwargs_reach_harbor_agent_config_unchanged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, agent_shape: str
+) -> None:
+    """``agent_kwargs`` must land on Harbor's ``AgentConfig.kwargs`` (its ``--ak``) for every agent shape.
+
+    Harbor merges ``AgentConfig.kwargs`` into the agent constructor for built-in and import-path agents
+    alike, so a shape that dropped them would silently run the agent with its defaults.
+    """
+    import harbor.job
+
+    agent_kwargs = {"fabric_adapter_id": "nvidia.fabric.codex", "fabric_harness_settings": {"turns": [1, 2]}}
+    jobs_dir = tmp_path / "jobs"
+    jobs_dir.mkdir()
+    agent_options: dict[str, object] = {"agent_kwargs": agent_kwargs}
+    if agent_shape == "installed_import_path":
+        agent_options["agent_import_path"] = "mypkg.agent:WrappedAgent"
+    elif agent_shape == "agent_dir":
+        agent_dir = tmp_path / "agent"
+        agent_dir.mkdir()
+        (agent_dir / "harbor_wrapper.py").write_text("x = 1\n", encoding="utf-8")
+        agent_options.update(agent_import_path="harbor_wrapper:WrappedAgent", agent_dir=agent_dir)
+    config = HarborRuntimeConfig(jobs_dir=jobs_dir, job_name="kwargs-job", **agent_options)
+
+    created: list[Any] = []
+
+    class FakeJob:
+        @classmethod
+        async def create(cls, job_config: Any) -> "FakeJob":
+            created.append(job_config)
+            return cls()
+
+        async def run(self) -> None:
+            return None
+
+    monkeypatch.setattr(harbor.job, "Job", FakeJob)
+    _, run_job = _build_native_job(config, tmp_path / "dataset", None, job_name="kwargs-job")
+    await run_job()
+
+    assert len(created) == 1
+    (agent_config,) = created[0].agents
+    assert agent_config.kwargs == agent_kwargs
+    if agent_shape == "builtin":
+        assert agent_config.name == "oracle"
+    else:
+        assert agent_config.import_path is not None and agent_config.import_path.endswith(":WrappedAgent")
 
 
 @pytest.mark.asyncio

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_run_metadata.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_run_metadata.py
@@ -103,6 +103,7 @@ def test_every_shipped_runner_reports_a_stable_name_and_result_shaping_config() 
             {
                 "agent_name",
                 "agent_import_path",
+                "agent_kwargs",
                 "effective_agent",
                 "n_attempts",
                 "jobs_dir",
@@ -227,6 +228,35 @@ def test_gym_redacts_credential_looking_hydra_params() -> None:
         "models": [{"name": "m", "api_key": "<redacted>"}],
         # A credential-shaped key wins over descending into it — the whole list goes.
         "api_keys": "<redacted>",
+    }
+    assert "should-not-be-recorded" not in json.dumps(recorded)
+
+
+def test_harbor_redacts_credential_looking_agent_kwargs() -> None:
+    # agent_kwargs is forwarded verbatim to the Harbor agent's constructor and RunnerInfo.config is
+    # persisted into the run bundle — the same exposure as Gym's hydra_params, so the same redaction.
+    from pathlib import Path
+
+    from nemo_evaluator_sdk.agent_eval.runtimes.harbor_runtime import HarborAgentTaskRunner, HarborRuntimeConfig
+
+    runner = HarborAgentTaskRunner(
+        config=HarborRuntimeConfig(
+            jobs_dir=Path("/jobs"),
+            agent_import_path="pkg:Agent",
+            agent_kwargs={
+                "fabric_adapter_id": "nvidia.fabric.codex",
+                "extra_env": {"OPENAI_API_KEY": "sk-should-not-be-recorded", "HOME": "/root"},
+                "fabric_harness_settings": {"auth": {"token": "tok-should-not-be-recorded"}},
+            },
+        )
+    )
+
+    recorded = runner.runner_info().config["agent_kwargs"]
+
+    assert recorded == {
+        "fabric_adapter_id": "nvidia.fabric.codex",
+        "extra_env": {"OPENAI_API_KEY": "<redacted>", "HOME": "/root"},
+        "fabric_harness_settings": {"auth": {"token": "<redacted>"}},
     }
     assert "should-not-be-recorded" not in json.dumps(recorded)
 

--- a/plugins/nemo-evaluator/openapi/openapi.yaml
+++ b/plugins/nemo-evaluator/openapi/openapi.yaml
@@ -4334,6 +4334,14 @@ components:
           title: Agent Model Name
           description: Optional model slug passed to the Harbor agent.
           type: string
+        agent_kwargs:
+          additionalProperties:
+            $ref: '#/components/schemas/JsonValue'
+          type: object
+          title: Agent Kwargs
+          description: Keyword arguments forwarded to the Harbor agent's constructor,
+            the equivalent of Harbor's `--ak key=value`. Recorded in run provenance
+            with credential-looking values redacted.
         n_attempts:
           type: integer
           minimum: 1.0

--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/agent_evaluate.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/agent_evaluate.py
@@ -584,6 +584,7 @@ class AgentEvalJob(NemoJob):
                     agent_name=target.agent_name,
                     agent_import_path=target.agent_import_path,
                     agent_model_name=target.agent_model_name,
+                    agent_kwargs=target.agent_kwargs,
                     n_attempts=target.n_attempts,
                     n_concurrent_trials=target.n_concurrent_trials,
                     max_retries=target.max_retries,

--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/agent_spec.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/agent_spec.py
@@ -29,7 +29,7 @@ from nemo_evaluator_sdk.agent_eval.tasks import SemanticView
 from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial
 from nemo_evaluator_sdk.values import Agent, Model, RunConfigOnline, RunConfigOnlineModel, SecretRef
 from nemo_evaluator_sdk.values.agents import AgentBase
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, JsonValue, field_validator, model_validator
 
 
 class ModelTarget(BaseModel):
@@ -122,6 +122,11 @@ class HarborRunnerTarget(BaseModel):
         "The module must already be importable in the run environment.",
     )
     agent_model_name: str | None = Field(default=None, description="Optional model slug passed to the Harbor agent.")
+    agent_kwargs: dict[str, JsonValue] = Field(
+        default_factory=dict,
+        description="Keyword arguments forwarded to the Harbor agent's constructor, the equivalent of Harbor's "
+        "`--ak key=value`. Recorded in run provenance with credential-looking values redacted.",
+    )
     n_attempts: int = Field(default=1, ge=1, description="Number of attempts Harbor runs per task.")
     n_concurrent_trials: int = Field(default=4, ge=1, description="Maximum concurrent Harbor trials.")
     max_retries: int = Field(default=0, ge=0, description="Harbor per-trial retry attempts on transient failures.")

--- a/plugins/nemo-evaluator/tests/test_agent_evaluate.py
+++ b/plugins/nemo-evaluator/tests/test_agent_evaluate.py
@@ -319,6 +319,7 @@ def test_resolve_target_builds_harbor_runtime_from_runner_target(tmp_path: Path)
     harbor_target = HarborRunnerTarget(
         agent_name="oracle",
         agent_model_name="openai/gpt-5.4",
+        agent_kwargs={"fabric_adapter_id": "nvidia.fabric.codex", "fabric_harness_settings": {"max_turns": 3}},
         n_attempts=2,
         n_concurrent_trials=8,
         max_retries=1,
@@ -331,6 +332,10 @@ def test_resolve_target_builds_harbor_runtime_from_runner_target(tmp_path: Path)
     assert target._config.jobs_dir == ctx.storage.persistent / "harbor"
     # Spec knobs are forwarded onto the Harbor runtime config.
     assert target._config.agent_model_name == "openai/gpt-5.4"
+    assert target._config.agent_kwargs == {
+        "fabric_adapter_id": "nvidia.fabric.codex",
+        "fabric_harness_settings": {"max_turns": 3},
+    }
     assert target._config.n_attempts == 2
     assert target._config.reward_key == "score"
     # A runner shapes its own request, so it contributes no prompt template or inference params.
@@ -448,6 +453,27 @@ def test_runner_target_is_accepted(tmp_path: Path) -> None:
 def test_harbor_runner_target_is_accepted() -> None:
     spec = AgentEvalSpec(tasks=[_task_spec()], target=HarborRunnerTarget(agent_name="oracle"))
     assert isinstance(spec.target, HarborRunnerTarget)
+
+
+def test_harbor_agent_kwargs_round_trip_the_wire_unchanged() -> None:
+    """Nested kwargs survive JSON serialization, so what the submitter wrote is what the agent's ``__init__`` gets."""
+    agent_kwargs = {
+        "fabric_adapter_id": "nvidia.fabric.codex",
+        "fabric_package": "nemo-fabric[codex]==0.3.0b1",
+        "fabric_harness_settings": {"max_turns": 3, "tools": ["shell", None], "strict": True},
+    }
+    spec = AgentEvalSpec(
+        tasks=[_task_spec()],
+        target=HarborRunnerTarget(
+            agent_import_path="nemo_fabric.integrations.harbor:FabricAgent", agent_kwargs=agent_kwargs
+        ),
+    )
+
+    restored = AgentEvalSpec.model_validate(json.loads(spec.model_dump_json()))
+
+    assert isinstance(restored.target, HarborRunnerTarget)
+    assert restored.target.agent_kwargs == agent_kwargs
+    assert HarborRunnerTarget().agent_kwargs == {}
 
 
 def test_agent_eval_job_source_is_distinct_from_evaluate_job() -> None:

--- a/skills/nemo-evaluator-plugin/references/agent-evaluation.md
+++ b/skills/nemo-evaluator-plugin/references/agent-evaluation.md
@@ -395,6 +395,9 @@ target = HarborRunnerTarget(
 - A secondary reward discovered for one task does not apply to another task.
 
 Use `agent_import_path` for a custom Harbor agent and `agent_model_name` when
-the agent requires a model. The module must be importable in the execution
+the agent requires a model. Pass the agent's constructor arguments as
+`agent_kwargs` (a JSON mapping, Harbor's `--ak key=value`); they are recorded in
+run provenance with credential-looking keys redacted, so prefer the environment
+for secrets. The module must be importable in the execution
 environment. Durable execution additionally requires an execution image and
 runtime that provide Harbor and Docker access.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
`HarborRunnerTarget` (and the SDK's `HarborRuntimeConfig`) gain `agent_kwargs`, forwarded to the Harbor agent's constructor as Harbor's `AgentConfig.kwargs` (its `--ak key=value`). Before, a custom agent selected via `agent_import_path` could only be configured through the environment; now constructor arguments such as `FabricAgent`'s required `fabric_adapter_id` reach it unchanged. A kwargs change invalidates a pinned Harbor job dir instead of reusing stale results.

Tracks AALGO-639.

## Changes
- `agent_kwargs: dict[str, JsonValue]` (default empty) on `HarborRunnerTarget` and `HarborRuntimeConfig`; the job maps it through in `AgentEvalJob._resolve_target`.
- `run_job` passes `kwargs=` on all three `AgentConfig` shapes (built-in name, installed import path, `agent_dir` wrapper).
- Cache stamp: the options hash already covers every non-excluded field, so kwargs participate automatically. `CACHE_STAMP_VERSION` bumped 1 → 2 so pre-existing stamps read as "version changed" rather than an unexplained option drift.
- Provenance: `runner_info()` records `agent_kwargs` with credential-looking keys redacted. Gym's `redact_hydra_params` moved to a shared `runtimes/provenance.py` as `redact_credentials`, used by both runners (behaviour unchanged for Gym; its tests still pass). Note this covers the run bundle only: Harbor itself persists `AgentConfig.kwargs` unredacted in the job dir's `config.json`, so the field descriptions and docs say `agent_kwargs` is not for secrets and point at the environment. A proper secret route (`env_secrets` on the Harbor target feeding Harbor's `AgentConfig.env`, which templatizes sensitive values) is a follow-up.
- Regenerated `plugins/nemo-evaluator/openapi/openapi.yaml`.
- Docs: `harbor-runner.mdx` (new bullet, field → `AgentConfig` mapping diagram, linked `FabricAgent` example, cache identity note), `targets-and-runners.mdx`, skill reference `agent-evaluation.md`, SDK Harbor example README.
- Tests: kwargs reach `AgentConfig.kwargs` for each agent shape; kwargs change is stale in the stamp; plugin target → runtime mapping; JSON round-trip of nested kwargs; Harbor provenance redaction.

Deliberately left alone: `target_agent_identity` and result-persistence filter traits do not include kwargs (identity stays `import_path`/`agent_name`), per the ticket. The Experimentalist's `HarborRunnerConfig` is a narrower surface and does not expose kwargs yet.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `uv run pytest packages/nemo_evaluator_sdk/tests/agent_eval plugins/nemo-evaluator/tests/test_agent_evaluate.py plugins/nemo-evaluator/tests/test_result_persistence.py plugins/nemo-evaluator/tests/jobs` → 1275 passed, 12 skipped (slow).
- `tools/lint/lint-python-types.sh` → All checks passed.
- `uv run ruff check` / `ruff format --check` on `packages/nemo_evaluator_sdk` and `plugins/nemo-evaluator` → clean.
- `uv run pre-commit run -a` → all hooks pass. The `uv-lock` hook fails on the host's uv 0.9.30 (pinned 0.9.14); re-run under `flox activate` with uv 0.9.14 → Passed. `uv.lock` is untouched.
- `make refresh-openapi` → only the `agent_kwargs` property added to `HarborRunnerTarget`. `tools/lint/lint-openapi.sh` cannot run on macOS bash 3.2 (`mapfile`); the drift invariant was checked directly by regenerating and diffing.
- Manual (local Docker, Python 3.12): one `hello-world` Harbor task through `nemo_fabric.integrations.harbor:FabricAgent` with the ticket's kwargs (`fabric_adapter_id`, `fabric_package`, `fabric_telemetry`). Harbor's persisted `config.json` carries the kwargs, `FabricAgent.__init__` accepted them, the in-container `nemo-fabric[codex]==0.3.0b1` install ran, and the Fabric run spec shows the codex adapter with relay telemetry enabled. The trial then failed inside Fabric spawning `nemo_fabric_adapters.codex.adapter` in the container venv, and no OpenAI credential was available for Codex, so a passing reward was **not** reached. The stock hello-world image (alpine) has no `python3`, so a `python:3.12-slim` copy of the task was used.
- Independent Codex review: one finding (unredacted kwargs in provenance), fixed as described above; verdict otherwise clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Harbor evaluations now support JSON-compatible constructor arguments for built-in and custom agents through `agent_kwargs`.
  - These settings are forwarded across supported agent configurations and included in cache identity.

- **Security**
  - Credential-like values in provenance are automatically redacted, including nested agent arguments and environment settings.
  - Harbor stores agent arguments unredacted in `config.json`; provide secrets through the job environment instead.

- **Documentation**
  - Added examples and guidance for custom Harbor agents, argument formatting, provenance redaction, and secret handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
