### PR TITLE
fix(eval-author): validate trace candidate metadata before construction

### DIFF
--- a/plugins/nemo-eval-author/skills/eval-author-trace-environment/SKILL.md
+++ b/plugins/nemo-eval-author/skills/eval-author-trace-environment/SKILL.md
@@ -175,6 +175,11 @@ text field in `safe/trace.atif.json`, every audit finding and host, then record
 who performed this trace review. Generated task files do not exist yet; review
 the complete publication separately after finalization.
 
+Use the audit's field and character denominator to plan bounded reads. If a tool
+truncates output, continue through the omitted fields or character ranges; a
+truncated display does not establish missing trace evidence. If review cannot
+finish, retain that limitation without issuing a complete review attestation.
+
 ```bash
 python <skill_dir>/scripts/trace_environment.py review-privacy \
   --task-dir <task-dir> \
@@ -235,6 +240,8 @@ Read only `safe/trace.atif.json`. Later user corrections outrank earlier turns.
 Every decision must cite real ATIF `step_id` values. Read
 [references/candidate-record.md](references/candidate-record.md) for the
 `candidate.json` shape before writing the decision.
+Run its read-only `check-candidate` command before construction; it checks
+metadata, not execution, privacy review or readiness.
 
 Use `candidate` only when the request and expected outcome are complete,
 reproducible without private or live external state, and objectively testable.
@@ -259,7 +266,8 @@ folding them into `insufficient_trace_evidence`: use `malformed_atif`,
 `source_too_large`, `build_dependency_unavailable`,
 `verifier_dependency_unavailable`, `network_dependency_required`, and
 `verifier_not_isolated` where applicable. Record the concrete failed command or
-contract check in `did_not_work`; keep `reason_codes` stable and aggregateable.
+contract check in the summary using Step 7's `finalize --did-not-work`, not as an
+extra field in `candidate.json`; keep `reason_codes` stable and aggregateable.
 
 ## Step 6: author and prove a candidate environment
 

--- a/plugins/nemo-eval-author/skills/eval-author-trace-environment/references/candidate-record.md
+++ b/plugins/nemo-eval-author/skills/eval-author-trace-environment/references/candidate-record.md
@@ -5,7 +5,46 @@
 
 Read this when writing the Step 5 decision. Replace illustrative values with
 reviewed evidence; this example is not a ready candidate while required software
-availability remains unknown. The helper validates the record during finalization.
+availability remains unknown. Validate metadata before building a task:
+
+```bash
+python <skill_dir>/scripts/trace_environment.py check-candidate --task-dir <task-dir>
+```
+
+This read-only check validates the existing record, prepared safe-trace digest,
+evidence step references and retained ground-truth artifacts. It does not edit
+values, finalize the workspace, attest privacy review or prove the environment.
+Finalization still enforces its full contract.
+
+## Accepted values
+
+Use these exact enum values, not product names, SPDX identifiers or descriptive
+synonyms. Put those details in `name`, `version` or `notes` instead.
+
+| Field | Accepted values |
+| --- | --- |
+| `ground_truth.availability` | `available`, `partial`, `absent`, `unknown` |
+| `ground_truth.use` | `none`, `comparison_only`, `verification` |
+| Artifact `kind` | `reference_trace`, `expected_output`, `dataset`, `fixture`, `verifier`, `human_feedback`, `other` |
+| Software `category` | `library`, `cli`, `desktop_application`, `service`, `hardware`, `other` |
+| Software `license` | `open_source`, `proprietary`, `commercial`, `unknown`, `not_applicable` |
+| Software `availability` | `available`, `installable`, `unavailable`, `unknown` |
+| Provenance `kind` | `atif_step`, `external` |
+
+Software `required` is a boolean; `redistributable` is a boolean or null.
+`version` is nonempty text or null. Software names must be unique ignoring case.
+Every software item and ground-truth artifact needs nonempty `notes` and complete
+provenance; use the skill's ATIF-versus-external evidence rules.
+
+Available or partial ground truth must retain at least one hashed artifact and
+declare comparison or verification use. Partial ground truth needs an
+`absence_reason`; available ground truth sets it to null. Absent or unknown
+ground truth needs an empty artifact list, `use: "none"`, and a nonempty reason.
+
+## Example
+
+Include exactly the keys shown below. Summary fields such as `did_not_work`
+belong to `finalize` arguments, not the candidate record.
 
 ```json
 {

--- a/plugins/nemo-eval-author/skills/eval-author-trace-environment/references/environment-integrity.md
+++ b/plugins/nemo-eval-author/skills/eval-author-trace-environment/references/environment-integrity.md
@@ -33,6 +33,16 @@ accepts separate verification; the task-specific preflight fails closed there.
 Do not flatten a multi-step task just to pass. Every actual job must still pass
 the existing checksum, identity, reward and separate-mode result checks.
 
+## Preserve the recorded task's scope
+
+Minimal construction does not authorize narrowing the requested outcome or
+permitted implementation choices. Preserve allowed languages, dependencies and
+multi-file deliverables; declare their complete output closure for transfer
+instead of imposing a single-file or standard-library-only solution for
+convenience. Record any evidence-backed generalization explicitly. If necessary
+dependencies or outputs cannot be supported within isolation, retain that
+limitation rather than silently substituting an easier task.
+
 ## Network isolation
 
 In addition to the separate no-network verifier contract, require the agent
@@ -72,6 +82,49 @@ environment_mode = "separate"
 [steps.verifier.environment]
 network_mode = "no-network"
 ```
+
+### Artifact handoff and verifier images
+
+In Harbor's separate environment, explicitly declared artifacts are restored at
+their original `source` paths. An artifact `destination` changes the host result
+layout, not the path used by the verifier. For example:
+
+```toml
+# Top-level task.toml, before any section header:
+artifacts = [{ source = "/app/result.txt", destination = "submission/result.txt" }]
+```
+
+The verifier reads `/app/result.txt`, not `/logs/artifacts/submission/result.txt`.
+The conventional `/logs/artifacts` directory is a different publish mechanism;
+do not mix these layouts. Check the installed Harbor artifact API when using a
+different provider revision, and prove the actual handoff with NOP and Oracle.
+Transfer only the declared outputs; do not broaden the transfer to make a path
+mismatch disappear.
+
+Choose one verifier image path and include its complete offline grading closure:
+
+- **Build recipe:** provide `tests/Dockerfile` with the required runtime and
+  `COPY . /tests/`; leave `[verifier.environment].docker_image` unset so Harbor
+  builds that recipe. The resulting image must contain `/tests/test.sh` and every
+  file it needs.
+- **Prebuilt image:** set `docker_image` to an immutable image already containing
+  the complete `/tests` tree and runtime. A vanilla language image does not
+  contain the authored tests. Do not assume a sibling Dockerfile is built or
+  tests are uploaded when a prebuilt image is selected.
+
+Check inherited image entrypoints, commands, users and environment variables
+against Harbor's startup and execution lifecycle. A successful image build does
+not prove that the container stays available or its tools work under the
+configured user. Retain build, startup and grading failures separately; do not
+infer a verifier or reference-solution defect when execution never reached them.
+
+Separate verification does not preserve the agent's running processes. For a
+configuration deliverable, a fresh verifier-owned service can test the declared
+configuration. This proves replay, not that the agent left a service running.
+Do not substitute replay for a requested live-state outcome; if the provider
+cannot test that outcome within the isolation contract, retain the limitation
+and use `verifier_not_isolated` rather than weakening the task. Label agent-side
+collected observations as untrusted evidence, not independent runtime proof.
 
 ## Reviewer documentation
 
@@ -129,6 +182,11 @@ credentials, credential-bearing URLs, and symlinks. It is a static task-tree
 gate, not an inspection of opaque image layers. Keep image-construction
 transcripts private and inspect pre-existing opaque images separately.
 
+A duplicate-file finding establishes byte equality, not the file's semantic role:
+public starting-state fixtures can also be retained by the verifier. Report that
+distinction when supported by the instruction and file contents, while retaining
+the failed gate. Do not reformat duplicates or weaken the scanner to evade it.
+
 ## Repeat and negative-control proof
 
 Run every arm as an independent Harbor invocation with new task containers.
@@ -140,6 +198,11 @@ The negative control must be a deliberately incomplete or subtly incorrect,
 non-crashing solution relevant to the task and must receive reward `0`. Do not
 reuse NOP as the negative control. Record the mutation in private construction
 notes without exposing verifier logic.
+
+Check the installed Harbor custom-agent constructor and execution interface
+before choosing a base class. Built-in Oracle may receive task paths and other
+orchestration arguments that custom import-path agents do not; importing an
+Oracle subclass alone does not prove it can be instantiated as a custom control.
 
 Before **every** invocation, run `record-run-inputs` with its arm and future job
 directory (see the skill's NOP example). This writes an owner-private receipt

--- a/plugins/nemo-eval-author/skills/eval-author-trace-environment/scripts/trace_environment.py
+++ b/plugins/nemo-eval-author/skills/eval-author-trace-environment/scripts/trace_environment.py
@@ -967,14 +967,14 @@ def _validate_ground_truth(task_dir: Path, value: Any, step_ids: set[int]) -> di
     if not isinstance(value, dict) or set(value) != _GROUND_TRUTH_KEYS:
         raise ContractError("candidate.ground_truth fields do not match the versioned contract")
     availability = value.get("availability")
-    if availability not in {"available", "partial", "absent", "unknown"}:
+    if not isinstance(availability, str) or availability not in {"available", "partial", "absent", "unknown"}:
         raise ContractError("candidate.ground_truth.availability is not recognized")
     artifacts = value.get("artifacts")
     if not isinstance(artifacts, list):
         raise ContractError("candidate.ground_truth.artifacts must be a list")
     absence_reason = value.get("absence_reason")
     use = value.get("use")
-    if use not in {"none", "comparison_only", "verification"}:
+    if not isinstance(use, str) or use not in {"none", "comparison_only", "verification"}:
         raise ContractError("candidate.ground_truth.use is not recognized")
     if absence_reason is not None and (not isinstance(absence_reason, str) or not absence_reason.strip()):
         raise ContractError("candidate.ground_truth.absence_reason must be null or nonempty text")
@@ -1004,7 +1004,7 @@ def _validate_ground_truth(task_dir: Path, value: Any, step_ids: set[int]) -> di
         label = f"candidate.ground_truth.artifacts[{index}]"
         if not isinstance(artifact, dict) or set(artifact) != _GROUND_TRUTH_ARTIFACT_KEYS:
             raise ContractError(f"{label} fields do not match the versioned contract")
-        if artifact.get("kind") not in allowed_kinds:
+        if not isinstance(artifact.get("kind"), str) or artifact["kind"] not in allowed_kinds:
             raise ContractError(f"{label}.kind is not recognized")
         relative_path = artifact.get("path")
         if not isinstance(relative_path, str) or not relative_path.startswith("private/ground-truth/"):
@@ -1044,16 +1044,19 @@ def _validate_software_requirements(value: Any, step_ids: set[int]) -> list[dict
         if not isinstance(name, str) or not name.strip() or name.casefold() in names:
             raise ContractError(f"{label}.name must be nonempty and unique")
         names.add(name.casefold())
-        if requirement.get("category") not in allowed_categories:
+        if not isinstance(requirement.get("category"), str) or requirement["category"] not in allowed_categories:
             raise ContractError(f"{label}.category is not recognized")
         if type(requirement.get("required")) is not bool:
             raise ContractError(f"{label}.required must be a boolean")
         version = requirement.get("version")
         if version is not None and (not isinstance(version, str) or not version.strip()):
             raise ContractError(f"{label}.version must be null or nonempty text")
-        if requirement.get("license") not in allowed_licenses:
+        if not isinstance(requirement.get("license"), str) or requirement["license"] not in allowed_licenses:
             raise ContractError(f"{label}.license is not recognized")
-        if requirement.get("availability") not in allowed_availability:
+        if (
+            not isinstance(requirement.get("availability"), str)
+            or requirement["availability"] not in allowed_availability
+        ):
             raise ContractError(f"{label}.availability is not recognized")
         redistributable = requirement.get("redistributable")
         if redistributable is not None and type(redistributable) is not bool:
@@ -1101,6 +1104,36 @@ def _validate_candidate(task_dir: Path, status: str, step_ids: set[int]) -> dict
         if candidate.get("requirements") != []:
             raise ContractError("no_candidate records must set requirements to an empty list")
     return candidate
+
+
+def _check_candidate(args: argparse.Namespace) -> dict[str, Any]:
+    """Check authored metadata against its prepared evidence without changing it."""
+    task_dir = _ensure_task_dir(args.task_dir)
+    summary = _load_summary(task_dir)
+    source = summary["source"]
+    if source is None:
+        raise ContractError("prepare ATIF evidence before checking candidate metadata")
+    safe_path = task_dir / source["safe_path"]
+    if safe_path.is_symlink() or not safe_path.is_file():
+        raise ContractError("safe ATIF must be a retained regular file")
+    if safe_path.stat().st_size > MAX_CANONICAL_BYTES:
+        raise ContractError(f"safe ATIF exceeds the {MAX_CANONICAL_BYTES}-byte limit")
+    safe_bytes = safe_path.read_bytes()
+    if _sha256(safe_bytes) != source["safe_sha256"] or len(safe_bytes) != source["safe_size_bytes"]:
+        raise ContractError("safe ATIF digest or size changed")
+    safe_payload = _load_object(safe_path, label="safe ATIF")
+    _validate_trajectory(safe_payload)
+    status = _load_object(task_dir / "candidate.json", label="candidate").get("status")
+    if status not in ("candidate", "no_candidate"):
+        raise ContractError("candidate.status must be candidate or no_candidate")
+    _validate_candidate(task_dir, status, {step["step_id"] for step in safe_payload["steps"]})
+    return {
+        "task_dir": str(task_dir),
+        "valid": True,
+        "scope": "candidate_metadata",
+        "status": status,
+        "execution_verified": False,
+    }
 
 
 def _task_tree_info(root: Path) -> dict[str, Any]:
@@ -2501,6 +2534,13 @@ def _parser() -> argparse.ArgumentParser:
     review.add_argument("--reviewer-kind", choices=("agent", "human"), required=True)
     review.add_argument("--note", required=True)
     review.set_defaults(run=_review_privacy)
+
+    candidate_check = subparsers.add_parser(
+        "check-candidate",
+        help="read-only metadata and evidence-reference check; does not prove execution or privacy review",
+    )
+    candidate_check.add_argument("--task-dir", required=True, type=Path)
+    candidate_check.set_defaults(run=_check_candidate)
 
     reproducibility = subparsers.add_parser(
         "record-reproducibility", help="hash the task tree and record portability and contamination evidence"

--- a/plugins/nemo-eval-author/tests/test_trace_environment.py
+++ b/plugins/nemo-eval-author/tests/test_trace_environment.py
@@ -131,6 +131,159 @@ def _candidate(
     _write_json(task_dir / "candidate.json", payload)
 
 
+@pytest.mark.parametrize("status", ["candidate", "no_candidate"])
+def test_check_candidate_is_read_only_before_construction(tmp_path: Path, status: str) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _candidate(task_dir, status=status)
+    before = {
+        path.relative_to(task_dir): (path.read_bytes(), path.stat().st_mode)
+        for path in task_dir.rglob("*")
+        if path.is_file()
+    }
+
+    code, result = _run("check-candidate", "--task-dir", str(task_dir))
+
+    assert code == 0, result
+    assert result["scope"] == "candidate_metadata"
+    assert result["execution_verified"] is False
+    assert result["status"] == status
+    assert not (task_dir / "task/task.toml").exists()
+    assert json.loads((task_dir / "summary.json").read_text())["status"] == "pending"
+    assert before == {
+        path.relative_to(task_dir): (path.read_bytes(), path.stat().st_mode)
+        for path in task_dir.rglob("*")
+        if path.is_file()
+    }
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("category", "runtime"),
+        ("license", "Apache-2.0"),
+        ("availability", "not_installed"),
+        ("category", []),
+        ("license", {}),
+        ("availability", []),
+    ],
+)
+def test_check_candidate_rejects_unknown_software_enum_without_repair(tmp_path: Path, field: str, value: Any) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    software = _software(required=False, availability="unknown")
+    software[field] = value
+    _candidate(task_dir, software_requirements=[software])
+    before = (task_dir / "candidate.json").read_bytes()
+
+    code, result = _run("check-candidate", "--task-dir", str(task_dir))
+
+    assert code == 1
+    assert f"software_requirements[0].{field} is not recognized" in result["error"]
+    assert (task_dir / "candidate.json").read_bytes() == before
+
+
+@pytest.mark.parametrize("field,value", [("availability", []), ("use", {})])
+def test_check_candidate_rejects_invalid_ground_truth_enum(tmp_path: Path, field: str, value: Any) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _candidate(task_dir)
+    path = task_dir / "candidate.json"
+    candidate = json.loads(path.read_text())
+    candidate["ground_truth"][field] = value
+    _write_json(path, candidate)
+    code, result = _run("check-candidate", "--task-dir", str(task_dir))
+    assert code == 1
+    assert f"ground_truth.{field} is not recognized" in result["error"]
+
+
+def test_check_candidate_rejects_unknown_evidence_step(tmp_path: Path) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _candidate(task_dir)
+    path = task_dir / "candidate.json"
+    candidate = json.loads(path.read_text())
+    candidate["evidence_steps"] = [999]
+    _write_json(path, candidate)
+
+    code, result = _run("check-candidate", "--task-dir", str(task_dir))
+
+    assert code == 1
+    assert "evidence_steps" in result["error"]
+
+
+def test_check_candidate_rejects_changed_safe_trace(tmp_path: Path) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _candidate(task_dir)
+    path = task_dir / "safe/trace.atif.json"
+    safe = json.loads(path.read_text())
+    safe["steps"][0]["message"] = "Changed evidence"
+    _write_json(path, safe)
+
+    code, result = _run("check-candidate", "--task-dir", str(task_dir))
+
+    assert code == 1
+    assert "safe ATIF digest or size changed" in result["error"]
+
+
+@pytest.mark.parametrize("status", ["pending", [], None])
+def test_check_candidate_rejects_invalid_status(tmp_path: Path, status: Any) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _candidate(task_dir)
+    path = task_dir / "candidate.json"
+    candidate = json.loads(path.read_text())
+    candidate["status"] = status
+    _write_json(path, candidate)
+    code, result = _run("check-candidate", "--task-dir", str(task_dir))
+    assert code == 1
+    assert "candidate.status" in result["error"]
+
+
+def test_check_candidate_requires_prepared_evidence(tmp_path: Path) -> None:
+    root = tmp_path / ".eval-author" / "trace-environments"
+    code, result = _run("init", "--root", str(root), "--task-id", "repair-fixture")
+    assert code == 0, result
+    task_dir = Path(result["task_dir"])
+    _candidate(task_dir)
+    code, result = _run("check-candidate", "--task-dir", str(task_dir))
+    assert code == 1
+    assert "prepare ATIF evidence" in result["error"]
+
+
+def test_check_candidate_rejects_summary_fields_without_moving_them(tmp_path: Path) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _candidate(task_dir, status="no_candidate")
+    path = task_dir / "candidate.json"
+    candidate = json.loads(path.read_text())
+    candidate["did_not_work"] = ["Construction note for the summary."]
+    _write_json(path, candidate)
+    before = path.read_bytes()
+    summary_before = (task_dir / "summary.json").read_bytes()
+    code, result = _run("check-candidate", "--task-dir", str(task_dir))
+    assert code == 1
+    assert "candidate fields do not match" in result["error"]
+    assert path.read_bytes() == before
+    assert (task_dir / "summary.json").read_bytes() == summary_before
+
+
+def test_check_candidate_rejects_oversized_safe_trace_before_loading(tmp_path: Path) -> None:
+    task_dir, _ = _workspace(tmp_path)
+    _candidate(task_dir)
+    path = task_dir / "safe/trace.atif.json"
+    with path.open("wb") as stream:
+        stream.truncate(25 * 1024 * 1024 + 1)
+    code, result = _run("check-candidate", "--task-dir", str(task_dir))
+    assert code == 1
+    assert "safe ATIF exceeds" in result["error"]
+
+
+def test_check_candidate_rejects_symlinked_safe_trace(tmp_path: Path) -> None:
+    task_dir, source = _workspace(tmp_path)
+    _candidate(task_dir)
+    path = task_dir / "safe/trace.atif.json"
+    path.unlink()
+    path.symlink_to(source)
+    code, result = _run("check-candidate", "--task-dir", str(task_dir))
+    assert code == 1
+    assert "safe ATIF must be a retained regular file" in result["error"]
+
+
 def _review_privacy(task_dir: Path, *, reviewer_kind: str = "agent") -> None:
     code, result = _run(
         "review-privacy",


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
<!-- In 1-3 plain sentences, explain what changes and why. Describe before-and-after behavior when it applies. -->

Stacked on #1980: catch trace-candidate metadata errors before environment construction and clarify evidence-based authoring for separate verifier environments. These general changes address findings from the completed 89-trace baseline; they do not patch generated tasks or relax proof/security gates.

## Changes
<!-- List the concrete changes included in this pull request. -->

- Add read-only `check-candidate` for prepared evidence integrity, candidate metadata, evidence references and retained ground truth; no repair, finalization or execution claim.
- Return contract errors for malformed enum types instead of unhashable-value exceptions; preserve accepted enum values.
- Document exact candidate keys/enums and direct summary notes to `finalize --did-not-work`.
- Clarify separate-verifier source paths, complete verifier image/test packaging, custom negative-agent interfaces and image startup compatibility.
- Require bounded complete privacy reads and preservation of allowed languages, dependencies, multi-file deliverables and live-state outcomes. Retain duplicate-input gate failures rather than evading them.
- Add regression coverage for read-only behavior, malformed metadata, missing/changed/oversized/symlinked evidence and misplaced summary fields.

Scope: exactly five files in the trace-environment skill and its test module. No shared eval-author router, generated task, benchmark-specific patch, schema/frontmatter, credential fixture, or scanner-exclusion change.

Experiment provenance: parent `8062358921963f1398e3364e5bf9869155c28337`; this patch's SHA-256 is `01b45e1d255cd414a9b8faf89ec2e0da2409bf0ce3908b52f48ce351f552b130`, identical to the frozen revision used for fresh generation. See [fixtures PR #22](https://github.com/NVIDIA-dev/nemo-eval-author-fixtures/pull/22) for status. Baseline: 89 attempts, 26 candidates, five technical passes, all five blocked by metadata finalization. Revised run is incomplete: first six attempts have two technical passes with successful finalization/check, both still unproven/unreviewed. No full-campaign yield or benchmark-equivalence claim.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

<!-- List each command and result. Explain skipped, blocked, or non-successful checks without marking them as passed. -->

Commands run in the isolated source worktree, with `PYTHONDONTWRITEBYTECODE=1`. Interpreter paths below are represented by variables to avoid publishing machine-specific paths; no dependencies or provider installation were changed.

- `uv run --no-project --python "$HARBOR_PYTHON" -m pytest --confcutdir=plugins/nemo-eval-author/tests plugins/nemo-eval-author/tests/test_trace_environment.py -q`: **170 passed**, 94 existing Harbor checksum deprecation warnings, 145.66s. Existing Harbor 0.22.0 interpreter used because the platform runtime has a different Harbor contract.
- `uv run --no-project --python "$PLATFORM_PYTHON" -m pre_commit run --files <the five changed paths>`: all applicable checks passed (Ruff lint/format, ty, copyright, import boundary, merge conflicts).
- `uv run --no-project --python "$PLATFORM_PYTHON" -m pre_commit run -a`: **not fully passing**. Missing `helm-docs` and `yq`; installed uv 0.12.3 differs from repository-required 0.9.14. Other hooks passed; no unrelated file changes retained. This draft does not claim full-repository validation.
- `git diff --check` and staged whitespace check: passed. DCO audited against both refreshed main and the explicit stack base.
- Private evaluation harness: 16 tests passed. Two unchanged generated candidates completed ten independent proof jobs (NOP 0/0, Oracle 1/1, negative 0 for each), with separate verifiers and no exceptions. These are experimental evidence, not included generated files or readiness claims.

Remaining: finish the fresh 89-trace comparison and broader validation. Main CI/security workflows currently target main/release PR bases, so they may not run automatically while this PR targets #1980's feature branch; absence of checks is not a pass. Keep draft until remaining review/validation requirements are resolved.
