### PR TITLE
feat(evaluator): Add orchestration logic for custom Gym e2e test script

### DIFF
--- a/plugins/nemo-evaluator/scripts/gym-custom-environment/README.md
+++ b/plugins/nemo-evaluator/scripts/gym-custom-environment/README.md
@@ -1,0 +1,299 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Custom Gym environment workflow
+
+This directory contains a repeatable workflow for validating custom `wheels-v1` Gym environments
+with NeMo Evaluator and OpenSandbox. The workflow prepares or accepts an environment, uploads it,
+runs an evaluation, verifies the result, records evidence, and removes temporary Platform
+resources. With no input flags it runs the bundled ASCII Tree example; developers can instead
+provide any complete compatible environment and Gym dataset.
+
+## What makes the environment custom?
+
+The published `nmp-gym-host` image provides Gym and a standard `simple_agent`. It does not contain
+the evaluation-specific code used here.
+
+The default example builds and uploads a `wheels-v1` environment FileSet containing:
+
+- a Python wheel that implements an ASCII Tree reward function; and
+- a Gym resources server that extracts the model response and invokes that function.
+
+Evaluator installs the wheel and launches the resources server inside a fresh OpenSandbox sandbox.
+The workflow confirms that the uploaded resources server produced the persisted reward, which
+demonstrates that Evaluator delivered and executed the selected custom environment.
+
+The example data and scoring semantics come from `primeintellect/ascii-tree==0.1.5`. Prime Intellect
+is an implementation detail of this fixture, not the workflow's interface. Its converter normally
+produces an `adapter-wheels-v1` package for the unsupported `verifiers` runtime. This utility adapts
+that output to Evaluator's supported `wheels-v1` format.
+
+## Project layout
+
+The workflow is organized into the following components:
+
+- `run.py` is the command-line entry point.
+- `workflow.py` coordinates generic preparation, upload, inference, evaluation, verification, and
+  cleanup.
+- `prerequisites.py` performs read-only workstation, cluster, configuration, and image checks.
+- `prepare.py` validates and stages complete environment packages and datasets.
+- `ascii_tree_example.py` converts the default fixture, builds its scorer wheel, and adapts its
+  dataset.
+- `submit.py` constructs the Evaluator job, waits for it, and validates downloaded results.
+- `config.py` derives settings, temporary resource names, and evidence paths.
+- `commands.py`, `artifacts.py`, and `console.py` contain shared helpers.
+- `environment/` and `scorer/` contain the bundled example package and wheel source.
+- `helm/` contains the values example for enabling the required sandboxed Gym configuration.
+
+## Setup
+
+### Prerequisites
+
+The workflow expects an existing, correctly configured environment. Its prerequisite checks are
+read-only; it does not install or upgrade Kubernetes components.
+
+Required infrastructure and access:
+
+- a non-production Kubernetes cluster with NeMo Platform installed;
+- OpenSandbox installed and reachable from the Platform namespace;
+- sandboxed Gym enabled in the Platform ConfigMap;
+- an empty or absent `evaluator.sandbox_runtime_image`;
+- the OpenSandbox API-key Secret in the Platform namespace;
+- a registry pull Secret for the configured Platform images;
+- a `ReadWriteMany` Platform files PVC;
+- matching published `nmp-api`, `nmp-cpu-tasks`, and `nmp-gym-host` images at an immutable tag;
+- a local checkout compatible with the deployed images;
+- `uv`, Docker Buildx, `kubectl`, and Helm;
+- workstation access to NGC and, for the default example, Prime Intellect Hub, GitHub, and Hugging
+  Face; and
+- an NVIDIA API key authorized for the selected Inference Hub model.
+
+The `nmp-temp1` deployment in `nemo-dev-blue` already satisfies these prerequisites.
+Before running the workflow there, follow the **Configure sandboxed Gym** steps to apply the
+settings required by this test.
+
+The defaults are:
+
+- Helm release `nemo-platform` in namespace `nmp-temp1`;
+- OpenSandbox service `opensandbox-server-crun` in namespace `opensandbox-system`;
+- Secrets `opensandbox-server-crun-api-key` and `nvcrimagepullsecret`;
+- PVC `nemo-platform-core-storage`;
+- workspace `default`
+- model entity `default/nvidia-meta-llama-3-3-70b-instruct`.
+
+### Configure sandboxed Gym
+
+Apply the example values to an existing Platform release before running the workflow. The
+`--reuse-values` flag preserves the release's current image coordinates and unrelated settings.
+
+```bash
+export KUBECONFIG="${HOME}/teleport-kubeconfig.yaml"
+export NMP_GYM_CUSTOM_NAMESPACE="${NMP_GYM_CUSTOM_NAMESPACE:-nmp-temp1}"
+export NMP_GYM_CUSTOM_RELEASE="${NMP_GYM_CUSTOM_RELEASE:-nemo-platform}"
+export GYM_VALUES=/tmp/gym-custom-environment-values.yaml
+
+cp \
+  plugins/nemo-evaluator/scripts/gym-custom-environment/helm/opensandbox-values.example.yaml \
+  "$GYM_VALUES"
+
+# Set the namespace used by the internal Platform API URL.
+export INTERNAL_PLATFORM_API_URL="http://nemo-platform-api.${NMP_GYM_CUSTOM_NAMESPACE}.svc.cluster.local:8080"
+yq -i '
+  .platformConfig.evaluator.sandbox_policy_base_urls = [strenv(INTERNAL_PLATFORM_API_URL)]
+' "$GYM_VALUES"
+
+# Render against the live cluster first. Review this output locally; existing
+# ConfigMap values can include sensitive configuration.
+helm upgrade "$NMP_GYM_CUSTOM_RELEASE" k8s/helm \
+  -n "$NMP_GYM_CUSTOM_NAMESPACE" \
+  --reuse-values \
+  -f "$GYM_VALUES" \
+  --dry-run=server \
+  --hide-secret
+
+helm upgrade "$NMP_GYM_CUSTOM_RELEASE" k8s/helm \
+  -n "$NMP_GYM_CUSTOM_NAMESPACE" \
+  --reuse-values \
+  -f "$GYM_VALUES" \
+  --timeout 20m
+
+# The Platform config is mounted with subPath, so restart consumers after the
+# ConfigMap changes.
+kubectl rollout restart deployment \
+  -l "app.kubernetes.io/instance=${NMP_GYM_CUSTOM_RELEASE}" \
+  -n "$NMP_GYM_CUSTOM_NAMESPACE"
+
+kubectl rollout status deployment \
+  -l "app.kubernetes.io/instance=${NMP_GYM_CUSTOM_RELEASE}" \
+  -n "$NMP_GYM_CUSTOM_NAMESPACE" \
+  --timeout 20m
+```
+
+Confirm that both Platform and Evaluator sandboxing are enabled and that
+`sandbox_runtime_image` is empty:
+
+```bash
+kubectl get configmap nemo-platform-config \
+  -n "$NMP_GYM_CUSTOM_NAMESPACE" \
+  -o 'jsonpath={.data.config\.yaml}' |
+  yq '.platform, .evaluator'
+```
+
+Optionally, override only values that differ:
+
+```bash
+export NMP_GYM_CUSTOM_NAMESPACE="<platform-namespace>"
+export NMP_GYM_CUSTOM_RELEASE="<helm-release>"
+export NMP_GYM_CUSTOM_WORKSPACE="<workspace>"
+export NMP_GYM_CUSTOM_JOB_PVC="<read-write-many-pvc>"
+export NMP_GYM_CUSTOM_REGISTRY_SECRET="<registry-pull-secret>"
+export NMP_GYM_CUSTOM_OPENSANDBOX_NAMESPACE="<opensandbox-namespace>"
+export NMP_GYM_CUSTOM_OPENSANDBOX_SERVICE="<opensandbox-service>"
+export NMP_GYM_CUSTOM_OPENSANDBOX_API_SECRET="<opensandbox-api-key-secret>"
+export NMP_GYM_CUSTOM_PLATFORM_API_SERVICE="<platform-api-service>"
+export NMP_GYM_CUSTOM_MODEL_ENTITY_ID="<workspace>/<model-entity>"
+export NMP_GYM_CUSTOM_LOCAL_PORT=18080
+```
+
+If Docker is not authenticated to NGC, log in without putting the key in shell history:
+
+```bash
+test -n "${NGC_API_KEY:-}" || {
+  printf 'NGC API key: ' >&2
+  IFS= read -rs NGC_API_KEY
+  printf '\n' >&2
+  export NGC_API_KEY
+}
+
+printf '%s' "$NGC_API_KEY" |
+  docker login nvcr.io --username '$oauthtoken' --password-stdin
+```
+
+### Connect to the Platform API
+
+The workflow accesses the Platform API through a local Kubernetes port-forward. It checks
+`127.0.0.1:18080` first and reuses an existing healthy connection. If none exists, the workflow
+starts a temporary port-forward automatically and closes it when the run finishes.
+
+To manage the connection yourself, run the following in a separate terminal and leave it running
+for the duration of the workflow:
+
+```bash
+export KUBECONFIG="${HOME}/teleport-kubeconfig.yaml"
+export NMP_GYM_CUSTOM_NAMESPACE="${NMP_GYM_CUSTOM_NAMESPACE:-nmp-temp1}"
+export NMP_GYM_CUSTOM_PLATFORM_API_SERVICE="${NMP_GYM_CUSTOM_PLATFORM_API_SERVICE:-nemo-platform-api}"
+export NMP_GYM_CUSTOM_LOCAL_PORT="${NMP_GYM_CUSTOM_LOCAL_PORT:-18080}"
+
+kubectl port-forward \
+  -n "$NMP_GYM_CUSTOM_NAMESPACE" \
+  "service/$NMP_GYM_CUSTOM_PLATFORM_API_SERVICE" \
+  "$NMP_GYM_CUSTOM_LOCAL_PORT:8080"
+```
+
+## Run
+
+### Bundled example
+
+From the repository root, run the workflow without input flags to use the bundled ASCII Tree
+example:
+
+```bash
+export KUBECONFIG="${HOME}/teleport-kubeconfig.yaml"
+
+uv run --isolated --frozen \
+  --package nemo-evaluator-plugin \
+  --with-editable packages/filesets \
+  --with-editable packages/models \
+  python \
+  plugins/nemo-evaluator/scripts/gym-custom-environment/run.py
+```
+
+The script securely prompts for the NVIDIA API key. For non-interactive use, export
+`INFERENCE_NVIDIA_API_KEY` before running it.
+
+The command runs the workflow in an isolated, package-scoped uv environment and does not modify
+the repository `.venv`. Within that environment, the pinned Prime Intellect converter runs with
+only its `conversion` extra. The workflow retains and caches only the two-row JSONL fixture,
+discarding the converter's adapter package and dataset snapshot. The custom scorer wheel is also
+cached by a digest of its source. Subsequent runs reuse both artifacts until their inputs change.
+
+### A different custom environment
+
+Supply a complete environment directory and its separate Gym JSONL dataset:
+
+```bash
+uv run --isolated --frozen \
+  --package nemo-evaluator-plugin \
+  --with-editable packages/filesets \
+  --with-editable packages/models \
+  python \
+  plugins/nemo-evaluator/scripts/gym-custom-environment/run.py \
+  --environment-dir path/to/environment \
+  --dataset path/to/dataset.jsonl
+```
+
+The environment directory must:
+
+- contain a valid `nemo-environment.yaml` with `format: wheels-v1`;
+- contain every manifest-listed config and a non-empty, flat `wheels/` directory;
+- declare at least one resources server; and
+- remain separate from the JSONL dataset.
+
+Every dataset row must satisfy Gym's dataset contract, including a
+`responses_create_params` mapping. The workflow copies both inputs into its run directory and
+does not modify the originals. If the package declares multiple resources servers, select one:
+
+```bash
+--resources-server <config-instance-name>
+```
+
+The evaluation uses the Gym host's standard `simple_agent`; custom packages provide the
+resources server and its wheel-delivered dependencies.
+
+The terminal shows seven numbered stages:
+
+1. check workstation and cluster prerequisites;
+2. prepare the custom environment;
+3. create temporary Platform resources;
+4. smoke-test the selected model;
+5. run the custom Gym evaluation;
+6. verify evaluation evidence; and
+7. clean up temporary resources.
+
+A successful run ends with:
+
+```text
+SUCCESS: Custom Gym environment evaluation passed
+```
+
+The model does not need a perfect reward. The workflow passes when the FileSet-provided resources
+server returns a finite reward, persisted trial and metric values agree, image and OpenSandbox
+lifecycle checks pass, and there are no failed or missing results.
+
+## Evidence
+
+Each invocation creates a unique `/tmp/nmp-gym-custom-environment-*` directory. Pass
+`--run-dir <path>` to choose a different location. Important evidence includes:
+
+- `evidence/run-summary.json`;
+- `evidence/platform-config.json`;
+- `evidence/job-status.json` and `evidence/job-logs.json`;
+- `evidence/verification.json`;
+- `evidence/agent-eval-results/summary.json`, `scores.jsonl`, and `trials.jsonl`;
+- `evidence/nmp-api-image.txt`;
+- `evidence/nmp-cpu-tasks-image.txt`; and
+- `evidence/nmp-gym-host-image.txt`.
+
+Evidence contains prompts and model responses but never the NVIDIA API key.
+
+## Troubleshooting
+
+- **An image cannot be inspected:** authenticate Docker to the configured registry and confirm all
+  three images exist at the configured tag.
+- **A stale Gym host override is reported:** clear `evaluator.sandbox_runtime_image` and restart
+  API/controller deployments.
+- **The PVC check fails:** configure `evaluator.sandbox_job_storage_pvc_claim` with a
+  `ReadWriteMany` claim shared by task and sandbox pods.
+- **The local API port is occupied:** set `NMP_GYM_CUSTOM_LOCAL_PORT` to another port.
+- **The model is unavailable:** select an entity served by the temporary Inference Hub provider.
+- **The job fails:** inspect `evidence/job-status.json` and `evidence/job-logs.json`.

