### PR TITLE
feat(evaluator): Set up environment for custom Gym e2e test script

### DIFF
--- a/plugins/nemo-evaluator/scripts/gym-custom-environment/artifacts.py
+++ b/plugins/nemo-evaluator/scripts/gym-custom-environment/artifacts.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Internal JSON evidence helpers used by preparation, submission, and verification.
+
+These functions keep artifact encoding and validation consistent across the
+implementation modules. Evidence is written beneath the run directory selected
+by ``run.py``; this module is not itself executable.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, is_dataclass
+from datetime import date, datetime
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+
+def _json_default(value: Any) -> Any:
+    """Convert common SDK, dataclass, enum, date, and path values to JSON data."""
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        return model_dump(mode="json")
+    if is_dataclass(value) and not isinstance(value, type):
+        return asdict(value)
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, date | datetime):
+        return value.isoformat()
+    if isinstance(value, Path):
+        return str(value)
+    raise TypeError(f"cannot serialize {type(value).__name__} as JSON")
+
+
+def write_json(path: Path, value: Any) -> None:
+    """Serialize Python and SDK values, creating parent directories as needed."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            value,
+            indent=2,
+            ensure_ascii=False,
+            default=_json_default,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    """Read an evidence file and require a JSON object at its root."""
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return value
+
+
+def read_jsonl(path: Path) -> list[dict[str, Any]]:
+    """Read non-empty JSON Lines records and require each record to be an object."""
+    rows: list[dict[str, Any]] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        if not line.strip():
+            continue
+        value = json.loads(line)
+        if not isinstance(value, dict):
+            raise ValueError(f"{path}:{line_number} must contain a JSON object")
+        rows.append(value)
+    return rows

--- a/plugins/nemo-evaluator/scripts/gym-custom-environment/ascii_tree_example.py
+++ b/plugins/nemo-evaluator/scripts/gym-custom-environment/ascii_tree_example.py
@@ -25,9 +25,15 @@ from commands import CommandRunner
 SCRIPT_DIRECTORY = Path(__file__).resolve().parent
 ENVIRONMENT_TEMPLATE = SCRIPT_DIRECTORY / "environment"
 WHEEL_SOURCE = SCRIPT_DIRECTORY / "scorer"
+
+# Cache converted data and built wheels by their inputs so repeated manual runs
+# spend their time on the Platform workflow rather than local preparation.
 WHEEL_CACHE = Path(tempfile.gettempdir()) / "nmp-gym-custom-environment-wheel-cache"
 FIXTURE_CACHE = Path(tempfile.gettempdir()) / "nmp-gym-custom-environment-fixture-cache"
 SCORER_DISTRIBUTION = "nmp_ascii_tree_evaluator"
+
+# Pin the small upstream fixture so every developer exercises the same prompts
+# and expected answers.
 PRIME_FIXTURE_HUB_ID = "primeintellect/ascii-tree"
 PRIME_FIXTURE_HUB_VERSION = "0.1.5"
 PRIME_FIXTURE_SIZE = 2
@@ -49,7 +55,7 @@ def _fixture_cache_path() -> Path:
 
 
 def _valid_fixture_cache(cache_path: Path) -> bool:
-    """Return whether a cached conversion contains the expected usable rows."""
+    """Check that cached conversion output is complete enough to reuse safely."""
     if not cache_path.is_file():
         return False
     try:
@@ -89,11 +95,14 @@ def _convert_fixture(
         _copy_cached_fixture(cache_path, converter_dataset)
         return
 
+    # Remove partial output from an interrupted conversion before rebuilding.
     if cache_path.exists():
         cache_path.unlink()
     cache_path.parent.mkdir(parents=True, exist_ok=True)
 
     try:
+        # Keep Prime Intellect's optional conversion dependencies out of the
+        # repository environment used by the rest of this workflow.
         runner.run(
             [
                 "uv",
@@ -125,6 +134,8 @@ def _convert_fixture(
 
         shutil.copy2(converted_dataset, cache_path)
     finally:
+        # Only training.jsonl is part of this example. The converter's generated
+        # environment and dataset snapshot can be large and are not reused.
         if converter_environment.exists():
             shutil.rmtree(converter_environment)
         if converter_dataset.exists():
@@ -156,13 +167,16 @@ def _adapt_dataset(converter_dataset: Path, dataset_output: Path) -> int:
 
 
 def _wheel_source_digest() -> str:
-    """Hash scorer source paths and contents for deterministic cache invalidation."""
+    """Hash scorer paths and contents so source changes invalidate its wheel."""
     digest = hashlib.sha256()
     source_files = sorted(
         path for path in WHEEL_SOURCE.rglob("*") if path.is_file() and "__pycache__" not in path.parts
     )
     for source_file in source_files:
         relative_path = source_file.relative_to(WHEEL_SOURCE)
+
+        # Separators prevent different path/content combinations from producing
+        # the same byte stream.
         digest.update(relative_path.as_posix().encode())
         digest.update(b"\0")
         digest.update(source_file.read_bytes())
@@ -171,7 +185,7 @@ def _wheel_source_digest() -> str:
 
 
 def _cached_scorer_wheel(runner: CommandRunner) -> Path:
-    """Return a source-matched scorer wheel, building it only when absent."""
+    """Reuse the wheel matching the current scorer source, or build it once."""
     cache_directory = WHEEL_CACHE / _wheel_source_digest()
     cached_wheels = sorted(cache_directory.glob(f"{SCORER_DISTRIBUTION}-*.whl"))
     if cached_wheels:
@@ -221,7 +235,11 @@ def prepare_example(
     environment_output: Path,
     dataset_output: Path,
 ) -> dict[str, Any]:
-    """Build the default complete environment and dataset for generic validation."""
+    """Produce the complete package and dataset used by the default workflow.
+
+    The returned summary is merged into preparation evidence by ``workflow.py``;
+    all concrete paths are written beneath the caller's run directory.
+    """
     _convert_fixture(
         runner,
         converter_environment=converter_environment,

--- a/plugins/nemo-evaluator/scripts/gym-custom-environment/ascii_tree_example.py
+++ b/plugins/nemo-evaluator/scripts/gym-custom-environment/ascii_tree_example.py
@@ -1,0 +1,237 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Prepare the bundled ASCII Tree example consumed by the generic workflow.
+
+This module contains every Prime Intellect and ASCII Tree implementation detail:
+it converts the pinned source fixture, adapts its rows to Gym's image-provided
+``simple_agent``, builds and caches the custom scorer wheel, and materializes a
+complete ``wheels-v1`` package. The shared preparation, submission, and
+verification modules treat its outputs like any caller-provided environment.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from artifacts import read_jsonl
+from commands import CommandRunner
+
+SCRIPT_DIRECTORY = Path(__file__).resolve().parent
+ENVIRONMENT_TEMPLATE = SCRIPT_DIRECTORY / "environment"
+WHEEL_SOURCE = SCRIPT_DIRECTORY / "scorer"
+WHEEL_CACHE = Path(tempfile.gettempdir()) / "nmp-gym-custom-environment-wheel-cache"
+FIXTURE_CACHE = Path(tempfile.gettempdir()) / "nmp-gym-custom-environment-fixture-cache"
+SCORER_DISTRIBUTION = "nmp_ascii_tree_evaluator"
+PRIME_FIXTURE_HUB_ID = "primeintellect/ascii-tree"
+PRIME_FIXTURE_HUB_VERSION = "0.1.5"
+PRIME_FIXTURE_SIZE = 2
+PRIME_FIXTURE_SEED = 0
+FIXTURE_CACHE_FORMAT_VERSION = 1
+
+
+def _fixture_cache_path() -> Path:
+    """Return the content-addressed cache path for the pinned source fixture."""
+    cache_inputs = {
+        "format_version": FIXTURE_CACHE_FORMAT_VERSION,
+        "hub_id": PRIME_FIXTURE_HUB_ID,
+        "hub_version": PRIME_FIXTURE_HUB_VERSION,
+        "size": PRIME_FIXTURE_SIZE,
+        "seed": PRIME_FIXTURE_SEED,
+    }
+    cache_key = hashlib.sha256(json.dumps(cache_inputs, sort_keys=True).encode()).hexdigest()
+    return FIXTURE_CACHE / cache_key / "training.jsonl"
+
+
+def _valid_fixture_cache(cache_path: Path) -> bool:
+    """Return whether a cached conversion contains the expected usable rows."""
+    if not cache_path.is_file():
+        return False
+    try:
+        rows = read_jsonl(cache_path)
+        return len(rows) == PRIME_FIXTURE_SIZE and all(
+            isinstance(row.get("responses_create_params"), dict)
+            and isinstance(row.get("answer"), str)
+            and bool(row["answer"].strip())
+            for row in rows
+        )
+    except (OSError, ValueError, json.JSONDecodeError):
+        return False
+
+
+def _copy_cached_fixture(cache_path: Path, converter_dataset: Path) -> None:
+    """Copy the reusable JSONL fixture into this run's working directory."""
+    if converter_dataset.exists():
+        shutil.rmtree(converter_dataset)
+    converter_dataset.mkdir(parents=True)
+    shutil.copy2(cache_path, converter_dataset / "training.jsonl")
+
+
+def _convert_fixture(
+    runner: CommandRunner,
+    *,
+    converter_environment: Path,
+    converter_dataset: Path,
+) -> None:
+    """Create or reuse the pinned two-row Prime Intellect fixture.
+
+    The converter runs in an isolated uv environment. Only its JSONL output is
+    cached; generated adapters, snapshots, and package caches are discarded.
+
+    """
+    cache_path = _fixture_cache_path()
+    if _valid_fixture_cache(cache_path):
+        _copy_cached_fixture(cache_path, converter_dataset)
+        return
+
+    if cache_path.exists():
+        cache_path.unlink()
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        runner.run(
+            [
+                "uv",
+                "run",
+                "--isolated",
+                "--frozen",
+                "--package",
+                "nmp-rl",
+                "--extra",
+                "conversion",
+                "pi-to-gym-conversion",
+                "--hub-id",
+                PRIME_FIXTURE_HUB_ID,
+                "--hub-version",
+                PRIME_FIXTURE_HUB_VERSION,
+                "--out-dir",
+                str(converter_environment),
+                "--dataset-dir",
+                str(converter_dataset),
+                "--dataset-size",
+                str(PRIME_FIXTURE_SIZE),
+                "--dataset-seed",
+                str(PRIME_FIXTURE_SEED),
+            ]
+        )
+        converted_dataset = converter_dataset / "training.jsonl"
+        if not _valid_fixture_cache(converted_dataset):
+            raise RuntimeError(f"converter did not produce {PRIME_FIXTURE_SIZE} valid rows at {converted_dataset}")
+
+        shutil.copy2(converted_dataset, cache_path)
+    finally:
+        if converter_environment.exists():
+            shutil.rmtree(converter_environment)
+        if converter_dataset.exists():
+            shutil.rmtree(converter_dataset)
+
+    _copy_cached_fixture(cache_path, converter_dataset)
+
+
+def _adapt_row(row: dict[str, Any]) -> dict[str, Any]:
+    """Retarget one source row from Prime Intellect's agent to ``simple_agent``."""
+    adapted_row = dict(row)
+    adapted_row["agent_ref"] = {
+        "type": "responses_api_agents",
+        "name": "simple_agent",
+    }
+    return adapted_row
+
+
+def _adapt_dataset(converter_dataset: Path, dataset_output: Path) -> int:
+    """Write source rows in the standard Gym JSONL shape and return their count."""
+    source_rows = read_jsonl(converter_dataset)
+    adapted_rows = [_adapt_row(row) for row in source_rows]
+    dataset_output.parent.mkdir(parents=True, exist_ok=True)
+    dataset_output.write_text(
+        "".join(json.dumps(row, ensure_ascii=False) + "\n" for row in adapted_rows),
+        encoding="utf-8",
+    )
+    return len(adapted_rows)
+
+
+def _wheel_source_digest() -> str:
+    """Hash scorer source paths and contents for deterministic cache invalidation."""
+    digest = hashlib.sha256()
+    source_files = sorted(
+        path for path in WHEEL_SOURCE.rglob("*") if path.is_file() and "__pycache__" not in path.parts
+    )
+    for source_file in source_files:
+        relative_path = source_file.relative_to(WHEEL_SOURCE)
+        digest.update(relative_path.as_posix().encode())
+        digest.update(b"\0")
+        digest.update(source_file.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _cached_scorer_wheel(runner: CommandRunner) -> Path:
+    """Return a source-matched scorer wheel, building it only when absent."""
+    cache_directory = WHEEL_CACHE / _wheel_source_digest()
+    cached_wheels = sorted(cache_directory.glob(f"{SCORER_DISTRIBUTION}-*.whl"))
+    if cached_wheels:
+        return cached_wheels[0]
+
+    cache_directory.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="nmp-ascii-tree-wheel-") as temporary_directory:
+        distribution_directory = Path(temporary_directory)
+        runner.run(
+            [
+                "uv",
+                "build",
+                "--wheel",
+                "--clear",
+                "--out-dir",
+                str(distribution_directory),
+                str(WHEEL_SOURCE),
+            ]
+        )
+        built_wheels = sorted(distribution_directory.glob(f"{SCORER_DISTRIBUTION}-*.whl"))
+        if len(built_wheels) != 1:
+            raise RuntimeError(f"expected one {SCORER_DISTRIBUTION} wheel, found: {built_wheels}")
+        cached_wheel = cache_directory / built_wheels[0].name
+        shutil.copy2(built_wheels[0], cached_wheel)
+        return cached_wheel
+
+
+def _materialize_environment(runner: CommandRunner, environment_output: Path) -> Path:
+    """Copy the example package and place its cached scorer wheel in the wheelhouse."""
+    if environment_output.exists():
+        shutil.rmtree(environment_output)
+    shutil.copytree(ENVIRONMENT_TEMPLATE, environment_output)
+
+    scorer_wheel = _cached_scorer_wheel(runner)
+    wheels_directory = environment_output / "wheels"
+    wheels_directory.mkdir(parents=True, exist_ok=True)
+    wheel_destination = wheels_directory / scorer_wheel.name
+    shutil.copy2(scorer_wheel, wheel_destination)
+    return wheel_destination
+
+
+def prepare_example(
+    runner: CommandRunner,
+    *,
+    converter_environment: Path,
+    converter_dataset: Path,
+    environment_output: Path,
+    dataset_output: Path,
+) -> dict[str, Any]:
+    """Build the default complete environment and dataset for generic validation."""
+    _convert_fixture(
+        runner,
+        converter_environment=converter_environment,
+        converter_dataset=converter_dataset,
+    )
+    scorer_wheel = _materialize_environment(runner, environment_output)
+    row_count = _adapt_dataset(converter_dataset / "training.jsonl", dataset_output)
+    return {
+        "input_mode": "default-ascii-tree",
+        "input_label": "bundled ASCII Tree example",
+        "rows": row_count,
+        "wheels": [scorer_wheel.name],
+    }

