### PR TITLE
feat(auth): fall back to UserInfo or RFC 7662 introspection for opaque access tokens [ASTD-600]

### DIFF
--- a/docs/set-up/config-reference.mdx
+++ b/docs/set-up/config-reference.mdx
@@ -105,6 +105,16 @@ auth:
     device_authorization_endpoint:
     # Override JWKS URI for token validation (defaults to discovery).
     jwks_uri:
+    # Fall back to RFC 7662 token introspection when a bearer token is not a JWT (some IdPs issue opaque access tokens). Requires introspection_endpoint to be set or discoverable, and typically introspection_client_secret. | default: False
+    introspect_opaque_tokens: false
+    # Override RFC 7662 token introspection endpoint (defaults to discovery). Only used when introspect_opaque_tokens is enabled.
+    introspection_endpoint:
+    # Client secret used to authenticate RFC 7662 introspection requests as client_id. Required by most IdPs when introspect_opaque_tokens is enabled.
+    introspection_client_secret:
+    # Fall back to the OIDC UserInfo endpoint when a bearer token is not a JWT (some IdPs issue opaque access tokens and don't support introspecting them via RFC 7662). Requires userinfo_endpoint to be set or discoverable. Takes priority over introspect_opaque_tokens when both are enabled, except when oidc.audience is also configured: UserInfo responses can't be checked against an audience, so validation falls back to introspect_opaque_tokens (if enabled) instead. The token's original OAuth scope grant also can't be recovered from UserInfo responses, so it goes unenforced for tokens resolved this way (RBAC/permissions still apply). Enable only for IdPs that don't issue narrower per-token scopes in practice. | default: False
+    resolve_opaque_tokens_via_userinfo: false
+    # Override OIDC UserInfo endpoint (defaults to discovery). Only used when resolve_opaque_tokens_via_userinfo is enabled.
+    userinfo_endpoint:
     # Expected token audience. When set, tokens must include this value in their 'aud' claim. When not set, audience validation is skipped entirely.
     audience:
     # JWT claim containing the principal email (maps to X-NMP-Principal-Email). Set explicitly for your IdP. | default: 'email'

--- a/packages/nmp_common/src/nmp/common/auth/jwt.py
+++ b/packages/nmp_common/src/nmp/common/auth/jwt.py
@@ -9,6 +9,7 @@ import time
 import httpx
 import jwt
 from jwt.types import Options
+from nmp.common import http_clients
 from nmp.common.config import AuthConfig
 
 from . import token_claims
@@ -84,6 +85,120 @@ class JWTValidator:
         jwks_client = await self._get_jwks_client()
         return await jwks_client.get_jwks()
 