--- a/plugins/nemo-evaluator/scripts/gym-custom-environment/helm/opensandbox-values.example.yaml
+++ b/plugins/nemo-evaluator/scripts/gym-custom-environment/helm/opensandbox-values.example.yaml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Example values for enabling sandboxed Gym through an existing OpenSandbox
+# deployment. Apply this file with `helm upgrade --reuse-values` so unrelated
+# settings and deployed image coordinates remain unchanged.
+#
+# If the Platform namespace is not nmp-temp1, update sandbox_policy_base_urls
+# before applying this file.
+
+sandboxClusterCapable: true
+
+opensandbox:
+  domain: opensandbox-server-crun.opensandbox-system.svc.cluster.local
+  protocol: http
+  apiKeySecret: opensandbox-server-crun-api-key
+  apiKeySecretKey: api-key
+
+platformConfig:
+  evaluator:
+    sandboxed_gym_default: true
+    sandbox_cluster_capable: true
+    sandbox_host_provider: opensandbox
+    # Allow enough time for OpenSandbox to pull and start the 6+ GiB Gym host
+    # image. The SDK's 30-second default might be too short on an uncached node.
+    sandbox_host_provider_options:
+      connection:
+        request_timeout_s: 120
+
+    # Keep this unset so Evaluator derives nmp-gym-host from the Platform
+    # registry and immutable release tag.
+    sandbox_runtime_image: null
+
+    sandbox_job_storage_pvc_claim: nemo-platform-core-storage
+    sandbox_resources:
+      cpu: "1"
+      memory: 2Gi
+    sandbox_policy_base_urls:
+      - http://nemo-platform-api.nmp-temp1.svc.cluster.local:8080
+    sandbox_egress_allow:
+      - pypi.org:443
+      - files.pythonhosted.org:443

