### PR TITLE
fix: link recovery docs in forward-merge alerts

### DIFF
--- a/.github/scripts/forward-merge-alert.cjs
+++ b/.github/scripts/forward-merge-alert.cjs
@@ -176,6 +176,7 @@ function buildSlackMessage({
   conflicts,
   runUrl,
   userGroupId,
+  recoveryDocsUrl,
 }) {
   const mention = slackUserGroupMention(userGroupId);
   const lines = [
@@ -208,6 +209,11 @@ function buildSlackMessage({
     "The bot will not retry. Manual recovery is required.",
     `<${commentUrl}|View failure details>`,
   );
+  if (recoveryDocsUrl?.trim()) {
+    lines.push(
+      `<${escapeSlackText(recoveryDocsUrl.trim())}|Forward-merge recovery guide>`,
+    );
+  }
   return lines.join("\n");
 }
 
@@ -312,6 +318,7 @@ async function sendForwardMergeAlert({
     conflicts,
     runUrl: env.RUN_URL,
     userGroupId: env.SLACK_ALERT_USERGROUP_ID,
+    recoveryDocsUrl: env.FORWARD_MERGE_RECOVERY_DOCS_URL,
   });
   await postSlack({
     fetchImpl,

--- a/.github/scripts/forward-merge-alert.cjs
+++ b/.github/scripts/forward-merge-alert.cjs
@@ -204,16 +204,13 @@ function buildSlackMessage({
     lines.push("", "Conflict metadata unavailable; see the failure details.");
   }
 
-  lines.push(
-    "",
-    "The bot will not retry. Manual recovery is required.",
-    `<${commentUrl}|View failure details>`,
-  );
+  lines.push("", "The bot will not retry. Manual recovery is required.");
   if (recoveryDocsUrl?.trim()) {
     lines.push(
-      `<${escapeSlackText(recoveryDocsUrl.trim())}|Forward-merge recovery guide>`,
+      `:point_right: *<${escapeSlackText(recoveryDocsUrl.trim())}|Follow these steps to fix the forward merge>*`,
     );
   }
+  lines.push(`<${commentUrl}|View failure details>`);
   return lines.join("\n");
 }
 

--- a/.github/scripts/tests/forward-merge-alert.test.cjs
+++ b/.github/scripts/tests/forward-merge-alert.test.cjs
@@ -200,7 +200,7 @@ test("includes the configured recovery guide for every failure kind", () => {
     );
     assert.match(
       message,
-      /<https:\/\/docs\.example\.com\/forward-merge\/\|Forward-merge recovery guide>/,
+      /<https:\/\/docs\.example\.com\/forward-merge\/\|Follow these steps to fix the forward merge>/,
     );
     assert.match(message, /View failure details/);
   }
@@ -209,7 +209,7 @@ test("includes the configured recovery guide for every failure kind", () => {
 test("omits the recovery guide when its secret is missing or blank", () => {
   for (const recoveryDocsUrl of [undefined, "", "   "]) {
     const message = buildSlackMessage(messageFixture({ recoveryDocsUrl }));
-    assert.doesNotMatch(message, /Forward-merge recovery guide/);
+    assert.doesNotMatch(message, /Follow these steps to fix the forward merge/);
     assert.match(message, /Manual recovery is required/);
   }
 });
@@ -294,7 +294,7 @@ test("falls back to the basic alert when PR metadata fails", async () => {
   assert.match(result.text, /Source: unavailable/);
   assert.ok(
     JSON.parse(requests[0].options.body).text.includes(
-      "<https://docs.example.com/forward-merge/|Forward-merge recovery guide>",
+      "<https://docs.example.com/forward-merge/|Follow these steps to fix the forward merge>",
     ),
   );
   assert.match(result.text, /Conflict metadata unavailable/);

--- a/.github/scripts/tests/forward-merge-alert.test.cjs
+++ b/.github/scripts/tests/forward-merge-alert.test.cjs
@@ -190,6 +190,30 @@ test("omits a missing or invalid Slack user group", () => {
   );
 });
 
+test("includes the configured recovery guide for every failure kind", () => {
+  for (const kind of ["conflicts", "clean", "unavailable"]) {
+    const message = buildSlackMessage(
+      messageFixture({
+        conflicts: { kind, files: ["uv.lock"] },
+        recoveryDocsUrl: " https://docs.example.com/forward-merge/ ",
+      }),
+    );
+    assert.match(
+      message,
+      /<https:\/\/docs\.example\.com\/forward-merge\/\|Forward-merge recovery guide>/,
+    );
+    assert.match(message, /View failure details/);
+  }
+});
+
+test("omits the recovery guide when its secret is missing or blank", () => {
+  for (const recoveryDocsUrl of [undefined, "", "   "]) {
+    const message = buildSlackMessage(messageFixture({ recoveryDocsUrl }));
+    assert.doesNotMatch(message, /Forward-merge recovery guide/);
+    assert.match(message, /Manual recovery is required/);
+  }
+});
+
 test("escapes untrusted Slack labels", () => {
   const message = buildSlackMessage(
     messageFixture({
@@ -251,6 +275,8 @@ test("falls back to the basic alert when PR metadata fails", async () => {
       RUN_URL: "https://github.com/NVIDIA-NeMo/nemo-platform/actions/runs/1234",
       SLACK_ALERTS_WEBHOOK: "https://hooks.slack.test/example",
       SLACK_ALERT_USERGROUP_ID: "S0123456789",
+      FORWARD_MERGE_RECOVERY_DOCS_URL:
+        "https://docs.example.com/forward-merge/",
     },
     fetchImpl: async (url, options) => {
       requests.push({ url, options });
@@ -266,6 +292,11 @@ test("falls back to the basic alert when PR metadata fails", async () => {
     /^<!subteam\^S0123456789>/,
   );
   assert.match(result.text, /Source: unavailable/);
+  assert.ok(
+    JSON.parse(requests[0].options.body).text.includes(
+      "<https://docs.example.com/forward-merge/|Forward-merge recovery guide>",
+    ),
+  );
   assert.match(result.text, /Conflict metadata unavailable/);
   assert.match(warnings[0], /Unable to read forward-merge PR/);
 

--- a/.github/workflows/forward-merge-alert.yaml
+++ b/.github/workflows/forward-merge-alert.yaml
@@ -33,6 +33,7 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           SLACK_ALERTS_WEBHOOK: ${{ secrets.SLACK_RELEASE_WEBHOOK }}
           SLACK_ALERT_USERGROUP_ID: ${{ secrets.SLACK_ALERT_USERGROUP_ID }}
+          FORWARD_MERGE_RECOVERY_DOCS_URL: ${{ secrets.FORWARD_MERGE_RECOVERY_DOCS_URL }}
         with:
           script: |
             const { sendForwardMergeAlert } = require("./.github/scripts/forward-merge-alert.cjs");


### PR DESCRIPTION
Forward-merge failure alerts now include a recovery guide link so developers can find the manual recovery steps directly from Slack.

The workflow reads the optional `FORWARD_MERGE_RECOVERY_DOCS_URL` repository secret. When unset or blank, alerts retain their existing behavior. The URL stays out of the repository; secret configuration will be handled separately.

Validation: all 18 JavaScript helper tests passed; ESLint, Prettier, actionlint, and diff checks passed for the changed files. `make check-github-scripts` was blocked by missing pnpm, Flox by cache permissions, and the full pre-commit run by workspace packages omitted from the sparse checkout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Forward-merge failure alerts can now include an optional recovery guide link.
  - Recovery guidance is shown across supported failure scenarios when configured.

- **Bug Fixes**
  - Recovery guidance is also included when pull request details cannot be retrieved.

- **Tests**
  - Added coverage for configured, missing, and blank recovery guide URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->