--- a/plugins/nemo-evaluator/scripts/gym-custom-environment/commands.py
+++ b/plugins/nemo-evaluator/scripts/gym-custom-environment/commands.py
@@ -23,7 +23,11 @@ class CommandError(RuntimeError):
 
 
 class CommandRunner:
-    """Run argument-vector commands without shell interpolation."""
+    """Run the few external tools needed during local preparation.
+
+    Platform resources are managed through the Python SDK; this wrapper is
+    limited to workstation tools such as ``uv`` and ``kubectl``.
+    """
 
     def __init__(self, *, working_directory: Path) -> None:
         """Configure the working directory shared by child processes."""
@@ -37,7 +41,7 @@ class CommandRunner:
         input_text: str | None = None,
         output_path: Path | None = None,
     ) -> str:
-        """Run a command, optionally supply stdin, and return captured stdout."""
+        """Run to completion and optionally preserve stdout as workflow evidence."""
         try:
             result = subprocess.run(
                 list(arguments),
@@ -86,7 +90,7 @@ class CommandRunner:
         environment: Mapping[str, str] | None = None,
         stdout: TextIO | int | None = None,
     ) -> subprocess.Popen[str]:
-        """Start a long-running command and return its process handle."""
+        """Start a background helper, such as a temporary ``kubectl`` port-forward."""
         return subprocess.Popen(
             list(arguments),
             cwd=self.working_directory,

--- a/plugins/nemo-evaluator/scripts/gym-custom-environment/commands.py
+++ b/plugins/nemo-evaluator/scripts/gym-custom-environment/commands.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Internal subprocess wrapper shared by prerequisite and workflow modules.
+
+The wrapper executes argument vectors without a shell, merges only explicit
+environment overrides, converts command failures into readable exceptions, and
+optionally records stdout as evidence. Developers do not invoke this module.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, TextIO
+
+
+class CommandError(RuntimeError):
+    """Raised when an external command exits unsuccessfully."""
+
+
+class CommandRunner:
+    """Run argument-vector commands without shell interpolation."""
+
+    def __init__(self, *, working_directory: Path) -> None:
+        """Configure the working directory shared by child processes."""
+        self.working_directory = working_directory
+
+    def run(
+        self,
+        arguments: Sequence[str],
+        *,
+        environment: Mapping[str, str] | None = None,
+        input_text: str | None = None,
+        output_path: Path | None = None,
+    ) -> str:
+        """Run a command, optionally supply stdin, and return captured stdout."""
+        try:
+            result = subprocess.run(
+                list(arguments),
+                cwd=self.working_directory,
+                env={**os.environ, **(environment or {})},
+                input=input_text,
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+        except subprocess.CalledProcessError as error:
+            detail = error.stderr.strip() or error.stdout.strip() or f"exit code {error.returncode}"
+            command = " ".join(arguments)
+            raise CommandError(f"{command} failed: {detail}") from error
+
+        if output_path is not None:
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text(result.stdout, encoding="utf-8")
+        return result.stdout
+
+    def run_json(
+        self,
+        arguments: Sequence[str],
+        *,
+        environment: Mapping[str, str] | None = None,
+        input_text: str | None = None,
+        output_path: Path | None = None,
+    ) -> dict[str, Any]:
+        """Run a command and require its stdout to contain a JSON object."""
+        output = self.run(
+            arguments,
+            environment=environment,
+            input_text=input_text,
+            output_path=output_path,
+        )
+        value = json.loads(output)
+        if not isinstance(value, dict):
+            command = " ".join(arguments)
+            raise CommandError(f"{command} did not return a JSON object")
+        return value
+
+    def start(
+        self,
+        arguments: Sequence[str],
+        *,
+        environment: Mapping[str, str] | None = None,
+        stdout: TextIO | int | None = None,
+    ) -> subprocess.Popen[str]:
+        """Start a long-running command and return its process handle."""
+        return subprocess.Popen(
+            list(arguments),
+            cwd=self.working_directory,
+            env={**os.environ, **(environment or {})},
+            text=True,
+            stdout=stdout,
+            stderr=subprocess.STDOUT,
+        )

--- a/plugins/nemo-evaluator/scripts/gym-custom-environment/environment/nemo-environment.yaml
+++ b/plugins/nemo-evaluator/scripts/gym-custom-environment/environment/nemo-environment.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+format: wheels-v1
+config_paths:
+  - resources_servers/ascii_tree/configs/ascii_tree.yaml
+metadata:
+  name: custom-ascii-tree-environment
+  description: Custom ASCII Tree scorer delivered through an Evaluator FileSet
+  hub_id: primeintellect/ascii-tree
+  vf_env_id: ascii-tree

--- a/plugins/nemo-evaluator/scripts/gym-custom-environment/environment/resources_servers/ascii_tree/app.py
+++ b/plugins/nemo-evaluator/scripts/gym-custom-environment/environment/resources_servers/ascii_tree/app.py
@@ -41,12 +41,12 @@ class AsciiTreeVerifyResponse(BaseVerifyResponse):
 
 
 def _field(value: Any, name: str, default: Any = None) -> Any:
-    """Read one field from a response object or decoded mapping."""
+    """Read a field from either SDK response models or decoded test mappings."""
     return value.get(name, default) if isinstance(value, dict) else getattr(value, name, default)
 
 
 def assistant_text(response: Any) -> str:
-    """Collect assistant text from a Responses API payload."""
+    """Join assistant output-text parts in their original response order."""
     return "".join(
         _field(content, "text", "")
         for output in _field(response, "output", [])
@@ -65,8 +65,9 @@ class AsciiTreeResourcesServer(SimpleResourcesServer):
         self,
         body: AsciiTreeVerifyRequest,
     ) -> AsciiTreeVerifyResponse:
-        """Extract the assistant response, calculate its reward, and return evidence."""
+        """Score one Gym turn and return both the reward and readable evidence."""
         observed_text = assistant_text(body.response)
+
         return AsciiTreeVerifyResponse(
             **body.model_dump(),
             reward=ascii_tree_reward(observed_text, body.answer),

--- a/plugins/nemo-evaluator/scripts/gym-custom-environment/environment/resources_servers/ascii_tree/app.py
+++ b/plugins/nemo-evaluator/scripts/gym-custom-environment/environment/resources_servers/ascii_tree/app.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""FileSet-delivered Gym resources server for the ASCII Tree example.
+
+Gym launches this module inside OpenSandbox using ``ascii_tree.yaml``. It
+extracts assistant text from each model response, calls the scorer installed
+from the adjacent wheel requirement, and returns the reward and parsed tree.
+The server is environment code; developers invoke the parent ``run.py`` rather
+than running this file locally.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nemo_gym.base_resources_server import (  # ty: ignore[unresolved-import] - supplied by the Gym runtime
+    BaseResourcesServerConfig,
+    BaseVerifyRequest,
+    BaseVerifyResponse,
+    SimpleResourcesServer,
+)
+from nmp_ascii_tree_evaluator.scoring import (  # ty: ignore[unresolved-import] - installed from the FileSet wheel
+    ascii_tree_reward,
+    extract_ascii_formatted,
+)
+
+
+class AsciiTreeVerifyRequest(BaseVerifyRequest):
+    """Expected ASCII tree and model response supplied by Gym."""
+
+    answer: str
+
+
+class AsciiTreeVerifyResponse(BaseVerifyResponse):
+    """Custom reward and parsed model output returned to Gym."""
+
+    answer: str
+    observed_text: str
+    parsed_ascii: str | None
+
+
+def _field(value: Any, name: str, default: Any = None) -> Any:
+    """Read one field from a response object or decoded mapping."""
+    return value.get(name, default) if isinstance(value, dict) else getattr(value, name, default)
+
+
+def assistant_text(response: Any) -> str:
+    """Collect assistant text from a Responses API payload."""
+    return "".join(
+        _field(content, "text", "")
+        for output in _field(response, "output", [])
+        if _field(output, "type") == "message"
+        for content in _field(output, "content", [])
+        if _field(content, "type") == "output_text"
+    )
+
+
+class AsciiTreeResourcesServer(SimpleResourcesServer):
+    """Score model responses with FileSet-provided ASCII Tree code."""
+
+    config: BaseResourcesServerConfig
+
+    async def verify(
+        self,
+        body: AsciiTreeVerifyRequest,
+    ) -> AsciiTreeVerifyResponse:
+        """Extract the assistant response, calculate its reward, and return evidence."""
+        observed_text = assistant_text(body.response)
+        return AsciiTreeVerifyResponse(
+            **body.model_dump(),
+            reward=ascii_tree_reward(observed_text, body.answer),
+            observed_text=observed_text,
+            parsed_ascii=extract_ascii_formatted(observed_text),
+        )
+
+
+if __name__ == "__main__":
+    AsciiTreeResourcesServer.run_webserver()

--- a/plugins/nemo-evaluator/scripts/gym-custom-environment/environment/resources_servers/ascii_tree/configs/ascii_tree.yaml
+++ b/plugins/nemo-evaluator/scripts/gym-custom-environment/environment/resources_servers/ascii_tree/configs/ascii_tree.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+ascii_tree:
+  resources_servers:
+    ascii_tree:
+      entrypoint: app.py
+      domain: instruction_following
+      verified: false
+      description: Score structured ASCII trees with Prime Intellect ascii-tree 0.1.5 semantics
+      value: Compare generated ASCII tree lines with the expected tree

--- a/plugins/nemo-evaluator/scripts/gym-custom-environment/environment/resources_servers/ascii_tree/requirements.txt
+++ b/plugins/nemo-evaluator/scripts/gym-custom-environment/environment/resources_servers/ascii_tree/requirements.txt
@@ -1,0 +1,2 @@
+# Installed by Gym from the wheel bundled in this environment FileSet.
+nmp-ascii-tree-evaluator==0.1.0

--- a/plugins/nemo-evaluator/scripts/gym-custom-environment/prepare.py
+++ b/plugins/nemo-evaluator/scripts/gym-custom-environment/prepare.py
@@ -28,7 +28,7 @@ from sandboxed_gym.environment_package import (
 
 @dataclass(frozen=True, slots=True)
 class PreparedEnvironment:
-    """Validated environment and dataset metadata consumed by later stages."""
+    """Carry validated paths and manifest details into upload and verification."""
 
     root: Path
     dataset: Path
@@ -63,18 +63,23 @@ def _copy_custom_inputs(
     environment_output: Path,
     dataset_output: Path,
 ) -> None:
-    """Copy caller-owned package and dataset into the isolated run directory."""
+    """Copy caller-owned inputs without modifying their original files."""
     if not environment_source.is_dir():
         raise ValueError(f"environment directory does not exist: {environment_source}")
     if not dataset_source.is_file():
         raise ValueError(f"dataset does not exist or is not a file: {dataset_source}")
+
+    # A nested source or destination could erase inputs when an old run
+    # directory is removed, or recursively copy the output into itself.
     _require_safe_copy(environment_source, environment_output, label="environment")
     _require_safe_copy(dataset_source, dataset_output, label="dataset")
 
     if environment_output.exists():
         shutil.rmtree(environment_output)
+
     environment_output.parent.mkdir(parents=True, exist_ok=True)
     shutil.copytree(environment_source, environment_output)
+
     dataset_output.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(dataset_source, dataset_output)
 
@@ -91,6 +96,7 @@ def _select_resources_server(
                 f"available servers: {', '.join(sorted(available_servers))}"
             )
         return requested_server
+
     if len(available_servers) != 1:
         raise ValueError(
             "environment must declare exactly one resources server or select one with "
@@ -106,12 +112,14 @@ def inspect_prepared_inputs(
     requested_resources_server: str | None,
     input_mode: str,
 ) -> PreparedEnvironment:
-    """Validate staged inputs and derive all component metadata dynamically."""
+    """Validate staged inputs and derive runtime choices from their contents."""
     environment_package = load_environment_package(environment)
     if not isinstance(environment_package, WheelsV1Package):
         actual_format = type(environment_package).__name__
         raise ValueError(f"expected a wheels-v1 package, got {actual_format}")
 
+    # Resource-server names come from the package itself; the workflow contains
+    # no knowledge of the bundled example's ``ascii_tree`` server.
     components = inspect_environment_components(environment_package)
     resources_server = _select_resources_server(
         components.resources_servers,
@@ -121,6 +129,8 @@ def inspect_prepared_inputs(
     if not tasks:
         raise ValueError(f"Gym discovered no tasks in {dataset}")
 
+    # Keep this summary independent of SDK/Pydantic models so it can be logged,
+    # serialized as evidence, and passed between workflow stages predictably.
     return PreparedEnvironment(
         root=environment_package.root,
         dataset=dataset.resolve(),
@@ -141,7 +151,11 @@ def prepare_custom_inputs(
     dataset_output: Path,
     requested_resources_server: str | None,
 ) -> PreparedEnvironment:
-    """Copy and validate a developer-provided environment package and dataset."""
+    """Stage and inspect a developer-provided wheels-v1 package and Gym dataset.
+
+    Validation happens once against the source tree to preserve symlink checks,
+    then again against the exact copy that later stages upload.
+    """
     # Validate the caller-owned tree before copying so symlinks cannot be
     # dereferenced into apparently valid files inside the run directory.
     source_package = load_environment_package(environment_source)

--- a/plugins/nemo-evaluator/scripts/gym-custom-environment/prepare.py
+++ b/plugins/nemo-evaluator/scripts/gym-custom-environment/prepare.py
@@ -1,0 +1,163 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Validate and stage complete custom Gym environment inputs.
+
+The shared workflow calls this module after either a developer supplies a
+complete ``wheels-v1`` directory and Gym JSONL dataset or the default example
+adapter produces those same inputs. This module copies caller-owned inputs into
+the run directory, validates the package and dataset without importing customer
+code, discovers selectable resources servers, and extracts package metadata
+used by generic runtime verification.
+"""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from nemo_evaluator_sdk.agent_eval.runtimes.gym import discover_gym_tasks
+from sandboxed_gym.environment_package import (
+    WheelsV1Package,
+    inspect_environment_components,
+    load_environment_package,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedEnvironment:
+    """Validated environment and dataset metadata consumed by later stages."""
+
+    root: Path
+    dataset: Path
+    name: str
+    resources_server: str
+    resources_servers: tuple[str, ...]
+    wheel_names: tuple[str, ...]
+    task_count: int
+    input_mode: str
+
+    def evidence(self) -> dict[str, Any]:
+        """Return JSON-serializable preparation evidence."""
+        return asdict(self)
+
+
+def _require_safe_copy(source: Path, destination: Path, *, label: str) -> None:
+    """Reject copy layouts that could overwrite or recursively copy an input."""
+    resolved_source = source.resolve()
+    resolved_destination = destination.resolve()
+    if (
+        resolved_source == resolved_destination
+        or resolved_source in resolved_destination.parents
+        or resolved_destination in resolved_source.parents
+    ):
+        raise ValueError(f"{label} source and run destination must not contain one another")
+
+
+def _copy_custom_inputs(
+    environment_source: Path,
+    dataset_source: Path,
+    *,
+    environment_output: Path,
+    dataset_output: Path,
+) -> None:
+    """Copy caller-owned package and dataset into the isolated run directory."""
+    if not environment_source.is_dir():
+        raise ValueError(f"environment directory does not exist: {environment_source}")
+    if not dataset_source.is_file():
+        raise ValueError(f"dataset does not exist or is not a file: {dataset_source}")
+    _require_safe_copy(environment_source, environment_output, label="environment")
+    _require_safe_copy(dataset_source, dataset_output, label="dataset")
+
+    if environment_output.exists():
+        shutil.rmtree(environment_output)
+    environment_output.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(environment_source, environment_output)
+    dataset_output.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(dataset_source, dataset_output)
+
+
+def _select_resources_server(
+    available_servers: frozenset[str],
+    requested_server: str | None,
+) -> str:
+    """Select a declared resources server or explain why selection is ambiguous."""
+    if requested_server is not None:
+        if requested_server not in available_servers:
+            raise ValueError(
+                f"resources server {requested_server!r} is not declared; "
+                f"available servers: {', '.join(sorted(available_servers))}"
+            )
+        return requested_server
+    if len(available_servers) != 1:
+        raise ValueError(
+            "environment must declare exactly one resources server or select one with "
+            f"--resources-server; available: {', '.join(sorted(available_servers)) or 'none'}"
+        )
+    return next(iter(available_servers))
+
+
+def inspect_prepared_inputs(
+    environment: Path,
+    dataset: Path,
+    *,
+    requested_resources_server: str | None,
+    input_mode: str,
+) -> PreparedEnvironment:
+    """Validate staged inputs and derive all component metadata dynamically."""
+    environment_package = load_environment_package(environment)
+    if not isinstance(environment_package, WheelsV1Package):
+        actual_format = type(environment_package).__name__
+        raise ValueError(f"expected a wheels-v1 package, got {actual_format}")
+
+    components = inspect_environment_components(environment_package)
+    resources_server = _select_resources_server(
+        components.resources_servers,
+        requested_resources_server,
+    )
+    tasks = discover_gym_tasks(dataset)
+    if not tasks:
+        raise ValueError(f"Gym discovered no tasks in {dataset}")
+
+    return PreparedEnvironment(
+        root=environment_package.root,
+        dataset=dataset.resolve(),
+        name=environment_package.manifest.metadata.name,
+        resources_server=resources_server,
+        resources_servers=tuple(sorted(components.resources_servers)),
+        wheel_names=tuple(wheel.name for wheel in environment_package.wheel_files),
+        task_count=len(tasks),
+        input_mode=input_mode,
+    )
+
+
+def prepare_custom_inputs(
+    environment_source: Path,
+    dataset_source: Path,
+    *,
+    environment_output: Path,
+    dataset_output: Path,
+    requested_resources_server: str | None,
+) -> PreparedEnvironment:
+    """Copy and validate a developer-provided environment package and dataset."""
+    # Validate the caller-owned tree before copying so symlinks cannot be
+    # dereferenced into apparently valid files inside the run directory.
+    source_package = load_environment_package(environment_source)
+    if not isinstance(source_package, WheelsV1Package):
+        actual_format = type(source_package).__name__
+        raise ValueError(f"expected a wheels-v1 package, got {actual_format}")
+
+    _copy_custom_inputs(
+        environment_source,
+        dataset_source,
+        environment_output=environment_output,
+        dataset_output=dataset_output,
+    )
+    return inspect_prepared_inputs(
+        environment_output,
+        dataset_output,
+        requested_resources_server=requested_resources_server,
+        input_mode="custom",
+    )

--- a/plugins/nemo-evaluator/scripts/gym-custom-environment/scorer/pyproject.toml
+++ b/plugins/nemo-evaluator/scripts/gym-custom-environment/scorer/pyproject.toml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Build metadata used by prepare.py to create the wheel delivered in the environment FileSet.
+# This project is not published independently.
+
+[project]
+name = "nmp-ascii-tree-evaluator"
+version = "0.1.0"
+description = "Custom ASCII Tree scorer for thenmp-ascii-tree-evaluator Gym environment workflow"
+requires-python = ">=3.11"
+license = "Apache-2.0"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/nmp_ascii_tree_evaluator"]

--- a/plugins/nemo-evaluator/scripts/gym-custom-environment/scorer/src/nmp_ascii_tree_evaluator/scoring.py
+++ b/plugins/nemo-evaluator/scripts/gym-custom-environment/scorer/src/nmp_ascii_tree_evaluator/scoring.py
@@ -31,7 +31,7 @@ def extract_ascii_formatted(text: str) -> str | None:
 
 
 def _format_multiplier(lines: list[str]) -> float:
-    """Apply indentation and tree-branch formatting penalties."""
+    """Discount output that lacks indentation or recognizable tree branches."""
     multiplier = 1.0
     if not all(line.startswith(" ") or line.rstrip() == lines[0] for line in lines[1:]):
         multiplier *= 0.5
@@ -41,7 +41,7 @@ def _format_multiplier(lines: list[str]) -> float:
 
 
 def similarity_reward(completion: str, answer: str) -> float:
-    """Score whole-sequence line similarity with ASCII formatting penalties."""
+    """Compare the complete predicted and expected trees line by line."""
     parsed_tree = extract_ascii_formatted(completion)
     if parsed_tree is None or not answer.strip():
         return 0.0
@@ -53,7 +53,7 @@ def similarity_reward(completion: str, answer: str) -> float:
 
 
 def continuous_reward(completion: str, answer: str) -> float:
-    """Score the longest contiguous line match with formatting penalties."""
+    """Reward the longest uninterrupted run of expected tree lines."""
     parsed_tree = extract_ascii_formatted(completion)
     if parsed_tree is None or not answer.strip():
         return 0.0

--- a/plugins/nemo-evaluator/scripts/gym-custom-environment/scorer/src/nmp_ascii_tree_evaluator/scoring.py
+++ b/plugins/nemo-evaluator/scripts/gym-custom-environment/scorer/src/nmp_ascii_tree_evaluator/scoring.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""FileSet-delivered reward functions for the ASCII Tree example.
+
+``prepare.py`` packages this module into a wheel. Gym installs that wheel in the
+OpenSandbox runtime because the resources server declares it in
+``requirements.txt``. The resources server then calls ``ascii_tree_reward()``
+for each model response. The formulas preserve Prime Intellect ASCII Tree 0.1.5
+semantics while remaining independent of its unsupported ``verifiers`` runtime.
+"""
+
+from __future__ import annotations
+
+import difflib
+import re
+
+_ASCII_FORMATTED = re.compile(
+    r"<ascii_formatted>\s*(.*?)\s*</ascii_formatted>",
+    flags=re.DOTALL,
+)
+
+
+def extract_ascii_formatted(text: str) -> str | None:
+    """Return the first ``ascii_formatted`` payload, or ``None`` when absent."""
+    match = _ASCII_FORMATTED.search(text)
+    if match is None:
+        return None
+    parsed_tree = match.group(1).strip()
+    return parsed_tree or None
+
+
+def _format_multiplier(lines: list[str]) -> float:
+    """Apply indentation and tree-branch formatting penalties."""
+    multiplier = 1.0
+    if not all(line.startswith(" ") or line.rstrip() == lines[0] for line in lines[1:]):
+        multiplier *= 0.5
+    if not any("--" in line for line in lines[1:]):
+        multiplier *= 0.5
+    return multiplier
+
+
+def similarity_reward(completion: str, answer: str) -> float:
+    """Score whole-sequence line similarity with ASCII formatting penalties."""
+    parsed_tree = extract_ascii_formatted(completion)
+    if parsed_tree is None or not answer.strip():
+        return 0.0
+
+    completion_lines = parsed_tree.split("\n")
+    expected_lines = answer.strip().split("\n")
+    similarity = difflib.SequenceMatcher(None, completion_lines, expected_lines).ratio()
+    return similarity * _format_multiplier(completion_lines)
+
+
+def continuous_reward(completion: str, answer: str) -> float:
+    """Score the longest contiguous line match with formatting penalties."""
+    parsed_tree = extract_ascii_formatted(completion)
+    if parsed_tree is None or not answer.strip():
+        return 0.0
+
+    completion_lines = parsed_tree.split("\n")
+    expected_lines = answer.strip().split("\n")
+    matcher = difflib.SequenceMatcher(None, completion_lines, expected_lines)
+    longest_block = max(matcher.get_matching_blocks(), key=lambda block: block.size)
+    contiguous_fraction = longest_block.size / len(expected_lines)
+    return contiguous_fraction * _format_multiplier(completion_lines)
+
+
+def ascii_tree_reward(completion: str, answer: str) -> float:
+    """Combine global similarity (30%) and contiguous matching (70%)."""
+    return 0.3 * similarity_reward(completion, answer) + 0.7 * continuous_reward(
+        completion,
+        answer,
+    )


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary

PR 1 of 3 to add a manual end-to-end Gym Evaluation test script that enables testing and validating a built-in custom Gym environment against a Kubernetes deployment.

This PR focuses on the environment setup portion of the script. It supports an out-of-the-box custom Gym environment, and wires up support for bringing your own environment. 

## Changes
**Built-in ASCII Tree environment**
- Supports a built-in custom environment whose dependencies are packaged as a wheel. Includes all the relevant plumbing for generating and caching the required components of the custom environment.
- This PR also ships its own custom dependency, rather than pulling an external dependency. This gets packaged in the wheel and imported by the resource server.

**Bring-your-own custom environment**
- Supports validating and staging your own custom environment via CLI args. You are responsible for packaging external dependencies as wheels and supplying those as a `wheels-v1` environment.
- Automatically extracts relevant metadata from the environment used in later PRs to validate the job outcome.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: This adds a manually invoked validation workflow; targeted linting and type checks cover the preparation code.
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: This adds a manually invoked validation workflow; not published anywhere.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- Targeted `ruff check` and `ruff format --check` passed for the changed Python files.
- Commit hooks passed Ruff, formatting, `ty`, DCO, and repository checks.
- Full pre-commit validation was blocked only by the unavailable Studio `lint-staged` command in the isolated worktree.