--- a/plugins/nemo-evaluator/scripts/gym-custom-environment/run.py
+++ b/plugins/nemo-evaluator/scripts/gym-custom-environment/run.py
@@ -20,13 +20,18 @@ from config import Settings
 
 
 def _parser() -> argparse.ArgumentParser:
-    """Build the command-line parser for the single developer entry point."""
+    """Describe artifact controls and optional bring-your-own inputs."""
     parser = argparse.ArgumentParser(description=__doc__)
+
+    # This option changes only where local evidence is retained.
     parser.add_argument(
         "--run-dir",
         type=Path,
         help="Artifact directory; defaults to a unique /tmp/nmp-gym-custom-environment-* path",
     )
+
+    # Supplying neither path selects the bundled example. Supplying both runs
+    # the same workflow against a developer-owned package and dataset.
     parser.add_argument(
         "--environment-dir",
         type=Path,
@@ -45,7 +50,7 @@ def _parser() -> argparse.ArgumentParser:
 
 
 def _inference_api_key() -> str:
-    """Read the inference API key from the environment or a hidden prompt."""
+    """Use the configured inference key, prompting securely when it is absent."""
     configured_key = os.environ.get("INFERENCE_NVIDIA_API_KEY", "")
     if configured_key:
         return configured_key
@@ -53,9 +58,10 @@ def _inference_api_key() -> str:
 
 
 def main() -> int:
-    """Parse configuration and execute the complete workflow once."""
+    """Translate CLI arguments into settings and execute all workflow stages."""
     parser = _parser()
     arguments = parser.parse_args()
+
     if (arguments.environment_dir is None) != (arguments.dataset is None):
         parser.error("--environment-dir and --dataset must be supplied together")
 
@@ -68,6 +74,7 @@ def main() -> int:
         dataset=arguments.dataset,
         resources_server=arguments.resources_server,
     )
+
     workflow = CustomGymEnvironmentWorkflow(settings)
     workflow.run(inference_api_key=_inference_api_key())
     return 0