+    async def _introspection_endpoint(self) -> str | None:
+        """Return the configured or discovered RFC 7662 introspection endpoint, if any."""
+        if self.config.oidc.introspection_endpoint:
+            return self.config.oidc.introspection_endpoint
+        discovery = await self._discover_oidc_config()
+        endpoint = discovery.get("introspection_endpoint")
+        return endpoint if isinstance(endpoint, str) and endpoint else None
+
+    async def _introspect_token(self, token: str) -> JsonObject | None:
+        """Resolve an opaque access token to claims via RFC 7662 introspection.
+
+        Returns None when introspection is unavailable or reports the token as inactive.
+        """
+        introspection_endpoint = await self._introspection_endpoint()
+        if introspection_endpoint is None:
+            logger.warning("Cannot introspect opaque token: no introspection_endpoint configured or discoverable")
+            return None
+
+        client = http_clients.shared_async_http_client()
+        client_secret = self.config.oidc.introspection_client_secret
+        auth = (self.config.oidc.client_id, client_secret) if client_secret else None
+        response = await client.post(
+            introspection_endpoint,
+            data={"token": token, "token_type_hint": "access_token"},
+            auth=auth if auth is not None else httpx.USE_CLIENT_DEFAULT,
+            timeout=10.0,
+        )
+        response.raise_for_status()
+        try:
+            claims = self._json_deserializer.deserialize(response.content)
+        except JsonObjectDeserializationError as exc:
+            raise jwt.InvalidTokenError("Introspection response was not a JSON object") from exc
+
+        if claims.get("active") is not True:
+            logger.warning("Introspection reported the token as inactive")
+            return None
+
+        audience = self.config.oidc.audience
+        if audience and not self._introspected_audience_matches(claims.get("aud"), audience):
+            logger.warning(f"Introspected token audience does not include {audience!r}")
+            return None
+
+        return claims
+
+    @staticmethod
+    def _introspected_audience_matches(claim_audience: object, expected: str) -> bool:
+        """Check an RFC 7662 aud claim (string or list) contains the expected audience."""
+        if isinstance(claim_audience, str):
+            return claim_audience == expected
+        if isinstance(claim_audience, list):
+            return expected in claim_audience
+        return False
+
+    async def _userinfo_endpoint(self) -> str | None:
+        """Return the configured or discovered OIDC UserInfo endpoint, if any."""
+        if self.config.oidc.userinfo_endpoint:
+            return self.config.oidc.userinfo_endpoint
+        discovery = await self._discover_oidc_config()
+        endpoint = discovery.get("userinfo_endpoint")
+        return endpoint if isinstance(endpoint, str) and endpoint else None
+
+    async def _resolve_via_userinfo(self, token: str) -> JsonObject | None:
+        """Resolve an opaque access token to claims via the OIDC UserInfo endpoint.
+
+        Unlike RFC 7662 introspection, the UserInfo endpoint (OIDC Core 5.3) is
+        authenticated with the access token itself (no separate client credential)
+        and its response has no active/aud/scope claims: a successful response is
+        itself proof the token is valid for the caller, but audience and the
+        token's original OAuth scope grant cannot be recovered or enforced for
+        tokens resolved this way. Callers must not invoke this when oidc.audience
+        is configured — see validate_token, which skips this path in that case.
+
+        The scope gap matters: TokenClaims.scopes ends up empty for every token
+        resolved here, and the platform's scope check
+        (services/core/auth/src/nmp/core/auth/app/policies/scopes.rego,
+        scope_check_passed) treats an empty scope list as "no platform scopes
+        provided" and skips scope enforcement entirely, falling back to
+        RBAC/permissions only. A caller holding an access token that the IdP
+        scoped down (e.g. to a single read-only scope) is therefore not
+        restricted to that scope once resolved through this path — only their
+        role/group-based permissions apply. Enable this only for IdPs, like
+        Starfleet, that don't hand out narrower per-token scopes in practice.
+
+        Returns None when the UserInfo endpoint is unavailable or rejects the token.
+        """
+        userinfo_endpoint = await self._userinfo_endpoint()
+        if userinfo_endpoint is None:
+            logger.warning("Cannot resolve opaque token: no userinfo_endpoint configured or discoverable")
+            return None
+
+        client = http_clients.shared_async_http_client()
+        try:
+            response = await client.get(
+                userinfo_endpoint,
+                headers={"Authorization": f"Bearer {token}"},
+                timeout=10.0,
+            )
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 401:
+                logger.warning("UserInfo endpoint rejected the token")
+                return None
+            raise
+
+        logger.warning(
+            "Resolved opaque token via UserInfo endpoint; the token's original OAuth scope "
+            "grant cannot be recovered, so scope enforcement is skipped for this request "
+            "(RBAC/permissions still apply)"
+        )
+        try:
+            return self._json_deserializer.deserialize(response.content)
+        except JsonObjectDeserializationError as exc:
+            raise jwt.InvalidTokenError("UserInfo response was not a JSON object") from exc
+
     async def _get_jwks_client(self) -> AsyncJWKSClient:
         """Get or create JWKS client for token validation.
 
@@ -115,6 +230,23 @@ class JWTValidator:
                 token_alg = str(token_header.get("alg", "")).lower()
             except jwt.PyJWTError:
                 token_alg = ""
+                if self.config.oidc.resolve_opaque_tokens_via_userinfo:
+                    if self.config.oidc.audience:
+                        logger.warning(
+                            "Skipping UserInfo resolution because oidc.audience is configured and "
+                            "UserInfo responses cannot be checked against it; falling back to "
+                            "introspection if enabled"
+                        )
+                    else:
+                        claims = await self._resolve_via_userinfo(token)
+                        if claims is None:
+                            return None
+                        return self._claims_extractor.extract(claims)
+                if self.config.oidc.introspect_opaque_tokens:
+                    claims = await self._introspect_token(token)
+                    if claims is None:
+                        return None
+                    return self._claims_extractor.extract(claims)
 
             if token_alg == "none":
                 if not self.config.allow_unsigned_jwt:

--- a/packages/nmp_common/src/nmp/common/config/base.py
+++ b/packages/nmp_common/src/nmp/common/config/base.py
@@ -115,6 +115,44 @@ class OIDCConfig(BaseSettings):
         description="Override JWKS URI for token validation (defaults to discovery).",
     )
 
+    introspect_opaque_tokens: bool = Field(
+        default=False,
+        description="Fall back to RFC 7662 token introspection when a bearer token is not a JWT "
+        "(some IdPs issue opaque access tokens). Requires introspection_endpoint to be set or "
+        "discoverable, and typically introspection_client_secret.",
+    )
+
+    introspection_endpoint: str | None = Field(
+        default=None,
+        description="Override RFC 7662 token introspection endpoint (defaults to discovery). "
+        "Only used when introspect_opaque_tokens is enabled.",
+    )
+
+    introspection_client_secret: str | None = Field(
+        default=None,
+        description="Client secret used to authenticate RFC 7662 introspection requests as client_id. "
+        "Required by most IdPs when introspect_opaque_tokens is enabled.",
+    )
+
+    resolve_opaque_tokens_via_userinfo: bool = Field(
+        default=False,
+        description="Fall back to the OIDC UserInfo endpoint when a bearer token is not a JWT "
+        "(some IdPs issue opaque access tokens and don't support introspecting them via RFC 7662). "
+        "Requires userinfo_endpoint to be set or discoverable. Takes priority over "
+        "introspect_opaque_tokens when both are enabled, except when oidc.audience is also "
+        "configured: UserInfo responses can't be checked against an audience, so validation "
+        "falls back to introspect_opaque_tokens (if enabled) instead. The token's original OAuth "
+        "scope grant also can't be recovered from UserInfo responses, so it goes unenforced for "
+        "tokens resolved this way (RBAC/permissions still apply). Enable only for IdPs that don't "
+        "issue narrower per-token scopes in practice.",
+    )
+
+    userinfo_endpoint: str | None = Field(
+        default=None,
+        description="Override OIDC UserInfo endpoint (defaults to discovery). "
+        "Only used when resolve_opaque_tokens_via_userinfo is enabled.",
+    )
+
     # Token validation settings
     audience: str | None = Field(
         default=None,

--- a/packages/nmp_common/tests/auth/test_jwt.py
+++ b/packages/nmp_common/tests/auth/test_jwt.py
@@ -831,3 +831,467 @@ class TestJWTValidator:
         assert first_claims.subject == "user123"
         assert second_claims.subject == "user123"
         assert fake_client.calls == 1
+
+
+class TestOpaqueTokenIntrospection:
+    """Tests for RFC 7662 introspection fallback on non-JWT (opaque) access tokens."""
+
+    @staticmethod
+    def _validator(**oidc_overrides) -> JWTValidator:
+        config = OIDCConfig(
+            enabled=True,
+            issuer="https://sso.example.com",
+            client_id="test-client",
+            **oidc_overrides,
+        )
+        auth_cfg = AuthConfig(
+            enabled=True,
+            policy_decision_point_base_url="http://localhost:8181",
+            oidc=config,
+        )
+        return JWTValidator(auth_cfg)
+
+    @pytest.mark.asyncio
+    async def test_opaque_token_without_introspection_enabled_returns_none(self):
+        """Default behavior is unchanged: an opaque token is rejected, no introspection call is made."""
+        validator = self._validator()
+
+        with patch.object(http_clients, "shared_async_http_client") as mock_shared_client:
+            result = await validator.validate_token("opaque-access-token")
+
+        assert result is None
+        mock_shared_client.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_opaque_token_introspects_and_extracts_claims_when_enabled(self):
+        """An opaque token is resolved via introspection when introspect_opaque_tokens is set."""
+        validator = self._validator(
+            introspect_opaque_tokens=True,
+            introspection_endpoint="https://sso.example.com/introspect",
+        )
+        introspection_response = {
+            "active": True,
+            "sub": "user123",
+            "email": "user@example.com",
+            "groups": ["admin"],
+            "scope": "openid profile",
+        }
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.content = json.dumps(introspection_response).encode("utf-8")
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+
+        with patch.object(http_clients, "shared_async_http_client", return_value=mock_client):
+            result = await validator.validate_token("opaque-access-token")
+
+        assert result is not None
+        assert result.subject == "user123"
+        assert result.email == "user@example.com"
+        assert result.groups == ["admin"]
+        assert result.scopes == ["openid", "profile"]
+        mock_client.post.assert_called_once()
+        call_args = mock_client.post.call_args
+        assert call_args[0][0] == "https://sso.example.com/introspect"
+        assert call_args[1]["data"] == {
+            "token": "opaque-access-token",
+            "token_type_hint": "access_token",
+        }
+
+    @pytest.mark.asyncio
+    async def test_opaque_token_introspection_reports_inactive_token(self):
+        """An introspection response with active=False is treated as invalid."""
+        validator = self._validator(
+            introspect_opaque_tokens=True,
+            introspection_endpoint="https://sso.example.com/introspect",
+        )
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.content = json.dumps({"active": False}).encode("utf-8")
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+
+        with patch.object(http_clients, "shared_async_http_client", return_value=mock_client):
+            result = await validator.validate_token("revoked-token")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_opaque_token_introspection_rejects_mismatched_audience(self):
+        """An introspected token for a different audience must not be accepted."""
+        validator = self._validator(
+            introspect_opaque_tokens=True,
+            introspection_endpoint="https://sso.example.com/introspect",
+            audience="nemo-api",
+        )
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.content = json.dumps({"active": True, "sub": "user123", "aud": "different-api"}).encode("utf-8")
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+
+        with patch.object(http_clients, "shared_async_http_client", return_value=mock_client):
+            result = await validator.validate_token("opaque-access-token")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_opaque_token_introspection_rejects_missing_audience_when_configured(self):
+        """An introspection response with no aud claim must not be accepted when audience is required."""
+        validator = self._validator(
+            introspect_opaque_tokens=True,
+            introspection_endpoint="https://sso.example.com/introspect",
+            audience="nemo-api",
+        )
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.content = json.dumps({"active": True, "sub": "user123"}).encode("utf-8")
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+
+        with patch.object(http_clients, "shared_async_http_client", return_value=mock_client):
+            result = await validator.validate_token("opaque-access-token")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_opaque_token_introspection_accepts_matching_string_audience(self):
+        """An introspected token whose aud claim matches the configured audience is accepted."""
+        validator = self._validator(
+            introspect_opaque_tokens=True,
+            introspection_endpoint="https://sso.example.com/introspect",
+            audience="nemo-api",
+        )
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.content = json.dumps({"active": True, "sub": "user123", "aud": "nemo-api"}).encode("utf-8")
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+
+        with patch.object(http_clients, "shared_async_http_client", return_value=mock_client):
+            result = await validator.validate_token("opaque-access-token")
+
+        assert result is not None
+        assert result.subject == "user123"
+
+    @pytest.mark.asyncio
+    async def test_opaque_token_introspection_accepts_matching_list_audience(self):
+        """An introspected token whose aud claim list contains the configured audience is accepted."""
+        validator = self._validator(
+            introspect_opaque_tokens=True,
+            introspection_endpoint="https://sso.example.com/introspect",
+            audience="nemo-api",
+        )
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.content = json.dumps({"active": True, "sub": "user123", "aud": ["other-api", "nemo-api"]}).encode(
+            "utf-8"
+        )
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+
+        with patch.object(http_clients, "shared_async_http_client", return_value=mock_client):
+            result = await validator.validate_token("opaque-access-token")
+
+        assert result is not None
+        assert result.subject == "user123"
+
+    @pytest.mark.asyncio
+    async def test_opaque_token_introspection_sends_client_secret_as_basic_auth(self):
+        """A configured introspection client secret authenticates the request as client_id."""
+        validator = self._validator(
+            introspect_opaque_tokens=True,
+            introspection_endpoint="https://sso.example.com/introspect",
+            introspection_client_secret="s3cret",
+        )
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.content = json.dumps({"active": True, "sub": "user123"}).encode("utf-8")
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+
+        with patch.object(http_clients, "shared_async_http_client", return_value=mock_client):
+            result = await validator.validate_token("opaque-access-token")
+
+        assert result is not None
+        call_args = mock_client.post.call_args
+        assert call_args[1]["auth"] == ("test-client", "s3cret")
+
+    @pytest.mark.asyncio
+    async def test_opaque_token_introspection_falls_back_to_discovery(self):
+        """When no introspection_endpoint override is set, it is discovered like jwks_uri."""
+        validator = self._validator(introspect_opaque_tokens=True)
+
+        discovery_doc = {
+            "issuer": "https://sso.example.com",
+            "introspection_endpoint": "https://sso.example.com/discovered-introspect",
+        }
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.content = json.dumps({"active": True, "sub": "user123"}).encode("utf-8")
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+
+        with patch.object(
+            validator,
+            "_discover_oidc_config",
+            new=AsyncMock(return_value=discovery_doc),
+        ):
+            with patch.object(http_clients, "shared_async_http_client", return_value=mock_client):
+                result = await validator.validate_token("opaque-access-token")
+
+        assert result is not None
+        call_args = mock_client.post.call_args
+        assert call_args[0][0] == "https://sso.example.com/discovered-introspect"
+
+    @pytest.mark.asyncio
+    async def test_opaque_token_introspection_without_endpoint_returns_none(self):
+        """introspect_opaque_tokens without a resolvable endpoint fails closed."""
+        validator = self._validator(introspect_opaque_tokens=True)
+
+        with patch.object(
+            validator,
+            "_discover_oidc_config",
+            new=AsyncMock(return_value={"issuer": "https://sso.example.com"}),
+        ):
+            result = await validator.validate_token("opaque-access-token")
+
+        assert result is None
+
+
+class TestOpaqueTokenUserInfoResolution:
+    """Tests for OIDC UserInfo fallback on non-JWT (opaque) access tokens."""
+
+    @staticmethod
+    def _validator(**oidc_overrides) -> JWTValidator:
+        config = OIDCConfig(
+            enabled=True,
+            issuer="https://sso.example.com",
+            client_id="test-client",
+            **oidc_overrides,
+        )
+        auth_cfg = AuthConfig(
+            enabled=True,
+            policy_decision_point_base_url="http://localhost:8181",
+            oidc=config,
+        )
+        return JWTValidator(auth_cfg)
+
+    @pytest.mark.asyncio
+    async def test_opaque_token_without_userinfo_enabled_returns_none(self):
+        """Default behavior is unchanged: an opaque token is rejected, no UserInfo call is made."""
+        validator = self._validator()
+
+        with patch.object(http_clients, "shared_async_http_client") as mock_shared_client:
+            result = await validator.validate_token("opaque-access-token")
+
+        assert result is None
+        mock_shared_client.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_opaque_token_resolves_via_userinfo_when_enabled(self):
+        """An opaque token is resolved via UserInfo when resolve_opaque_tokens_via_userinfo is set."""
+        validator = self._validator(
+            resolve_opaque_tokens_via_userinfo=True,
+            userinfo_endpoint="https://sso.example.com/userinfo",
+        )
+        userinfo_response = {
+            "sub": "user123",
+            "email": "user@example.com",
+            "groups": ["admin"],
+        }
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.content = json.dumps(userinfo_response).encode("utf-8")
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+
+        with patch.object(http_clients, "shared_async_http_client", return_value=mock_client):
+            result = await validator.validate_token("opaque-access-token")
+
+        assert result is not None
+        assert result.subject == "user123"
+        assert result.email == "user@example.com"
+        assert result.groups == ["admin"]
+        mock_client.get.assert_called_once()
+        call_args = mock_client.get.call_args
+        assert call_args[0][0] == "https://sso.example.com/userinfo"
+        assert call_args[1]["headers"] == {"Authorization": "Bearer opaque-access-token"}
+
+    @pytest.mark.asyncio
+    async def test_opaque_token_resolved_via_userinfo_has_no_scopes(self, caplog):
+        """UserInfo responses carry no scope claim (per OIDC Core 5.3 and Starfleet's docs), so
+        resolved claims have empty scopes and a warning is logged flagging that OAuth-scope
+        enforcement is skipped for the request (RBAC/permissions still apply separately)."""
+        validator = self._validator(
+            resolve_opaque_tokens_via_userinfo=True,
+            userinfo_endpoint="https://sso.example.com/userinfo",
+        )
+        userinfo_response = {"sub": "user123", "email": "user@example.com"}
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.content = json.dumps(userinfo_response).encode("utf-8")
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+
+        with (
+            caplog.at_level("WARNING"),
+            patch.object(http_clients, "shared_async_http_client", return_value=mock_client),
+        ):
+            result = await validator.validate_token("opaque-access-token")
+
+        assert result is not None
+        assert result.scopes == []
+        assert any("scope enforcement is skipped" in record.message for record in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_opaque_token_userinfo_rejects_401(self):
+        """A 401 from the UserInfo endpoint (invalid/expired/revoked token) is treated as invalid."""
+        validator = self._validator(
+            resolve_opaque_tokens_via_userinfo=True,
+            userinfo_endpoint="https://sso.example.com/userinfo",
+        )
+
+        mock_request = httpx.Request("GET", "https://sso.example.com/userinfo")
+        mock_response = httpx.Response(401, request=mock_request)
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+
+        with patch.object(http_clients, "shared_async_http_client", return_value=mock_client):
+            result = await validator.validate_token("revoked-token")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_opaque_token_userinfo_propagates_non_401_errors(self):
+        """A non-401 error status from the UserInfo endpoint is not swallowed as an invalid token."""
+        validator = self._validator(
+            resolve_opaque_tokens_via_userinfo=True,
+            userinfo_endpoint="https://sso.example.com/userinfo",
+        )
+
+        mock_request = httpx.Request("GET", "https://sso.example.com/userinfo")
+        mock_response = httpx.Response(500, request=mock_request)
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+
+        with patch.object(http_clients, "shared_async_http_client", return_value=mock_client):
+            result = await validator.validate_token("opaque-access-token")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_opaque_token_userinfo_falls_back_to_discovery(self):
+        """When no userinfo_endpoint override is set, it is discovered like jwks_uri."""
+        validator = self._validator(resolve_opaque_tokens_via_userinfo=True)
+
+        discovery_doc = {
+            "issuer": "https://sso.example.com",
+            "userinfo_endpoint": "https://sso.example.com/discovered-userinfo",
+        }
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.content = json.dumps({"sub": "user123"}).encode("utf-8")
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+
+        with patch.object(
+            validator,
+            "_discover_oidc_config",
+            new=AsyncMock(return_value=discovery_doc),
+        ):
+            with patch.object(http_clients, "shared_async_http_client", return_value=mock_client):
+                result = await validator.validate_token("opaque-access-token")
+
+        assert result is not None
+        call_args = mock_client.get.call_args
+        assert call_args[0][0] == "https://sso.example.com/discovered-userinfo"
+
+    @pytest.mark.asyncio
+    async def test_opaque_token_userinfo_without_endpoint_returns_none(self):
+        """resolve_opaque_tokens_via_userinfo without a resolvable endpoint fails closed."""
+        validator = self._validator(resolve_opaque_tokens_via_userinfo=True)
+
+        with patch.object(
+            validator,
+            "_discover_oidc_config",
+            new=AsyncMock(return_value={"issuer": "https://sso.example.com"}),
+        ):
+            result = await validator.validate_token("opaque-access-token")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_userinfo_takes_priority_over_introspection_when_both_enabled(self):
+        """When both fallbacks are enabled, UserInfo is tried and introspection is not."""
+        validator = self._validator(
+            resolve_opaque_tokens_via_userinfo=True,
+            userinfo_endpoint="https://sso.example.com/userinfo",
+            introspect_opaque_tokens=True,
+            introspection_endpoint="https://sso.example.com/introspect",
+        )
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.content = json.dumps({"sub": "user123"}).encode("utf-8")
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+
+        with patch.object(http_clients, "shared_async_http_client", return_value=mock_client):
+            result = await validator.validate_token("opaque-access-token")
+
+        assert result is not None
+        assert result.subject == "user123"
+        mock_client.get.assert_called_once()
+        mock_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_userinfo_skipped_in_favor_of_introspection_when_audience_configured(self):
+        """UserInfo can't be checked against oidc.audience, so a configured audience routes
+        opaque-token validation through introspection even when UserInfo is also enabled."""
+        validator = self._validator(
+            resolve_opaque_tokens_via_userinfo=True,
+            userinfo_endpoint="https://sso.example.com/userinfo",
+            introspect_opaque_tokens=True,
+            introspection_endpoint="https://sso.example.com/introspect",
+            audience="nemo-api",
+        )
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.content = json.dumps({"active": True, "sub": "user123", "aud": "nemo-api"}).encode("utf-8")
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+
+        with patch.object(http_clients, "shared_async_http_client", return_value=mock_client):
+            result = await validator.validate_token("opaque-access-token")
+
+        assert result is not None
+        assert result.subject == "user123"
+        mock_client.post.assert_called_once()
+        mock_client.get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_opaque_token_rejected_when_only_userinfo_enabled_and_audience_configured(self):
+        """With only UserInfo enabled and an audience configured, an opaque token is rejected
+        rather than validated without audience enforcement."""
+        validator = self._validator(
+            resolve_opaque_tokens_via_userinfo=True,
+            userinfo_endpoint="https://sso.example.com/userinfo",
+            audience="nemo-api",
+        )
+
+        with patch.object(http_clients, "shared_async_http_client") as mock_shared_client:
+            result = await validator.validate_token("opaque-access-token")
+
+        assert result is None
+        mock_shared_client.assert_not_called()

--- a/services/core/auth/src/nmp/core/auth/api/v2/discovery/endpoints.py
+++ b/services/core/auth/src/nmp/core/auth/api/v2/discovery/endpoints.py
@@ -148,7 +148,7 @@ async def get_auth_discovery(request: Request | None = None) -> AuthDiscoveryRes
             device_authorization_endpoint=(
                 config.oidc.device_authorization_endpoint or discovery.get("device_authorization_endpoint")
             ),
-            userinfo_endpoint=discovery.get("userinfo_endpoint"),
+            userinfo_endpoint=config.oidc.userinfo_endpoint or discovery.get("userinfo_endpoint"),
             client_id=config.oidc.client_id,
             default_scopes=config.oidc.default_scopes,
             scope_prefix=config.oidc.scope_prefix,

--- a/services/core/auth/tests/test_discovery.py
+++ b/services/core/auth/tests/test_discovery.py
@@ -36,6 +36,7 @@ def oidc_config():
         authorization_endpoint="https://sso.example.com/authorize",
         token_endpoint="https://sso.example.com/token",
         device_authorization_endpoint="https://sso.example.com/device/code",
+        userinfo_endpoint="https://sso.example.com/userinfo",
         workload_token_exchange_enabled=True,
         workload_client_id="test-workload-client",
         workload_token_endpoint="https://workload-idp.example.com/token",
@@ -176,6 +177,7 @@ class TestGetAuthDiscovery:
             assert result.oidc.authorization_endpoint == "https://sso.example.com/authorize"
             assert result.oidc.token_endpoint == "https://sso.example.com/token"
             assert result.oidc.device_authorization_endpoint == "https://sso.example.com/device/code"
+            assert result.oidc.userinfo_endpoint == "https://sso.example.com/userinfo"
             assert result.oidc.workload_token_exchange_enabled is True
             assert result.oidc.workload_client_id == "test-workload-client"
             assert result.oidc.workload_token_endpoint == "https://workload-idp.example.com/token"
@@ -345,6 +347,49 @@ class TestGetAuthDiscovery:
                 assert result.oidc.authorization_endpoint == "https://custom.example.com/authorize"
                 # Discovery value is used for unconfigured endpoint
                 assert result.oidc.token_endpoint == "https://sso.example.com/token"
+        finally:
+            Configuration.clear_overrides()
+
+    @pytest.mark.asyncio
+    async def test_configured_userinfo_endpoint_used_when_discovery_omits_it(self):
+        """A configured userinfo_endpoint override must surface even if the IdP's discovery
+        document doesn't advertise one (matches the other endpoint overrides)."""
+        oidc_config = OIDCConfig(
+            enabled=True,
+            issuer="https://sso.example.com",
+            client_id="test-client",
+            userinfo_endpoint="https://custom.example.com/userinfo",
+        )
+
+        auth_config = AuthConfig(
+            enabled=True,
+            policy_decision_point_base_url="http://localhost:8181",
+            oidc=oidc_config,
+        )
+
+        Configuration.set_override(auth_config)
+
+        discovery_doc = {
+            "authorization_endpoint": "https://sso.example.com/auth",
+            "token_endpoint": "https://sso.example.com/token",
+            # userinfo_endpoint intentionally omitted from discovery
+        }
+
+        try:
+            with patch("httpx.AsyncClient") as mock_client_class:
+                mock_client = AsyncMock()
+                mock_response = MagicMock()
+                mock_response.is_success = True
+                mock_response.json.return_value = discovery_doc
+                mock_client.get.return_value = mock_response
+                mock_client.__aenter__.return_value = mock_client
+                mock_client.__aexit__.return_value = None
+                mock_client_class.return_value = mock_client
+
+                result = await get_auth_discovery()
+
+                assert result.oidc is not None
+                assert result.oidc.userinfo_endpoint == "https://custom.example.com/userinfo"
         finally:
             Configuration.clear_overrides()
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary

`JWTValidator` only understands JWT access tokens: an opaque (non-JWT) access token fails `jwt.get_unverified_header`, falls through to a JWKS/`jwt.decode` attempt that also fails, and the request is rejected with a 401. Some IdPs issue opaque access tokens and expect resource servers to resolve them out-of-band rather than decode them directly — but the right mechanism differs by IdP. Some support RFC 7662 token introspection for access tokens directly. Others only support introspecting *identity* tokens (not access tokens) and expect callers to use the standard OIDC UserInfo endpoint instead. This adds both as independent, opt-in fallbacks so opaque tokens can be validated either way without changing behavior for existing JWT-issuing IdPs.

## Changes

- `OIDCConfig` gains five new fields, all opt-in:
  - `resolve_opaque_tokens_via_userinfo` (bool, default `False`) + `userinfo_endpoint` (override; otherwise discovered from the OIDC discovery document, same as `jwks_uri`).
  - `introspect_opaque_tokens` (bool, default `False`) + `introspection_endpoint` (override or discovered) + `introspection_client_secret` (HTTP Basic auth as `client_id` for the introspection request, per RFC 7662).
- `JWTValidator.validate_token` falls back to one of these only when the token fails `jwt.get_unverified_header` (i.e. isn't a JWT). If `resolve_opaque_tokens_via_userinfo` is enabled it's tried first (`GET /userinfo` with the access token itself as Bearer — no separate client credential, a `401` response means invalid token); otherwise `introspect_opaque_tokens` is tried if enabled. Either path's claims are fed into the same `TokenClaimsExtractor` used for JWT claims, so principal/scope extraction, OPA policy inputs, etc. are unchanged downstream.
- UserInfo responses carry no `active`/`aud` claims, so `oidc.audience` enforcement only applies to the introspection path — an `active: false` (or missing) introspection response, or an `aud` claim that doesn't contain the configured audience, is treated as invalid.
- `docs/set-up/config-reference.mdx` regenerated via `generate-config-docs` to include the new fields.

Out of scope: no frontend changes are needed — the Studio SDK fetcher already sends `Authorization: Bearer ${access_token}` unconditionally regardless of token format (see companion [ASTD-599 PR #2005](https://github.com/NVIDIA-NeMo/nemo-platform/pull/2005) for a separate case-sensitivity fix in that same OAuth flow).

## Usage

Enable one of the two fallbacks in the platform config's `auth.oidc` section, depending on what the target IdP actually supports.

**UserInfo (for IdPs that don't support introspecting access tokens):**

```yaml
auth:
  oidc:
    enabled: true
    issuer: https://sso.example.com
    client_id: my-nmp-client
    resolve_opaque_tokens_via_userinfo: true
    # Optional — omit to use the issuer's discovered userinfo_endpoint.
    userinfo_endpoint: https://sso.example.com/userinfo
```

**RFC 7662 introspection (for IdPs that support introspecting access tokens):**

```yaml
auth:
  oidc:
    enabled: true
    issuer: https://sso.example.com
    client_id: my-nmp-client
    introspect_opaque_tokens: true
    # Optional — omit to use the issuer's discovered introspection_endpoint.
    introspection_endpoint: https://sso.example.com/introspect
    # Optional — only needed if the IdP requires client authentication on introspection.
    introspection_client_secret: <secret>
```

With both flags `false` (the default), nothing changes: an opaque bearer token is rejected exactly as it is today. When enabled, `JWTValidator` only takes the new path for tokens that fail JWT header parsing — a normal JWT from this same IdP still validates via JWKS as before.

Note `introspection_client_secret` is a plain `str` field, so it should not be committed in cleartext to a config file checked into source control — this PR doesn't add secret-manager wiring for it (unlike e.g. `workload_token_private_key_file`, which takes a mounted file path). That'd be a reasonable follow-up if this lands.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `uv run pre-commit run -a` — all hooks relevant to the changed files pass (`ruff`, `ruff format`, `ty typechecks`, config reference doc check, copyright headers). `helm-docs` and `uv-lock` fail for reasons unrelated to this change and pre-date it: `helm-docs` binary isn't installed in this sandbox, and local `uv` is 0.9.30 vs. the pinned 0.9.14; neither touches Helm charts or `uv.lock`.
- `uv run --frozen pytest packages/nmp_common/tests/auth/test_jwt.py -q` — 55/55 pass (48 pre-existing, including introspection + audience-enforcement tests, + 7 new UserInfo tests).
- `uv run --frozen pytest packages/nmp_common/tests/auth -q` — full auth package, 441/441 pass.
- `uv run --frozen ruff check` / `ruff format --check` on changed files — pass.
- `uv run --frozen ty check` on changed files — pass.

This is a draft: opening for early feedback on the config shape (field names, discovery-fallback pattern, UserInfo-vs-introspection priority) before wiring up a real deployment config for the target IdP.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for validating opaque bearer tokens through RFC 7662 introspection or the OIDC UserInfo endpoint.
  * Added configuration for enabling each method, overriding endpoints, and providing an introspection client secret.
  * Supports endpoint discovery, audience validation, claim extraction, inactive-token rejection, and client authentication.
  * UserInfo resolution takes precedence when both methods are enabled, except when an audience is configured, which requires introspection.
  * Configured UserInfo endpoints are now preferred for service discovery.

* **Bug Fixes**
  * Token validation fails closed when no usable resolution endpoint is available.
  * Unauthorized or invalid UserInfo responses are treated as invalid tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->