### PR TITLE
feat(studio): create an agent from one seen in imported traces

### DIFF
--- a/web/packages/studio/src/routes/agents/AgentsListRoute/NewAgentModal/index.test.tsx
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/NewAgentModal/index.test.tsx
@@ -128,13 +128,11 @@ const submit = async (dialog: HTMLElement, user: ReturnType<typeof userEvent.set
 };
 
 describe('NewAgentModal coding agent prompt tab', () => {
-  it('reaches the prompt in one click, so an agent already in a repository needs no upload', async () => {
-    const user = userEvent.setup();
+  it('opens on the prompt, so an agent already in a repository needs no upload', async () => {
     mockPlatform();
 
     renderModal();
     const dialog = await screen.findByRole('dialog');
-    await user.click(within(dialog).getByRole('tab', { name: 'Coding agent prompt' }));
 
     expect(within(dialog).getByRole('tab', { name: 'Coding agent prompt' })).toHaveAttribute(
       'aria-selected',
@@ -150,7 +148,6 @@ describe('NewAgentModal coding agent prompt tab', () => {
 
     renderModal();
     const dialog = await screen.findByRole('dialog');
-    await user.click(within(dialog).getByRole('tab', { name: 'Coding agent prompt' }));
     // The prompt editor is a lazily imported chunk, so it can miss the default find timeout.
     await user.click(
       await within(dialog).findByRole('button', { name: 'Copy to clipboard' }, { timeout: 10_000 })
@@ -164,12 +161,10 @@ describe('NewAgentModal coding agent prompt tab', () => {
   });
 
   it('offers Close rather than Create, since the prompt has nothing to submit', async () => {
-    const user = userEvent.setup();
     mockPlatform();
 
     renderModal();
     const dialog = await screen.findByRole('dialog');
-    await user.click(within(dialog).getByRole('tab', { name: 'Coding agent prompt' }));
 
     expect(within(dialog).getByRole('button', { name: 'Close' })).toBeInTheDocument();
     expect(within(dialog).queryByRole('button', { name: 'Create' })).not.toBeInTheDocument();
@@ -431,17 +426,18 @@ describe('NewAgentModal imported traces tab', () => {
     );
   };
 
-  it('lands on the traces tab and offers each distinct agent seen in them', async () => {
+  const openTracesTab = async (dialog: HTMLElement, user: ReturnType<typeof userEvent.setup>) => {
+    await user.click(within(dialog).getByRole('tab', { name: 'Create from traces' }));
+  };
+
+  it('offers each distinct agent seen in the traces', async () => {
     const user = userEvent.setup();
     mockPlatform();
     mockTraces(['billing-agent', 'billing-agent', 'research-agent', undefined]);
 
     renderModal();
     const dialog = await screen.findByRole('dialog');
-
-    expect(
-      within(dialog).getByRole('tab', { name: 'Create from Imported traces' })
-    ).toHaveAttribute('aria-selected', 'true');
+    await openTracesTab(dialog, user);
 
     await user.click(await within(dialog).findByRole('combobox', { name: /imported traces/i }));
     // Deduped, and a trace with no agent contributes nothing.
@@ -457,21 +453,24 @@ describe('NewAgentModal imported traces tab', () => {
 
     renderModal();
     const dialog = await screen.findByRole('dialog');
+    await openTracesTab(dialog, user);
 
     await user.click(await within(dialog).findByRole('combobox', { name: /imported traces/i }));
     expect(await screen.findByRole('option', { name: 'billing-agent' })).toBeInTheDocument();
     expect(screen.queryByRole('option', { name: 'research-agent' })).not.toBeInTheDocument();
   });
 
-  it('says so when every traced agent is already registered', async () => {
+  it('shows the import prompt when no unregistered agent is left to offer', async () => {
+    const user = userEvent.setup();
     mockPlatform();
     mockTraces(['research-agent'], ['research-agent']);
 
     renderModal();
     const dialog = await screen.findByRole('dialog');
+    await openTracesTab(dialog, user);
 
     expect(await within(dialog).findByTestId('no-traced-agents')).toHaveTextContent(
-      'already registered'
+      'intake trace import skill'
     );
   });
 
@@ -482,6 +481,7 @@ describe('NewAgentModal imported traces tab', () => {
 
     renderModal();
     const dialog = await screen.findByRole('dialog');
+    await openTracesTab(dialog, user);
 
     expect(within(dialog).getByRole('button', { name: 'Create' })).toBeDisabled();
 

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/NewAgentModal/index.test.tsx
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/NewAgentModal/index.test.tsx
@@ -113,7 +113,7 @@ const renderModal = () =>
     ],
   });
 
-/** The prompt tab is the default, so upload tests have to switch before the form exists. */
+/** Upload tests have to switch tabs before the form exists. */
 const openUploadTab = async (dialog: HTMLElement) => {
   fireEvent.click(within(dialog).getByRole('tab', { name: 'Upload agent' }));
   await screen.findByTestId('agent-directory-input');
@@ -128,11 +128,13 @@ const submit = async (dialog: HTMLElement, user: ReturnType<typeof userEvent.set
 };
 
 describe('NewAgentModal coding agent prompt tab', () => {
-  it('opens on the prompt, so an agent already in a repository needs no upload', async () => {
+  it('reaches the prompt in one click, so an agent already in a repository needs no upload', async () => {
+    const user = userEvent.setup();
     mockPlatform();
 
     renderModal();
     const dialog = await screen.findByRole('dialog');
+    await user.click(within(dialog).getByRole('tab', { name: 'Coding agent prompt' }));
 
     expect(within(dialog).getByRole('tab', { name: 'Coding agent prompt' })).toHaveAttribute(
       'aria-selected',
@@ -148,6 +150,7 @@ describe('NewAgentModal coding agent prompt tab', () => {
 
     renderModal();
     const dialog = await screen.findByRole('dialog');
+    await user.click(within(dialog).getByRole('tab', { name: 'Coding agent prompt' }));
     // The prompt editor is a lazily imported chunk, so it can miss the default find timeout.
     await user.click(
       await within(dialog).findByRole('button', { name: 'Copy to clipboard' }, { timeout: 10_000 })
@@ -161,10 +164,12 @@ describe('NewAgentModal coding agent prompt tab', () => {
   });
 
   it('offers Close rather than Create, since the prompt has nothing to submit', async () => {
+    const user = userEvent.setup();
     mockPlatform();
 
     renderModal();
     const dialog = await screen.findByRole('dialog');
+    await user.click(within(dialog).getByRole('tab', { name: 'Coding agent prompt' }));
 
     expect(within(dialog).getByRole('button', { name: 'Close' })).toBeInTheDocument();
     expect(within(dialog).queryByRole('button', { name: 'Create' })).not.toBeInTheDocument();
@@ -404,5 +409,88 @@ describe('NewAgentModal folder drop', () => {
 
     await waitFor(() => expect(created).toHaveLength(1));
     expect([...uploaded].sort()).toEqual(['agent.yaml', 'mcps/calculator.py']);
+  });
+});
+
+describe('NewAgentModal imported traces tab', () => {
+  const mockTraces = (agentNames: (string | undefined)[], registered: string[] = []) => {
+    server.use(
+      http.get('*/apis/intake/v2/workspaces/:workspace/traces', () =>
+        HttpResponse.json({
+          data: agentNames.map((agent_name, index) => ({
+            trace_id: `t-${index}`,
+            root_span_id: `s-${index}`,
+            started_at: '2026-01-01T00:00:00Z',
+            ...(agent_name ? { agent_name } : {}),
+          })),
+        })
+      ),
+      http.get('*/apis/agents/v2/workspaces/:workspace/agents', () =>
+        HttpResponse.json({ data: registered.map((name) => ({ name, workspace })) })
+      )
+    );
+  };
+
+  it('lands on the traces tab and offers each distinct agent seen in them', async () => {
+    const user = userEvent.setup();
+    mockPlatform();
+    mockTraces(['billing-agent', 'billing-agent', 'research-agent', undefined]);
+
+    renderModal();
+    const dialog = await screen.findByRole('dialog');
+
+    expect(
+      within(dialog).getByRole('tab', { name: 'Create from Imported traces' })
+    ).toHaveAttribute('aria-selected', 'true');
+
+    await user.click(await within(dialog).findByRole('combobox', { name: /imported traces/i }));
+    // Deduped, and a trace with no agent contributes nothing.
+    expect(await screen.findByRole('option', { name: 'billing-agent' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'research-agent' })).toBeInTheDocument();
+    expect(screen.getAllByRole('option')).toHaveLength(2);
+  });
+
+  it('leaves out agents that are registered already', async () => {
+    const user = userEvent.setup();
+    mockPlatform();
+    mockTraces(['billing-agent', 'research-agent'], ['research-agent']);
+
+    renderModal();
+    const dialog = await screen.findByRole('dialog');
+
+    await user.click(await within(dialog).findByRole('combobox', { name: /imported traces/i }));
+    expect(await screen.findByRole('option', { name: 'billing-agent' })).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: 'research-agent' })).not.toBeInTheDocument();
+  });
+
+  it('says so when every traced agent is already registered', async () => {
+    mockPlatform();
+    mockTraces(['research-agent'], ['research-agent']);
+
+    renderModal();
+    const dialog = await screen.findByRole('dialog');
+
+    expect(await within(dialog).findByTestId('no-traced-agents')).toHaveTextContent(
+      'already registered'
+    );
+  });
+
+  it('creates the chosen agent and cannot submit before one is chosen', async () => {
+    const user = userEvent.setup();
+    const { created } = mockPlatform();
+    mockTraces(['billing-agent']);
+
+    renderModal();
+    const dialog = await screen.findByRole('dialog');
+
+    expect(within(dialog).getByRole('button', { name: 'Create' })).toBeDisabled();
+
+    await user.click(await within(dialog).findByRole('combobox', { name: /imported traces/i }));
+    await user.click(await screen.findByRole('option', { name: 'billing-agent' }));
+    await user.click(within(dialog).getByRole('button', { name: 'Create' }));
+
+    await waitFor(() => expect(created).toHaveLength(1));
+    // Telemetry carries no config, and the platform defaults an empty one.
+    expect(created[0]).toMatchObject({ name: 'billing-agent', config: {} });
   });
 });

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/NewAgentModal/index.tsx
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/NewAgentModal/index.tsx
@@ -12,6 +12,7 @@ import {
 } from '@nemo/sdk/generated/agents/agents';
 import {
   Button,
+  Flex,
   Select,
   Stack,
   TabsContent,
@@ -82,7 +83,7 @@ export const NewAgentModal: FC<NewAgentModalProps> = ({ open, onClose, workspace
   const [directoryName, setDirectoryName] = useState('');
   const [selectionError, setSelectionError] = useState<string | undefined>(undefined);
   const [replaceArmedFor, setReplaceArmedFor] = useState<string | null>(null);
-  const [tab, setTab] = useState<NewAgentTab>('imported-traces');
+  const [tab, setTab] = useState<NewAgentTab>('coding-agent-prompt');
   const [tracedAgent, setTracedAgent] = useState('');
 
   const {
@@ -152,7 +153,7 @@ export const NewAgentModal: FC<NewAgentModalProps> = ({ open, onClose, workspace
     setDirectoryName('');
     setSelectionError(undefined);
     setReplaceArmedFor(null);
-    setTab('imported-traces');
+    setTab('coding-agent-prompt');
     setTracedAgent('');
     onClose();
   };
@@ -316,35 +317,10 @@ export const NewAgentModal: FC<NewAgentModalProps> = ({ open, onClose, workspace
     >
       <TabsRoot value={tab} onValueChange={(value) => setTab(value as NewAgentTab)}>
         <TabsList aria-label="Ways to instrument an agent">
-          <TabsTrigger value="imported-traces">Create from Imported traces</TabsTrigger>
           <TabsTrigger value="coding-agent-prompt">Coding agent prompt</TabsTrigger>
           <TabsTrigger value="upload">Upload agent</TabsTrigger>
+          <TabsTrigger value="imported-traces">Create from traces</TabsTrigger>
         </TabsList>
-
-        <TabsContent value="imported-traces" className="items-stretch p-0 pt-density-lg">
-          <Stack gap="density-md">
-            <Text kind="body/regular/sm" color="secondary">
-              Agents that appear in ingested traces but are not registered yet. Registering one
-              gives its traces, evaluations, and insights an agent to hang from.
-            </Text>
-            {!tracedAgents.isLoading && tracedAgents.names.length === 0 ? (
-              <Text kind="body/regular/sm" color="secondary" data-testid="no-traced-agents">
-                {tracedAgents.registeredCount > 0
-                  ? 'Every agent named in recent traces is already registered.'
-                  : 'No agent names found in recent traces. Import traces first, then come back.'}
-              </Text>
-            ) : (
-              <Select
-                aria-label="Agent from imported traces"
-                value={tracedAgent}
-                onValueChange={setTracedAgent}
-                disabled={isCreatingTraced || tracedAgents.isLoading}
-                placeholder={tracedAgents.isLoading ? 'Loading...' : 'Select an agent'}
-                items={tracedAgents.names.map((name) => ({ value: name, children: name }))}
-              />
-            )}
-          </Stack>
-        </TabsContent>
 
         <TabsContent value="coding-agent-prompt" className="items-stretch p-0 pt-density-lg">
           <CodingAgentPromptEditor
@@ -377,6 +353,39 @@ export const NewAgentModal: FC<NewAgentModalProps> = ({ open, onClose, workspace
               label="Name"
               formFieldProps={{ slotError: errors.name?.message }}
             />
+          </Stack>
+        </TabsContent>
+
+        <TabsContent value="imported-traces" className="items-stretch p-0 pt-density-lg">
+          <Stack gap="density-md">
+            <Text kind="body/regular/sm" color="secondary">
+              Unregistered agents that appear in ingested traces.
+            </Text>
+            {!tracedAgents.isLoading && tracedAgents.names.length === 0 ? (
+              // The min-height gives the panel something to center within; the tab's content
+              // is otherwise only as tall as this sentence.
+              <Flex
+                direction="col"
+                align="center"
+                justify="center"
+                className="min-h-[220px] w-full text-center"
+                data-testid="no-traced-agents"
+              >
+                <Text kind="body/regular/sm" color="subtle" className="max-w-[46ch]">
+                  No traces with agent.name parameter found. You can import traces with the intake
+                  trace import skill to get started.
+                </Text>
+              </Flex>
+            ) : (
+              <Select
+                aria-label="Agent from imported traces"
+                value={tracedAgent}
+                onValueChange={setTracedAgent}
+                disabled={isCreatingTraced || tracedAgents.isLoading}
+                placeholder={tracedAgents.isLoading ? 'Loading...' : 'Select an agent'}
+                items={tracedAgents.names.map((name) => ({ value: name, children: name }))}
+              />
+            )}
           </Stack>
         </TabsContent>
       </TabsRoot>

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/NewAgentModal/index.tsx
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/NewAgentModal/index.tsx
@@ -13,6 +13,7 @@ import {
 import {
   Button,
   Flex,
+  Label,
   Select,
   Stack,
   TabsContent,
@@ -357,26 +358,24 @@ export const NewAgentModal: FC<NewAgentModalProps> = ({ open, onClose, workspace
         </TabsContent>
 
         <TabsContent value="imported-traces" className="items-stretch p-0 pt-density-lg">
-          <Stack gap="density-md">
-            <Text kind="body/regular/sm" color="secondary">
-              Unregistered agents that appear in ingested traces.
-            </Text>
-            {!tracedAgents.isLoading && tracedAgents.names.length === 0 ? (
-              // The min-height gives the panel something to center within; the tab's content
-              // is otherwise only as tall as this sentence.
-              <Flex
-                direction="col"
-                align="center"
-                justify="center"
-                className="min-h-[220px] w-full text-center"
-                data-testid="no-traced-agents"
-              >
-                <Text kind="body/regular/sm" color="subtle" className="max-w-[46ch]">
-                  No traces with agent.name parameter found. You can import traces with the intake
-                  trace import skill to get started.
-                </Text>
-              </Flex>
-            ) : (
+          {!tracedAgents.isLoading && tracedAgents.names.length === 0 ? (
+            // The min-height gives the panel something to center within; the tab's content
+            // is otherwise only as tall as this sentence.
+            <Flex
+              direction="col"
+              align="center"
+              justify="center"
+              className="min-h-[220px] w-full text-center"
+              data-testid="no-traced-agents"
+            >
+              <Text kind="body/regular/md" color="subtle" className="max-w-[64ch]">
+                No traces with agent.name parameter found. You can import traces with the intake
+                trace import skill to get started.
+              </Text>
+            </Flex>
+          ) : (
+            <Stack gap="density-sm">
+              <Label>Unregistered agents that appear in ingested traces</Label>
               <Select
                 aria-label="Agent from imported traces"
                 value={tracedAgent}
@@ -385,8 +384,8 @@ export const NewAgentModal: FC<NewAgentModalProps> = ({ open, onClose, workspace
                 placeholder={tracedAgents.isLoading ? 'Loading...' : 'Select an agent'}
                 items={tracedAgents.names.map((name) => ({ value: name, children: name }))}
               />
-            )}
-          </Stack>
+            </Stack>
+          )}
         </TabsContent>
       </TabsRoot>
     </FormModal>

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/NewAgentModal/index.tsx
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/NewAgentModal/index.tsx
@@ -6,9 +6,13 @@ import { getErrorMessage } from '@nemo/common/src/api/common/utils';
 import { ControlledTextInput } from '@nemo/common/src/components/form/ControlledTextInput';
 import { FormModal } from '@nemo/common/src/components/FormModal';
 import { useToast } from '@nemo/common/src/providers/toast/useToast';
-import { getAgentsListAgentsQueryKey } from '@nemo/sdk/generated/agents/agents';
+import {
+  getAgentsListAgentsQueryKey,
+  useAgentsCreateAgent,
+} from '@nemo/sdk/generated/agents/agents';
 import {
   Button,
+  Select,
   Stack,
   TabsContent,
   TabsList,
@@ -37,6 +41,7 @@ import type {
   UploadAgentEntry,
   UploadAgentFormData,
 } from '@studio/routes/agents/AgentsListRoute/NewAgentModal/type';
+import { useTraceAgentNames } from '@studio/routes/agents/AgentsListRoute/NewAgentModal/useTraceAgentNames';
 import {
   agentNameFromConfig,
   collectAgentEntries,
@@ -77,7 +82,8 @@ export const NewAgentModal: FC<NewAgentModalProps> = ({ open, onClose, workspace
   const [directoryName, setDirectoryName] = useState('');
   const [selectionError, setSelectionError] = useState<string | undefined>(undefined);
   const [replaceArmedFor, setReplaceArmedFor] = useState<string | null>(null);
-  const [tab, setTab] = useState<NewAgentTab>('coding-agent-prompt');
+  const [tab, setTab] = useState<NewAgentTab>('imported-traces');
+  const [tracedAgent, setTracedAgent] = useState('');
 
   const {
     mutateAsync: createAgent,
@@ -106,6 +112,24 @@ export const NewAgentModal: FC<NewAgentModalProps> = ({ open, onClose, workspace
     mode: 'onChange',
   });
 
+  const tracedAgents = useTraceAgentNames(workspace, open && tab === 'imported-traces');
+
+  const {
+    mutateAsync: createTracedAgent,
+    error: tracedCreateError,
+    isPending: isCreatingTraced,
+    reset: resetTracedMutation,
+  } = useAgentsCreateAgent({
+    mutation: {
+      onSuccess: (agent) => {
+        toast.success(`Agent "${agent.name}" created`);
+        void queryClient.invalidateQueries({ queryKey: getAgentsListAgentsQueryKey(workspace) });
+        resetAndClose();
+        if (agent.name) navigate(getAgentDetailRoute(workspace, agent.name));
+      },
+    },
+  });
+
   // useWatch re-renders this modal on every keystroke; the summary depends only on entries.
   const entriesSummary = useMemo(
     () =>
@@ -122,12 +146,14 @@ export const NewAgentModal: FC<NewAgentModalProps> = ({ open, onClose, workspace
 
   const resetAndClose = () => {
     resetMutation();
+    resetTracedMutation();
     resetForm({ name: '' });
     setEntries([]);
     setDirectoryName('');
     setSelectionError(undefined);
     setReplaceArmedFor(null);
-    setTab('coding-agent-prompt');
+    setTab('imported-traces');
+    setTracedAgent('');
     onClose();
   };
 
@@ -238,12 +264,25 @@ export const NewAgentModal: FC<NewAgentModalProps> = ({ open, onClose, workspace
     }
   };
 
+  // An agent seen only in telemetry has no config to register, and the platform defaults an
+  // empty one to nat-workflow-v1. It exists so its traces, evaluations and insights attach to a
+  // real agent; deploying or chatting with it still needs a config.
+  const createFromTraces = async () => {
+    if (!tracedAgent) return;
+    await createTracedAgent({ workspace, data: { name: tracedAgent, config: {} } }).catch(() => {
+      // Rendered through errorText.
+    });
+  };
+
   // No fallback argument: getErrorMessage prefers one over a plain Error's own message.
+  const failure = createError ?? tracedCreateError;
   const errorMessage =
     selectionError ??
-    (createError ? getErrorMessage(createError as Error) || 'Failed to create agent' : undefined);
+    (failure ? getErrorMessage(failure as Error) || 'Failed to create agent' : undefined);
 
   const onUploadTab = tab === 'upload';
+  const onTracesTab = tab === 'imported-traces';
+  const onCreateTab = onUploadTab || onTracesTab;
 
   return (
     <FormModal
@@ -253,13 +292,22 @@ export const NewAgentModal: FC<NewAgentModalProps> = ({ open, onClose, workspace
       title="Instrument an agent with NeMo Platform"
       instruction="Integrated agents allow users to evaluate, optimize, and deploy agents."
       submitButtonText={replaceOrphan ? 'Replace and create' : 'Create'}
-      onSubmit={handleSubmit(onSubmit)}
-      disabled={isPending}
-      loading={isPending}
-      submitDisabled={entries.length === 0}
-      errorText={onUploadTab ? errorMessage : undefined}
+      onSubmit={(event) => {
+        // The traced-agent choice is not part of the upload form, so it submits on its own
+        // rather than through a resolver that would reject the empty name field.
+        if (onTracesTab) {
+          event.preventDefault();
+          void createFromTraces();
+          return;
+        }
+        handleSubmit(onSubmit)(event);
+      }}
+      disabled={isPending || isCreatingTraced}
+      loading={isPending || isCreatingTraced}
+      submitDisabled={onTracesTab ? !tracedAgent : entries.length === 0}
+      errorText={onCreateTab ? errorMessage : undefined}
       slotFooterRight={
-        onUploadTab ? undefined : (
+        onCreateTab ? undefined : (
           <Button color="brand" type="button" onClick={resetAndClose}>
             Close
           </Button>
@@ -268,9 +316,35 @@ export const NewAgentModal: FC<NewAgentModalProps> = ({ open, onClose, workspace
     >
       <TabsRoot value={tab} onValueChange={(value) => setTab(value as NewAgentTab)}>
         <TabsList aria-label="Ways to instrument an agent">
+          <TabsTrigger value="imported-traces">Create from Imported traces</TabsTrigger>
           <TabsTrigger value="coding-agent-prompt">Coding agent prompt</TabsTrigger>
           <TabsTrigger value="upload">Upload agent</TabsTrigger>
         </TabsList>
+
+        <TabsContent value="imported-traces" className="items-stretch p-0 pt-density-lg">
+          <Stack gap="density-md">
+            <Text kind="body/regular/sm" color="secondary">
+              Agents that appear in ingested traces but are not registered yet. Registering one
+              gives its traces, evaluations, and insights an agent to hang from.
+            </Text>
+            {!tracedAgents.isLoading && tracedAgents.names.length === 0 ? (
+              <Text kind="body/regular/sm" color="secondary" data-testid="no-traced-agents">
+                {tracedAgents.registeredCount > 0
+                  ? 'Every agent named in recent traces is already registered.'
+                  : 'No agent names found in recent traces. Import traces first, then come back.'}
+              </Text>
+            ) : (
+              <Select
+                aria-label="Agent from imported traces"
+                value={tracedAgent}
+                onValueChange={setTracedAgent}
+                disabled={isCreatingTraced || tracedAgents.isLoading}
+                placeholder={tracedAgents.isLoading ? 'Loading...' : 'Select an agent'}
+                items={tracedAgents.names.map((name) => ({ value: name, children: name }))}
+              />
+            )}
+          </Stack>
+        </TabsContent>
 
         <TabsContent value="coding-agent-prompt" className="items-stretch p-0 pt-density-lg">
           <CodingAgentPromptEditor

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/NewAgentModal/type.ts
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/NewAgentModal/type.ts
@@ -19,8 +19,9 @@ export interface UploadAgentEntry {
   readonly file: File;
 }
 
-/** Which route into a new agent the modal is showing: a prompt to hand off, or a directory to upload. */
-export type NewAgentTab = 'coding-agent-prompt' | 'upload';
+/** Which route into a new agent the modal is showing: an agent already seen in ingested traces, a
+ *  prompt to hand off, or a directory to upload. */
+export type NewAgentTab = 'imported-traces' | 'coding-agent-prompt' | 'upload';
 
 export interface NewAgentModalProps extends Pick<FormModalProps, 'open' | 'onClose'> {
   workspace: string;

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/NewAgentModal/useTraceAgentNames.ts
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/NewAgentModal/useTraceAgentNames.ts
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useAgentsListAgents } from '@nemo/sdk/generated/agents/agents';
+import { useListTraces } from '@nemo/sdk/generated/platform/traces';
+import { useMemo } from 'react';
+
+/** The API's ceiling. Intake exposes no distinct-agent facet, so the names are deduped from a
+ *  page of traces; anything older than this many traces is not offered. */
+const TRACE_SCAN_PAGE_SIZE = 1000;
+
+export interface TraceAgentNames {
+  /** Agent names seen on traces that have no agent entity yet, oldest naming preserved. */
+  names: string[];
+  /** Names already registered, so the caller can say why the list is short. */
+  registeredCount: number;
+  isLoading: boolean;
+}
+
+/**
+ * Agent names observed in ingested traces that are not registered agents yet.
+ *
+ * `summary` mode is the cheapest response that still carries `agent_name`: it omits payloads and
+ * rollups, which this never reads.
+ */
+export const useTraceAgentNames = (workspace: string, enabled: boolean): TraceAgentNames => {
+  const { data: tracesResponse, isLoading: isTracesLoading } = useListTraces(
+    workspace,
+    { page_size: TRACE_SCAN_PAGE_SIZE, mode: 'summary', sort: '-started_at' },
+    { query: { enabled: enabled && !!workspace } }
+  );
+
+  const { data: agentsResponse, isLoading: isAgentsLoading } = useAgentsListAgents(
+    workspace,
+    undefined,
+    { query: { enabled: enabled && !!workspace } }
+  );
+
+  return useMemo(() => {
+    const registered = new Set(
+      (agentsResponse?.data ?? []).flatMap((agent) => (agent.name ? [agent.name] : []))
+    );
+    const seen = new Set<string>();
+    for (const trace of tracesResponse?.data ?? []) {
+      const name = trace.agent_name?.trim();
+      if (name && !registered.has(name)) seen.add(name);
+    }
+    return {
+      names: [...seen].sort((a, b) => a.localeCompare(b)),
+      registeredCount: registered.size,
+      isLoading: isTracesLoading || isAgentsLoading,
+    };
+  }, [tracesResponse, agentsResponse, isTracesLoading, isAgentsLoading]);
+};

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/NewAgentModal/useTraceAgentNames.ts
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/NewAgentModal/useTraceAgentNames.ts
@@ -12,8 +12,6 @@ const TRACE_SCAN_PAGE_SIZE = 1000;
 export interface TraceAgentNames {
   /** Agent names seen on traces that have no agent entity yet, oldest naming preserved. */
   names: string[];
-  /** Names already registered, so the caller can say why the list is short. */
-  registeredCount: number;
   isLoading: boolean;
 }
 
@@ -47,7 +45,6 @@ export const useTraceAgentNames = (workspace: string, enabled: boolean): TraceAg
     }
     return {
       names: [...seen].sort((a, b) => a.localeCompare(b)),
-      registeredCount: registered.size,
       isLoading: isTracesLoading || isAgentsLoading,
     };
   }, [tracesResponse, agentsResponse, isTracesLoading, isAgentsLoading]);


### PR DESCRIPTION


https://github.com/user-attachments/assets/2e94a3c6-5763-4c06-ad80-2c98e20c9024




<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary

Ingested telemetry often names an agent the platform has no record of.  This leaves users unable to view experiments for the agent, or run and view insights against the traces.

Until now the only routes into a new agent were integrating with fabric, handing off an integration prompt or uploading a directory, neither of which helps when the agent has already run and its traces are sitting in Intake. This adds a first tab to the new-agent modal that lists every distinct `agent_name` seen in ingested traces without a registered agent, and registers the one the user picks.

## Changes

- Add a `Create from Imported traces` tab to `NewAgentModal`, listing unregistered agent names from ingested traces and creating the selected one.
- Add `useTraceAgentNames`, which dedupes `agent_name` across a page of traces and subtracts the agents that already exist.
- Extend `NewAgentTab` with `imported-traces` and make it the tab the modal opens on.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: Studio UI affordance; no documented surface describes the new-agent modal's tabs.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `pnpm --filter nemo-studio-ui test` — 355 files, 3519 tests passed (exit 0). Four new tests cover deduping names across traces, excluding already-registered agents, the all-registered empty state, and creating with an empty config.
- `pnpm --filter nemo-studio-ui typecheck`, `pnpm lint`, `pnpm format` — clean. Typecheck required `pnpm --filter @nemo/sdk gen:all-force` first, as the generated SDK is built on demand and lacked the `insights` surface main has since added.
- Manual end-to-end against a local platform: with 8 distinct agent names across 1000 traces and 4 already registered, the tab offered exactly the 5 unregistered ones; selecting one created the agent, routed to its detail page, and its existing traces attached. Test agent deleted afterwards.

## Notes for reviewers

Three decisions worth a look, since the change had to settle them:

- **The created agent carries an empty config.** `CreateAgentRequest` requires `config` and telemetry supplies nothing for it. An empty object is accepted and defaults to `nat-workflow-v1`; a minimal `nemo-agents-spec-v1` stub is rejected for missing `default_harness` and `harnesses`. So the agent exists to give traces, evaluations, and insights something to attach to, and still needs a real config before it can be deployed or chatted with.
- **The name list is recent traces, not all time.** Intake has no distinct-agent facet, so names are deduped from a single page at the API's 1000-trace ceiling. An agent appearing only in older traces will not be offered; a facet endpoint would be the durable fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **Imported Traces** tab to the New Agent dialog.
  * View agent names detected in imported traces, with duplicates and already-registered names excluded.
  * Select an agent name to create a new agent with an empty default configuration.
  * Added loading, empty, error, and submission states for the imported-traces workflow.
* **Tests**
  * Added coverage for trace-based agent discovery, filtering, selection, validation, and creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->