--- a/plugins/nemo-evaluator/scripts/gym-custom-environment/run.py
+++ b/plugins/nemo-evaluator/scripts/gym-custom-environment/run.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Developer entry point for the custom Gym environment workflow.
+
+Run this file directly from the repository root. It parses the small public CLI,
+loads optional environment overrides, obtains the NVIDIA API key, and delegates
+the complete operation to ``CustomGymEnvironmentWorkflow``. The other Python
+files in this directory are implementation modules and are not run directly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import os
+from pathlib import Path
+
+from config import Settings
+
+
+def _parser() -> argparse.ArgumentParser:
+    """Build the command-line parser for the single developer entry point."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--run-dir",
+        type=Path,
+        help="Artifact directory; defaults to a unique /tmp/nmp-gym-custom-environment-* path",
+    )
+    parser.add_argument(
+        "--environment-dir",
+        type=Path,
+        help="Complete wheels-v1 environment directory; requires --dataset",
+    )
+    parser.add_argument(
+        "--dataset",
+        type=Path,
+        help="Gym JSONL dataset for --environment-dir",
+    )
+    parser.add_argument(
+        "--resources-server",
+        help="Resources server to run; inferred when the environment declares exactly one",
+    )
+    return parser
+
+
+def _inference_api_key() -> str:
+    """Read the inference API key from the environment or a hidden prompt."""
+    configured_key = os.environ.get("INFERENCE_NVIDIA_API_KEY", "")
+    if configured_key:
+        return configured_key
+    return getpass.getpass("NVIDIA Inference API key: ")
+
+
+def main() -> int:
+    """Parse configuration and execute the complete workflow once."""
+    parser = _parser()
+    arguments = parser.parse_args()
+    if (arguments.environment_dir is None) != (arguments.dataset is None):
+        parser.error("--environment-dir and --dataset must be supplied together")
+
+    # Delay plugin-heavy imports so ``--help`` stays fast and side-effect free.
+    from workflow import CustomGymEnvironmentWorkflow
+
+    settings = Settings.from_environment(
+        run_dir=arguments.run_dir,
+        environment_dir=arguments.environment_dir,
+        dataset=arguments.dataset,
+        resources_server=arguments.resources_server,
+    )
+    workflow = CustomGymEnvironmentWorkflow(settings)
+    workflow.run(inference_api_key=_inference_api_key())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/nemo-evaluator/scripts/gym-custom-environment/workflow.py
+++ b/plugins/nemo-evaluator/scripts/gym-custom-environment/workflow.py
@@ -68,7 +68,11 @@ class CreatedResources:
 
 
 class CustomGymEnvironmentWorkflow:
-    """Run the documented developer workflow and clean up temporary resources."""
+    """Coordinate the seven documented stages and own resource cleanup.
+
+    Each public method represents one visible workflow stage or a focused piece
+    of its lifecycle. Mutable fields record only outputs needed by later stages.
+    """
 
     def __init__(
         self,
@@ -82,6 +86,8 @@ class CustomGymEnvironmentWorkflow:
         self.runner = runner or CommandRunner(working_directory=settings.repo_root)
         self.console = console or Console()
         self.sdk = NeMoPlatform(base_url=settings.base_url, max_retries=2)
+
+        # These values become available as their corresponding stages complete.
         self.images: DeploymentImages | None = None
         self.prepared_environment: prepare.PreparedEnvironment | None = None
         self.job_name: str | None = None
@@ -106,10 +112,13 @@ class CustomGymEnvironmentWorkflow:
         self.images = checker.check()
 
     def prepare_custom_environment(self) -> None:
-        """Prepare and validate default or caller-provided environment inputs."""
+        """Stage either input mode and record its dynamically discovered metadata."""
         self.console.step(2, TOTAL_STEPS, "Preparing the custom Gym environment")
         adapter_evidence: dict[str, Any] = {}
+
         if self.settings.environment_source is None:
+            # The bundled adapter produces the same package and dataset shape
+            # expected from callers, so all later stages remain generic.
             adapter_evidence = ascii_tree_example.prepare_example(
                 self.runner,
                 converter_environment=self.settings.paths.converter_environment,
@@ -125,6 +134,8 @@ class CustomGymEnvironmentWorkflow:
             )
             self.console.detail("Input", adapter_evidence["input_label"])
         else:
+            # Settings validates this pair at the CLI boundary; retain the check
+            # here because this class can also be instantiated directly.
             environment_source = self.settings.environment_source
             dataset_source = self.settings.dataset_source
             if environment_source is None or dataset_source is None:
@@ -138,6 +149,8 @@ class CustomGymEnvironmentWorkflow:
                 requested_resources_server=self.settings.requested_resources_server,
             )
 
+        # Persist one normalized summary regardless of which input mode produced
+        # the staged package.
         self.prepared_environment = prepared_environment
         preparation_summary = {
             **prepared_environment.evidence(),
@@ -169,12 +182,14 @@ class CustomGymEnvironmentWorkflow:
 
     @contextmanager
     def platform_connection(self) -> Iterator[None]:
-        """Reuse a healthy API endpoint or own a temporary kubectl port-forward."""
+        """Yield with a ready API, cleaning up only a port-forward created here."""
         if self._api_is_ready(self.settings.local_port):
             self.console.detail("Platform API", f"{self.settings.base_url} (existing)")
             yield
             return
 
+        # Keep port-forward output with the run evidence so early startup
+        # failures do not disappear into a background process.
         port_forward_log = self.settings.paths.evidence / "port-forward.log"
         with port_forward_log.open("a", encoding="utf-8") as log:
             process = self.runner.start(
@@ -189,6 +204,8 @@ class CustomGymEnvironmentWorkflow:
                 stdout=log,
             )
             try:
+                # Readiness is a stronger signal than merely observing that the
+                # kubectl process is still running.
                 for _ in range(30):
                     if self._api_is_ready(self.settings.local_port):
                         break
@@ -203,6 +220,8 @@ class CustomGymEnvironmentWorkflow:
                 )
                 yield
             finally:
+                # This context owns only the process it started. An existing
+                # developer-managed port-forward is never terminated.
                 process.terminate()
                 try:
                     process.wait(timeout=5)
@@ -220,7 +239,7 @@ class CustomGymEnvironmentWorkflow:
         return self.settings.model_entity_id.removeprefix(workspace_prefix)
 
     def upload_custom_environment(self) -> None:
-        """Create a temporary FileSet and upload the custom environment package."""
+        """Upload the staged package and prove every local file reached the FileSet."""
         self.sdk.files.filesets.create(
             name=self.settings.fileset,
             workspace=self.settings.workspace,
@@ -228,11 +247,15 @@ class CustomGymEnvironmentWorkflow:
             description="Custom wheels-v1 Gym environment workflow",
         )
         self.created_resources.fileset = True
+
         self.sdk.files.upload(
             local_path=f"{self.settings.paths.environment}/",
             fileset=self.settings.fileset,
             workspace=self.settings.workspace,
         )
+
+        # Compare exact relative paths before submitting a job; a partial upload
+        # otherwise fails much later inside environment staging.
         fileset_listing = self.sdk.files.list(
             fileset=self.settings.fileset,
             workspace=self.settings.workspace,
@@ -258,11 +281,14 @@ class CustomGymEnvironmentWorkflow:
         self.console.detail("Environment FileSet", self.settings.fileset)
 
     def create_inference_provider(self, inference_api_key: str) -> None:
-        """Create a temporary NVIDIA Inference Hub Secret and provider."""
+        """Create temporary inference resources and wait for model discovery."""
         require_result(
             bool(inference_api_key),
             "INFERENCE_NVIDIA_API_KEY is required",
         )
+
+        # Resource flags are set immediately after successful creation so the
+        # failure path can clean up a partially configured provider.
         self.sdk.secrets.create(
             name=self.settings.inference_secret,
             value=inference_api_key,
@@ -270,6 +296,7 @@ class CustomGymEnvironmentWorkflow:
             description="Temporary key for the custom Gym environment workflow",
         )
         self.created_resources.inference_secret = True
+
         self.sdk.inference.providers.create(
             name=self.settings.inference_provider,
             workspace=self.settings.workspace,
@@ -278,6 +305,8 @@ class CustomGymEnvironmentWorkflow:
         )
         self.created_resources.inference_provider = True
 
+        # Provider creation is asynchronous. Do not smoke-test the model until
+        # its requested entity appears in the provider's served-model list.
         deadline = time.monotonic() + 120
         while True:
             provider = self.sdk.inference.providers.retrieve(
@@ -287,10 +316,12 @@ class CustomGymEnvironmentWorkflow:
             served_model_ids = {model.model_entity_id for model in (provider.served_models or [])}
             if self.settings.model_entity_id in served_model_ids:
                 break
+
             if provider.status in {"ERROR", "DELETED", "LOST"}:
                 raise ResultVerificationError(
                     f"provider entered {provider.status}: {provider.status_message or 'no status message'}"
                 )
+
             if time.monotonic() >= deadline:
                 raise ResultVerificationError(
                     f"provider did not discover {self.settings.model_entity_id} within 120 seconds"
@@ -335,7 +366,7 @@ class CustomGymEnvironmentWorkflow:
         self.console.detail("Model route", "ready")
 
     def submit_evaluation(self) -> dict[str, Any]:
-        """Submit one trial and download its validated result artifacts."""
+        """Run one trial, then preserve its status and logs for lifecycle checks."""
         self.console.step(5, TOTAL_STEPS, "Running the custom Gym evaluation")
         prepared_environment = self._require_prepared_environment()
         submission = EvaluationSubmission(
@@ -357,6 +388,8 @@ class CustomGymEnvironmentWorkflow:
         self.console.detail("Job", evaluation_result.job_name)
         self.console.detail("Custom reward", evaluation_result.verification["reward"])
 
+        # Submission validation owns trial and score evidence. The orchestration
+        # layer also saves Platform status/logs for image and sandbox assertions.
         job_status = self.sdk.jobs.get_status(
             evaluation_result.job_name,
             workspace=self.settings.workspace,
@@ -376,7 +409,7 @@ class CustomGymEnvironmentWorkflow:
         return evaluation_result.verification
 
     def verify_results(self, verification: dict[str, Any]) -> dict[str, Any]:
-        """Verify runtime images, sandbox lifecycle, and complete custom scoring."""
+        """Verify generic runtime evidence without inspecting environment output."""
         self.console.step(6, TOTAL_STEPS, "Verifying evaluation evidence")
         images = self._require_images()
         require_result(bool(self.job_name), "evaluation job name is missing")
@@ -386,6 +419,7 @@ class CustomGymEnvironmentWorkflow:
         status_messages = nested_messages(job_status)
         log_messages = nested_messages(job_logs)
 
+        # Match immutable release images rather than example-specific task data.
         require_result(
             sum(images.cpu_tasks in message for message in status_messages) >= 2,
             "both job steps did not use the configured CPU Tasks image",
@@ -423,8 +457,11 @@ class CustomGymEnvironmentWorkflow:
         return run_summary
 
     def cleanup(self) -> None:
-        """Delete every run-scoped Platform resource that was created."""
+        """Delete every created resource in reverse dependency order."""
         cleanup_errors: list[str] = []
+
+        # The provider references the secret, while the evaluation references
+        # the FileSet, so deleting in this order avoids dangling dependencies.
         resources: tuple[tuple[str, bool, Callable[..., object], str], ...] = (
             (
                 "inference provider",
@@ -445,6 +482,7 @@ class CustomGymEnvironmentWorkflow:
                 self.settings.fileset,
             ),
         )
+
         created_count = sum(was_created for _, was_created, _, _ in resources)
         if created_count == 0:
             self.console.detail("Temporary resources", "none created")
@@ -465,11 +503,16 @@ class CustomGymEnvironmentWorkflow:
         self.console.detail("Temporary resources", f"{deleted_count} deleted")
 
     def run(self, *, inference_api_key: str) -> dict[str, Any]:
-        """Execute the complete workflow through one developer-facing invocation."""
+        """Execute all seven stages and clean up after success or failure."""
         self.settings.paths.evidence.mkdir(parents=True, exist_ok=True)
+
+        # Read-only and local preparation happen before opening an API connection
+        # or creating Platform resources.
         self.verify_prerequisites()
         self.prepare_custom_environment()
 
+        # Every mutation lives inside the cleanup boundary. If evaluation raises,
+        # the original error remains primary and cleanup failures become warnings.
         workflow_failed = False
         with self.platform_connection():
             try:

--- a/plugins/nemo-evaluator/scripts/gym-custom-environment/workflow.py
+++ b/plugins/nemo-evaluator/scripts/gym-custom-environment/workflow.py
@@ -1,0 +1,501 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Internal orchestration for the developer-facing ``run.py`` script.
+
+``run.py`` constructs ``CustomGymEnvironmentWorkflow`` and calls ``run()``.
+This module owns the ordered operation: prepare and upload an environment,
+configure inference, submit an evaluation, verify generic runtime evidence,
+and clean up. Submission details, input adapters, and prerequisite checks live
+in dedicated modules so this file remains focused on the lifecycle.
+"""
+
+from __future__ import annotations
+
+import http.client
+import subprocess
+import time
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any
+
+import ascii_tree_example
+import prepare
+from artifacts import read_json, write_json
+from commands import CommandRunner
+from config import Settings
+from console import Console
+from nemo_platform import NeMoPlatform
+from prerequisites import DeploymentImages, PrerequisiteChecker
+from submit import EvaluationSubmission, submit_and_validate
+
+TOTAL_STEPS = 7
+
+
+class ResultVerificationError(RuntimeError):
+    """Raised when a completed workflow does not meet an acceptance criterion."""
+
+
+def require_result(condition: bool, message: str) -> None:
+    """Raise a focused verification error when an acceptance criterion fails."""
+    if not condition:
+        raise ResultVerificationError(message)
+
+
+def nested_messages(value: Any) -> list[str]:
+    """Collect every string-valued ``message`` field from nested JSON data."""
+    messages: list[str] = []
+    if isinstance(value, dict):
+        message = value.get("message")
+        if isinstance(message, str):
+            messages.append(message)
+        for child in value.values():
+            messages.extend(nested_messages(child))
+    elif isinstance(value, list):
+        for child in value:
+            messages.extend(nested_messages(child))
+    return messages
+
+
+@dataclass(slots=True)
+class CreatedResources:
+    """Track run-scoped resources that need cleanup."""
+
+    fileset: bool = False
+    inference_secret: bool = False
+    inference_provider: bool = False
+
+
+class CustomGymEnvironmentWorkflow:
+    """Run the documented developer workflow and clean up temporary resources."""
+
+    def __init__(
+        self,
+        settings: Settings,
+        *,
+        runner: CommandRunner | None = None,
+        console: Console | None = None,
+    ) -> None:
+        """Create a workflow with injectable command and output collaborators."""
+        self.settings = settings
+        self.runner = runner or CommandRunner(working_directory=settings.repo_root)
+        self.console = console or Console()
+        self.sdk = NeMoPlatform(base_url=settings.base_url, max_retries=2)
+        self.images: DeploymentImages | None = None
+        self.prepared_environment: prepare.PreparedEnvironment | None = None
+        self.job_name: str | None = None
+        self.created_resources = CreatedResources()
+
+    def _require_images(self) -> DeploymentImages:
+        """Return resolved deployment images after prerequisite validation."""
+        if self.images is None:
+            raise ResultVerificationError("deployment images have not been resolved")
+        return self.images
+
+    def _require_prepared_environment(self) -> prepare.PreparedEnvironment:
+        """Return validated package metadata after preparation has completed."""
+        if self.prepared_environment is None:
+            raise ResultVerificationError("custom environment has not been prepared")
+        return self.prepared_environment
+
+    def verify_prerequisites(self) -> None:
+        """Run the dedicated read-only workstation and cluster checks."""
+        self.console.step(1, TOTAL_STEPS, "Checking workstation and cluster prerequisites")
+        checker = PrerequisiteChecker(self.settings, self.runner, self.console)
+        self.images = checker.check()
+
+    def prepare_custom_environment(self) -> None:
+        """Prepare and validate default or caller-provided environment inputs."""
+        self.console.step(2, TOTAL_STEPS, "Preparing the custom Gym environment")
+        adapter_evidence: dict[str, Any] = {}
+        if self.settings.environment_source is None:
+            adapter_evidence = ascii_tree_example.prepare_example(
+                self.runner,
+                converter_environment=self.settings.paths.converter_environment,
+                converter_dataset=self.settings.paths.converter_dataset,
+                environment_output=self.settings.paths.environment,
+                dataset_output=self.settings.paths.dataset,
+            )
+            prepared_environment = prepare.inspect_prepared_inputs(
+                self.settings.paths.environment,
+                self.settings.paths.dataset,
+                requested_resources_server=self.settings.requested_resources_server,
+                input_mode=str(adapter_evidence["input_mode"]),
+            )
+            self.console.detail("Input", adapter_evidence["input_label"])
+        else:
+            environment_source = self.settings.environment_source
+            dataset_source = self.settings.dataset_source
+            if environment_source is None or dataset_source is None:
+                raise ResultVerificationError("custom environment inputs are incomplete")
+            self.console.detail("Input", environment_source)
+            prepared_environment = prepare.prepare_custom_inputs(
+                environment_source,
+                dataset_source,
+                environment_output=self.settings.paths.environment,
+                dataset_output=self.settings.paths.dataset,
+                requested_resources_server=self.settings.requested_resources_server,
+            )
+
+        self.prepared_environment = prepared_environment
+        preparation_summary = {
+            **prepared_environment.evidence(),
+            **adapter_evidence,
+        }
+        write_json(
+            self.settings.paths.evidence / "preparation.json",
+            preparation_summary,
+        )
+        self.console.detail("Environment format", "wheels-v1")
+        self.console.detail("Environment", prepared_environment.name)
+        self.console.detail("Dataset tasks", prepared_environment.task_count)
+        self.console.detail("Custom wheels", ", ".join(prepared_environment.wheel_names))
+        self.console.detail("Resources server", prepared_environment.resources_server)
+
+    @staticmethod
+    def _api_is_ready(port: int) -> bool:
+        """Return whether the local Platform readiness endpoint responds successfully."""
+        connection = http.client.HTTPConnection("127.0.0.1", port, timeout=1)
+        try:
+            connection.request("GET", "/health/ready")
+            response = connection.getresponse()
+            response.read()
+            return response.status == 200
+        except OSError:
+            return False
+        finally:
+            connection.close()
+
+    @contextmanager
+    def platform_connection(self) -> Iterator[None]:
+        """Reuse a healthy API endpoint or own a temporary kubectl port-forward."""
+        if self._api_is_ready(self.settings.local_port):
+            self.console.detail("Platform API", f"{self.settings.base_url} (existing)")
+            yield
+            return
+
+        port_forward_log = self.settings.paths.evidence / "port-forward.log"
+        with port_forward_log.open("a", encoding="utf-8") as log:
+            process = self.runner.start(
+                [
+                    "kubectl",
+                    "port-forward",
+                    "-n",
+                    self.settings.namespace,
+                    f"service/{self.settings.platform_api_service}",
+                    f"{self.settings.local_port}:8080",
+                ],
+                stdout=log,
+            )
+            try:
+                for _ in range(30):
+                    if self._api_is_ready(self.settings.local_port):
+                        break
+                    if process.poll() is not None:
+                        raise ResultVerificationError(f"Platform API port-forward failed; see {port_forward_log}")
+                    time.sleep(1)
+                else:
+                    raise ResultVerificationError("Platform API port-forward did not become ready")
+                self.console.detail(
+                    "Platform API",
+                    f"{self.settings.base_url} (temporary port-forward)",
+                )
+                yield
+            finally:
+                process.terminate()
+                try:
+                    process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait()
+
+    def _model_name(self) -> str:
+        """Return the workspace-relative model name required by API routes."""
+        workspace_prefix = f"{self.settings.workspace}/"
+        require_result(
+            self.settings.model_entity_id.startswith(workspace_prefix),
+            (f"NMP_GYM_CUSTOM_MODEL_ENTITY_ID must start with {workspace_prefix}"),
+        )
+        return self.settings.model_entity_id.removeprefix(workspace_prefix)
+
+    def upload_custom_environment(self) -> None:
+        """Create a temporary FileSet and upload the custom environment package."""
+        self.sdk.files.filesets.create(
+            name=self.settings.fileset,
+            workspace=self.settings.workspace,
+            purpose="environment",
+            description="Custom wheels-v1 Gym environment workflow",
+        )
+        self.created_resources.fileset = True
+        self.sdk.files.upload(
+            local_path=f"{self.settings.paths.environment}/",
+            fileset=self.settings.fileset,
+            workspace=self.settings.workspace,
+        )
+        fileset_listing = self.sdk.files.list(
+            fileset=self.settings.fileset,
+            workspace=self.settings.workspace,
+        )
+        expected_paths = {
+            path.relative_to(self.settings.paths.environment).as_posix()
+            for path in self.settings.paths.environment.rglob("*")
+            if path.is_file()
+        }
+        uploaded_paths = {uploaded_file.path for uploaded_file in fileset_listing.data}
+        require_result(
+            uploaded_paths == expected_paths,
+            (
+                "uploaded environment FileSet does not match the local package: "
+                f"missing={sorted(expected_paths - uploaded_paths)}, "
+                f"unexpected={sorted(uploaded_paths - expected_paths)}"
+            ),
+        )
+        write_json(
+            self.settings.paths.evidence / "fileset-listing.json",
+            fileset_listing,
+        )
+        self.console.detail("Environment FileSet", self.settings.fileset)
+
+    def create_inference_provider(self, inference_api_key: str) -> None:
+        """Create a temporary NVIDIA Inference Hub Secret and provider."""
+        require_result(
+            bool(inference_api_key),
+            "INFERENCE_NVIDIA_API_KEY is required",
+        )
+        self.sdk.secrets.create(
+            name=self.settings.inference_secret,
+            value=inference_api_key,
+            workspace=self.settings.workspace,
+            description="Temporary key for the custom Gym environment workflow",
+        )
+        self.created_resources.inference_secret = True
+        self.sdk.inference.providers.create(
+            name=self.settings.inference_provider,
+            workspace=self.settings.workspace,
+            host_url="https://inference-api.nvidia.com/v1",
+            api_key_secret_name=self.settings.inference_secret,
+        )
+        self.created_resources.inference_provider = True
+
+        deadline = time.monotonic() + 120
+        while True:
+            provider = self.sdk.inference.providers.retrieve(
+                self.settings.inference_provider,
+                workspace=self.settings.workspace,
+            )
+            served_model_ids = {model.model_entity_id for model in (provider.served_models or [])}
+            if self.settings.model_entity_id in served_model_ids:
+                break
+            if provider.status in {"ERROR", "DELETED", "LOST"}:
+                raise ResultVerificationError(
+                    f"provider entered {provider.status}: {provider.status_message or 'no status message'}"
+                )
+            if time.monotonic() >= deadline:
+                raise ResultVerificationError(
+                    f"provider did not discover {self.settings.model_entity_id} within 120 seconds"
+                )
+            time.sleep(2)
+
+        write_json(
+            self.settings.paths.evidence / "provider.json",
+            provider,
+        )
+        self.console.detail("Model", self.settings.model_entity_id)
+
+    def configure_platform_resources(self, inference_api_key: str) -> None:
+        """Upload the environment and create temporary inference resources."""
+        self.console.step(3, TOTAL_STEPS, "Creating temporary Platform resources")
+        self.upload_custom_environment()
+        self.create_inference_provider(inference_api_key)
+
+    def smoke_test_model(self) -> None:
+        """Send a small environment-independent prompt through the selected model route."""
+        self.console.step(4, TOTAL_STEPS, "Smoke-testing the selected model")
+        request_body: dict[str, object] = {
+            "model": self.settings.model_entity_id,
+            "messages": [{"role": "user", "content": "Reply with OK."}],
+            "max_tokens": 16,
+            "temperature": 0,
+        }
+        smoke_response = self.sdk.inference.gateway.model.post(
+            "v1/chat/completions",
+            name=self._model_name(),
+            workspace=self.settings.workspace,
+            body=request_body,
+        )
+        require_result(
+            isinstance(smoke_response.get("choices"), list) and bool(smoke_response["choices"]),
+            "model smoke test returned no choices",
+        )
+        write_json(
+            self.settings.paths.evidence / "inference-smoke.json",
+            smoke_response,
+        )
+        self.console.detail("Model route", "ready")
+
+    def submit_evaluation(self) -> dict[str, Any]:
+        """Submit one trial and download its validated result artifacts."""
+        self.console.step(5, TOTAL_STEPS, "Running the custom Gym evaluation")
+        prepared_environment = self._require_prepared_environment()
+        submission = EvaluationSubmission(
+            base_url=self.settings.base_url,
+            internal_api=self.settings.internal_api,
+            workspace=self.settings.workspace,
+            fileset=self.settings.fileset,
+            model=self._model_name(),
+            dataset=self.settings.paths.dataset,
+            resources_server=prepared_environment.resources_server,
+            evidence_directory=self.settings.paths.evidence,
+        )
+        evaluation_result = submit_and_validate(
+            submission,
+            sdk=self.sdk,
+            progress=lambda message: self.console.detail("Job progress", message),
+        )
+        self.job_name = evaluation_result.job_name
+        self.console.detail("Job", evaluation_result.job_name)
+        self.console.detail("Custom reward", evaluation_result.verification["reward"])
+
+        job_status = self.sdk.jobs.get_status(
+            evaluation_result.job_name,
+            workspace=self.settings.workspace,
+        )
+        job_logs = self.sdk.jobs.get_logs(
+            evaluation_result.job_name,
+            workspace=self.settings.workspace,
+        )
+        write_json(
+            self.settings.paths.evidence / "job-status.json",
+            job_status,
+        )
+        write_json(
+            self.settings.paths.evidence / "job-logs.json",
+            {"data": list(job_logs)},
+        )
+        return evaluation_result.verification
+
+    def verify_results(self, verification: dict[str, Any]) -> dict[str, Any]:
+        """Verify runtime images, sandbox lifecycle, and complete custom scoring."""
+        self.console.step(6, TOTAL_STEPS, "Verifying evaluation evidence")
+        images = self._require_images()
+        require_result(bool(self.job_name), "evaluation job name is missing")
+
+        job_status = read_json(self.settings.paths.evidence / "job-status.json")
+        job_logs = read_json(self.settings.paths.evidence / "job-logs.json")
+        status_messages = nested_messages(job_status)
+        log_messages = nested_messages(job_logs)
+
+        require_result(
+            sum(images.cpu_tasks in message for message in status_messages) >= 2,
+            "both job steps did not use the configured CPU Tasks image",
+        )
+        require_result(
+            any(f"Creating sandbox with startup source: {images.gym_host}" in message for message in log_messages),
+            "OpenSandbox did not use the configured Gym host image",
+        )
+
+        # Together these markers show that execution entered and exited OpenSandbox cleanly.
+        for expected_message in (
+            "Successfully created sandbox:",
+            "Collecting 1 example(s)",
+            "Successfully terminated sandbox:",
+        ):
+            require_result(
+                any(expected_message in message for message in log_messages),
+                f"missing job evidence: {expected_message}",
+            )
+
+        run_summary = {
+            "status": "passed",
+            "job_name": self.job_name,
+            "image_registry": images.registry,
+            "image_tag": images.tag,
+            "cpu_tasks_image": images.cpu_tasks,
+            "gym_host_image": images.gym_host,
+            "model": self.settings.model_entity_id,
+            "evaluation": verification,
+        }
+        write_json(self.settings.paths.evidence / "run-summary.json", run_summary)
+        self.console.detail("CPU Tasks image", images.cpu_tasks)
+        self.console.detail("Gym host image", images.gym_host)
+        self.console.detail("Sandbox lifecycle", "created and terminated")
+        return run_summary
+
+    def cleanup(self) -> None:
+        """Delete every run-scoped Platform resource that was created."""
+        cleanup_errors: list[str] = []
+        resources: tuple[tuple[str, bool, Callable[..., object], str], ...] = (
+            (
+                "inference provider",
+                self.created_resources.inference_provider,
+                self.sdk.inference.providers.delete,
+                self.settings.inference_provider,
+            ),
+            (
+                "inference secret",
+                self.created_resources.inference_secret,
+                self.sdk.secrets.delete,
+                self.settings.inference_secret,
+            ),
+            (
+                "environment FileSet",
+                self.created_resources.fileset,
+                self.sdk.files.filesets.delete,
+                self.settings.fileset,
+            ),
+        )
+        created_count = sum(was_created for _, was_created, _, _ in resources)
+        if created_count == 0:
+            self.console.detail("Temporary resources", "none created")
+            return
+
+        deleted_count = 0
+        for resource_name, was_created, delete_resource, name in resources:
+            if not was_created:
+                continue
+            try:
+                delete_resource(name, workspace=self.settings.workspace)
+                deleted_count += 1
+            except Exception as error:
+                # Attempt all deletions so one failure does not leak unrelated resources.
+                cleanup_errors.append(f"{resource_name}: {error}")
+        if cleanup_errors:
+            raise RuntimeError("cleanup failed:\n" + "\n".join(cleanup_errors))
+        self.console.detail("Temporary resources", f"{deleted_count} deleted")
+
+    def run(self, *, inference_api_key: str) -> dict[str, Any]:
+        """Execute the complete workflow through one developer-facing invocation."""
+        self.settings.paths.evidence.mkdir(parents=True, exist_ok=True)
+        self.verify_prerequisites()
+        self.prepare_custom_environment()
+
+        workflow_failed = False
+        with self.platform_connection():
+            try:
+                self.configure_platform_resources(inference_api_key)
+                self.smoke_test_model()
+                verification = self.submit_evaluation()
+                run_summary = self.verify_results(verification)
+            except Exception:
+                workflow_failed = True
+                raise
+            finally:
+                if workflow_failed:
+                    self.console.warning("Workflow stopped; cleaning up resources created before the failure")
+                else:
+                    self.console.step(7, TOTAL_STEPS, "Cleaning up temporary resources")
+                try:
+                    self.cleanup()
+                except RuntimeError as cleanup_error:
+                    if workflow_failed:
+                        self.console.warning(str(cleanup_error))
+                    else:
+                        raise
+
+        self.console.success("Custom Gym environment evaluation passed")
+        self.console.detail("Job", run_summary["job_name"])
+        self.console.detail("Model", run_summary["model"])
+        self.console.detail("Reward", run_summary["evaluation"]["reward"])
+        self.console.detail("Evidence", self.settings.paths.evidence)
+        return run_summary


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary

PR 3 of 3 to add a manual end-to-end Gym Evaluation test script that enables testing and validating a built-in custom Gym environment against a Kubernetes deployment.

This PR adds a single-command workflow for running the test. It prepares and uploads the environment, configures inference, runs evaluation, verifies generic runtime evidence, and cleans up temporary resources.

It also adds a detailed ReadME - it makes the assumption that you already have a Kubernetes environment with NMP and OpenSandbox deployed.

## Changes

- Add the seven-stage workflow and command-line entry point.
- Use the bundled ASCII Tree example by default.
- Accept custom environments through `--environment-dir`, `--dataset`, and `--resources-server`.
- Reuse an existing Platform port-forward or create a temporary one.
- Verify release images and sandbox lifecycle evidence.
- Clean up temporary FileSet, secret, and inference-provider resources.
- Document prerequisites, Helm configuration, port-forwarding, execution, and customization.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: The deliverable is a manually invoked end-to-end validation workflow and was verified against a live cluster.
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

