### PR TITLE
fix(ci): remove on-call ping from forward merge alerts

### DIFF
--- a/.github/scripts/forward-merge-alert.cjs
+++ b/.github/scripts/forward-merge-alert.cjs
@@ -14,14 +14,6 @@ function escapeSlackText(value) {
     .replaceAll("\n", "\\n");
 }
 
-function slackUserGroupMention(value) {
-  const userGroupId = String(value || "").trim();
-  if (!/^S[A-Z0-9]{8,}$/.test(userGroupId)) {
-    return "";
-  }
-  return `<!subteam^${userGroupId}>`;
-}
-
 function selectSourcePullRequest({
   pulls,
   forwardPullNumber,
@@ -175,12 +167,10 @@ function buildSlackMessage({
   source,
   conflicts,
   runUrl,
-  userGroupId,
   recoveryDocsUrl,
 }) {
-  const mention = slackUserGroupMention(userGroupId);
   const lines = [
-    `${mention ? `${mention} ` : ""}:warning: *Forward merge needs attention*`,
+    ":warning: *Forward merge needs attention*",
     `Repository: ${escapeSlackText(repository)}`,
     `PR: <${pullUrl}|${escapeSlackText(pullTitle)}>`,
     sourceLine(source),
@@ -314,7 +304,6 @@ async function sendForwardMergeAlert({
     source,
     conflicts,
     runUrl: env.RUN_URL,
-    userGroupId: env.SLACK_ALERT_USERGROUP_ID,
     recoveryDocsUrl: env.FORWARD_MERGE_RECOVERY_DOCS_URL,
   });
   await postSlack({
@@ -336,5 +325,4 @@ module.exports = {
   resolveSource,
   selectSourcePullRequest,
   sendForwardMergeAlert,
-  slackUserGroupMention,
 };

--- a/.github/scripts/tests/forward-merge-alert.test.cjs
+++ b/.github/scripts/tests/forward-merge-alert.test.cjs
@@ -14,7 +14,6 @@ const {
   resolveSource,
   selectSourcePullRequest,
   sendForwardMergeAlert,
-  slackUserGroupMention,
 } = require("../forward-merge-alert.cjs");
 
 function git(workspace, ...args) {
@@ -170,26 +169,6 @@ test("shows only ten conflict files and links the remainder", () => {
   assert.match(message, /\+2 more/);
 });
 
-test("tags the configured Slack user group", () => {
-  const message = buildSlackMessage(
-    messageFixture({ userGroupId: "S0123456789" }),
-  );
-
-  assert.match(
-    message,
-    /^<!subteam\^S0123456789> :warning: \*Forward merge needs attention\*/,
-  );
-});
-
-test("omits a missing or invalid Slack user group", () => {
-  assert.equal(slackUserGroupMention(), "");
-  assert.equal(slackUserGroupMention("not-a-slack-group"), "");
-  assert.match(
-    buildSlackMessage(messageFixture()),
-    /^:warning: \*Forward merge needs attention\*/,
-  );
-});
-
 test("includes the configured recovery guide for every failure kind", () => {
   for (const kind of ["conflicts", "clean", "unavailable"]) {
     const message = buildSlackMessage(
@@ -289,8 +268,9 @@ test("falls back to the basic alert when PR metadata fails", async () => {
   assert.equal(requests[0].options.redirect, "error");
   assert.match(
     JSON.parse(requests[0].options.body).text,
-    /^<!subteam\^S0123456789>/,
+    /^:warning: \*Forward merge needs attention\*/,
   );
+  assert.doesNotMatch(result.text, /<!subteam\^/);
   assert.match(result.text, /Source: unavailable/);
   assert.ok(
     JSON.parse(requests[0].options.body).text.includes(

--- a/.github/workflows/forward-merge-alert.yaml
+++ b/.github/workflows/forward-merge-alert.yaml
@@ -32,7 +32,6 @@ jobs:
         env:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           SLACK_ALERTS_WEBHOOK: ${{ secrets.SLACK_RELEASE_WEBHOOK }}
-          SLACK_ALERT_USERGROUP_ID: ${{ secrets.SLACK_ALERT_USERGROUP_ID }}
           FORWARD_MERGE_RECOVERY_DOCS_URL: ${{ secrets.FORWARD_MERGE_RECOVERY_DOCS_URL }}
         with:
           script: |


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
<!-- In 1-3 plain sentences, explain what changes and why. Describe before-and-after behavior when it applies. -->

Forward-merge failure alerts no longer ping the on-call Slack group.

## Changes
<!-- List the concrete changes included in this pull request. -->

- Remove group-mention rendering and the workflow secret mapping.
- Update the existing alert test to verify no group mention is sent, even when the legacy environment variable is set.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [x] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: internal Slack notification change.

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

<!-- List each command and result. Explain skipped, blocked, or non-successful checks without marking them as passed. -->

- `node --test .github/scripts/tests/forward-merge-alert.test.cjs`: 10 passed after rebasing onto main.
- `actionlint .github/workflows/forward-merge-alert.yaml`: passed.
- `git diff --check`: passed.
- `make check-github-scripts`: blocked by unavailable pnpm in the Flox environment.
- `uv run pre-commit run -a`: failed because helm-docs and lint-staged are missing and installed uv 0.11.26 differs from required 0.9.14.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Forward-merge Slack alerts no longer include configured user-group mentions.
  - Alerts now omit user-group tags, including when a group ID is configured.
  - Removed the related workflow configuration and mention-specific behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->