### PR TITLE
fix(studio): preserve case-sensitive OAuth client IDs [ASTD-599]

### DIFF
--- a/web/packages/studio/src/constants/environment.test.ts
+++ b/web/packages/studio/src/constants/environment.test.ts
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+describe('environment', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('preserves the case of a case-sensitive env var like AUTH_CLIENT_ID', async () => {
+    vi.stubEnv('VITE_AUTH_CLIENT_ID', 'MixedCaseClientId');
+    const { AUTH_CLIENT_ID } = await import('./environment');
+    expect(AUTH_CLIENT_ID).toBe('MixedCaseClientId');
+  });
+
+  it.each([
+    ['true', true],
+    ['True', true],
+    ['false', false],
+  ])('normalizes VITE_TELEMETRY_ENABLED=%s to %s regardless of case', async (value, expected) => {
+    vi.stubEnv('VITE_TELEMETRY_ENABLED', value);
+    const { TELEMETRY_ENABLED } = await import('./environment');
+    expect(TELEMETRY_ENABLED).toBe(expected);
+  });
+});

--- a/web/packages/studio/src/constants/environment.ts
+++ b/web/packages/studio/src/constants/environment.ts
@@ -19,7 +19,7 @@ import { featureFlags } from '@studio/constants/featureFlags';
  * @param envVarKey - The key of the environment variable to get.
  * @returns The value of the environment variable, or undefined if the environment variable is not set.
  */
-const getEnvVar = (envVarKey: string) => (import.meta.env[envVarKey] as string)?.toLowerCase();
+const getEnvVar = (envVarKey: string) => import.meta.env[envVarKey] as string;
 
 // Special keyword env vars
 export const IS_PROD = import.meta.env.PROD;
@@ -62,12 +62,12 @@ export const TOOL_CALLING_ENABLED = featureFlags.toolCallingEnabled !== false;
 export const TOUR_ENABLED = featureFlags.tourEnabled !== false;
 
 // Vars used by OpenTelemetry
-export const TELEMETRY_ENABLED = getEnvVar('VITE_TELEMETRY_ENABLED') === 'true';
+export const TELEMETRY_ENABLED = getEnvVar('VITE_TELEMETRY_ENABLED')?.toLowerCase() === 'true';
 const normalizedBaseUrl = BASE_URL.replace(/\/+$/, '');
 export const OTEL_PROXY_URL = `${normalizedBaseUrl}/telemetry`;
 export const OTEL_SERVICE_NAME = getEnvVar('VITE_OTEL_SERVICE_NAME');
 
-export const isLocalDevelopmentEnv = getEnvVar('VITE_IS_LOC_ENV') === 'true';
+export const isLocalDevelopmentEnv = getEnvVar('VITE_IS_LOC_ENV')?.toLowerCase() === 'true';
 
 // Vars used by the oidc provider
 export const AUTH_CLIENT_ID = getEnvVar('VITE_AUTH_CLIENT_ID');


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary

`getEnvVar` in `web/packages/studio/src/constants/environment.ts` called `.toLowerCase()` on every env var it read, which silently mangles case-sensitive values like `AUTH_CLIENT_ID` (passed as OAuth `client_id`, e.g. to the Starfleet IdP). This stops lowercasing globally and only lowercases the two boolean flags (`TELEMETRY_ENABLED`, `isLocalDevelopmentEnv`) that compare against the literal `'true'`.

## Changes

- `getEnvVar` returns the raw env var value instead of lowercasing it.
- `TELEMETRY_ENABLED` and `isLocalDevelopmentEnv` now call `.toLowerCase()` locally before comparing to `'true'`, preserving their prior case-insensitive behavior.
- `AUTH_CLIENT_ID`, `AUTH_AUTHORITY`, `AUTH_SCOPES`, `AUTH_SCOPE_PREFIX`, `OTEL_SERVICE_NAME`, `VERSION_SHA`, and `PLATFORM_BASE_URL` now keep their original case.
- Added `web/packages/studio/src/constants/environment.test.ts` covering case preservation for `AUTH_CLIENT_ID` and case-insensitive parsing of `VITE_TELEMETRY_ENABLED`.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: internal env-var parsing helper, no user-facing docs reference this behavior.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `uv run pre-commit run -a` — all hooks pass on the changed files. Two hooks fail repo-wide for reasons unrelated to this change and pre-date it: `helm-docs` (binary not installed in this sandbox) and `uv-lock` (local `uv` is 0.9.30 vs. the pinned 0.9.14); neither touches Helm charts or `uv.lock`.
- `npm run --prefix packages/studio typecheck` (`tsc --noEmit --noErrorTruncation`) — passes.
- `pnpm --filter="...[origin/main]" run --parallel --if-present typecheck` — passes.
- `npx vitest run src/constants/environment.test.ts` (packages/studio) — 4/4 new tests pass.
- `pnpm --filter="...[origin/main]" run --parallel --if-present test:ci` — 3501/3504 pass; the 3 failures are in `src/util/date.test.ts` and are a pre-existing locale artifact of this sandbox (`LANG=en_CA.UTF-8` makes `toLocaleDateString()` return ISO-style dates instead of `M/D/YYYY`), unrelated to `environment.ts`.
- `npx eslint packages/studio/src/constants/environment.ts packages/studio/src/constants/environment.test.ts` — no issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Environment variable values now preserve their original casing where applicable.
  - Boolean settings such as telemetry and local-development mode continue to recognize `true` and `false` values regardless of capitalization.

- **Tests**
  - Added coverage for case preservation and case-insensitive boolean environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->